### PR TITLE
Add support for version policy conditions

### DIFF
--- a/src/main/java/org/dependencytrack/model/PolicyCondition.java
+++ b/src/main/java/org/dependencytrack/model/PolicyCondition.java
@@ -70,7 +70,8 @@ public class PolicyCondition implements Serializable {
         LICENSE_GROUP,
         PACKAGE_URL,
         SEVERITY,
-        SWID_TAGID
+        SWID_TAGID,
+        VERSION
     }
 
     @PrimaryKey

--- a/src/main/java/org/dependencytrack/policy/CoordinatesPolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/CoordinatesPolicyEvaluator.java
@@ -24,9 +24,13 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Coordinates;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
+import org.dependencytrack.util.ComponentVersion;
 import org.json.JSONObject;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Evaluates a components group + name + version against a policy.
@@ -37,6 +41,7 @@ import java.util.List;
 public class CoordinatesPolicyEvaluator extends AbstractPolicyEvaluator {
 
     private static final Logger LOGGER = Logger.getLogger(CoordinatesPolicyEvaluator.class);
+    private static final Pattern VERSION_OPERATOR_PATTERN = Pattern.compile("^(?<operator>[<>]=?|[!=]=)\\s*");
 
     /**
      * {@inheritDoc}
@@ -52,12 +57,12 @@ public class CoordinatesPolicyEvaluator extends AbstractPolicyEvaluator {
     @Override
     public List<PolicyConditionViolation> evaluate(final Policy policy, final Component component) {
         final List<PolicyConditionViolation> violations = new ArrayList<>();
-        for (final PolicyCondition condition: super.extractSupportedConditions(policy)) {
+        for (final PolicyCondition condition : super.extractSupportedConditions(policy)) {
             LOGGER.debug("Evaluating component (" + component.getUuid() + ") against policy condition (" + condition.getUuid() + ")");
             final Coordinates coordinates = parseCoordinatesDefinition(condition);
             if (matches(condition.getOperator(), coordinates.getGroup(), component.getGroup())
                     && matches(condition.getOperator(), coordinates.getName(), component.getName())
-                    && matches(condition.getOperator(), coordinates.getVersion(), component.getVersion())) {
+                    && versionMatches(condition.getOperator(), coordinates.getVersion(), component.getVersion())) {
                 violations.add(new PolicyConditionViolation(condition, component));
             }
         }
@@ -90,6 +95,53 @@ public class CoordinatesPolicyEvaluator extends AbstractPolicyEvaluator {
         return false;
     }
 
+    private boolean versionMatches(final PolicyCondition.Operator conditionOperator, final String conditionValue, final String part) {
+        final Matcher versionOperatorMatcher = VERSION_OPERATOR_PATTERN.matcher(conditionValue);
+        if (!versionOperatorMatcher.find()) {
+            // No operator provided, use default matching algorithm
+            return matches(conditionOperator, conditionValue, part);
+        }
+
+        final PolicyCondition.Operator versionOperator;
+        switch (versionOperatorMatcher.group(1)) {
+            case "==":
+                versionOperator = PolicyCondition.Operator.NUMERIC_EQUAL;
+                break;
+            case "!=":
+                versionOperator = PolicyCondition.Operator.NUMERIC_NOT_EQUAL;
+                break;
+            case "<":
+                versionOperator = PolicyCondition.Operator.NUMERIC_LESS_THAN;
+                break;
+            case "<=":
+                versionOperator = PolicyCondition.Operator.NUMERIC_LESSER_THAN_OR_EQUAL;
+                break;
+            case ">":
+                versionOperator = PolicyCondition.Operator.NUMERIC_GREATER_THAN;
+                break;
+            case ">=":
+                versionOperator = PolicyCondition.Operator.NUMERIC_GREATER_THAN_OR_EQUAL;
+                break;
+            default:
+                versionOperator = null;
+                break;
+        }
+        if (versionOperator == null) {
+            // Shouldn't ever happen because the regex won't match anything else
+            LOGGER.error("Failed to infer version operator from " + versionOperatorMatcher.group(1));
+            return false;
+        }
+
+        final var componentVersion = new ComponentVersion(part);
+        final var conditionVersion = new ComponentVersion(VERSION_OPERATOR_PATTERN.split(conditionValue)[1]);
+
+        final boolean versionMatches = VersionPolicyEvaluator.matches(componentVersion, conditionVersion, versionOperator);
+        if (PolicyCondition.Operator.NO_MATCH == conditionOperator) {
+            return !versionMatches;
+        }
+        return versionMatches;
+    }
+
     /**
      * Expects the format of condition.getValue() to be:
      * <pre>
@@ -99,6 +151,7 @@ public class CoordinatesPolicyEvaluator extends AbstractPolicyEvaluator {
      *     'version': '1.0.0'
      * }
      * </pre>
+     *
      * @param condition teh condition to evaluate
      * @return the Coordinates
      */

--- a/src/main/java/org/dependencytrack/policy/PolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/PolicyEngine.java
@@ -51,6 +51,7 @@ public class PolicyEngine {
         evaluators.add(new PackageURLPolicyEvaluator());
         evaluators.add(new CpePolicyEvaluator());
         evaluators.add(new SwidTagIdPolicyEvaluator());
+        evaluators.add(new VersionPolicyEvaluator());
     }
 
     public void evaluate(final List<Component> components) {
@@ -118,6 +119,7 @@ public class PolicyEngine {
             case PACKAGE_URL:
             case CPE:
             case SWID_TAGID:
+            case VERSION:
                 return PolicyViolation.Type.OPERATIONAL;
             case LICENSE:
             case LICENSE_GROUP:

--- a/src/main/java/org/dependencytrack/policy/VersionPolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/VersionPolicyEvaluator.java
@@ -47,40 +47,22 @@ public class VersionPolicyEvaluator extends AbstractPolicyEvaluator {
     }
 
     static boolean matches(final ComponentVersion componentVersion,
-                    final ComponentVersion conditionVersion,
-                    final PolicyCondition.Operator operator) {
+                           final ComponentVersion conditionVersion,
+                           final PolicyCondition.Operator operator) {
         final int comparisonResult = componentVersion.compareTo(conditionVersion);
         switch (operator) {
             case NUMERIC_EQUAL:
-                if (comparisonResult == 0) {
-                    return true;
-                }
-                break;
+                return comparisonResult == 0;
             case NUMERIC_NOT_EQUAL:
-                if (comparisonResult != 0) {
-                    return true;
-                }
-                break;
+                return comparisonResult != 0;
             case NUMERIC_LESS_THAN:
-                if (comparisonResult < 0) {
-                    return true;
-                }
-                break;
+                return comparisonResult < 0;
             case NUMERIC_LESSER_THAN_OR_EQUAL:
-                if (comparisonResult <= 0) {
-                    return true;
-                }
-                break;
+                return comparisonResult <= 0;
             case NUMERIC_GREATER_THAN:
-                if (comparisonResult > 0) {
-                    return true;
-                }
-                break;
+                return comparisonResult > 0;
             case NUMERIC_GREATER_THAN_OR_EQUAL:
-                if (comparisonResult >= 0) {
-                    return true;
-                }
-                break;
+                return comparisonResult >= 0;
             default:
                 LOGGER.warn("Unsupported operation " + operator);
                 break;

--- a/src/main/java/org/dependencytrack/policy/VersionPolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/VersionPolicyEvaluator.java
@@ -38,45 +38,54 @@ public class VersionPolicyEvaluator extends AbstractPolicyEvaluator {
                 continue;
             }
 
-            final int comparisonResult = componentVersion.compareTo(conditionVersion);
-            switch (condition.getOperator()) {
-                case NUMERIC_EQUAL:
-                    if (comparisonResult == 0) {
-                        violations.add(new PolicyConditionViolation(condition, component));
-                    }
-                    break;
-                case NUMERIC_NOT_EQUAL:
-                    if (comparisonResult != 0) {
-                        violations.add(new PolicyConditionViolation(condition, component));
-                    }
-                    break;
-                case NUMERIC_LESS_THAN:
-                    if (comparisonResult < 0) {
-                        violations.add(new PolicyConditionViolation(condition, component));
-                    }
-                    break;
-                case NUMERIC_LESSER_THAN_OR_EQUAL:
-                    if (comparisonResult <= 0) {
-                        violations.add(new PolicyConditionViolation(condition, component));
-                    }
-                    break;
-                case NUMERIC_GREATER_THAN:
-                    if (comparisonResult > 0) {
-                        violations.add(new PolicyConditionViolation(condition, component));
-                    }
-                    break;
-                case NUMERIC_GREATER_THAN_OR_EQUAL:
-                    if (comparisonResult >= 0) {
-                        violations.add(new PolicyConditionViolation(condition, component));
-                    }
-                    break;
-                default:
-                    LOGGER.warn("Unsupported operation " + condition.getOperator());
-                    break;
+            if (matches(componentVersion, conditionVersion, condition.getOperator())) {
+                violations.add(new PolicyConditionViolation(condition, component));
             }
         }
 
         return violations;
+    }
+
+    static boolean matches(final ComponentVersion componentVersion,
+                    final ComponentVersion conditionVersion,
+                    final PolicyCondition.Operator operator) {
+        final int comparisonResult = componentVersion.compareTo(conditionVersion);
+        switch (operator) {
+            case NUMERIC_EQUAL:
+                if (comparisonResult == 0) {
+                    return true;
+                }
+                break;
+            case NUMERIC_NOT_EQUAL:
+                if (comparisonResult != 0) {
+                    return true;
+                }
+                break;
+            case NUMERIC_LESS_THAN:
+                if (comparisonResult < 0) {
+                    return true;
+                }
+                break;
+            case NUMERIC_LESSER_THAN_OR_EQUAL:
+                if (comparisonResult <= 0) {
+                    return true;
+                }
+                break;
+            case NUMERIC_GREATER_THAN:
+                if (comparisonResult > 0) {
+                    return true;
+                }
+                break;
+            case NUMERIC_GREATER_THAN_OR_EQUAL:
+                if (comparisonResult >= 0) {
+                    return true;
+                }
+                break;
+            default:
+                LOGGER.warn("Unsupported operation " + operator);
+                break;
+        }
+        return false;
     }
 
 }

--- a/src/test/java/org/dependencytrack/policy/CoordinatesPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/CoordinatesPolicyEvaluatorTest.java
@@ -169,4 +169,268 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         Assert.assertEquals(0, violations.size());
     }
 
+    @Test
+    public void matchWithVersionOperatorLessThan() {
+        final String def = "{ 'version': '< 1.1.1' }";
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
+
+        final var component = new Component();
+        final var evaluator = new CoordinatesPolicyEvaluator();
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+    }
+
+    @Test
+    public void noMatchWithVersionOperatorLessThan() {
+        final String def = "{ 'version': '< 1.1.1' }";
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
+
+        final var component = new Component();
+        final var evaluator = new CoordinatesPolicyEvaluator();
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+    }
+
+    @Test
+    public void matchWithVersionOperatorLessThanOrEqual() {
+        final String def = "{ 'version': '<= 1.1.1' }";
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
+
+        final var component = new Component();
+        final var evaluator = new CoordinatesPolicyEvaluator();
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+    }
+
+    @Test
+    public void noMatchWithVersionOperatorLessThanOrEqual() {
+        final String def = "{ 'version': '<= 1.1.1' }";
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
+
+        final var component = new Component();
+        final var evaluator = new CoordinatesPolicyEvaluator();
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+    }
+
+    @Test
+    public void matchWithVersionOperatorEqual() {
+        final String def = "{ 'version': '== 1.1.1' }";
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
+
+        final var component = new Component();
+        final var evaluator = new CoordinatesPolicyEvaluator();
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+    }
+
+    @Test
+    public void noMatchWithVersionOperatorEqual() {
+        final String def = "{ 'version': '== 1.1.1' }";
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
+
+        final var component = new Component();
+        final var evaluator = new CoordinatesPolicyEvaluator();
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+    }
+
+    @Test
+    public void matchWithVersionOperatorNotEqual() {
+        final String def = "{ 'version': '!= 1.1.1' }";
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
+
+        final var component = new Component();
+        final var evaluator = new CoordinatesPolicyEvaluator();
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+    }
+
+    @Test
+    public void noMatchWithVersionOperatorNotEqual() {
+        final String def = "{ 'version': '!= 1.1.1' }";
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
+
+        final var component = new Component();
+        final var evaluator = new CoordinatesPolicyEvaluator();
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+    }
+
+    @Test
+    public void matchWithVersionOperatorGreaterThan() {
+        final String def = "{ 'version': '> 1.1.1' }";
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
+
+        final var component = new Component();
+        final var evaluator = new CoordinatesPolicyEvaluator();
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+    }
+
+    @Test
+    public void noMatchWithVersionOperatorGreaterThan() {
+        final String def = "{ 'version': '> 1.1.1' }";
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
+
+        final var component = new Component();
+        final var evaluator = new CoordinatesPolicyEvaluator();
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+    }
+
+    @Test
+    public void matchWithVersionOperatorGreaterThanOrEqual() {
+        final String def = "{ 'version': '>= 1.1.1' }";
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
+
+        final var component = new Component();
+        final var evaluator = new CoordinatesPolicyEvaluator();
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+    }
+
+    @Test
+    public void noMatchWithVersionOperatorGreaterThanOrEqual() {
+        final String def = "{ 'version': '>= 1.1.1' }";
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
+
+        final var component = new Component();
+        final var evaluator = new CoordinatesPolicyEvaluator();
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+    }
+
 }

--- a/src/test/java/org/dependencytrack/policy/VersionPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/VersionPolicyEvaluatorTest.java
@@ -1,0 +1,152 @@
+package org.dependencytrack.policy;
+
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Policy;
+import org.dependencytrack.model.PolicyCondition;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class VersionPolicyEvaluatorTest extends PersistenceCapableTest {
+
+    private VersionPolicyEvaluator evaluator;
+
+    @Before
+    public void setUp() {
+        evaluator = new VersionPolicyEvaluator();
+    }
+
+    @Test
+    public void testLessThanOperator() {
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.VERSION, PolicyCondition.Operator.NUMERIC_LESS_THAN, "1.1.1");
+
+        final var component = new Component();
+        component.setGroup("Acme");
+        component.setName("Test Component");
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+    }
+
+    @Test
+    public void testLessThanOrEqualOperator() {
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.VERSION, PolicyCondition.Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "1.1.1");
+
+        final var component = new Component();
+        component.setGroup("Acme");
+        component.setName("Test Component");
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+    }
+
+    @Test
+    public void testEqualOperator() {
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.VERSION, PolicyCondition.Operator.NUMERIC_EQUAL, "1.1.1");
+
+        final var component = new Component();
+        component.setGroup("Acme");
+        component.setName("Test Component");
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+    }
+
+    @Test
+    public void testNotEqualOperator() {
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.VERSION, PolicyCondition.Operator.NUMERIC_NOT_EQUAL, "1.1.1");
+
+        final var component = new Component();
+        component.setGroup("Acme");
+        component.setName("Test Component");
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+    }
+
+    @Test
+    public void testGreaterThanOperator() {
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.VERSION, PolicyCondition.Operator.NUMERIC_GREATER_THAN, "1.1.1");
+
+        final var component = new Component();
+        component.setGroup("Acme");
+        component.setName("Test Component");
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+    }
+
+    @Test
+    public void testGreaterThanOrEqualOperator() {
+        final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.VERSION, PolicyCondition.Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "1.1.1");
+
+        final var component = new Component();
+        component.setGroup("Acme");
+        component.setName("Test Component");
+
+        // Component version is lower
+        component.setVersion("1.1.0");
+        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+
+        // Component version is equal
+        component.setVersion("1.1.1");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+
+        // Component version is higher
+        component.setVersion("1.1.2");
+        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+    }
+
+}


### PR DESCRIPTION
This PR adds a new *Version* policy condition that allows for matching of specific component versions or version ranges:

![Version Condition](https://user-images.githubusercontent.com/5693141/107566694-7801d180-6be5-11eb-9a81-9e1efae17727.png)

Additionally, as suggested by @stevespringett in Slack, the *Coordinates* condition was extended to support version operators as well:

![Coordinates Condition with Version Operator](https://user-images.githubusercontent.com/5693141/107566740-88b24780-6be5-11eb-9b6e-297d2d86fae6.png)

![Policy Violation with Version Operator](https://user-images.githubusercontent.com/5693141/107566821-9d8edb00-6be5-11eb-9af5-6e4b78c269b2.png)

All numeric comparison operators are supported (`<`, `<=`, `>`, `>=`, `==`, `!=`). If a coordinate's version does not start with any of those operators, DT will fall back to the default `contains` logic.
