### PR TITLE
Feature/update dockerfile after linting

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -32,7 +32,7 @@ USER 1000
 WORKDIR ${APP_DIR}
 
 # Launch Dependency-Track
-CMD ["java", "$JAVA_OPTIONS", "-DdependencyTrack.logging.level=$LOGGING_LEVEL", "-jar", "dependency-track-embedded.war", "-context", "${CONTEXT}"]
+CMD ["sh", "-c", "java ${JAVA_OPTIONS} -DdependencyTrack.logging.level=$LOGGING_LEVEL -jar dependency-track-embedded.war -context ${CONTEXT}"]
 
 # Specify which port Dependency-Track listens on
 EXPOSE 8080

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -13,7 +13,8 @@ ARG USERNAME=dtrack
 # Create a user and assign home directory to a ${DATA_DIR}
 # Download optional JDBC drivers to the external library directory
 # Ensure UID 1000 & GID 1000 own all the needed directories
-RUN mkdir -p -m 770 ${DATA_DIR} ${EXTLIB_DIR} \
+RUN mkdir -p ${DATA_DIR} ${EXTLIB_DIR} \
+    && chmod 770 ${DATA_DIR} ${EXTLIB_DIR} \
     && adduser -D -h ${DATA_DIR} -u 1000 ${USERNAME} \
     && wget -P ${EXTLIB_DIR} https://repo1.maven.org/maven2/org/postgresql/postgresql/42.2.11/postgresql-42.2.11.jar \
     && wget -P ${EXTLIB_DIR} https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar \
@@ -31,7 +32,7 @@ USER 1000
 WORKDIR ${APP_DIR}
 
 # Launch Dependency-Track
-CMD java $JAVA_OPTIONS -DdependencyTrack.logging.level=$LOGGING_LEVEL -jar dependency-track-embedded.war -context ${CONTEXT}
+CMD ["java", "$JAVA_OPTIONS", "-DdependencyTrack.logging.level=$LOGGING_LEVEL", "-jar", "dependency-track-embedded.war", "-context", "${CONTEXT}"]
 
 # Specify which port Dependency-Track listens on
 EXPOSE 8080


### PR DESCRIPTION
I used [hadolint](https://github.com/hadolint/hadolint) to lint the main Dockerfile and fixed up a couple of minor issues it had:
```
docker run --rm -i hadolint/hadolint < src/main/docker/Dockerfile
/dev/stdin:16 SC2174 When used with -p, -m only applies to the deepest directory.
/dev/stdin:34 DL3025 Use arguments JSON notation for CMD and ENTRYPOINT arguments
```

You might be able to run hadolint automatically in the Github CI environment (if you wanted to).  

Testing done as follows:

Use the testing docker-compose file to pass in LOGGING_LEVEL and CONTEXT env variables:
<img width="665" alt="Screen Shot 2020-10-12 at 7 40 31 PM" src="https://user-images.githubusercontent.com/574865/95713836-b2a13f00-0cc3-11eb-8fad-ddaf3a469b13.png">

Verified some debug logging occured.
<img width="1065" alt="Screen Shot 2020-10-12 at 7 41 35 PM" src="https://user-images.githubusercontent.com/574865/95713930-e0868380-0cc3-11eb-9f2e-25b01e217dee.png">

And the context path was working as expected
<img width="1065" alt="Screen Shot 2020-10-12 at 7 42 29 PM" src="https://user-images.githubusercontent.com/574865/95713960-ec724580-0cc3-11eb-8e45-03bb460f7fbd.png">

Then set the JAVA_OPTIONS to a bad value:
<img width="638" alt="Screen Shot 2020-10-12 at 7 43 07 PM" src="https://user-images.githubusercontent.com/574865/95714013-0744ba00-0cc4-11eb-9338-3aca2ccfa2af.png">

And verified:
<img width="1061" alt="Screen Shot 2020-10-12 at 7 43 19 PM" src="https://user-images.githubusercontent.com/574865/95714034-10358b80-0cc4-11eb-92df-59e42d3507a9.png">

