### PR TITLE
Fix error on policy deletion

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1443,6 +1443,17 @@ public class QueryManager extends AlpineQueryManager {
     }
 
     /**
+     * Deletes a {@link Policy}, including all related {@link PolicyViolation}s and {@link PolicyCondition}s.
+     * @param policy the {@link Policy} to delete
+     */
+    public void deletePolicy(final Policy policy) {
+        for (final PolicyCondition condition : policy.getPolicyConditions()) {
+            deletePolicyCondition(condition);
+        }
+        delete(policy);
+    }
+
+    /**
      * Deleted all PolicyViolation associated for the specified Component.
      * @param component the Component to delete PolicyViolation for
      */

--- a/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
@@ -33,6 +33,7 @@ import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.persistence.QueryManager;
+
 import javax.validation.Validator;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -182,7 +183,7 @@ public class PolicyResource extends AlpineResource {
         try (QueryManager qm = new QueryManager()) {
             final Policy policy = qm.getObjectByUuid(Policy.class, uuid);
             if (policy != null) {
-                qm.delete(policy);
+                qm.deletePolicy(policy);
                 return Response.status(Response.Status.NO_CONTENT).build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the policy could not be found.").build();

--- a/src/test/java/org/dependencytrack/ResourceTest.java
+++ b/src/test/java/org/dependencytrack/ResourceTest.java
@@ -61,6 +61,7 @@ public abstract class ResourceTest extends JerseyTest {
     protected final String V1_NOTIFICATION_RULE = "/v1/notification/rule";
     protected final String V1_OIDC = "/v1/oidc";
     protected final String V1_PERMISSION = "/v1/permission";
+    protected final String V1_POLICY = "/v1/policy";
     protected final String V1_PROJECT = "/v1/project";
     protected final String V1_REPOSITORY = "/v1/repository";
     protected final String V1_SCAN = "/v1/scan";

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
@@ -19,5 +19,221 @@
 
 package org.dependencytrack.resources.v1;
 
-public class PolicyResourceTest {
+import alpine.filters.AuthenticationFilter;
+import alpine.util.UuidUtil;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.model.*;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.junit.Test;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Date;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PolicyResourceTest extends ResourceTest {
+
+    @Override
+    protected DeploymentContext configureDeployment() {
+        return ServletDeploymentContext.forServlet(new ServletContainer(
+                new ResourceConfig(PolicyResource.class)
+                        .register(AuthenticationFilter.class)))
+                .build();
+    }
+
+    @Test
+    public void getPoliciesTest() {
+        for (int i = 0; i < 1000; i++) {
+            qm.createPolicy("policy" + i, Policy.Operator.ANY, Policy.ViolationState.INFO);
+        }
+
+        final Response response = target(V1_POLICY)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1000");
+
+        final JsonArray json = parseJsonArray(response);
+        assertThat(json).isNotNull();
+        assertThat(json).hasSize(100);
+        assertThat(json.getJsonObject(0).getString("name")).isEqualTo("policy0");
+    }
+
+    @Test
+    public void getPolicyByUuidTest() {
+        final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+
+        final Response response = target(V1_POLICY + "/" + policy.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+
+        final JsonObject json = parseJsonObject(response);
+        assertThat(json).isNotNull();
+        assertThat(json.getString("name")).isEqualTo("policy");
+    }
+
+    @Test
+    public void createPolicyTest() {
+        final Policy policy = new Policy();
+        policy.setName("policy");
+        policy.setOperator(Policy.Operator.ANY);
+        policy.setViolationState(Policy.ViolationState.INFO);
+
+        final Response response = target(V1_POLICY)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(policy, MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(201);
+
+        final JsonObject json = parseJsonObject(response);
+        assertThat(json).isNotNull();
+        assertThat(json.getString("name")).isEqualTo("policy");
+        assertThat(json.getString("operator")).isEqualTo("ANY");
+        assertThat(json.getString("violationState")).isEqualTo("INFO");
+        assertThat(UuidUtil.isValidUUID(json.getString("uuid")));
+    }
+
+    @Test
+    public void updatePolicyTest() {
+        final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+
+        policy.setViolationState(Policy.ViolationState.FAIL);
+        final Response response = target(V1_POLICY)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.entity(policy, MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        final JsonObject json = parseJsonObject(response);
+        assertThat(json).isNotNull();
+        assertThat(json.getString("name")).isEqualTo("policy");
+        assertThat(json.getString("operator")).isEqualTo("ANY");
+        assertThat(json.getString("violationState")).isEqualTo("FAIL");
+    }
+
+    @Test
+    public void deletePolicyTest() {
+        final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+
+        final Response response = target(V1_POLICY + "/" + policy.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+
+        assertThat(response.getStatus()).isEqualTo(204);
+        assertThat(qm.getObjectByUuid(Policy.class, policy.getUuid())).isNull();
+    }
+
+    /**
+     * This test verifies that associated conditions and violations get deleted as well when deleting a Policy.
+     */
+    @Test
+    public void deletePolicyCascadingTest() {
+        final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
+
+        Component component = new Component();
+        component.setProject(project);
+        component.setName("ABC");
+        component = qm.createComponent(component, false);
+
+        final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        final PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, "<coordinates>");
+
+        PolicyViolation violation = new PolicyViolation();
+        violation.setComponent(component);
+        violation.setPolicyCondition(condition);
+        violation.setType(PolicyViolation.Type.OPERATIONAL);
+        violation.setTimestamp(new Date());
+        violation = qm.addPolicyViolationIfNotExist(violation);
+
+        qm.reconcilePolicyViolations(component, singletonList(violation));
+
+        final Response response = target(V1_POLICY + "/" + policy.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+
+        assertThat(response.getStatus()).isEqualTo(204);
+        assertThat(qm.getObjectByUuid(Policy.class, policy.getUuid())).isNull();
+        assertThat(qm.getObjectByUuid(PolicyCondition.class, condition.getUuid())).isNull();
+    }
+
+    @Test
+    public void addProjectToPolicyTest() {
+        final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
+
+        final Response response = target(V1_POLICY + "/" + policy.getUuid() + "/project/" + project.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(null);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        final JsonObject json = parseJsonObject(response);
+        assertThat(json.getJsonArray("projects")).hasSize(1);
+        assertThat(json.getJsonArray("projects").get(0).asJsonObject().getString("uuid")).isEqualTo(project.getUuid().toString());
+    }
+
+    @Test
+    public void addProjectToPolicyProjectAlreadyAddedTest() {
+        final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
+
+        policy.setProjects(singletonList(project));
+        qm.persist(policy);
+
+        final Response response = target(V1_POLICY + "/" + policy.getUuid() + "/project/" + project.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(null);
+
+        assertThat(response.getStatus()).isEqualTo(304);
+    }
+
+    @Test
+    public void removeProjectFromPolicyTest() {
+        final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
+
+        policy.setProjects(singletonList(project));
+        qm.persist(policy);
+
+        final Response response = target(V1_POLICY + "/" + policy.getUuid() + "/project/" + project.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void removeProjectFromPolicyProjectAlreadyRemovedTest() {
+        final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
+
+        final Response response = target(V1_POLICY + "/" + policy.getUuid() + "/project/" + project.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+
+        assertThat(response.getStatus()).isEqualTo(304);
+    }
+
 }


### PR DESCRIPTION
This PR fixes an issue where it wouldn't be possible to delete a policy as long as there were violations associated with at least one of the policy's conditions. 

```
ERROR [Transaction] Operation commit failed on resource: org.datanucleus.store.rdbms.ConnectionFactoryImpl$EmulatedXAResource@39e78fc7, error code UNKNOWN and transaction [DataNucleus Transaction, ID=134478005-188223, enlisted resources=[org.datanucleus.store.rdbms.ConnectionFactoryImpl$EmulatedXAResource@39e78fc7]] : ERROR: update or delete on table "POLICYCONDITION" violates foreign key constraint "POLICYVIOLATION_FK2" on table "POLICYVIOLATION"
	Detail: Key (ID)=(1) is still referenced from table "POLICYVIOLATION".
```

This is also reproducable by checking out b9dcc880094c68257d30a27fbff68dd910d63736 and running `PolicyResourceTest#deletePolicyCascadingTest`.