### PR TITLE
Fix a few typos

### DIFF
--- a/docs/_docs/FAQ.md
+++ b/docs/_docs/FAQ.md
@@ -49,7 +49,7 @@ was dropped. A comparison can be found in the [Dependency Check Comparison](./..
 
 Make sure the container is allowed to allocate enough RAM. For memory requirements see
 [Deploying Docker Container](./../getting-started/deploy-docker/). A common source for limited memory is Docker for
-Windows's default memory limit of 2GB which is too less. You can change this in docker's settings.
+Windows's default memory limit of 2GB which is too little. You can change this in Docker's settings.
 
 #### Dependency Track stops working after 1-2 weeks
 

--- a/docs/_docs/datasources/npm.md
+++ b/docs/_docs/datasources/npm.md
@@ -11,7 +11,7 @@ NPM public advisories is a centralized source of vulnerability intelligence spec
 or may not be documented in the National Vulnerability Database. Projects that leverage Node.js will benefit from the 
 NPM Audit datasource as it provides visibility on vulnerabilities specific to the ecosystem.
 
-Dependency-Track integrates with NPM using it's public advisory API. In doing so, Dependency-Track is able to create a 
+Dependency-Track integrates with NPM using its public advisory API. In doing so, Dependency-Track is able to create a
 mirror of all NPM advisory data. The mirror is kept up-to-date on a daily basis, or upon the restarting of the 
 Dependency-Track instance.
 

--- a/docs/_docs/datasources/ossindex.md
+++ b/docs/_docs/datasources/ossindex.md
@@ -9,7 +9,7 @@ Sonatype OSS Index provides transparent and highly accurate results for componen
 The majority of vulnerabilities directly map to CVEs in the National Vulnerability Database (NVD), however, 
 OSS Index does contain many vulnerabilities that are not present in the NVD.
 
-Dependency-Track integrates with OSS Index using it's public API. Dependency-Track does not mirror OSS Index, 
+Dependency-Track integrates with OSS Index using its public API. Dependency-Track does not mirror OSS Index,
 but it does consume vulnerabilities from OSS Index on a 'as-identified' basis.
 
 > Starting with Dependency-Track v4.0, OSS Index is enabled by default and does not require an account. For prior 

--- a/docs/_docs/datasources/private-vuln-repo.md
+++ b/docs/_docs/datasources/private-vuln-repo.md
@@ -9,8 +9,8 @@ redirect_from:
 
 > This feature was experimental in Dependency-Track v3.x and is not yet available in Dependency-Track v4.x
 
-Dependency-Track has the ability to maintain it's own repository of internally managed vulnerabilities. The private
-repository behaves identical to other sources of vulnerability intelligence such as the NVD.
+Dependency-Track has the ability to maintain its own repository of internally managed vulnerabilities. The private
+repository behaves identically to other sources of vulnerability intelligence such as the NVD.
 
 ![add vulnerability](/images/screenshots/vulnerability-add.png)
 

--- a/docs/_docs/datasources/repositories.md
+++ b/docs/_docs/datasources/repositories.md
@@ -55,4 +55,4 @@ means to populate project dependencies, organizations benefit from the many use-
 leveraging repositories to identify outdated components.
 
 Refer to [Datasource Routing]({{ site.baseurl }}{% link _docs/datasources/routing.md %})
-for information on Package URL and the various ways its used throughout Dependency-Track.
+for information on Package URL and the various ways it is used throughout Dependency-Track.

--- a/docs/_docs/terminology.md
+++ b/docs/_docs/terminology.md
@@ -15,8 +15,8 @@ The process of evaluating findings to determine the accuracy of the findings and
 affected projects. The auditing process creates an audit trail that captures the thought process and decisions made 
 for each finding.
 
-### Bill of Material (BOM)
-In supply chains, a bill of material (BOM) defines and describes the contents of what is used in the manufacturing and 
+### Bill of Materials (BOM)
+In supply chains, a bill of materials (BOM) defines and describes the contents of what is used in the manufacturing and
 packaging of the deliverable. In software supply chains, this refers to the contents of all components bundled with the
 software including, authors, publishers, names, versions, licenses, and copyrights. Dependency-Track supports the 
 CycloneDX format. Bill of Materials specific to software components are commonly referred to as SBOMs.

--- a/docs/_docs/usage/cicd.md
+++ b/docs/_docs/usage/cicd.md
@@ -27,7 +27,7 @@ For other environments, cURL (or similar) can be used.
 
 #### CycloneDX
 To publish CycloneDX BOMs, use a valid API Key and project UUID. Finally, Base64 encode the 
-bom and insert the resulting text into the 'bom' field.
+BOM and insert the resulting text into the 'bom' field.
 
 ```bash
 curl -X "PUT" "http://dtrack.example.com/api/v1/bom" \
@@ -50,7 +50,7 @@ curl -X "POST" "http://dtrack.example.com/api/v1/bom" \
 ```
 
 #### Large Payloads
-In cases where the scan or BOM being uploaded is large, using cURLs capability of specifying a file
+In cases where the scan or BOM being uploaded is large, using cURL's capability of specifying a file
 containing a payload may be preferred.
 
 ```bash


### PR DESCRIPTION
Just fixing a few typos that I spotted in the documentation website.