### PR TITLE
Added jetty maven plugin for easy command line start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/.jekyll-metadata
 target/
 .classpath
 .project
+.idea/

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ CI/CD environments.
 
 
 ## Ecosystem Overview
-![alt text](https://raw.githubusercontent.com/DependencyTrack/dependency-track/master/docs/images/integrations.png)
+![alt text](./docs/images/integrations.png)
 
 ## Features
 * Component support for:
@@ -96,7 +96,7 @@ CI/CD environments.
 
 <hr>
 
-![alt text](https://raw.githubusercontent.com/DependencyTrack/dependency-track/master/docs/images/screenshots/dashboard.png)
+![alt text](./docs/images/screenshots/dashboard.png)
 
 ### Quickstart (Docker Compose)
 
@@ -198,6 +198,12 @@ To create the Bundled (API Server + Frontend) executable WAR that is ready to be
 ```shell
 mvn clean package -P embedded-jetty -P bundle-ui -Dlogback.configuration.file=src/main/docker/logback.xml
 ```
+
+## To run for local dev
+### Command Line
+Using the maven jetty plugin, you can just run `mvn jetty:run` and `mvn jetty:stop`.
+
+The plugin will periodically scan your project for changes and automatically redeploy the application.
 
 ## Resources
 

--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,17 @@
                     </fileSets>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>9.4.15.v20190215</version>
+                <configuration>
+                    <webApp>
+                        <contextPath>/</contextPath>
+                    </webApp>
+                    <scanIntervalSeconds>10</scanIntervalSeconds>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Adding this just as a quick start to any devs who want to be able to quickly fix an issue they find. They should just be able to test their changes locally by running `mvn jetty:run`. The added bonus is that any changes you make it will poll every 10 seconds and re-deploy automatically, as well as it seems to work with debug mode too in intellij.

Also while trying to set this up and test it I managed to corrupt the database but thought it was something wrong with the way I was configuring the setup stages. So I will just post a reference in case anyone is searching for a fix.

# Just a quick side note in case anyone runs into database issues
This goes for any way of running with the dev h2 database. Just adding this in case someone starts searching for JdbcSQLNonTransientException or chunk not found errors while doing dev as I've seen an issue also raised once though they wanted to recover the data. In my case, I just wanted to nuke it to keep doing some dev.

Any errors such as `Caused by: org.h2.jdbc.JdbcSQLNonTransientException: General error: "java.lang.IllegalStateException: Chunk 30534 not found [1.4.200/9]" [50000-200]` Just make sure you delete the database at `~/.dependency-track` and you should be good to go. Just took me a few hours of debugging thinking id configured the jetty plugin wrong due to other errors during config e.g. library version.