### PR TITLE
Adds sast-scan workflow

### DIFF
--- a/.github/workflows/sastscan.yml
+++ b/.github/workflows/sastscan.yml
@@ -1,0 +1,30 @@
+name: SAST scan
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: '1.8.0'
+    - name: Compile with Maven
+      run: |
+        mvn clean compile
+    - name: Perform sast-scan
+      uses: AppThreat/sast-scan-action@v1.0.0
+      env:
+        WORKSPACE: https://github.com/prabhu/dependency-track/blob/${{ env.GITHUB_SHA }}
+      with:
+        output: reports
+      continue-on-error: true
+    - name: Upload scan reports
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: sast-scan-reports
+        path: reports

--- a/.github/workflows/sastscan.yml
+++ b/.github/workflows/sastscan.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Perform sast-scan
       uses: AppThreat/sast-scan-action@v1.0.0
       env:
-        WORKSPACE: https://github.com/prabhu/dependency-track/blob/${{ env.GITHUB_SHA }}
+        WORKSPACE: https://github.com/DependencyTrack/dependency-track/blob/master
       with:
         output: reports
       continue-on-error: true


### PR DESCRIPTION
Hello,

I have been using this project heavily. This PR (a shameless plug) introduces [sast-scan](https://github.com/AppThreat/sast-scan/), a free open-source SAST tool powered by a number of tools including find security bugs, dependency-check and so on. I noticed that the tool was highlighting few security findings which can be viewed [here](https://github.com/prabhu/dependency-track/commit/9c96e2967120ffce2fe43757415d191114e5cfff/checks?check_suite_id=397685707#step:6:32)

The full reports can be downloaded from the artifacts for the run. The SARIF files can be viewed online using a viewer such as [this](http://sarifviewer.azurewebsites.net/)

I would appreciate if you could take a look at the PR and let me know if this is something you would like to integrate with this project and make the SAST scan data available along with Container scan data.