### PR TITLE
Add a view to list affected projects / dependencies by specific vulnerability with analysis comment. 

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1607,7 +1607,9 @@ public class QueryManager extends AlpineQueryManager {
     /**
      * Returns a List of Projects affected by a specific vulnerability.
      * @param vulnerability the vulnerability to query on
-     * @param suppressed
+     * @param includeSuppressed if includeSuppressed is true, return all dependencies which are affected by given
+     *                          vulnerability and suppressed dependencies. If includeSuppressed is false,
+     *                          return only affected dependencies.
      * @return a List of Projects
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1607,23 +1607,28 @@ public class QueryManager extends AlpineQueryManager {
     /**
      * Returns a List of Projects affected by a specific vulnerability.
      * @param vulnerability the vulnerability to query on
+     * @param suppressed
      * @return a List of Projects
      */
     @SuppressWarnings("unchecked")
-    public List<Project> getProjects(Vulnerability vulnerability) {
+    public List<Project> getProjects(Vulnerability vulnerability, boolean includeSuppressed) {
         final List<Project> projects = new ArrayList<>();
         for (final Component component: vulnerability.getComponents()) {
             for (final Dependency dependency: getAllDependencies(component)) {
                 boolean affected = true;
                 final Analysis globalAnalysis = getAnalysis(null, component, vulnerability);
                 final Analysis projectAnalysis = getAnalysis(dependency.getProject(), component, vulnerability);
-                if (globalAnalysis != null && globalAnalysis.isSuppressed()) {
-                    affected = false;
-                }
-                if (projectAnalysis != null && projectAnalysis.isSuppressed()) {
-                    affected = false;
-                }
-                if (affected) {
+                if (!includeSuppressed) {
+                    if (globalAnalysis != null && globalAnalysis.isSuppressed()) {
+                        affected = false;
+                    }
+                    if (projectAnalysis != null && projectAnalysis.isSuppressed()) {
+                        affected = false;
+                    }
+                    if (affected) {
+                        projects.add(dependency.getProject());
+                    }
+                } else {
                     projects.add(dependency.getProject());
                 }
             }

--- a/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
@@ -205,7 +205,6 @@ public class VulnerabilityResource extends AlpineResource {
                         for (Component component : vulnerability.getComponents()) {
                             DependencyAnalysisResponse dependencyAnalysisResponse;
                             Analysis analysis = qm.getAnalysis(project, component, vulnerability);
-                            System.out.println(analysis.getProject().getName());
                             // to hold the last mitigation comment of a dependency
                             String lastComment;
                             if (analysis != null) {
@@ -214,7 +213,6 @@ public class VulnerabilityResource extends AlpineResource {
                                 List<String> comments = new ArrayList<>();
                                 for (AnalysisComment analysisComment : analysis.getAnalysisComments()) {
                                     String comment = analysisComment.getComment();
-                                    System.out.println("current comment:" + comment);
                                     // if a comment contains any analysis state transition , ignore that comment.
                                     if (comment.contains("EXPLOITABLE") || comment
                                             .contains("FALSE_POSITIVE") || comment
@@ -231,7 +229,6 @@ public class VulnerabilityResource extends AlpineResource {
                                 } else {
                                     lastComment = null;
                                 }
-                                System.out.println(lastComment);
                                 dependencyAnalysisResponse = new DependencyAnalysisResponse(
                                         project.getName(), project.getVersion(), project.getUuid(), component.getName(),
                                         lastComment, analysis.getAnalysisState(), analysis.isSuppressed());

--- a/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
@@ -178,13 +178,14 @@ public class VulnerabilityResource extends AlpineResource {
     }
 
     @GET
-    @Path("/source/{source}/vuln/{vuln}/suppressed/{suppressed}/analysis")
+    @Path("/source/{source}/vuln/{vuln}/includeSuppressed/{includeSuppressed}/analysis")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
-            value = "Returns a list of all analysis metadata of dependencies based on given vulnerability ",
+            value = "Returns a list of all analysis metadata of affected dependency based on given vulnerability ",
             response = DependencyAnalysisResponse.class,
             responseContainer = "List",
-            responseHeaders = @ResponseHeader(name = TOTAL_COUNT_HEADER, response = Long.class, description = "The total number of projects")
+            responseHeaders = @ResponseHeader(name = TOTAL_COUNT_HEADER, response = Long.class,
+                    description = "The total number of projects")
     )
     @ApiResponses(value = {
             @ApiResponse(code = 401, message = "Unauthorized"),
@@ -193,34 +194,35 @@ public class VulnerabilityResource extends AlpineResource {
     @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
     public Response getAffectedDependencies(@PathParam("source") String source,
                                        @PathParam("vuln") String vuln,
-                                       @PathParam("suppressed") boolean suppressed) {
+                                       @PathParam("includeSuppressed") boolean includeSuppressed) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final List<DependencyAnalysisResponse> dependencyAnalysisResponsesList = new ArrayList<>();
             final Vulnerability vulnerability = qm.getVulnerabilityByVulnId(source, vuln);
             if (vulnerability != null) {
-                // Get all projects affected by given vulnerability
-                final List<Project> affectedProjects = qm.getProjects(vulnerability, suppressed);
+                // Get all projects affected by given vulnerability.
+                final List<Project> affectedProjects = qm.getProjects(vulnerability, includeSuppressed);
                 if (affectedProjects != null) {
                     for (Project project : affectedProjects) {
                         for (Component component : vulnerability.getComponents()) {
                             DependencyAnalysisResponse dependencyAnalysisResponse;
                             Analysis analysis = qm.getAnalysis(project, component, vulnerability);
-                            // to hold the last mitigation comment of a dependency
+                            // To hold the last mitigation comment of a dependency.
                             String lastComment;
                             if (analysis != null) {
-                                // list to hold all mitigation comments. This list doesn't hold comment which represent
-                                // analysis state comments
+                                // List to hold all mitigation comments. This list doesn't hold comment which represent
+                                // analysis state comments.
                                 List<String> comments = new ArrayList<>();
                                 for (AnalysisComment analysisComment : analysis.getAnalysisComments()) {
                                     String comment = analysisComment.getComment();
-                                    // if a comment contains any analysis state transition , ignore that comment.
-                                    if (comment.contains("EXPLOITABLE") || comment
-                                            .contains("FALSE_POSITIVE") || comment
-                                            .contains("IN_TRIAGE") || comment
-                                            .contains("NOT_AFFECTED") || comment
-                                            .contains("NOT_SET")) {
-                                        continue;
-                                    } else {
+                                    boolean isStateChangeComment =false;
+                                    // If a comment contains any analysis state transition , ignore comment.
+                                    for(AnalysisState state : AnalysisState.values()){
+                                        if(comment.contains(state.name())){
+                                            isStateChangeComment = true;
+                                            break;
+                                        }
+                                    }
+                                    if(!isStateChangeComment){
                                         comments.add(comment);
                                     }
                                 }

--- a/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
@@ -30,11 +30,15 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.ResponseHeader;
 import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.Analysis;
+import org.dependencytrack.model.AnalysisComment;
+import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Cwe;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.response.DependencyAnalysisResponse;
 import us.springett.cvss.Cvss;
 import us.springett.cvss.Score;
 import javax.validation.Validator;
@@ -50,6 +54,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -173,11 +178,11 @@ public class VulnerabilityResource extends AlpineResource {
     }
 
     @GET
-    @Path("/source/{source}/vuln/{vuln}/projects")
+    @Path("/source/{source}/vuln/{vuln}/suppressed/{suppressed}/analysis")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
-            value = "Returns a list of all projects affected by a specific vulnerability",
-            response = Project.class,
+            value = "Returns a list of all analysis metadata of dependencies based on given vulnerability ",
+            response = DependencyAnalysisResponse.class,
             responseContainer = "List",
             responseHeaders = @ResponseHeader(name = TOTAL_COUNT_HEADER, response = Long.class, description = "The total number of projects")
     )
@@ -186,14 +191,62 @@ public class VulnerabilityResource extends AlpineResource {
             @ApiResponse(code = 404, message = "The vulnerability could not be found")
     })
     @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
-    public Response getAffectedProject(@PathParam("source") String source,
-                                                @PathParam("vuln") String vuln) {
+    public Response getAffectedDependencies(@PathParam("source") String source,
+                                       @PathParam("vuln") String vuln,
+                                       @PathParam("suppressed") boolean suppressed) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+            final List<DependencyAnalysisResponse> dependencyAnalysisResponsesList = new ArrayList<>();
             final Vulnerability vulnerability = qm.getVulnerabilityByVulnId(source, vuln);
             if (vulnerability != null) {
-                final List<Project> projects = qm.getProjects(vulnerability);
-                final long totalCount = projects.size();
-                return Response.ok(projects).header(TOTAL_COUNT_HEADER, totalCount).build();
+                // Get all projects affected by given vulnerability
+                final List<Project> affectedProjects = qm.getProjects(vulnerability, suppressed);
+                if (affectedProjects != null) {
+                    for (Project project : affectedProjects) {
+                        for (Component component : vulnerability.getComponents()) {
+                            DependencyAnalysisResponse dependencyAnalysisResponse;
+                            Analysis analysis = qm.getAnalysis(project, component, vulnerability);
+                            System.out.println(analysis.getProject().getName());
+                            // to hold the last mitigation comment of a dependency
+                            String lastComment;
+                            if (analysis != null) {
+                                // list to hold all mitigation comments. This list doesn't hold comment which represent
+                                // analysis state comments
+                                List<String> comments = new ArrayList<>();
+                                for (AnalysisComment analysisComment : analysis.getAnalysisComments()) {
+                                    String comment = analysisComment.getComment();
+                                    System.out.println("current comment:" + comment);
+                                    // if a comment contains any analysis state transition , ignore that comment.
+                                    if (comment.contains("EXPLOITABLE") || comment
+                                            .contains("FALSE_POSITIVE") || comment
+                                            .contains("IN_TRIAGE") || comment
+                                            .contains("NOT_AFFECTED") || comment
+                                            .contains("NOT_SET")) {
+                                        continue;
+                                    } else {
+                                        comments.add(comment);
+                                    }
+                                }
+                                if (comments.size() != 0) {
+                                    lastComment = comments.get(comments.size() - 1);
+                                } else {
+                                    lastComment = null;
+                                }
+                                System.out.println(lastComment);
+                                dependencyAnalysisResponse = new DependencyAnalysisResponse(
+                                        project.getName(), project.getVersion(), project.getUuid(), component.getName(),
+                                        lastComment, analysis.getAnalysisState(), analysis.isSuppressed());
+                            } else {
+                                dependencyAnalysisResponse = new DependencyAnalysisResponse(
+                                        project.getName(), project.getVersion(), project.getUuid(), component.getName(),
+                                        null, null, false);
+                            }
+                            dependencyAnalysisResponsesList.add(dependencyAnalysisResponse);
+                        }
+                    }
+                }
+                final long totalCount = dependencyAnalysisResponsesList.size();
+                return Response.ok(dependencyAnalysisResponsesList).header(TOTAL_COUNT_HEADER, totalCount)
+                        .build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The vulnerability could not be found.").build();
             }

--- a/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
@@ -44,6 +44,7 @@ import us.springett.cvss.Score;
 import javax.validation.Validator;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -178,14 +179,43 @@ public class VulnerabilityResource extends AlpineResource {
     }
 
     @GET
-    @Path("/source/{source}/vuln/{vuln}/includeSuppressed/{includeSuppressed}/analysis")
+    @Path("/source/{source}/vuln/{vuln}/projects")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Returns a list of all projects affected by a specific vulnerability",
+            response = Project.class,
+            responseContainer = "List",
+            responseHeaders = @ResponseHeader(name = TOTAL_COUNT_HEADER, response = Long.class, description = "The total number of projects")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 404, message = "The vulnerability could not be found")
+    })
+    @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
+    public Response getAffectedProject(@PathParam("source") String source,
+            @PathParam("vuln") String vuln,
+            @QueryParam("includeSuppressed") @DefaultValue("true") boolean includeSuppressed) {
+        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+            final Vulnerability vulnerability = qm.getVulnerabilityByVulnId(source, vuln);
+            if (vulnerability != null) {
+                final List<Project> projects = qm.getProjects(vulnerability,includeSuppressed);
+                final long totalCount = projects.size();
+                return Response.ok(projects).header(TOTAL_COUNT_HEADER, totalCount).build();
+            } else {
+                return Response.status(Response.Status.NOT_FOUND).entity("The vulnerability could not be found.").build();
+            }
+        }
+    }
+
+    @GET
+    @Path("/source/{source}/vuln/{vuln}/dependencyAnalysis")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
             value = "Returns a list of all analysis metadata of affected dependency based on given vulnerability ",
             response = DependencyAnalysisResponse.class,
             responseContainer = "List",
             responseHeaders = @ResponseHeader(name = TOTAL_COUNT_HEADER, response = Long.class,
-                    description = "The total number of projects")
+                    description = "The total number of dependencies")
     )
     @ApiResponses(value = {
             @ApiResponse(code = 401, message = "Unauthorized"),
@@ -194,7 +224,7 @@ public class VulnerabilityResource extends AlpineResource {
     @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
     public Response getAffectedDependencies(@PathParam("source") String source,
                                        @PathParam("vuln") String vuln,
-                                       @PathParam("includeSuppressed") boolean includeSuppressed) {
+                                       @QueryParam("includeSuppressed") boolean includeSuppressed) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final List<DependencyAnalysisResponse> dependencyAnalysisResponsesList = new ArrayList<>();
             final Vulnerability vulnerability = qm.getVulnerabilityByVulnId(source, vuln);
@@ -204,13 +234,17 @@ public class VulnerabilityResource extends AlpineResource {
                 if (affectedProjects != null) {
                     for (Project project : affectedProjects) {
                         for (Component component : vulnerability.getComponents()) {
-                            DependencyAnalysisResponse dependencyAnalysisResponse;
+                            DependencyAnalysisResponse dependencyAnalysisResponse = new DependencyAnalysisResponse();
+                            dependencyAnalysisResponse.setProjectName(project.getName());
+                            dependencyAnalysisResponse.setVersion(project.getVersion());
+                            dependencyAnalysisResponse.setUuid(project.getUuid());
+                            dependencyAnalysisResponse.setComponentName(component.getName());
                             Analysis analysis = qm.getAnalysis(project, component, vulnerability);
-                            // To hold the last mitigation comment of a dependency.
+                            // To hold the last audit comment of a dependency.
                             String lastComment;
                             if (analysis != null) {
                                 // List to hold all mitigation comments. This list doesn't hold comment which represent
-                                // analysis state comments.
+                                // analysis state changes (Eg: NOT_SET -> FALSE_POSITIVE).
                                 List<String> comments = new ArrayList<>();
                                 for (AnalysisComment analysisComment : analysis.getAnalysisComments()) {
                                     String comment = analysisComment.getComment();
@@ -231,13 +265,13 @@ public class VulnerabilityResource extends AlpineResource {
                                 } else {
                                     lastComment = null;
                                 }
-                                dependencyAnalysisResponse = new DependencyAnalysisResponse(
-                                        project.getName(), project.getVersion(), project.getUuid(), component.getName(),
-                                        lastComment, analysis.getAnalysisState(), analysis.isSuppressed());
+                                dependencyAnalysisResponse.setAnalysisState(analysis.getAnalysisState());
+                                dependencyAnalysisResponse.setLastComment(lastComment);
+                                dependencyAnalysisResponse.setSuppressed(analysis.isSuppressed());
                             } else {
-                                dependencyAnalysisResponse = new DependencyAnalysisResponse(
-                                        project.getName(), project.getVersion(), project.getUuid(), component.getName(),
-                                        null, null, false);
+                                dependencyAnalysisResponse.setAnalysisState(null);
+                                dependencyAnalysisResponse.setLastComment(null);
+                                dependencyAnalysisResponse.setSuppressed(false);
                             }
                             dependencyAnalysisResponsesList.add(dependencyAnalysisResponse);
                         }

--- a/src/main/java/org/dependencytrack/response/DependencyAnalysisResponse.java
+++ b/src/main/java/org/dependencytrack/response/DependencyAnalysisResponse.java
@@ -31,6 +31,7 @@ public class DependencyAnalysisResponse {
     private String version;
     private UUID uuid;
     private String componentName;
+    // last comment in audit trial
     private String lastComment;
     private AnalysisState analysisState;
     private boolean suppressed;

--- a/src/main/java/org/dependencytrack/response/DependencyAnalysisResponse.java
+++ b/src/main/java/org/dependencytrack/response/DependencyAnalysisResponse.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.dependencytrack.model.AnalysisState;
+import java.util.UUID;
+
+/**
+ * Defines a custom response object used when getting the analysis comment per component.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DependencyAnalysisResponse {
+    private String name;
+    private String version;
+    private UUID uuid;
+    private String componentName;
+    private String lastComment;
+    private AnalysisState analysisState;
+    private boolean suppressed;
+
+    public DependencyAnalysisResponse(String name, String version, UUID uuid, String componentName, String lastComment,
+            AnalysisState analysisState, boolean suppressed) {
+        this.name = name;
+        this.version = version;
+        this.uuid = uuid;
+        this.componentName = componentName;
+        this.lastComment = lastComment;
+        this.analysisState = analysisState;
+        this.suppressed = suppressed;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public String getLastComment() {
+        return lastComment;
+    }
+
+    public void setLastComment(String lastComment) {
+        this.lastComment = lastComment;
+    }
+
+    public AnalysisState getAnalysisState() {
+        return analysisState;
+    }
+
+    public void setAnalysisState(AnalysisState analysisState) {
+        this.analysisState = analysisState;
+    }
+
+    public boolean isSuppressed() {
+        return suppressed;
+    }
+
+    public void setSuppressed(boolean suppressed) {
+        this.suppressed = suppressed;
+    }
+
+    public String getComponentName() {
+        return componentName;
+    }
+
+    public void setComponentName(String componentName) {
+        this.componentName = componentName;
+    }
+}

--- a/src/main/java/org/dependencytrack/response/DependencyAnalysisResponse.java
+++ b/src/main/java/org/dependencytrack/response/DependencyAnalysisResponse.java
@@ -27,7 +27,7 @@ import java.util.UUID;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DependencyAnalysisResponse {
-    private String name;
+    private String projectName;
     private String version;
     private UUID uuid;
     private String componentName;
@@ -35,23 +35,15 @@ public class DependencyAnalysisResponse {
     private AnalysisState analysisState;
     private boolean suppressed;
 
-    public DependencyAnalysisResponse(String name, String version, UUID uuid, String componentName, String lastComment,
-            AnalysisState analysisState, boolean suppressed) {
-        this.name = name;
-        this.version = version;
-        this.uuid = uuid;
-        this.componentName = componentName;
-        this.lastComment = lastComment;
-        this.analysisState = analysisState;
-        this.suppressed = suppressed;
+    public DependencyAnalysisResponse() {
     }
 
-    public String getName() {
-        return name;
+    public String getProjectName() {
+        return projectName;
     }
 
-    public void setName(String name) {
-        this.name = name;
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
     }
 
     public String getVersion() {
@@ -101,4 +93,6 @@ public class DependencyAnalysisResponse {
     public void setComponentName(String componentName) {
         this.componentName = componentName;
     }
+
+
 }

--- a/src/main/webapp/vulnerability/functions.js
+++ b/src/main/webapp/vulnerability/functions.js
@@ -156,7 +156,7 @@ function vulnNotFound() {
 function formatProjectsTable(res) {
     for (let i=0; i<res.length; i++) {
         let projecturl = "../project/?uuid=" + res[i].uuid;
-        res[i].projecthref = "<a href=\"" + projecturl + "\">" + filterXSS(res[i].name) + "</a>";
+        res[i].projecthref = "<a href=\"" + projecturl + "\">" + filterXSS(res[i].projectName) + "</a>";
         if (!res[i].hasOwnProperty("lastComment")) {
             res[i].lastComment = "";
         }

--- a/src/main/webapp/vulnerability/functions.js
+++ b/src/main/webapp/vulnerability/functions.js
@@ -157,7 +157,17 @@ function formatProjectsTable(res) {
     for (let i=0; i<res.length; i++) {
         let projecturl = "../project/?uuid=" + res[i].uuid;
         res[i].projecthref = "<a href=\"" + projecturl + "\">" + filterXSS(res[i].name) + "</a>";
-        res[i].version = filterXSS(res[i].version);
+        if (!res[i].hasOwnProperty("lastComment")) {
+            res[i].lastComment = "";
+        }
+        if(!res[i].hasOwnProperty("analysisState")){
+            res[i].analysisState = "";
+        }
+        if(res[i].suppressed == true){
+            res[i].isSuppressedLabel = '<i class="fa fa-check-square-o" aria-hidden="true"></i>';
+        } else {
+            res[i].isSuppressedLabel = '';
+        }
     }
     return res;
 }

--- a/src/main/webapp/vulnerability/index.jsp
+++ b/src/main/webapp/vulnerability/index.jsp
@@ -48,7 +48,7 @@
                         <div class="tab-pane active" id="excludeSuppressionTab">
                             <table id="vulnerableProjectsTableExcludeSuppression" class="table table-striped"
                                    data-toggle="table"
-                                   data-url="<c:url value="/api/v1/vulnerability/source/${e:forUriComponent(param.source)}/vuln/${e:forUriComponent(param.vulnId)}/suppressed/false/analysis"/>"
+                                   data-url="<c:url value="/api/v1/vulnerability/source/${e:forUriComponent(param.source)}/vuln/${e:forUriComponent(param.vulnId)}/includeSuppressed/false/analysis"/>"
                                    data-show-refresh="true" data-show-columns="true" data-search="true"
                                    data-query-params-type="pageSize" data-side-pagination="client" data-pagination="true"
                                    data-silent-sort="false" data-page-size="10" data-page-list="[10, 25, 50, 100]"
@@ -68,7 +68,7 @@
                         <div class="tab-pane" id="includeSuppressionTab">
                             <table id="vulnerableProjectsTableIncludeSuppression" class="table table-striped"
                                    data-toggle="table"
-                                   data-url="<c:url value="/api/v1/vulnerability/source/${e:forUriComponent(param.source)}/vuln/${e:forUriComponent(param.vulnId)}/suppressed/true/analysis"/>"
+                                   data-url="<c:url value="/api/v1/vulnerability/source/${e:forUriComponent(param.source)}/vuln/${e:forUriComponent(param.vulnId)}/includeSuppressed/true/analysis"/>"
                                    data-show-refresh="true" data-show-columns="true" data-search="true"
                                    data-query-params-type="pageSize" data-side-pagination="client" data-pagination="true"
                                    data-silent-sort="false" data-page-size="10" data-page-list="[10, 25, 50, 100]"

--- a/src/main/webapp/vulnerability/index.jsp
+++ b/src/main/webapp/vulnerability/index.jsp
@@ -33,17 +33,64 @@
             <div id="vulndata"></div>
 
             <h3 style="margin-top:50px;">Affected Projects</h3>
-            <table id="vulnerableProjectsTable" class="table table-striped" data-toggle="table"
-                   data-url="<c:url value="/api/v1/vulnerability/source/${e:forUriComponent(param.source)}/vuln/${e:forUriComponent(param.vulnId)}/projects"/>"
-                   data-show-refresh="true" data-show-columns="true" data-search="true"
-                   data-response-handler="formatProjectsTable" data-height="100%">
-                <thead>
-                <tr>
-                    <th data-align="left" data-field="projecthref">Name</th>
-                    <th data-align="left" data-field="version">Version</th>
-                </tr>
-                </thead>
-            </table>
+            <div class="panel with-nav-tabs panel-default tight">
+                <div class="panel-heading">
+                    <ul class="nav nav-tabs">
+                        <li><a href="#excludeSuppressionTab" data-toggle="tab"><i
+                                class="fa fa-tasks"></i> Exclude Suppression</a></li>
+                        <li><a href="#includeSuppressionTab" data-toggle="tab"><i
+                                class="fa fa-tasks"></i> Include Suppression</a></li>
+            
+                    </ul>
+                </div>
+                <div class="panel-body tight">
+                    <div class="tab-content">
+                        <div class="tab-pane active" id="excludeSuppressionTab">
+                            <table id="vulnerableProjectsTableExcludeSuppression" class="table table-striped"
+                                   data-toggle="table"
+                                   data-url="<c:url value="/api/v1/vulnerability/source/${e:forUriComponent(param.source)}/vuln/${e:forUriComponent(param.vulnId)}/suppressed/false/analysis"/>"
+                                   data-show-refresh="true" data-show-columns="true" data-search="true"
+                                   data-query-params-type="pageSize" data-side-pagination="client" data-pagination="true"
+                                   data-silent-sort="false" data-page-size="10" data-page-list="[10, 25, 50, 100]"
+                                   data-response-handler="formatProjectsTable" data-height="100%">
+                                <thead>
+                                <tr>
+                                    <th data-align="left" data-field="projecthref">Name</th>
+                                    <th data-align="left" data-field="version">Version</th>
+                                    <th data-align="left" data-field="componentName">Component</th>
+                                    <th data-align="left" data-field="lastComment">Comment</th>
+                                    <th data-align="left" data-field="analysisState">Analysis State</th>
+                                </tr>
+                                </thead>
+                            </table>
+                        </div>
+                
+                        <div class="tab-pane" id="includeSuppressionTab">
+                            <table id="vulnerableProjectsTableIncludeSuppression" class="table table-striped"
+                                   data-toggle="table"
+                                   data-url="<c:url value="/api/v1/vulnerability/source/${e:forUriComponent(param.source)}/vuln/${e:forUriComponent(param.vulnId)}/suppressed/true/analysis"/>"
+                                   data-show-refresh="true" data-show-columns="true" data-search="true"
+                                   data-query-params-type="pageSize" data-side-pagination="client" data-pagination="true"
+                                   data-silent-sort="false" data-page-size="10" data-page-list="[10, 25, 50, 100]"
+                                   data-response-handler="formatProjectsTable" data-height="100%">
+                                <thead>
+                                <tr>
+                                    <th data-align="left" data-field="projecthref">Name</th>
+                                    <th data-align="left" data-field="version">Version</th>
+                                    <th data-align="left" data-field="componentName">Component</th>
+                                    <th data-align="left" data-field="lastComment">Comment</th>
+                                    <th data-align="left" data-field="analysisState">Analysis State</th>
+                                    <th data-align="center" data-field="isSuppressedLabel" data-sortable="true"
+                                        data-class="tight">Suppressed
+                                    </th>
+                                </tr>
+                                </thead>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
 
         </div>
 

--- a/src/main/webapp/vulnerability/index.jsp
+++ b/src/main/webapp/vulnerability/index.jsp
@@ -48,7 +48,7 @@
                         <div class="tab-pane active" id="excludeSuppressionTab">
                             <table id="vulnerableProjectsTableExcludeSuppression" class="table table-striped"
                                    data-toggle="table"
-                                   data-url="<c:url value="/api/v1/vulnerability/source/${e:forUriComponent(param.source)}/vuln/${e:forUriComponent(param.vulnId)}/includeSuppressed/false/analysis"/>"
+                                   data-url="<c:url value="/api/v1/vulnerability/source/${e:forUriComponent(param.source)}/vuln/${e:forUriComponent(param.vulnId)}/dependencyAnalysis?includeSuppressed=false"/>"
                                    data-show-refresh="true" data-show-columns="true" data-search="true"
                                    data-query-params-type="pageSize" data-side-pagination="client" data-pagination="true"
                                    data-silent-sort="false" data-page-size="10" data-page-list="[10, 25, 50, 100]"
@@ -68,7 +68,7 @@
                         <div class="tab-pane" id="includeSuppressionTab">
                             <table id="vulnerableProjectsTableIncludeSuppression" class="table table-striped"
                                    data-toggle="table"
-                                   data-url="<c:url value="/api/v1/vulnerability/source/${e:forUriComponent(param.source)}/vuln/${e:forUriComponent(param.vulnId)}/includeSuppressed/true/analysis"/>"
+                                   data-url="<c:url value="/api/v1/vulnerability/source/${e:forUriComponent(param.source)}/vuln/${e:forUriComponent(param.vulnId)}/dependencyAnalysis?includeSuppressed=true"/>"
                                    data-show-refresh="true" data-show-columns="true" data-search="true"
                                    data-query-params-type="pageSize" data-side-pagination="client" data-pagination="true"
                                    data-silent-sort="false" data-page-size="10" data-page-list="[10, 25, 50, 100]"

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -298,7 +298,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
     public void getAffectedDependencies() throws Exception {
         SampleData sampleData = new SampleData();
         Response response = target(V1_VULNERABILITY + "/source/" + sampleData.v5.getSource() + "/vuln/" +
-                sampleData.v5.getVulnId() + "/includeSuppressed/true/analysis").request()
+                sampleData.v5.getVulnId() + ("/dependencyAnalysis")).queryParam("suppressed", "true").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -302,7 +302,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assert.assertEquals(String.valueOf(2), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
         Assert.assertNotNull(json);
         Assert.assertEquals("Project 2", json.getJsonObject(0).getString("name"));
@@ -311,6 +311,11 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Assert.assertEquals(sampleData.c2.getName(), json.getJsonObject(0).getString("componentName"));
         Assert.assertEquals("NOT_AFFECTED", json.getJsonObject(0).getString("analysisState"));
         Assert.assertEquals("true", json.getJsonObject(0).getString("suppressed"));
+        Assert.assertEquals("Project 1", json.getJsonObject(0).getString("name"));
+        Assert.assertEquals(sampleData.p1.getUuid().toString(), json.getJsonObject(0).getString("uuid"));
+        Assert.assertEquals(sampleData.p1.getVersion(), json.getJsonObject(0).getString("version"));
+        Assert.assertEquals(sampleData.c2.getName(), json.getJsonObject(0).getString("componentName"));
+        Assert.assertEquals("false", json.getJsonObject(0).getString("suppressed"));
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -308,12 +308,12 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Assert.assertEquals("Project 1", json.getJsonObject(0).getString("name"));
         Assert.assertEquals(sampleData.p1.getUuid().toString(), json.getJsonObject(0).getString("uuid"));
         Assert.assertEquals(sampleData.c2.getName(), json.getJsonObject(0).getString("componentName"));
-        Assert.assertEquals("false", json.getJsonObject(0).getString("suppressed"));
+        Assert.assertEquals(Boolean.parseBoolean("false"), json.getJsonObject(0).getBoolean("suppressed"));
         Assert.assertEquals("Project 2", json.getJsonObject(1).getString("name"));
         Assert.assertEquals(sampleData.p2.getUuid().toString(), json.getJsonObject(1).getString("uuid"));
         Assert.assertEquals(sampleData.c2.getName(), json.getJsonObject(1).getString("componentName"));
         Assert.assertEquals("NOT_AFFECTED", json.getJsonObject(1).getString("analysisState"));
-        Assert.assertEquals("true", json.getJsonObject(1).getString("suppressed"));
+        Assert.assertEquals(Boolean.parseBoolean("true"), json.getJsonObject(1).getString("suppressed"));
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -307,12 +307,10 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Assert.assertNotNull(json);
         Assert.assertEquals("Project 1", json.getJsonObject(0).getString("name"));
         Assert.assertEquals(sampleData.p1.getUuid().toString(), json.getJsonObject(0).getString("uuid"));
-        Assert.assertEquals(sampleData.p1.getVersion(), json.getJsonObject(0).getString("version"));
         Assert.assertEquals(sampleData.c2.getName(), json.getJsonObject(0).getString("componentName"));
         Assert.assertEquals("false", json.getJsonObject(1).getString("suppressed"));
         Assert.assertEquals("Project 2", json.getJsonObject(1).getString("name"));
         Assert.assertEquals(sampleData.p2.getUuid().toString(), json.getJsonObject(1).getString("uuid"));
-        Assert.assertEquals(sampleData.p2.getVersion(), json.getJsonObject(1).getString("version"));
         Assert.assertEquals(sampleData.c2.getName(), json.getJsonObject(1).getString("componentName"));
         Assert.assertEquals("NOT_AFFECTED", json.getJsonObject(0).getString("analysisState"));
         Assert.assertEquals("true", json.getJsonObject(0).getString("suppressed"));

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -305,17 +305,17 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Assert.assertEquals(String.valueOf(2), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals("Project 2", json.getJsonObject(0).getString("name"));
-        Assert.assertEquals(sampleData.p2.getUuid().toString(), json.getJsonObject(0).getString("uuid"));
-        Assert.assertEquals(sampleData.p2.getVersion(), json.getJsonObject(0).getString("version"));
-        Assert.assertEquals(sampleData.c2.getName(), json.getJsonObject(0).getString("componentName"));
-        Assert.assertEquals("NOT_AFFECTED", json.getJsonObject(0).getString("analysisState"));
-        Assert.assertEquals("true", json.getJsonObject(0).getString("suppressed"));
         Assert.assertEquals("Project 1", json.getJsonObject(0).getString("name"));
         Assert.assertEquals(sampleData.p1.getUuid().toString(), json.getJsonObject(0).getString("uuid"));
         Assert.assertEquals(sampleData.p1.getVersion(), json.getJsonObject(0).getString("version"));
         Assert.assertEquals(sampleData.c2.getName(), json.getJsonObject(0).getString("componentName"));
-        Assert.assertEquals("false", json.getJsonObject(0).getString("suppressed"));
+        Assert.assertEquals("false", json.getJsonObject(1).getString("suppressed"));
+        Assert.assertEquals("Project 2", json.getJsonObject(1).getString("name"));
+        Assert.assertEquals(sampleData.p2.getUuid().toString(), json.getJsonObject(1).getString("uuid"));
+        Assert.assertEquals(sampleData.p2.getVersion(), json.getJsonObject(1).getString("version"));
+        Assert.assertEquals(sampleData.c2.getName(), json.getJsonObject(1).getString("componentName"));
+        Assert.assertEquals("NOT_AFFECTED", json.getJsonObject(0).getString("analysisState"));
+        Assert.assertEquals("true", json.getJsonObject(0).getString("suppressed"));
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -297,7 +297,8 @@ public class VulnerabilityResourceTest extends ResourceTest {
     @Test
     public void getAffectedDependencies() throws Exception {
         SampleData sampleData = new SampleData();
-        Response response = target(V1_VULNERABILITY + "/source/" + sampleData.v5.getSource() + "/vuln/" + sampleData.v5.getVulnId() + "/suppressed/true/analysis").request()
+        Response response = target(V1_VULNERABILITY + "/source/" + sampleData.v5.getSource() + "/vuln/" +
+                sampleData.v5.getVulnId() + "/includeSuppressed/true/analysis").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -315,7 +316,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
     @Test
     public void getAffectedProjectInvalidTest() throws Exception {
         new SampleData();
-        Response response = target(V1_VULNERABILITY + "/source/INTERNAL/vuln/blah/suppressed/true/analysis").request()
+        Response response = target(V1_VULNERABILITY + "/source/INTERNAL/vuln/blah/includeSuppressed/true/analysis").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -308,12 +308,12 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Assert.assertEquals("Project 1", json.getJsonObject(0).getString("name"));
         Assert.assertEquals(sampleData.p1.getUuid().toString(), json.getJsonObject(0).getString("uuid"));
         Assert.assertEquals(sampleData.c2.getName(), json.getJsonObject(0).getString("componentName"));
-        Assert.assertEquals("false", json.getJsonObject(1).getString("suppressed"));
+        Assert.assertEquals("false", json.getJsonObject(0).getString("suppressed"));
         Assert.assertEquals("Project 2", json.getJsonObject(1).getString("name"));
         Assert.assertEquals(sampleData.p2.getUuid().toString(), json.getJsonObject(1).getString("uuid"));
         Assert.assertEquals(sampleData.c2.getName(), json.getJsonObject(1).getString("componentName"));
-        Assert.assertEquals("NOT_AFFECTED", json.getJsonObject(0).getString("analysisState"));
-        Assert.assertEquals("true", json.getJsonObject(0).getString("suppressed"));
+        Assert.assertEquals("NOT_AFFECTED", json.getJsonObject(1).getString("analysisState"));
+        Assert.assertEquals("true", json.getJsonObject(1).getString("suppressed"));
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -295,23 +295,27 @@ public class VulnerabilityResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getAffectedProjectTest() throws Exception {
+    public void getAffectedDependencies() throws Exception {
         SampleData sampleData = new SampleData();
-        Response response = target(V1_VULNERABILITY + "/source/" + sampleData.v1.getSource() + "/vuln/" + sampleData.v1.getVulnId() + "/projects").request()
+        Response response = target(V1_VULNERABILITY + "/source/" + sampleData.v5.getSource() + "/vuln/" + sampleData.v5.getVulnId() + "/suppressed/true/analysis").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
         Assert.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals("Project 1", json.getJsonObject(0).getString("name"));
-        Assert.assertEquals(sampleData.p1.getUuid().toString(), json.getJsonObject(0).getString("uuid"));
+        Assert.assertEquals("Project 2", json.getJsonObject(0).getString("name"));
+        Assert.assertEquals(sampleData.p2.getUuid().toString(), json.getJsonObject(0).getString("uuid"));
+        Assert.assertEquals(sampleData.p2.getVersion(), json.getJsonObject(0).getString("version"));
+        Assert.assertEquals(sampleData.c2.getName(), json.getJsonObject(0).getString("componentName"));
+        Assert.assertEquals("NOT_AFFECTED", json.getJsonObject(0).getString("analysisState"));
+        Assert.assertEquals("true", json.getJsonObject(0).getString("suppressed"));
     }
 
     @Test
     public void getAffectedProjectInvalidTest() throws Exception {
         new SampleData();
-        Response response = target(V1_VULNERABILITY + "/source/INTERNAL/vuln/blah/projects").request()
+        Response response = target(V1_VULNERABILITY + "/source/INTERNAL/vuln/blah/suppressed/true/analysis").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);


### PR DESCRIPTION
This PR modify the existing view with some additional metadata of affected products/dependencies by the specific vulnerability. Refer below for more information. 

**Current Behaviour:** 

When we search for specific vulnerability, it shows the page which contains the details of that particular vulnerability with affected products. 
<img width="1520" alt="vulnerability" src="https://user-images.githubusercontent.com/11587426/59010070-a8f50500-884d-11e9-9d0c-ab69a6fd2c3f.png">

**Proposed Improvement:** 

Currently above feature list down only affected project and version. If we want to get the metadata of affected components of a particular project and analysis metadata we have to navigate to that specific project and search for that vulnerability which increases users navigation effort. In order to avoid this, We can have following a complete view of particular vulnerability and how it affects projects dependencies.

**Solution:**

When we search particular vulnerability in the vaulnerability page, list down the projects, it's components which are bound to a specific vulnerability. In DT point of view, it considers a project as affected when the vulnerability is not suppressed for that project. It would be beneficial if we provide the two view which lists down only affected projects (Exclude Suppression) and which lists down affected projects as well as suppressed projects to get an idea why it was suppressed (Include Suppression). The following metadata will give a complete view of particular vulnerability across all the projects. 

01. Project
02. version
03. Component
04. Comment - Last audit comment (This excludes the state change comments)
05. Analysis State
06. Suppressed

**View 01:** Exclude Suppression - Lists down only affected projects which is default behavior and existing behavior

![excludeSuppression](https://user-images.githubusercontent.com/11587426/59011033-f6bf3c80-8850-11e9-8dd4-8e32c4d67a01.png)

**View 02:** Include Suppression - Lists down all projects that are affected and suppressed. This will give a complete view of particular vulnerability. 

![includeSuppression](https://user-images.githubusercontent.com/11587426/59011168-59b0d380-8851-11e9-9a20-01380f39f674.png)



