### PR TITLE
don't use a proxy for HEALTHCHECK

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -47,4 +47,4 @@ ENV JAVA_OPTIONS="-XX:MaxRAMPercentage=90.0"
 ENV CONTEXT=""
 
 # Add a healthcheck using the Dependency-Track version API
-HEALTHCHECK --interval=5m --timeout=3s CMD wget -q -O /dev/null http://127.0.0.1:8080${CONTEXT}/api/version || exit 1
+HEALTHCHECK --interval=5m --timeout=3s CMD wget --proxy off -q -O /dev/null http://127.0.0.1:8080${CONTEXT}/api/version || exit 1


### PR DESCRIPTION
in order to make it work in corporate Dockers that must set the `http_proxy` environment variable for their containers