### PR TITLE
Set Content-Type header in AbstractWebhookPublisher

### DIFF
--- a/src/main/java/org/dependencytrack/notification/publisher/AbstractWebhookPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/AbstractWebhookPublisher.java
@@ -45,6 +45,7 @@ public abstract class AbstractWebhookPublisher implements Publisher {
 
         final UnirestInstance ui = UnirestFactory.getUnirestInstance();
         final HttpResponse<JsonNode> response = ui.post(destination)
+                .header("content-type", "application/json")
                 .header("accept", "application/json")
                 .body(content)
                 .asJson();


### PR DESCRIPTION
So this is just a minor thing: Currently, Dependency-Track sends out WebHook notifications with Content-Type `text/plain;charset=UTF-8`, which is probably done implicitly by unirest. Dependency-Track should clearly indicate that the Payload is in fact of Content-Type `application/json`, which is what this change does.