### PR TITLE
Clarify that API_BASE_URL needs to be modified for server deployments

### DIFF
--- a/docs/_docs/getting-started/configuration.md
+++ b/docs/_docs/getting-started/configuration.md
@@ -367,7 +367,11 @@ This file resides in `<BASE_URL>/static/config.json`.
 ```json
 {
     // Required
-    // URL of the Dependency-Track backend
+    // The base URL of the API server.
+    // NOTE:
+    //   * This URL must be reachable by the browsers of your users.
+    //   * The frontend container itself does NOT communicate with the API server directly, it just serves static files.
+    //   * When deploying to dedicated servers, please use the external IP or domain of the API server.
     "API_BASE_URL": "",
     // Optional
     // Defines the issuer URL to be used for OpenID Connect.

--- a/docs/_docs/getting-started/deploy-docker.md
+++ b/docs/_docs/getting-started/deploy-docker.md
@@ -159,6 +159,11 @@ services:
     depends_on:
       - dtrack-apiserver
     environment:
+      # The base URL of the API server.
+      # NOTE:
+      #   * This URL must be reachable by the browsers of your users.
+      #   * The frontend container itself does NOT communicate with the API server directly, it just serves static files.
+      #   * When deploying to dedicated servers, please use the external IP or domain of the API server.
       - API_BASE_URL=http://localhost:8081
       # - "OIDC_ISSUER="
       # - "OIDC_CLIENT_ID="

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -89,6 +89,11 @@ services:
     depends_on:
       - dtrack-apiserver
     environment:
+      # The base URL of the API server.
+      # NOTE:
+      #   * This URL must be reachable by the browsers of your users.
+      #   * The frontend container itself does NOT communicate with the API server directly, it just serves static files.
+      #   * When deploying to dedicated servers, please use the external IP or domain of the API server.
       - API_BASE_URL=http://localhost:8081
       # - "OIDC_ISSUER="
       # - "OIDC_CLIENT_ID="


### PR DESCRIPTION
We regularly see users being confused that DT doesn't work when deploying the default `docker-compose.yml` to a server. 

Updated `docker-compose.yml` and related documentation pages to indicate that external addresses need to be used.