### PR TITLE
Parse latest date format from dependency-check XML reports

### DIFF
--- a/src/main/java/org/dependencytrack/parser/dependencycheck/model/DateAdapter.java
+++ b/src/main/java/org/dependencytrack/parser/dependencycheck/model/DateAdapter.java
@@ -20,7 +20,9 @@ package org.dependencytrack.parser.dependencycheck.model;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import java.text.SimpleDateFormat;
+import java.text.ParseException;
 import java.util.Date;
+import java.util.TimeZone;
 
 /**
  * XmlAdapter class used to convert date formats.
@@ -31,15 +33,27 @@ import java.util.Date;
 public class DateAdapter extends XmlAdapter<String, Date> {
 
     private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    private final SimpleDateFormat dateFormatInstant = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+    {
+        dateFormatInstant.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
 
     @Override
     public String marshal(final Date v) throws Exception {
-        return dateFormat.format(v);
+        return dateFormatInstant.format(v);
     }
 
     @Override
     public Date unmarshal(final String v) throws Exception {
-        return dateFormat.parse(v);
+        Date parsed;
+
+        try {
+            parsed = dateFormat.parse(v);
+        } catch (ParseException err) {
+            parsed = dateFormatInstant.parse(v);
+        }
+        return parsed;
     }
 
 }

--- a/src/test/java/org/dependencytrack/parser/dependencycheck/model/DateAdapterTest.java
+++ b/src/test/java/org/dependencytrack/parser/dependencycheck/model/DateAdapterTest.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+package org.dependencytrack.parser.dependencycheck.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.dependencytrack.PersistenceCapableTest;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+
+public class DateAdapterTest extends PersistenceCapableTest {
+
+    @Test
+    public void parseTest() throws Exception {
+        DateAdapter adapter = new DateAdapter();
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+        sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+
+        Assert.assertEquals(
+            "2017-09-08T07:28:27.566+0000",
+            sdf.format(adapter.unmarshal("2017-09-08T00:28:27.566-0700")));
+        Assert.assertEquals(
+            "2017-09-08T00:28:27.566+0000",
+            sdf.format(adapter.unmarshal("2017-09-08T00:28:27.566Z")));
+    }
+}


### PR DESCRIPTION
At some point [Dependency Check](https://github.com/jeremylong/DependencyCheck/blob/55d8f6659746e71b00f1f480d683b9660a5679d7/core/src/main/java/org/owasp/dependencycheck/reporting/ReportGenerator.java#L204) moved to using [DateTimeFormatter.ISO_INSTANT](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ISO_INSTANT) to generate the scan date inside the XML report.  This format reports dates in UTC without a timezone and causes Dependency Track to fail to parse these reports (and thus throw a NPE when one is ingested via the API).

This patch updates the date parsing code so that both the old and new formats are tried.  It should allow Dependency Track to parse reports from both versions.