### PR TITLE
Fixes query construction in preprocess ACL

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -705,11 +705,10 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
             if (teams != null && teams.size() > 0) {
                 final StringBuilder sb = new StringBuilder();
                 for (int i = 0, teamsSize = teams.size(); i < teamsSize; i++) {
-                    //final Team team = teams.get(i);
-                    final Team team = super.getObjectById(Team.class, teams.get(0).getId());
+                    final Team team = super.getObjectById(Team.class, teams.get(i).getId());
                     sb.append(" accessTeams.contains(:team").append(i).append(") ");
                     params.put("team" + i, team);
-                    if (i < teamsSize-2) {
+                    if (i < teamsSize-1) {
                         sb.append(" || ");
                     }
                 }


### PR DESCRIPTION
Fixes #1132 

The query is malformed if `teamSize > 1`. In this case, the resulting query was

`accessTeams.contains(:team0) accessTeams.contains(:team1)`

instead of

`accessTeams.contains(:team0) || accessTeams.contains(:team1)`