### PR TITLE
Update SQL driver and version-less filenames

### DIFF
--- a/docs/_docs/getting-started/deploy-docker.md
+++ b/docs/_docs/getting-started/deploy-docker.md
@@ -52,7 +52,7 @@ services:
     # - ALPINE_DATABASE_MODE=external
     # - ALPINE_DATABASE_URL=jdbc:postgresql://postgres10:5432/dtrack
     # - ALPINE_DATABASE_DRIVER=org.postgresql.Driver
-    # - ALPINE_DATABASE_DRIVER_PATH=/extlib/postgresql-42.2.18.jar
+    # - ALPINE_DATABASE_DRIVER_PATH=/extlib/postgresql.jar
     # - ALPINE_DATABASE_USERNAME=dtrack
     # - ALPINE_DATABASE_PASSWORD=changeme
     # - ALPINE_DATABASE_POOL_ENABLED=true
@@ -114,9 +114,9 @@ with `ALPINE_DATABASE_DRIVER_PATH`.
 
 | Driver        | Path                                      |
 | ------------- | ----------------------------------------- |
-| Microsoft SQL | /extlib/mssql-jdbc-7.1.3.jre8-preview.jar |
-| MySQL         | /extlib/mysql-connector-java-8.0.22.jar   |
-| PostgreSQL    | /extlib/postgresql-42.2.18.jar            |
+| Microsoft SQL | /extlib/mssql-jdbc.jar |
+| MySQL         | /extlib/mysql-connector-java.jar   |
+| PostgreSQL    | /extlib/postgresql.jar            |
 
 
 The inclusion of drivers does not preclude the use of other driver versions. They are

--- a/docs/_posts/2020-xx-xx-v4.0.0.md
+++ b/docs/_posts/2020-xx-xx-v4.0.0.md
@@ -15,8 +15,9 @@ TBD
 TBD
 
 **Upgrade Notes:**
-* The MySQL Connector distributed with the Docker image has been updated to version 8.0.22. When using MySQL, `ALPINE_DATABASE_DRIVER_PATH` has to be set to `/extlib/mysql-connector-java-8.0.22.jar`. Note that `ALPINE_DATABASE_DRIVER` may need to be updated as well. Refer to the [official upgrading instructions](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-upgrading-to-8.0.html).
-* The Postgres driver distributed with the Docker image has been updated to version 42.2.18. When using Postgres, `ALPINE_DATABASE_DRIVER_PATH` has to be set to `/extlib/postgresql-42.2.18.jar`.
+* The MySQL Connector distributed with the Docker image has been updated to version 8.0.22. When using MySQL, `ALPINE_DATABASE_DRIVER_PATH` has to be set to `/extlib/mysql-connector-java.jar`. Note that `ALPINE_DATABASE_DRIVER` may need to be updated as well. Refer to the [official upgrading instructions](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-upgrading-to-8.0.html).
+* The Postgres driver distributed with the Docker image has been updated to version 42.2.18. When using Postgres, `ALPINE_DATABASE_DRIVER_PATH` has to be set to `/extlib/postgresql.jar`.
+* The Microsoft SQL driver distributed with the Docker image has been updated to version 8.4.1. When using Microsoft SQL, `ALPINE_DATABASE_DRIVER_PATH` has to be set to `/extlib/mssql-jdbc.jar`.
 
 ###### dependency-track-embedded.war
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -15,9 +15,9 @@ ARG USERNAME=dtrack
 # Ensure UID 1000 & GID 1000 own all the needed directories
 RUN mkdir -p -m 770 ${DATA_DIR} ${EXTLIB_DIR} \
     && adduser -D -h ${DATA_DIR} -u 1000 ${USERNAME} \
-    && wget -P ${EXTLIB_DIR} https://repo1.maven.org/maven2/org/postgresql/postgresql/42.2.18/postgresql-42.2.18.jar \
-    && wget -P ${EXTLIB_DIR} https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.22/mysql-connector-java-8.0.22.jar \
-    && wget -P ${EXTLIB_DIR} https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/7.1.3.jre8-preview/mssql-jdbc-7.1.3.jre8-preview.jar \
+    && wget -O ${EXTLIB_DIR}/postgresql.jar https://repo1.maven.org/maven2/org/postgresql/postgresql/42.2.18/postgresql-42.2.18.jar \
+    && wget -O ${EXTLIB_DIR}/mysql-connector-java.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.22/mysql-connector-java-8.0.22.jar \
+    && wget -O ${EXTLIB_DIR}/mssql-jdbc.jar https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/8.4.1.jre8/mssql-jdbc-8.4.1.jre8.jar \
     && chown -R ${USERNAME}:${USERNAME} ${DATA_DIR} ${EXTLIB_DIR}
 
 # Copy the compiled WAR to the application directory created above

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     # - ALPINE_DATABASE_MODE=external
     # - ALPINE_DATABASE_URL=jdbc:postgresql://postgres10:5432/dtrack
     # - ALPINE_DATABASE_DRIVER=org.postgresql.Driver
-    # - ALPINE_DATABASE_DRIVER_PATH=/extlib/postgresql-42.2.11.jar
+    # - ALPINE_DATABASE_DRIVER_PATH=/extlib/postgresql.jar
     # - ALPINE_DATABASE_USERNAME=dtrack
     # - ALPINE_DATABASE_PASSWORD=changeme
     # - ALPINE_DATABASE_POOL_ENABLED=true


### PR DESCRIPTION
- updates the remaining MS SQL driver to 8.4.1
- **removes the version number from the files.** removes the need to adjust docker-compose files when using the "latest" tag of the docker image and the driver is updated in a future release.

references #808