### PR TITLE
Implement repository support for Go Modules

### DIFF
--- a/docs/_docs/datasources/repositories.md
+++ b/docs/_docs/datasources/repositories.md
@@ -15,20 +15,21 @@ off-the-shelf software.
 
 Dependency-Track supports the following default repositories:
 
-| Ecosystem | Repository       | Resolution Order |
-| --------- | ---------------- | ---------------- |
-| cargo     | Crates.io        | 1 |
-| composer  | Packagist        | 1 |
-| gem       | RubyGems         | 1 |
-| hex       | Hex              | 1 |
-| maven     | Maven Central    | 1 |
-|           | Atlassian Public | 2 |
-|           | JBoss Releases   | 3 |
-|           | Clojars          | 4 |
-|           | Google Android   | 5 |
-| npm       | NPM              | 1 |
-| nuget     | NuGet            | 1 |
-| pypi      | PyPi             | 1 |
+| Ecosystem  | Repository       | Resolution Order |
+| ---------- | ---------------- | ---------------- |
+| cargo      | Crates.io        | 1 |
+| composer   | Packagist        | 1 |
+| gem        | RubyGems         | 1 |
+| go modules | proxy.golang.org | 1 |
+| hex        | Hex              | 1 |
+| maven      | Maven Central    | 1 |
+|            | Atlassian Public | 2 |
+|            | JBoss Releases   | 3 |
+|            | Clojars          | 4 |
+|            | Google Android   | 5 |
+| npm        | NPM              | 1 |
+| nuget      | NuGet            | 1 |
+| pypi       | PyPi             | 1 |
 
 
 Additional repositories can be added for each supported ecosystem. Additionally, repositories can be enabled or disabled

