### PR TITLE
Update link to community-maintained Go client

### DIFF
--- a/docs/_docs/integrations/community-integrations.md
+++ b/docs/_docs/integrations/community-integrations.md
@@ -15,7 +15,7 @@ to make custom tools and integrations. Many tools that integrate with Dependency
 |:---------|:--------|
 | [Code Dx](https://codedx.com/) | [Code Dx](https://codedx.com/) |
 | [Dependency-Track Jenkins plugin](https://plugins.jenkins.io/dependency-track/) | [Jenkins](https://www.jenkins.io/) |
-| [Dependency-Track Client (Go)](https://github.com/nscuro/dependency-track-client) | |
+| [Dependency-Track Client (Go)](https://github.com/nscuro/dtrack-client) | |
 | [Dependency-Track Client (Python)](https://github.com/alvinchchen/dependency-track-python) | |
 | [Dependency-Track Client (Ruby)](https://github.com/mrtc0/dependency-tracker-client) | |
 | [Dependency-Track Reporting Tool](https://github.com/MO-Movia/Dependency-Track-Report-Tool) | [Modus Operandi](https://www.modusoperandi.com/) |


### PR DESCRIPTION
https://github.com/nscuro/dependency-track-client was archived and is superseded by https://github.com/nscuro/dtrack-client