### PR TITLE
WIP: Add filter

### DIFF
--- a/src/main/java/org/dependencytrack/util/VulnerabilityUtil.java
+++ b/src/main/java/org/dependencytrack/util/VulnerabilityUtil.java
@@ -19,7 +19,13 @@
 package org.dependencytrack.util;
 
 import org.dependencytrack.model.Severity;
+
+import java.lang.reflect.Array;
 import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 public final class VulnerabilityUtil {
 
@@ -58,21 +64,25 @@ public final class VulnerabilityUtil {
     public static Severity getSeverity(final Object severity, final Object cvssV2BaseScore, final Object cvssV3BaseScore) {
         if (severity instanceof String) {
             final String s = (String)severity;
-            if (s.equalsIgnoreCase(Severity.CRITICAL.name())) {
-                return Severity.CRITICAL;
-            } else if (s.equalsIgnoreCase(Severity.HIGH.name())) {
-                return Severity.HIGH;
-            } else if (s.equalsIgnoreCase(Severity.MEDIUM.name())) {
-                return Severity.MEDIUM;
-            } else if (s.equalsIgnoreCase(Severity.LOW.name())) {
-                return Severity.LOW;
-            } else if (s.equalsIgnoreCase(Severity.INFO.name())) {
-                return Severity.INFO;
-            }
+            return severityStringToSeverity(s);
         } else if (severity instanceof Severity) {
             return (Severity)severity;
         } else {
             return getSeverity(cvssV2BaseScore, cvssV3BaseScore);
+        }
+    }
+
+    public static Severity severityStringToSeverity(String s) {
+        if (s.equalsIgnoreCase(Severity.CRITICAL.name())) {
+            return Severity.CRITICAL;
+        } else if (s.equalsIgnoreCase(Severity.HIGH.name())) {
+            return Severity.HIGH;
+        } else if (s.equalsIgnoreCase(Severity.MEDIUM.name())) {
+            return Severity.MEDIUM;
+        } else if (s.equalsIgnoreCase(Severity.LOW.name())) {
+            return Severity.LOW;
+        } else if (s.equalsIgnoreCase(Severity.INFO.name())) {
+            return Severity.INFO;
         }
         return Severity.UNASSIGNED;
     }
@@ -133,4 +143,27 @@ public final class VulnerabilityUtil {
         }
     }
 
+    public static boolean isMinimalSeverity(Severity findingSeverity, Severity minimumSeverity) {
+        if(severityToNumeric(findingSeverity) >= severityToNumeric(minimumSeverity)) {
+            return true;
+        }
+        return false;
+    }
+
+    public static int severityToNumeric(Severity severity) {
+        switch (severity) {
+            case INFO:
+                return 1;
+            case LOW:
+                return 2;
+            case MEDIUM:
+                return 3;
+            case HIGH:
+                return 4;
+            case UNASSIGNED:
+            case CRITICAL:
+            default:
+                return 5;
+        }
+    }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -94,6 +94,195 @@ public class FindingResourceTest extends ResourceTest {
         Assert.assertFalse(json.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
         Assert.assertEquals(p1.getUuid().toString() + ":" + c2.getUuid().toString() + ":" + v3.getUuid().toString(), json.getJsonObject(2).getString("matrix"));
     }
+    @Test
+    public void getFindingsWithPurlFilterByProjectTest() {
+        Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+        Project p2 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+        Component c1 = createComponent(p1, "Component A", "3.115");
+        c1.setPurl("pkg:deb/debian/adduser@3.115?arch=all");
+        c1.setCpe("cpe:2.3:a:sample:sample:sample:sample:*:*:*:*:*:*");
+        Component c2 = createComponent(p1, "Component B", "9.3.20");
+        c2.setCpe("cpe:2.3:a:eclipse:jetty:9.3.20:20170531:*:*:*:*:*:*");
+        Component c3 = createComponent(p1, "Component C", "1.0");
+        Component c4 = createComponent(p2, "Component D", "1.0");
+        Component c5 = createComponent(p2, "Component E", "1.0");
+        c5.setPurl("pkg:deb/debian/glibc@1.1?arch=all");
+        Component c6 = createComponent(p2, "Component F", "1.0");
+        Vulnerability v1 = createVulnerability("Vuln-1", Severity.CRITICAL);
+        Vulnerability v2 = createVulnerability("Vuln-2", Severity.HIGH);
+        Vulnerability v3 = createVulnerability("Vuln-3", Severity.MEDIUM);
+        Vulnerability v4 = createVulnerability("Vuln-4", Severity.LOW);
+        qm.addVulnerability(v1, c1, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v2, c1, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v3, c2, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v4, c5, AnalyzerIdentity.NONE);
+
+        Response response = target(V1_FINDING + "/project/" + p1.getUuid().toString())
+                .queryParam("purl", "pkg:deb/debian/adduser@.*")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        JsonArray json = parseJsonArray(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals(2, json.size());
+        Assert.assertEquals("Component A", json.getJsonObject(0).getJsonObject("component").getString("name"));
+        Assert.assertEquals("3.115", json.getJsonObject(0).getJsonObject("component").getString("version"));
+        Assert.assertEquals("Vuln-1", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
+        Assert.assertEquals(Severity.CRITICAL.name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
+
+        Assert.assertEquals("Component A", json.getJsonObject(1).getJsonObject("component").getString("name"));
+        Assert.assertEquals("3.115", json.getJsonObject(1).getJsonObject("component").getString("version"));
+        Assert.assertEquals("Vuln-2", json.getJsonObject(1).getJsonObject("vulnerability").getString("vulnId"));
+        Assert.assertEquals(Severity.HIGH.name(), json.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
+    }
+
+    @Test
+    public void getFindingsWithPurlFilterNotExistingByProjectTest() {
+        Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+        Project p2 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+        Component c1 = createComponent(p1, "Component A", "3.115");
+        c1.setPurl("pkg:deb/debian/adduser@3.115?arch=all");
+        c1.setCpe("cpe:2.3:a:sample:sample:sample:sample:*:*:*:*:*:*");
+        Component c2 = createComponent(p1, "Component B", "9.3.20");
+        c2.setCpe("cpe:2.3:a:eclipse:jetty:9.3.20:20170531:*:*:*:*:*:*");
+        Component c3 = createComponent(p1, "Component C", "1.0");
+        Component c4 = createComponent(p2, "Component D", "1.0");
+        Component c5 = createComponent(p2, "Component E", "1.0");
+        c5.setPurl("pkg:deb/debian/glibc@1.1?arch=all");
+        Component c6 = createComponent(p2, "Component F", "1.0");
+        Vulnerability v1 = createVulnerability("Vuln-1", Severity.CRITICAL);
+        Vulnerability v2 = createVulnerability("Vuln-2", Severity.HIGH);
+        Vulnerability v3 = createVulnerability("Vuln-3", Severity.MEDIUM);
+        Vulnerability v4 = createVulnerability("Vuln-4", Severity.LOW);
+        qm.addVulnerability(v1, c1, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v2, c1, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v3, c2, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v4, c5, AnalyzerIdentity.NONE);
+
+        Response response = target(V1_FINDING + "/project/" + p1.getUuid().toString())
+                .queryParam("purl", "notexistingPurl")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        JsonArray json = parseJsonArray(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals(0, json.size());
+    }
+
+    @Test
+    public void getFindingsWithCpeFilterByProjectTest() {
+        Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+        Project p2 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+        Component c1 = createComponent(p1, "Component A", "3.115");
+        c1.setPurl("pkg:deb/debian/adduser@3.115?arch=all");
+        c1.setCpe("cpe:2.3:a:sample:sample:sample:sample:*:*:*:*:*:*");
+        Component c2 = createComponent(p1, "Component B", "9.3.20");
+        c2.setCpe("cpe:2.3:a:eclipse:jetty:9.3.20:20170531:*:*:*:*:*:*");
+        Component c3 = createComponent(p1, "Component C", "1.0");
+        Component c4 = createComponent(p2, "Component D", "1.0");
+        Component c5 = createComponent(p2, "Component E", "1.0");
+        c5.setPurl("pkg:deb/debian/glibc@1.1?arch=all");
+        Component c6 = createComponent(p2, "Component F", "1.0");
+        Vulnerability v1 = createVulnerability("Vuln-1", Severity.CRITICAL);
+        Vulnerability v2 = createVulnerability("Vuln-2", Severity.HIGH);
+        Vulnerability v3 = createVulnerability("Vuln-3", Severity.MEDIUM);
+        Vulnerability v4 = createVulnerability("Vuln-4", Severity.LOW);
+        qm.addVulnerability(v1, c1, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v2, c1, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v3, c2, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v4, c5, AnalyzerIdentity.NONE);
+
+        Response response = target(V1_FINDING + "/project/" + p1.getUuid().toString())
+                .queryParam("cpe", ".*jetty.*")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        JsonArray json= parseJsonArray(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals(1, json.size());
+        Assert.assertEquals("Component B", json.getJsonObject(0).getJsonObject("component").getString("name"));
+        Assert.assertEquals("1.0", json.getJsonObject(0).getJsonObject("component").getString("version"));
+        Assert.assertEquals("Vuln-3", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
+        Assert.assertEquals(Severity.MEDIUM.name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
+    }
+    @Test
+    public void getFindingsWithCpeFilterNotExistingByProjectTest() {
+        Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+        Project p2 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+        Component c1 = createComponent(p1, "Component A", "3.115");
+        c1.setPurl("pkg:deb/debian/adduser@3.115?arch=all");
+        c1.setCpe("cpe:2.3:a:sample:sample:sample:sample:*:*:*:*:*:*");
+        Component c2 = createComponent(p1, "Component B", "9.3.20");
+        c2.setCpe("cpe:2.3:a:eclipse:jetty:9.3.20:20170531:*:*:*:*:*:*");
+        Component c3 = createComponent(p1, "Component C", "1.0");
+        Component c4 = createComponent(p2, "Component D", "1.0");
+        Component c5 = createComponent(p2, "Component E", "1.0");
+        c5.setPurl("pkg:deb/debian/glibc@1.1?arch=all");
+        Component c6 = createComponent(p2, "Component F", "1.0");
+        Vulnerability v1 = createVulnerability("Vuln-1", Severity.CRITICAL);
+        Vulnerability v2 = createVulnerability("Vuln-2", Severity.HIGH);
+        Vulnerability v3 = createVulnerability("Vuln-3", Severity.MEDIUM);
+        Vulnerability v4 = createVulnerability("Vuln-4", Severity.LOW);
+        qm.addVulnerability(v1, c1, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v2, c1, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v3, c2, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v4, c5, AnalyzerIdentity.NONE);
+
+        Response response = target(V1_FINDING + "/project/" + p1.getUuid().toString())
+                .queryParam("cpe", "notexistingfilter")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        JsonArray json= parseJsonArray(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals(0, json.size());
+    }
+
+    @Test
+    public void getFindingsWithSeverityFilterByProjectTest() {
+        Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+        Project p2 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+        Component c1 = createComponent(p1, "Component A", "1.0");
+        Component c2 = createComponent(p1, "Component B", "1.0");
+        Component c3 = createComponent(p1, "Component C", "1.0");
+        Component c4 = createComponent(p2, "Component D", "1.0");
+        Component c5 = createComponent(p2, "Component E", "1.0");
+        Component c6 = createComponent(p2, "Component F", "1.0");
+        Vulnerability v1 = createVulnerability("Vuln-1", Severity.CRITICAL);
+        Vulnerability v2 = createVulnerability("Vuln-2", Severity.HIGH);
+        Vulnerability v3 = createVulnerability("Vuln-3", Severity.MEDIUM);
+        Vulnerability v4 = createVulnerability("Vuln-4", Severity.LOW);
+        qm.addVulnerability(v1, c1, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v2, c1, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v3, c2, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v4, c5, AnalyzerIdentity.NONE);
+        Response response = target(V1_FINDING + "/project/" + p1.getUuid().toString())
+                .queryParam("minimumSeverity", Severity.HIGH.name())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        Assert.assertEquals(String.valueOf(2), response.getHeaderString(TOTAL_COUNT_HEADER));
+        JsonArray json = parseJsonArray(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals(2, json.size()); // not 3, because Vuln-3 should be included
+        Assert.assertEquals("Component A", json.getJsonObject(0).getJsonObject("component").getString("name"));
+        Assert.assertEquals("1.0", json.getJsonObject(0).getJsonObject("component").getString("version"));
+        Assert.assertEquals("Vuln-1", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
+        Assert.assertEquals(Severity.CRITICAL.name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
+        Assert.assertFalse(json.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
+        Assert.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v1.getUuid().toString(), json.getJsonObject(0).getString("matrix"));
+        Assert.assertEquals("Component A", json.getJsonObject(1).getJsonObject("component").getString("name"));
+        Assert.assertEquals("1.0", json.getJsonObject(1).getJsonObject("component").getString("version"));
+        Assert.assertEquals("Vuln-2", json.getJsonObject(1).getJsonObject("vulnerability").getString("vulnId"));
+        Assert.assertEquals(Severity.HIGH.name(), json.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
+        Assert.assertFalse(json.getJsonObject(1).getJsonObject("analysis").getBoolean("isSuppressed"));
+        Assert.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v2.getUuid().toString(), json.getJsonObject(1).getString("matrix"));
+    }
 
     @Test
     public void getFindingsByProjectInvalidTest() {


### PR DESCRIPTION
As a project I want to know the SBOM of my projects including OS packages like debian/rpm and software vulnerabilities.
I want to alert on software vulnerabilities but not on OS packages or only for high/critical vulnerabilties.

This PR is there to discuss the approach.
In case you agree to this approach, I will add tests.

A future PR might include this user story:
As a project I want to filter on all attributes, e.g. CVE to filter _log4shell_ vulnerability, specific severity or CPEs.