### PR TITLE
Fixed URL encoded path to licenses and publishers 

### DIFF
--- a/src/main/java/org/dependencytrack/parser/spdx/json/SpdxLicenseDetailParser.java
+++ b/src/main/java/org/dependencytrack/parser/spdx/json/SpdxLicenseDetailParser.java
@@ -20,8 +20,13 @@ package org.dependencytrack.parser.spdx.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dependencytrack.model.License;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.File;
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -54,7 +59,7 @@ public class SpdxLicenseDetailParser {
         final List<License> licenses = new ArrayList<>();
         final String[] dirs = {"/license-list-data/json/details", "/license-list-data/json/exceptions"};
         for (final String s: dirs) {
-            final File dir = new File(getClass().getProtectionDomain().getCodeSource().getLocation().getPath() + s);
+        	final File dir = new File(URLDecoder.decode(getClass().getProtectionDomain().getCodeSource().getLocation().getPath(), UTF_8.name()) + s);
             final File[] files = dir.listFiles();
             if (files != null) {
                 for (final File nextFile : files) {

--- a/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
+++ b/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
@@ -40,8 +40,12 @@ import org.dependencytrack.parser.spdx.json.SpdxLicenseDetailParser;
 import org.dependencytrack.search.IndexManager;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.File;
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -245,10 +249,10 @@ public class DefaultObjectGenerator implements ServletContextListener {
     private void loadDefaultNotificicationPublishers() {
         try (QueryManager qm = new QueryManager()) {
             LOGGER.info("Synchronizing notification publishers to datastore");
-            for (final DefaultNotificationPublishers publisher : DefaultNotificationPublishers.values()) {
-                final File file = new File(this.getClass().getResource(publisher.getPublisherTemplateFile()).getFile());
+            for (final DefaultNotificationPublishers publisher : DefaultNotificationPublishers.values()) {                
                 try {
-                    final String templateContent = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+                	final File file = new File(URLDecoder.decode(this.getClass().getResource(publisher.getPublisherTemplateFile()).getFile(), UTF_8.name()));
+                    final String templateContent = FileUtils.readFileToString(file, UTF_8);
                     final NotificationPublisher existingPublisher = qm.getDefaultNotificationPublisher(publisher.getPublisherClass());
                     if (existingPublisher == null) {
                         qm.createNotificationPublisher(


### PR DESCRIPTION
This PR fixes the URL encoded path lo licenses and publishers that prevents those from being read when the path contains at least a space character. See #482 for details.

This has only been tested in the environment described in the aforementioned issue.