--- a/docs/_posts/2021-XX-XX-v4.3.0.md
+++ b/docs/_posts/2021-XX-XX-v4.3.0.md
@@ -6,6 +6,7 @@ type: patch
 **Features:**
 * OpenID Connect: Source user claims from `/userinfo` *and* ID token (#1008)
   * Resolves an issue where some IdPs would provide specific claims only in one and not the other of the two
+* Added Go Modules repository support
 
 **Fixes:**
 

--- a/src/main/java/org/dependencytrack/model/RepositoryType.java
+++ b/src/main/java/org/dependencytrack/model/RepositoryType.java
@@ -36,6 +36,7 @@ public enum RepositoryType {
     HEX,
     COMPOSER,
     CARGO,
+    GO_MODULES,
     UNSUPPORTED;
 
     /**
@@ -61,6 +62,8 @@ public enum RepositoryType {
             return COMPOSER;
         } else if (PackageURL.StandardTypes.CARGO.equals(type)) {
             return CARGO;
+        } else if (PackageURL.StandardTypes.GOLANG.equals(type)) {
+            return GO_MODULES;
         }
         return UNSUPPORTED;
     }

--- a/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
+++ b/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
@@ -246,6 +246,7 @@ public class DefaultObjectGenerator implements ServletContextListener {
             qm.createRepository(RepositoryType.NUGET, "nuget-gallery", "https://api.nuget.org/", true, false);
             qm.createRepository(RepositoryType.COMPOSER, "packagist", "https://repo.packagist.org/", true, false);
             qm.createRepository(RepositoryType.CARGO, "crates.io", "https://crates.io", true, false);
+            qm.createRepository(RepositoryType.GO_MODULES, "proxy.golang.org", "https://proxy.golang.org", true, false);
         }
     }
 

--- a/src/main/java/org/dependencytrack/tasks/repositories/GoModulesMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/GoModulesMetaAnalyzer.java
@@ -1,0 +1,99 @@
+package org.dependencytrack.tasks.repositories;
+
+import alpine.logging.Logger;
+import com.github.packageurl.PackageURL;
+import kong.unirest.HttpResponse;
+import kong.unirest.JsonNode;
+import kong.unirest.UnirestException;
+import kong.unirest.UnirestInstance;
+import org.apache.commons.lang3.StringUtils;
+import org.dependencytrack.common.UnirestFactory;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.RepositoryType;
+import org.json.JSONObject;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+/**
+ * @see <a href="https://golang.org/ref/mod#goproxy-protocol">GOPROXY protocol</a>
+ * @since 4.3.0
+ */
+public class GoModulesMetaAnalyzer extends AbstractMetaAnalyzer {
+
+    private static final Logger LOGGER = Logger.getLogger(GoModulesMetaAnalyzer.class);
+    private static final String DEFAULT_BASE_URL = "https://proxy.golang.org";
+    private static final String API_URL = "/%s/%s/@latest";
+
+    GoModulesMetaAnalyzer() {
+        this.baseUrl = DEFAULT_BASE_URL;
+    }
+
+    @Override
+    public RepositoryType supportedRepositoryType() {
+        return RepositoryType.GO_MODULES;
+    }
+
+    @Override
+    public boolean isApplicable(final Component component) {
+        return component.getPurl() != null && PackageURL.StandardTypes.GOLANG.equals(component.getPurl().getType());
+    }
+
+    @Override
+    public MetaModel analyze(final Component component) {
+        final var meta = new MetaModel(component);
+
+        if (component.getPurl() == null) {
+            return meta;
+        }
+
+        final UnirestInstance ui = UnirestFactory.getUnirestInstance();
+        final String url = String.format(baseUrl + API_URL, caseEncode(component.getPurl().getNamespace()), caseEncode(component.getPurl().getName()));
+
+        try {
+            final HttpResponse<JsonNode> response = ui.get(url)
+                    .header("accept", "application/json")
+                    .asJson();
+            if (response.getStatus() == 200) {
+                if (response.getBody() != null && response.getBody().getObject() != null) {
+                    final JSONObject responseJson = response.getBody().getObject();
+                    meta.setLatestVersion(responseJson.getString("Version"));
+
+                    // Module versions are prefixed with "v" in the Go ecosystem.
+                    // Because some services (like OSS Index as of July 2021) do not support
+                    // versions with this prefix, components in DT may not be prefixed either.
+                    //
+                    // In order to make the versions comparable still, we strip the "v" prefix as well,
+                    // if it was done for the analyzed component.
+                    if (component.getVersion() != null && !component.getVersion().startsWith("v")) {
+                        meta.setLatestVersion(StringUtils.stripStart(meta.getLatestVersion(), "v"));
+                    }
+
+                    final String commitTimestamp = responseJson.getString("Time");
+                    if (StringUtils.isNotBlank(commitTimestamp)) { // Time is optional
+                        meta.setPublishedTimestamp(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse(commitTimestamp));
+                    }
+                }
+            } else {
+                handleUnexpectedHttpResponse(LOGGER, url, response.getStatus(), response.getStatusText(), component);
+            }
+        } catch (UnirestException | ParseException e) {
+            handleRequestException(LOGGER, e);
+        }
+
+        return meta;
+    }
+
+    /**
+     * "To avoid ambiguity when serving from case-insensitive file systems, the $module [...] elements are
+     * case-encoded by replacing every uppercase letter with an exclamation mark followed by the corresponding
+     * lower-case letter."
+     *
+     * @param modulePath The module path to encode
+     * @return The encoded module path
+     */
+    String caseEncode(final String modulePath) {
+        return modulePath.replaceAll("([A-Z])", "!$1").toLowerCase();
+    }
+
+}

--- a/src/main/java/org/dependencytrack/tasks/repositories/IMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/IMetaAnalyzer.java
@@ -104,6 +104,11 @@ public interface IMetaAnalyzer {
                 if (analyzer.isApplicable(component)) {
                     return analyzer;
                 }
+            } else if (PackageURL.StandardTypes.GOLANG.equals(component.getPurl().getType())) {
+                IMetaAnalyzer analyzer = new GoModulesMetaAnalyzer();
+                if (analyzer.isApplicable(component)) {
+                    return analyzer;
+                }
             }
         }
 

--- a/src/test/java/org/dependencytrack/tasks/repositories/GoModulesMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/GoModulesMetaAnalyzerTest.java
@@ -1,0 +1,40 @@
+package org.dependencytrack.tasks.repositories;
+
+import com.github.packageurl.PackageURL;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.RepositoryType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GoModulesMetaAnalyzerTest {
+
+    @Test
+    public void testAnalyzer() throws Exception {
+        final var component = new Component();
+        component.setVersion("v0.1.0");
+        component.setPurl(new PackageURL("pkg:golang/github.com/CycloneDX/cyclonedx-go@v0.3.0"));
+
+        final var analyzer = new GoModulesMetaAnalyzer();
+        Assert.assertTrue(analyzer.isApplicable(component));
+        Assert.assertEquals(RepositoryType.GO_MODULES, analyzer.supportedRepositoryType());
+
+        MetaModel metaModel = analyzer.analyze(component);
+        Assert.assertNotNull(metaModel.getLatestVersion());
+        Assert.assertTrue(metaModel.getLatestVersion().startsWith("v"));
+        Assert.assertNotNull(metaModel.getPublishedTimestamp());
+
+        component.setVersion("0.1.0");
+        metaModel = analyzer.analyze(component);
+        Assert.assertNotNull(metaModel.getLatestVersion());
+        Assert.assertFalse(metaModel.getLatestVersion().startsWith("v"));
+    }
+
+    @Test
+    public void testCaseEncode() {
+        final var analyzer = new GoModulesMetaAnalyzer();
+
+        Assert.assertEquals("!cyclone!d!x", analyzer.caseEncode("CycloneDX"));
+        Assert.assertEquals("cyclonedx", analyzer.caseEncode("cyclonedx"));
+    }
+
+}


### PR DESCRIPTION
Add proxy.golang.org as default repository.

Go's module proxies / mirrors are not a repository per se, but they behave like one.

![outdated-components](https://user-images.githubusercontent.com/5693141/126214193-d2c8d3fa-9368-447a-be9a-ec47c6176ca1.gif)