### PR TITLE
Fix tests; Add license headers

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/repositories/GoModulesMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/GoModulesMetaAnalyzer.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
 package org.dependencytrack.tasks.repositories;
 
 import alpine.logging.Logger;

--- a/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
+++ b/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
@@ -68,7 +68,7 @@ public class DefaultObjectGeneratorTest extends PersistenceCapableTest {
         Method method = generator.getClass().getDeclaredMethod("loadDefaultRepositories");
         method.setAccessible(true);
         method.invoke(generator);
-        Assert.assertEquals(12, qm.getAllRepositories().size());
+        Assert.assertEquals(13, qm.getAllRepositories().size());
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/resources/v1/RepositoryResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/RepositoryResourceTest.java
@@ -60,10 +60,10 @@ public class RepositoryResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(12), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assert.assertEquals(String.valueOf(13), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals(12, json.size());
+        Assert.assertEquals(13, json.size());
         for (int i=0; i<json.size(); i++) {
             Assert.assertNotNull(json.getJsonObject(i).getString("type"));
             Assert.assertNotNull(json.getJsonObject(i).getString("identifier"));

--- a/src/test/java/org/dependencytrack/tasks/repositories/GoModulesMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/GoModulesMetaAnalyzerTest.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
 package org.dependencytrack.tasks.repositories;
 
 import com.github.packageurl.PackageURL;


### PR DESCRIPTION
Sorry, should've seen those before submitting https://github.com/DependencyTrack/dependency-track/pull/1110:

```
Error:  Failures: 
Error:    DefaultObjectGeneratorTest.testContextInitialized:33->testLoadDefaultRepositories:71 expected:<12> but was:<13>
Error:    DefaultObjectGeneratorTest.testLoadDefaultRepositories:71 expected:<12> but was:<13>
Error:    RepositoryResourceTest.getRepositoriesTest:63 expected:<1[2]> but was:<1[3]>
```