### PR TITLE
Remove @JsonDeserialize annotation from Project's purl field

### DIFF
--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -156,7 +156,6 @@ public class Project implements Serializable {
 
     @Persistent
     @Index(name = "PROJECT_PURL_IDX")
-    @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = RegexSequence.Definition.HTTP_URI, message = "The Package URL (purl) must be a valid URI and conform to https://github.com/package-url/purl-spec")
     private String purl;
 


### PR DESCRIPTION
This caused Jackson to trim the serialized value instead of using the PackageURL constructor, resulting in a type mismatch error when trying to call the setter.