### PR TITLE
Add backslash to docs cicd multiple line curl command

### DIFF
--- a/docs/_docs/usage/cicd.md
+++ b/docs/_docs/usage/cicd.md
@@ -65,11 +65,11 @@ In lieu of specifying the UUID of an existing project, the project name and vers
 If the project does not exist, it can optionally be automatically created using the `autoCreate` parameter.
 
 ```bash
-curl -X "POST" "http://dtrack.example.com/api/v1/bom"
-     -H 'Content-Type: multipart/form-data'
-     -H "X-Api-Key: xxxxxxx"
-     -F "autoCreate=true"
-     -F "projectName=xxxx"
-     -F "projectVersion=xxxx"
+curl -X "POST" "http://dtrack.example.com/api/v1/bom" \
+     -H 'Content-Type: multipart/form-data' \
+     -H "X-Api-Key: xxxxxxx" \
+     -F "autoCreate=true" \
+     -F "projectName=xxxx" \
+     -F "projectVersion=xxxx" \
      -F "bom=@target/bom.xml"
 ```


### PR DESCRIPTION
Hi!

This change adds the backslashes to the last curl command on the usage/cicd page. This is useful for people copying and pasting the code block.

@stevespringett Thank you so much for this great project!