### PR TITLE
fix: ConsolePublisherTest fails on Windows

### DIFF
--- a/src/test/java/org/dependencytrack/notification/publisher/ConsolePublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/ConsolePublisherTest.java
@@ -76,13 +76,13 @@ public class ConsolePublisherTest extends PersistenceCapableTest {
     }
 
     private String expectedResult(Notification notification) {
-        return "--------------------------------------------------------------------------------" + "\n" +
-                "Notification" + "\n" +
-                "  -- timestamp: " + notification.getTimestamp() + "\n" +
-                "  -- level:     " + notification.getLevel() + "\n" +
-                "  -- scope:     " + notification.getScope() + "\n" +
-                "  -- group:     " + notification.getGroup() + "\n" +
-                "  -- title:     " + notification.getTitle() + "\n" +
-                "  -- content:   " + notification.getContent() + "\n\n";
+        return "--------------------------------------------------------------------------------" + System.lineSeparator() +
+                "Notification" + System.lineSeparator() +
+                "  -- timestamp: " + notification.getTimestamp() + System.lineSeparator() +
+                "  -- level:     " + notification.getLevel() + System.lineSeparator() +
+                "  -- scope:     " + notification.getScope() + System.lineSeparator() +
+                "  -- group:     " + notification.getGroup() + System.lineSeparator() +
+                "  -- title:     " + notification.getTitle() + System.lineSeparator() +
+                "  -- content:   " + notification.getContent() + System.lineSeparator() + System.lineSeparator();
     }
 }


### PR DESCRIPTION
The system-dependent line separator should be used instead.