### PR TITLE
Send notifications when applying analysis from cache

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/scanners/BaseComponentAnalyzerTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/BaseComponentAnalyzerTask.java
@@ -154,6 +154,7 @@ public abstract class BaseComponentAnalyzerTask implements ScanTask {
                             final Vulnerability vulnerability = qm.getObjectById(Vulnerability.class, vulnId.longValue());
                             final Component c = qm.getObjectById(Component.class, component.getId());
                             if (vulnerability != null) {
+                                NotificationUtil.analyzeNotificationCriteria(qm, vulnerability, component);
                                 qm.addVulnerability(vulnerability, c, analyzerIdentity);
                             }
                         }

--- a/src/main/java/org/dependencytrack/tasks/scanners/BaseComponentAnalyzerTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/BaseComponentAnalyzerTask.java
@@ -35,6 +35,8 @@ import org.dependencytrack.notification.NotificationConstants;
 import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationScope;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.util.NotificationUtil;
+
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;


### PR DESCRIPTION
This PR fixes an issue where notifications wouldn't be sent when applying analyses from cache.

This should fix #1051. 