### PR TITLE
Docs/add section community implementations

### DIFF
--- a/docs/_docs/usage/community-implementation.md
+++ b/docs/_docs/usage/community-implementation.md
@@ -1,0 +1,16 @@
+---
+title: Community Implementations
+category: Usage
+chapter: 2
+order: 4
+---
+
+Since DependencyTrack follows the API-First approach of product development, the API itself provides huge amount
+of possibilities to make custom tools as per your need.
+Some of the custom tools that have been shared back to the community are as follow:
+
+| Name | Language | URL |
+|:---------|:--------|:--------|
+| dtrack-audit | Go | https://github.com/ozonru/dtrack-audit |
+| dependency-track-maven-plugin | Java | https://github.com/pmckeown/dependency-track-maven-plugin |
+| dtrack-auditor | Python | https://github.com/thinksabin/DTrackAuditor |


### PR DESCRIPTION
added the new section 'community implementations' under the chapter 2 (Usage). The tools listed are based on the recent active knowledge shared in the slack channel.