### PR TITLE
ALPINE_CORS_ALLOW_METHODS list separated by commas

### DIFF
--- a/docs/_docs/getting-started/deploy-docker.md
+++ b/docs/_docs/getting-started/deploy-docker.md
@@ -134,7 +134,7 @@ services:
     # Optional Cross-Origin Resource Sharing (CORS) Headers
     # - ALPINE_CORS_ENABLED=true
     # - ALPINE_CORS_ALLOW_ORIGIN=*
-    # - ALPINE_CORS_ALLOW_METHODS=GET POST PUT DELETE OPTIONS
+    # - ALPINE_CORS_ALLOW_METHODS=GET, POST, PUT, DELETE, OPTIONS
     # - ALPINE_CORS_ALLOW_HEADERS=Origin, Content-Type, Authorization, X-Requested-With, Content-Length, Accept, Origin, X-Api-Key, X-Total-Count, *
     # - ALPINE_CORS_EXPOSE_HEADERS=Origin, Content-Type, Authorization, X-Requested-With, Content-Length, Accept, Origin, X-Api-Key, X-Total-Count
     # - ALPINE_CORS_ALLOW_CREDENTIALS=true


### PR DESCRIPTION
The list without commas did not work for me (which is what I expected after uncommenting it).
The list with commas works in both Firefox and Chrome.