### PR TITLE
fix: Duplicate tag is created upon updating a project

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -616,6 +616,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
      * @param tags a List of Tag objects
      */
     @SuppressWarnings("unchecked")
+    @Override
     public void bind(Project project, List<Tag> tags) {
         final Query<Tag> query = pm.newQuery(Tag.class, "projects.contains(:project)");
         final List<Tag> currentProjectTags = (List<Tag>)query.execute(project);
@@ -627,7 +628,10 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         }
         project.setTags(tags);
         for (final Tag tag: tags) {
-            tag.getProjects().add(project);
+            final List<Project> projects = tag.getProjects();
+            if (!projects.contains(project)) {
+                projects.add(project);
+            }
         }
         pm.currentTransaction().commit();
     }


### PR DESCRIPTION
Add a project to the list of projects of a tag only if the list does not contain the project yet.

fixes #1165