### PR TITLE
Parse externalReferences property from OSS Index API response

### DIFF
--- a/src/main/java/org/dependencytrack/parser/ossindex/OssIndexParser.java
+++ b/src/main/java/org/dependencytrack/parser/ossindex/OssIndexParser.java
@@ -72,6 +72,12 @@ public class OssIndexParser {
             vulnerability.setCwe(vulnObject.optString("cwe", null));
             vulnerability.setCve(vulnObject.optString("cve", null));
             vulnerability.setReference(vulnObject.optString("reference", null));
+            final JSONArray externalRefsJSONArray = vulnObject.optJSONArray("externalReferences");
+            final List<String> externalReferences = new ArrayList<String>();
+            for (int j = 0; j < externalRefsJSONArray.length(); j++) {
+                externalReferences.add(externalRefsJSONArray.getString(j));
+            }
+            vulnerability.setExternalReferences(externalReferences);
             componentReport.addVulnerability(vulnerability);
         }
         return componentReport;

--- a/src/main/java/org/dependencytrack/parser/ossindex/model/ComponentReportVulnerability.java
+++ b/src/main/java/org/dependencytrack/parser/ossindex/model/ComponentReportVulnerability.java
@@ -18,6 +18,8 @@
  */
 package org.dependencytrack.parser.ossindex.model;
 
+import java.util.List;
+
 /**
  * The response from Sonatype OSS Index will respond with 0 or more ComponentReports. This
  * class defines the ComponentReportVulnerability objects returned within each ComponentReport.
@@ -35,6 +37,7 @@ public class ComponentReportVulnerability {
     private String cwe;
     private String cve;
     private String reference;
+    private List<String> externalReferences;
 
     public String getId() {
         return id;
@@ -98,5 +101,13 @@ public class ComponentReportVulnerability {
 
     public void setReference(final String reference) {
         this.reference = reference;
+    }
+
+    public List<String> getExternalReferences() {
+        return externalReferences;
+    }
+
+    public void setExternalReferences(final List<String> externalReferences) {
+        this.externalReferences = externalReferences;
     }
 }

--- a/src/main/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTask.java
@@ -305,8 +305,17 @@ public class OssIndexAnalysisTask extends BaseComponentAnalyzerTask implements C
             }
         }
 
-        if (reportedVuln.getReference() != null) {
-            vulnerability.setReferences("* [" + reportedVuln.getReference() + "](" + reportedVuln.getReference() + ")");
+        final StringBuilder sb = new StringBuilder();
+        final String reference = reportedVuln.getReference();
+        if (reference != null) {
+            sb.append("* [").append(reference).append("](").append(reference).append(")\n");
+        }
+        for (String externalReference: reportedVuln.getExternalReferences()) {
+            sb.append("* [").append(externalReference).append("](").append(externalReference).append(")\n");
+        }
+        final String references = sb.toString();
+        if (references.length() > 0) {
+            vulnerability.setReferences(references.substring(0, references.lastIndexOf("\n")));
         }
 
         if (reportedVuln.getCvssVector() != null) {


### PR DESCRIPTION
OSS Index API added recently a new property to their API responses called externalReferences which contains the references that are visible on their website. This PR adds these references to Dependency Track as well. I have never written any Java code so feedback is appreciated. Also I have not tested this as I have no clue how to do that and I do have to admit that I was too lazy to learn how to do that.

Relevant links:
https://github.com/OSSIndex/vulns/issues/193
https://ossindex.sonatype.org/rest