### PR TITLE
Fix NotificationRule#notifyOn not being deserialized

### DIFF
--- a/src/main/java/org/dependencytrack/model/NotificationRule.java
+++ b/src/main/java/org/dependencytrack/model/NotificationRule.java
@@ -99,7 +99,6 @@ public class NotificationRule implements Serializable {
 
     @Persistent
     @Column(name = "NOTIFY_ON", length = 1024)
-    @JsonDeserialize(using = TrimmedStringDeserializer.class)
     private String notifyOn;
 
     @Persistent

--- a/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
@@ -25,6 +25,7 @@ import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.NotificationPublisher;
 import org.dependencytrack.model.NotificationRule;
 import org.dependencytrack.model.Project;
+import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationScope;
 import org.dependencytrack.notification.publisher.DefaultNotificationPublishers;
 import org.dependencytrack.persistence.DefaultObjectGenerator;
@@ -42,6 +43,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -137,6 +139,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Rule 1", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         rule.setName("Example Rule");
+        rule.setNotifyOn(Collections.singleton(NotificationGroup.NEW_VULNERABILITY));
         Response response = target(V1_NOTIFICATION_RULE).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(rule, MediaType.APPLICATION_JSON));
@@ -147,7 +150,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Assert.assertTrue(json.getBoolean("enabled"));
         Assert.assertEquals("PORTFOLIO", json.getString("scope"));
         Assert.assertEquals("INFORMATIONAL", json.getString("notificationLevel"));
-        Assert.assertEquals(0, json.getJsonArray("notifyOn").size());
+        Assert.assertEquals("NEW_VULNERABILITY", json.getJsonArray("notifyOn").getString(0));
         Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
         Assert.assertEquals("Slack", json.getJsonObject("publisher").getString("name"));
     }


### PR DESCRIPTION
This pull request fixes an issue where `NotificationRule#notifyOn` was not deserialized correctly, which caused the *Notify On* preferences in Dependency-Track's *Alerts* settings to be dysfunctional.

### Steps to Reproduce the issue

* Navigate to D-Track's *Adminstration* settings
* Select the *Notifications* -> *Alerts* section
* Create a new alert - settings don't matter
* Select the new alert in the alerts table
* Select any of the *Notify On* checkboxes
* Wait for the page to reload, notice that the checkbox has been de-selected

In my case, the payload being sent by the frontend was:

```json
{
    "uuid": "0ca4a989-5f78-44bf-9ceb-fd7616a30a35",
    "name": "Test Alert",
    "notificationLevel": "WARNING",
    "publisherConfig": "{\"destination\":\"http://my-destination.local/notification\"}",
    "notifyOn": [
        "NEW_VULNERABILITY"
    ]
}
```

to which the backend responded with:

```json
{
    "name": "Test Alert",
    "enabled": true,
    "scope": "PORTFOLIO",
    "notificationLevel": "WARNING",
    "projects": [],
    "notifyOn": [],
    "publisher": {
        "name": "Outbound Webhook",
        "description": "Publishes notifications to a configurable endpoint",
        "publisherClass": "org.dependencytrack.notification.publisher.WebhookPublisher",
        "templateMimeType": "application/json",
        "defaultPublisher": true,
        "uuid": "9b6f54be-16ec-4bd7-a9e6-cfa381a2c4cc"
    },
    "publisherConfig": "{\"destination\":\"http://my-destination.local/notification\"}",
    "uuid": "0ca4a989-5f78-44bf-9ceb-fd7616a30a35"
}
```

### Additional details

Jackson was instructed to use the `TrimmedStringDeserializer` for `notifyOn`, which would parse the JSON value and return its content as `String` (using `JsonNode#asText()`).  The JSON value being an array, `JsonNode#asText()` [returns an empty `String`](https://github.com/FasterXML/jackson-databind/blob/master/src/main/java/com/fasterxml/jackson/databind/JsonNode.java#L528).