### PR TITLE
Fix building of Maven GAV URL in MavenMetaAnalyzer

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/repositories/MavenMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/MavenMetaAnalyzer.java
@@ -73,7 +73,7 @@ public class MavenMetaAnalyzer extends AbstractMetaAnalyzer {
     public MetaModel analyze(final Component component) {
         final MetaModel meta = new MetaModel(component);
         if (component.getPurl() != null) {
-            final String mavenGavUrl = component.getPurl().getNamespace().replaceAll("\\.", "/") + "/" + component.getPurl().getName().replaceAll("\\.", "/");
+            final String mavenGavUrl = component.getPurl().getNamespace().replaceAll("\\.", "/") + "/" + component.getPurl().getName();
             final String url = String.format(baseUrl + REPO_METADATA_URL, mavenGavUrl);
             try {
                 final HttpUriRequest request = new HttpGet(url);

--- a/src/test/java/org/dependencytrack/tasks/repositories/MavenMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/MavenMetaAnalyzerTest.java
@@ -41,6 +41,22 @@ public class MavenMetaAnalyzerTest {
     }
 
     @Test
+    public void testAnalyzerForScalaComponent() throws Exception {
+        Component component = new Component();
+        
+        // Scala packages differ from others in that their name always includes the version of
+        // the Scala compiler they were built with.
+        component.setPurl(new PackageURL("pkg:maven/com.typesafe.akka/akka-actor_2.13@2.5.23"));
+
+        MavenMetaAnalyzer analyzer = new MavenMetaAnalyzer();
+        Assert.assertTrue(analyzer.isApplicable(component));
+        Assert.assertEquals(RepositoryType.MAVEN, analyzer.supportedRepositoryType());
+        MetaModel metaModel = analyzer.analyze(component);
+        Assert.assertNotNull(metaModel.getLatestVersion());
+        Assert.assertNotNull(metaModel.getPublishedTimestamp());
+    }
+
+    @Test
     public void shouldNotBeApplicableWhenComponentIsInternal() throws MalformedPackageURLException {
         final Component component = new Component();
         component.setPurl(new PackageURL("pkg:maven/junit/junit@4.12"));


### PR DESCRIPTION
This PR fixes an issue where Dependeny-Track couldn't check Scala components for their latest version using `MavenMetaAnalyzer`. 

The issue was that the analyzer would replace all dots (`.`) in a components name with slashes (`/`). The names of Scala components are always suffixed with `_<COMPILER_VERSION>`, e.g. `_2.12`.

For `pkg:maven/com.typesafe.akka/akka-actor_2.13@2.5.23?type=jar`, the analyzer would produce the Maven GAV URL `http://central.maven.org/maven2/com/typesafe/akka/akka-actor_2/13/maven-metadata.xml`.

I removed the replacement of dots with slashes from the component name. As far as I understand, only the groupId / namespace is split into "folders" inside maven repos. 