### PR TITLE
Fix "Remove Dependency" functionality in project view

### DIFF
--- a/src/main/webapp/project/functions.js
+++ b/src/main/webapp/project/functions.js
@@ -471,7 +471,7 @@ $(document).ready(function () {
         let selections = dependenciesTable.bootstrapTable("getSelections");
         let componentUuids = [];
         for (let i=0; i<selections.length; i++) {
-            componentUuids[i] = selections[i].uuid;
+            componentUuids[i] = selections[i].component.uuid;
         }
         $rest.removeDependency(uuid, componentUuids, function() {
             $("#dependenciesTable").bootstrapTable("refresh", {silent: true});


### PR DESCRIPTION
This PR fixes an issue where removing a Dependency from a Project was not possible via web UI. The UI was submitting `null`s as Component UUIDs to the backend, which responded with HTTP 500. 

Turns out that simply one word was missing. `selections` contains objects of type `Dependency`, not `Component`.