### PR TITLE
Update the CPE field on components from BOM

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -181,6 +181,7 @@ public class BomUploadProcessingTask implements Subscriber {
             resolvedComponent.setFilename(component.getFilename());
             resolvedComponent.setExtension(component.getExtension());
             resolvedComponent.setLicense(component.getLicense());
+            resolvedComponent.setCpe(component.getCpe());
             resolvedComponent.setResolvedLicense(component.getResolvedLicense());
             qm.persist(resolvedComponent);
             bind(qm, project, resolvedComponent);


### PR DESCRIPTION
When an existing component is detected whilst processing a BOM most fields are updated to reflect the latest value from the BOM.  The `Cpe` field appears to be missing from this list.  This makes it difficult to update the `Cpe` and thus match against NVD vulnerabilities.

This patch adds the `Cpe` field to the list updated from the BOM.