### PR TITLE
Detach projects before notification dispatching

### DIFF
--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -60,7 +60,7 @@ public final class NotificationUtil {
             final Set<Project> affectedProjects = new HashSet<>();
             final List<Component> components = qm.matchIdentity(new ComponentIdentity(component));
             for (final Component c : components) {
-                affectedProjects.add(c.getProject());
+                affectedProjects.add(qm.detach(Project.class, c.getProject().getId()));
             }
 
             final Vulnerability detachedVuln =  qm.detach(Vulnerability.class, vulnerability.getId());


### PR DESCRIPTION
Affected projects haven't been detached from the persistence context before adding them to a `Notification` and dispatching it.

This caused all kinds of weird errors in when processing the notification, e.g.:

```
21:02:20.447 INFO [OssIndexAnalysisTask] Starting Sonatype OSS Index analysis task
21:02:21.960 WARN [Persistence] Exception thrown by StateManager.isLoaded for field=19 of StateManager[pc=org.dependencytrack.model.Project@cf8bee2, lifecycle=P_NONTRANS] : Somehow org.datanucleus.store.rdbms.fieldmanager.ParameterSetter.fetchObjectField() was called, which should have been impossible
21:02:21.961 ERROR [LoggableUncaughtExceptionHandler] An unknown error occurred in an asynchronous event or notification thread
javax.jdo.JDOFatalInternalException: Somehow org.datanucleus.store.rdbms.fieldmanager.ParameterSetter.fetchObjectField() was called, which should have been impossible
	at org.datanucleus.api.jdo.NucleusJDOHelper.getJDOExceptionForNucleusException(NucleusJDOHelper.java:672)
	at org.datanucleus.api.jdo.JDOAdapter.getApiExceptionForNucleusException(JDOAdapter.java:543)
	at org.datanucleus.state.StateManagerImpl.isLoaded(StateManagerImpl.java:4128)
	at org.dependencytrack.model.Project.dnGettags(Project.java)
	at org.dependencytrack.model.Project.getTags(Project.java:381)
	at org.dependencytrack.util.NotificationUtil.toJson(NotificationUtil.java:203)
	at org.dependencytrack.util.NotificationUtil.toJson(NotificationUtil.java:278)
	at org.dependencytrack.notification.publisher.Publisher.prepareTemplate(Publisher.java:72)
	at org.dependencytrack.notification.publisher.AbstractWebhookPublisher.publish(AbstractWebhookPublisher.java:40)
	at org.dependencytrack.notification.publisher.WebhookPublisher.inform(WebhookPublisher.java:32)
	at org.dependencytrack.notification.NotificationRouter.inform(NotificationRouter.java:64)
	at alpine.notification.NotificationService.lambda$alertSubscriber$0(NotificationService.java:100)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: org.datanucleus.exceptions.NucleusException: Somehow org.datanucleus.store.rdbms.fieldmanager.ParameterSetter.fetchObjectField() was called, which should have been impossible
	at org.datanucleus.store.fieldmanager.AbstractFieldManager.fetchObjectField(AbstractFieldManager.java:138)
	at org.datanucleus.state.StateManagerImpl.replacingObjectField(StateManagerImpl.java:1995)
	at org.dependencytrack.model.Project.dnReplaceField(Project.java)
	at org.datanucleus.state.StateManagerImpl.replaceField(StateManagerImpl.java:3241)
	at org.datanucleus.state.StateManagerImpl.replaceField(StateManagerImpl.java:4264)
	at org.datanucleus.state.StateManagerImpl.replaceField(StateManagerImpl.java:4160)
	at org.datanucleus.store.types.TypeManagerImpl.createSCOInstance(TypeManagerImpl.java:459)
	at org.datanucleus.store.rdbms.mapping.java.AbstractContainerMapping.replaceFieldWithWrapper(AbstractContainerMapping.java:442)
	at org.datanucleus.store.rdbms.mapping.java.AbstractContainerMapping.postFetch(AbstractContainerMapping.java:459)
	at org.datanucleus.store.rdbms.request.FetchRequest.execute(FetchRequest.java:502)
	at org.datanucleus.store.rdbms.RDBMSPersistenceHandler.fetchObject(RDBMSPersistenceHandler.java:316)
	at org.datanucleus.state.StateManagerImpl.loadFieldsFromDatastore(StateManagerImpl.java:1542)
	at org.datanucleus.state.StateManagerImpl.loadUnloadedFieldsInFetchPlan(StateManagerImpl.java:3897)
	at org.datanucleus.state.StateManagerImpl.isLoaded(StateManagerImpl.java:4112)
	... 12 common frames omitted
21:02:21.996 ERROR [WebhookPublisher] An error was encountered publishing notification to Outbound Webhook
21:02:21.997 ERROR [WebhookPublisher] HTTP Status : 501 Unsupported method ('POST')
21:02:21.997 ERROR [WebhookPublisher] Destination: http://localhost:8089
21:02:22.057 WARN [Persistence] Exception thrown by StateManager.isLoaded for field=13 of StateManager[pc=org.dependencytrack.model.Project@cf8bee2, lifecycle=P_NONTRANS] : Operation not allowed after ResultSet closed
21:02:22.057 ERROR [LoggableUncaughtExceptionHandler] An unknown error occurred in an asynchronous event or notification thread
javax.jdo.JDODataStoreException: Cannot set String parameter: value = 9 for column ""PROJECT"."LAST_BOM_IMPORTED_FORMAT"" : Operation not allowed after ResultSet closed
	at org.datanucleus.api.jdo.NucleusJDOHelper.getJDOExceptionForNucleusException(NucleusJDOHelper.java:542)
	at org.datanucleus.api.jdo.JDOAdapter.getApiExceptionForNucleusException(JDOAdapter.java:543)
	at org.datanucleus.state.StateManagerImpl.isLoaded(StateManagerImpl.java:4128)
	at org.dependencytrack.model.Project.dnGetname(Project.java)
	at org.dependencytrack.model.Project.getName(Project.java:272)
	at org.dependencytrack.util.NotificationUtil.toJson(NotificationUtil.java:197)
	at org.dependencytrack.util.NotificationUtil.toJson(NotificationUtil.java:278)
	at org.dependencytrack.notification.publisher.Publisher.prepareTemplate(Publisher.java:72)
	at org.dependencytrack.notification.publisher.AbstractWebhookPublisher.publish(AbstractWebhookPublisher.java:40)
	at org.dependencytrack.notification.publisher.WebhookPublisher.inform(WebhookPublisher.java:32)
	at org.dependencytrack.notification.NotificationRouter.inform(NotificationRouter.java:64)
	at alpine.notification.NotificationService.lambda$alertSubscriber$0(NotificationService.java:100)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.sql.SQLException: Operation not allowed after ResultSet closed
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:129)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:97)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:89)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:63)
	at com.mysql.cj.jdbc.result.ResultSetImpl.checkClosed(ResultSetImpl.java:470)
	at com.mysql.cj.jdbc.result.ResultSetImpl.checkRowPos(ResultSetImpl.java:514)
	at com.mysql.cj.jdbc.result.ResultSetImpl.getString(ResultSetImpl.java:870)
	at com.zaxxer.hikari.pool.HikariProxyResultSet.getString(HikariProxyResultSet.java)
	at org.datanucleus.store.rdbms.mapping.column.CharColumnMapping.getString(CharColumnMapping.java:280)
	at org.datanucleus.store.rdbms.mapping.java.SingleFieldMapping.getString(SingleFieldMapping.java:188)
	at org.datanucleus.store.rdbms.fieldmanager.ResultSetGetter.fetchStringField(ResultSetGetter.java:133)
	at org.datanucleus.state.StateManagerImpl.replacingStringField(StateManagerImpl.java:1980)
	at org.dependencytrack.model.Project.dnReplaceField(Project.java)
	at org.dependencytrack.model.Project.dnReplaceFields(Project.java)
	at org.datanucleus.state.StateManagerImpl.replaceFields(StateManagerImpl.java:4320)
	at org.datanucleus.state.StateManagerImpl.replaceFields(StateManagerImpl.java:4345)
	at org.datanucleus.store.rdbms.request.FetchRequest.execute(FetchRequest.java:468)
	at org.datanucleus.store.rdbms.RDBMSPersistenceHandler.fetchObject(RDBMSPersistenceHandler.java:316)
	at org.datanucleus.state.StateManagerImpl.loadFieldsFromDatastore(StateManagerImpl.java:1542)
	at org.datanucleus.state.StateManagerImpl.refreshLoadedFields(StateManagerImpl.java:4043)
	at org.datanucleus.api.jdo.state.PersistentNontransactional.transitionReadField(PersistentNontransactional.java:156)
	at org.datanucleus.state.StateManagerImpl.transitionReadField(StateManagerImpl.java:1038)
	at org.datanucleus.state.StateManagerImpl.isLoaded(StateManagerImpl.java:4091)
	... 12 common frames omitted
21:02:22.133 ERROR [LoggableUncaughtExceptionHandler] An unknown error occurred in an asynchronous event or notification thread
java.lang.IllegalStateException: null
	at org.datanucleus.transaction.ResourcedTransaction.enlistResource(ResourcedTransaction.java:158)
	at org.datanucleus.store.connection.ConnectionManagerImpl.allocateManagedConnection(ConnectionManagerImpl.java:429)
	at org.datanucleus.store.connection.ConnectionManagerImpl.getConnection(ConnectionManagerImpl.java:213)
	at org.datanucleus.store.connection.ConnectionManager.getConnection(ConnectionManager.java:62)
	at org.datanucleus.store.rdbms.scostore.JoinListStore.listIterator(JoinListStore.java:767)
	at org.datanucleus.store.rdbms.scostore.AbstractListStore.listIterator(AbstractListStore.java:92)
	at org.datanucleus.store.rdbms.scostore.AbstractListStore.iterator(AbstractListStore.java:82)
	at org.datanucleus.store.types.wrappers.backed.List.loadFromStore(List.java:267)
	at org.datanucleus.store.types.wrappers.backed.List.initialise(List.java:216)
	at org.datanucleus.store.types.TypeManagerImpl.createSCOInstance(TypeManagerImpl.java:471)
	at org.datanucleus.store.rdbms.mapping.java.AbstractContainerMapping.replaceFieldWithWrapper(AbstractContainerMapping.java:442)
	at org.datanucleus.store.rdbms.mapping.java.AbstractContainerMapping.postFetch(AbstractContainerMapping.java:459)
	at org.datanucleus.store.rdbms.request.FetchRequest.execute(FetchRequest.java:502)
	at org.datanucleus.store.rdbms.RDBMSPersistenceHandler.fetchObject(RDBMSPersistenceHandler.java:316)
	at org.datanucleus.state.StateManagerImpl.loadFieldsFromDatastore(StateManagerImpl.java:1542)
	at org.datanucleus.state.StateManagerImpl.loadUnloadedFieldsInFetchPlan(StateManagerImpl.java:3897)
	at org.datanucleus.state.StateManagerImpl.isLoaded(StateManagerImpl.java:4112)
	at org.dependencytrack.model.Project.dnGetuuid(Project.java)
	at org.dependencytrack.model.Project.getUuid(Project.java:349)
	at org.dependencytrack.util.NotificationUtil.toJson(NotificationUtil.java:196)
	at org.dependencytrack.util.NotificationUtil.toJson(NotificationUtil.java:278)
	at org.dependencytrack.notification.publisher.Publisher.prepareTemplate(Publisher.java:72)
	at org.dependencytrack.notification.publisher.AbstractWebhookPublisher.publish(AbstractWebhookPublisher.java:40)
	at org.dependencytrack.notification.publisher.WebhookPublisher.inform(WebhookPublisher.java:32)
	at org.dependencytrack.notification.NotificationRouter.inform(NotificationRouter.java:64)
	at alpine.notification.NotificationService.lambda$alertSubscriber$0(NotificationService.java:100)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```