### PR TITLE
Fix GLOBAL_AUDIT_CHANGE notifications not including affected projects

### DIFF
--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -116,8 +116,8 @@ public final class NotificationUtil {
             } else {
                 // This was a global analysis decision affecting all projects
                 notificationGroup = NotificationGroup.GLOBAL_AUDIT_CHANGE;
-                final List<Dependency> dependencies = qm.getAllDependencies(analysis.getProject());
-                for (final Dependency dependency : dependencies) {
+
+                for (final Dependency dependency : qm.getAllDependencies(analysis.getComponent())) {
                     affectedProjects.add(qm.detach(Project.class, dependency.getProject().getId()));
                 }
             }


### PR DESCRIPTION
This fixes an issue where `GLOBAL_AUDIT_CHANGE` notifications would not include an array of affected projects.

`NotificationUtil` used the project that's attached to an `Analysis` object in a [branch of execution where this project is always `null`](https://github.com/DependencyTrack/dependency-track/blob/3.5.0/src/main/java/org/dependencytrack/util/NotificationUtil.java#L119).