### PR TITLE
use a full date in console output

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -18,7 +18,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %level [%logger{0}] %msg%n</pattern>
+            <pattern>%date %level [%logger{0}] %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
The console output is used by Docker containers.
Since log entries do not include a date, it is unclear to which date an entry belongs.