### PR TITLE
use proper HEX const in `IMetaAnalyzer`

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/repositories/IMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/IMetaAnalyzer.java
@@ -99,7 +99,7 @@ public interface IMetaAnalyzer {
                 if (analyzer.isApplicable(component)) {
                     return analyzer;
                 }
-            } else if ("hex".equals(component.getPurl().getType())) {
+            } else if (PackageURL.StandardTypes.HEX.equals(component.getPurl().getType())) {
                 IMetaAnalyzer analyzer = new HexMetaAnalyzer();
                 if (analyzer.isApplicable(component)) {
                     return analyzer;


### PR DESCRIPTION
used `PackageURL.StandardTypes.HEX` in `org.dependencytrack.tasks.repositories.IMetaAnalyzer::build()` for hex purl