### PR TITLE
packaging: Overhaul Containerfile and use Temurin JRE

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,14 @@
 version: 2
 updates:
-  - package-ecosystem: "maven"
-    directory: "/"
+  - package-ecosystem: maven
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
+  - package-ecosystem: docker
+    directory: /src/main/docker
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,66 +12,79 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     env:
       DOCKER_APISERVER_REPO: dependencytrack/apiserver
       DOCKER_BUNDLED_REPO: dependencytrack/bundled
       DOCKER_TAG: snapshot
+
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v2
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
       id: buildx
       with:
         install: true
+
     - name: Available platforms
       run: echo ${{ steps.buildx.outputs.platforms }}
+
     - name: Set up JDK
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '11'
-    - name: Install tools
-      run: |
-        sudo apt-get install jq
-        wget -O ~/codacy-coverage-reporter-assembly.jar https://github.com/codacy/codacy-coverage-reporter/releases/download/4.0.5/codacy-coverage-reporter-4.0.5-assembly.jar
-        export DOCKLE_VERSION=$(curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-        wget -O ~/dockle.tar.gz https://github.com/goodwithtech/dockle/releases/download/v${DOCKLE_VERSION}/dockle_${DOCKLE_VERSION}_Linux-64bit.tar.gz
-        tar zxvf ~/dockle.tar.gz -C ~/
-        export TRIVY_VERSION=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-        wget -O ~/trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz
-        tar zxvf ~/trivy.tar.gz -C ~/
+        cache: 'maven'
+
     - name: Build with Maven
-      run: |
+      run: |-
         mvn clean
         mvn package -Dmaven.test.skip=true -P clean-exclude-wars -P embedded-jetty -Dlogback.configuration.file=src/main/docker/logback.xml
         mvn clean -P clean-exclude-wars
         mvn package -Dmaven.test.skip=true -P embedded-jetty -P bundle-ui -Dlogback.configuration.file=src/main/docker/logback.xml
         mvn clean -P clean-exclude-wars
+
     - name: Execute unit tests
       if: github.event.inputs.skipTests != 'true'
       run: mvn test
+
     - name: Publish test coverage
       if: github.ref == 'refs/heads/master' && github.event.inputs.skipTests != 'true'
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
       run: java -jar ~/codacy-coverage-reporter-assembly.jar report -l Java -r target/jacoco-ut/jacoco.xml
+
     - name: Logging into Docker Hub
       if: github.ref == 'refs/heads/master'
       env:
         HUB_USERNAME: ${{ secrets.HUB_USERNAME }}
         HUB_ACCESSS_TOKEN: ${{ secrets.HUB_ACCESSS_TOKEN }}
-      run: docker login -u "$HUB_USERNAME" -p "$HUB_ACCESSS_TOKEN"
+      run: docker login -u "${HUB_USERNAME}" -p "${HUB_ACCESSS_TOKEN}"
+
     - name: Building Docker API Server container
       if: github.ref == 'refs/heads/master'
-      run: |
-        docker build -f src/main/docker/Dockerfile --build-arg WAR_FILENAME=dependency-track-apiserver.jar -t $DOCKER_APISERVER_REPO:$DOCKER_TAG --platform linux/amd64,linux/arm64 --push .
+      run: |-
+        docker build -f src/main/docker/Dockerfile \
+          --build-arg COMMIT_SHA=${GITHUB_SHA} \
+          --build-arg APP_VERSION=${DOCKER_TAG} \
+          --build-arg WAR_FILENAME=dependency-track-apiserver.jar \
+          -t ${DOCKER_APISERVER_REPO}:${DOCKER_TAG} \
+          --platform linux/amd64,linux/arm64 \
+          --push .
+
     - name: Building Docker bundled container
       if: github.ref == 'refs/heads/master'
-      run: |
-        docker build -f src/main/docker/Dockerfile --build-arg WAR_FILENAME=dependency-track-bundled.jar -t $DOCKER_BUNDLED_REPO:$DOCKER_TAG --platform linux/amd64,linux/arm64 --push .
+      run: |-
+        docker build -f src/main/docker/Dockerfile \
+          --build-arg COMMIT_SHA=${GITHUB_SHA} \
+          --build-arg APP_VERSION=${DOCKER_TAG} \
+          --build-arg WAR_FILENAME=dependency-track-bundled.jar \
+          -t ${DOCKER_BUNDLED_REPO}:${DOCKER_TAG} \
+          --platform linux/amd64,linux/arm64 \
+          --push .

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,63 +1,70 @@
-FROM debian:stable-slim
-LABEL maintainer="steve.springett@owasp.org"
-LABEL vendor="OWASP"
+FROM eclipse-temurin:11.0.13_8-jre-focal AS jre-build
+
+FROM debian:bullseye-slim
 
 # Arguments that can be passed at build time
 # Directory names must end with / to avoid errors when ADDing and COPYing
+ARG COMMIT_SHA
+ARG APP_VERSION
 ARG APP_DIR=/opt/owasp/dependency-track/
 ARG DATA_DIR=/data/
-ARG USERNAME=dtrack
+ARG UID=1001
+ARG GID=1001
 ARG WAR_FILENAME=dependency-track-apiserver.jar
+
+ENV TZ=Etc/UTC \
+    # Dependency-Track's default logging level
+    LOGGING_LEVEL=INFO \
+    # Environment variables that can be passed at runtime
+    JAVA_OPTIONS="-XX:+UseParallelGC -XX:MaxRAMPercentage=90.0" \
+    # The web context defaults to the root. To override, supply an alternative context which starts with a / but does not end with one
+    # Example: /dtrack
+    CONTEXT="/" \
+    # Injects the build-time ARG "WAR_FILENAME" as an environment variable that can be used in the CMD.
+    WAR_FILENAME=${WAR_FILENAME} \
+    # Set JAVA_HOME for the copied over JRE
+    JAVA_HOME=/opt/java/openjdk \
+    PATH="/opt/java/openjdk/bin:${PATH}" \
+    LANG=C.UTF-8
+
+COPY --from=jre-build /opt/java/openjdk $JAVA_HOME
+
+# Copy the compiled WAR to the application directory created above
+# Automatically creates the $APP_DIR directory
+COPY ./target/${WAR_FILENAME} ${APP_DIR}
 
 # Create the directory where Dependency-Track will store its data (${DATA_DIR}) and the external library directory (${EXTLIB_DIR})
 # Create a user and assign home directory to a ${DATA_DIR}
 # Ensure UID 1000 & GID 1000 own all the needed directories
 RUN mkdir -p -m 770 ${DATA_DIR} \
-    && useradd --home-dir ${DATA_DIR} --uid 1000 ${USERNAME} \
-    && chown -R ${USERNAME}:${USERNAME} ${DATA_DIR} \
-    # install dependencies necessary in order to install Azul OpenJDK
-    && apt-get -q update && apt-get -y upgrade \
-    && apt-get -yq install gnupg curl \
-    # add Azul's public key
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 \
-    # download and install the package that adds
-    # the Azul APT repository to the list of sources
-    && curl -O https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb \
-    # install the package
-    && apt-get install ./zulu-repo_1.0.0-3_all.deb \
-    # update the package sources
-    && apt-get update \
-    # install Azul Zulu JRE
-    && apt-get -y install zulu17-ca-jre-headless
-
-# Copy the compiled WAR to the application directory created above
-# Automatically creates the $APP_DIR directory
-COPY --chown=1000 ./target/${WAR_FILENAME} ${APP_DIR}
+    && addgroup --system --gid ${GID} dtrack || true \
+    && adduser --system --disabled-login --ingroup dtrack --no-create-home --home ${DATA_DIR} --gecos "dtrack user" --shell /bin/false --uid ${UID} dtrack || true \
+    && chown -R dtrack:0 ${DATA_DIR} ${APP_DIR} \
+    && chmod -R g=u ${DATA_DIR} ${APP_DIR}
 
 # Specify the user to run as (in numeric format for compatibility with Kubernetes/OpenShift's SCC)
-USER 1000
+USER ${UID}
 
 # Specify the container working directory
 WORKDIR ${APP_DIR}
 
 # Launch Dependency-Track
-CMD java $JAVA_OPTIONS -DdependencyTrack.logging.level=$LOGGING_LEVEL -jar ${WAR_FILENAME} -context ${CONTEXT}
+CMD java ${JAVA_OPTIONS} -DdependencyTrack.logging.level=${LOGGING_LEVEL} -jar ${WAR_FILENAME} -context ${CONTEXT}
 
 # Specify which port Dependency-Track listens on
 EXPOSE 8080
 
-# Dependency-Track's default logging level
-ENV LOGGING_LEVEL=INFO
-
-# Environment variables that can be passed at runtime
-ENV JAVA_OPTIONS="-XX:+UseParallelGC -XX:MaxRAMPercentage=90.0"
-
-# The web context defaults to the root. To override, supply an alternative context which starts with a / but does not end with one
-# Example: /dtrack
-ENV CONTEXT=""
-
-# Injects the build-time ARG "WAR_FILENAME" as an environment variable that can be used in the CMD.
-ENV WAR_FILENAME ${WAR_FILENAME}
-
 # Add a healthcheck using the Dependency-Track version API
-HEALTHCHECK --interval=5m --timeout=3s CMD wget --proxy off -q -O /dev/null http://127.0.0.1:8080${CONTEXT}/api/version || exit 1
+HEALTHCHECK --interval=5m --timeout=3s CMD wget --proxy off -q -O /dev/null http://127.0.0.1:8080${CONTEXT}api/version || exit 1
+
+# metadata labels
+LABEL \
+    org.opencontainers.image.vendor="OWASP" \
+    org.opencontainers.image.title="Official Dependency-Track Container image" \
+    org.opencontainers.image.description="Dependency-Track is an intelligent Component Analysis platform" \
+    org.opencontainers.image.version="${APP_VERSION}" \
+    org.opencontainers.image.url="https://dependencytrack.org/" \
+    org.opencontainers.image.source="https://github.com/DependencyTrack/dependency-track" \
+    org.opencontainers.image.revision="${COMMIT_SHA}" \
+    org.opencontainers.image.licenses="Apache-2.0" \
+    maintainer="steve.springett@owasp.org"

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM eclipse-temurin:11.0.13_8-jre-focal AS jre-build
+FROM eclipse-temurin:17.0.2_8-jre-focal AS jre-build
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20220125-slim
 
 # Arguments that can be passed at build time
 # Directory names must end with / to avoid errors when ADDing and COPYing
@@ -8,8 +8,8 @@ ARG COMMIT_SHA
 ARG APP_VERSION
 ARG APP_DIR=/opt/owasp/dependency-track/
 ARG DATA_DIR=/data/
-ARG UID=1001
-ARG GID=1001
+ARG UID=1000
+ARG GID=1000
 ARG WAR_FILENAME=dependency-track-apiserver.jar
 
 ENV TZ=Etc/UTC \


### PR DESCRIPTION
### Description

I props these changes as I stumbled over this great tool while dealing with the aftermath that was the Log4Shell hell week and noticed that the Dockerfile could be improved. I did so since we would deploy dtrack to our OpenShift cluster which uses arbitrary UIDs, which is currently already supported by the fronted container yet not by the API server. And while I have made similar changes to packaging for an internal draft container to test deploy dtrack I wanted to offer these changes upstream as well.

Additionally, I noticed that there is the motivation to use the Eclipse-Temurin JVM based on the comment in https://github.com/DependencyTrack/dependency-track/issues/1213#issuecomment-978807113, so I took the liberty and migrated the Container to that alongside the other changes.

To answer questions as to why I did so via a [multi stage build](https://docs.docker.com/develop/develop-images/multistage-build/) I advice to read the following to issues that may be a long read but should explain it:

* https://github.com/adoptium/containers/issues/1 (also covers the glibc issue with Alpine and announces that there will be a Musl build of the Temurin JVM eventually :tada: )
* https://github.com/adoptium/containers/issues/54

***TLDR***: DockerHub apparently does not accept `slim` images anymore for their `Official Image` labelled images and the 'old' [`adoptopenjdk`](https://hub.docker.com/_/adoptopenjdk) too did only offer Ubuntu, CentOS7 and WindowsServerCore images. So the common consensus is to utilize multi stage builds to copy the JDK/JRE from a official image to a derived image with the same package manager (i.e. Ubuntu to Debian, CentOS to UBI or Fedora, etc.), a good example could be the [Jenkins Official Docker images](https://github.com/jenkinsci/docker/blob/master/11/debian/bullseye-slim/hotspot/Dockerfile), which use Jlink to minify the JDK and then copy it to their image. (I did the same without Jlink since the JRE does not have that nor need it to be slim)

If there are any further questions or any feedback please feel free to share them I will come back to them as soon as possible.

### Changes

* overhauls and (IMHO) simplifies/groups Dockerfile
* migrates Dockerfile to Eclipse-Temurin from Zulu JRE
* update `maven` workflow slightly 

### Issues

* relates to https://github.com/DependencyTrack/dependency-track/issues/1213#issuecomment-978807113
* relates to https://github.com/DependencyTrack/dependency-track/issues/1090
* similar to https://github.com/DependencyTrack/dependency-track/pull/994
* similar to https://github.com/DependencyTrack/dependency-track/pull/891

### Notes

I noticed that you seem to use a bash script to release new version of dtrack and want to propose moving that to CI (GitHub Actions) as well. I would be up for submitting the necessary PRs to do so if you are interested :slightly_smiling_face: 

**EDIT:** there are now official musl builds of Temurin 11, 16 and 17 available, so if you ever want to offer an alpine spin alongside the debian one you can now without any glibc hackery for the Alpine JVM variant.