### PR TITLE
Add `VIEW_VULNERABILITY` permission

### DIFF
--- a/docs/_docs/triage/auditing-basics.md
+++ b/docs/_docs/triage/auditing-basics.md
@@ -14,6 +14,7 @@ Project auditing is the process of triaging findings on the components for each 
 and audit history performed on a project only affect the findings for said project.
 
 The **VULNERABILITY_ANALYSIS** permission is required to perform project auditing.
+The audit trail will be visible to all users with **VIEW_VULNERABILITY** permission.
 
 ![Project Auditing](/images/screenshots/audit-finding-project.png)
 

--- a/docs/_posts/2021-xx-xx-v4.4.0.md
+++ b/docs/_posts/2021-xx-xx-v4.4.0.md
@@ -4,6 +4,8 @@ type: major
 ---
 
 **Features:**
+* Added new `VIEW_VULNERABILITY` permission that grants read-only access to project vulnerabilities and the audit trail.
+The permission also grants access to the findings API.
 
 **Fixes:**
 * Fix NPE in `GoModulesMetaAnalyzer` when a component without group was analyzed - [#1220](https://github.com/DependencyTrack/dependency-track/pull/1220)
@@ -13,6 +15,7 @@ type: major
 **Security:**
 
 **Upgrade Notes:**
+* Users and teams with `VULNERABILITY_ANALYSIS` permission are automatically granted the `VIEW_VULNERABILITY` permission during the automatic upgrade.
 
 ###### dependency-track-apiserver.war
 

--- a/src/main/java/org/dependencytrack/auth/Permissions.java
+++ b/src/main/java/org/dependencytrack/auth/Permissions.java
@@ -29,6 +29,7 @@ public enum Permissions {
     BOM_UPLOAD("Allows the ability to upload CycloneDX Software Bill of Materials (SBOM)"),
     VIEW_PORTFOLIO("Provides the ability to view the portfolio of projects, components, and licenses"),
     PORTFOLIO_MANAGEMENT("Allows the creation, modification, and deletion of data in the portfolio"),
+    VIEW_VULNERABILITY("Provides the ability to view the vulnerabilities projects are affected by"),
     VULNERABILITY_ANALYSIS("Provides the ability to make analysis decisions on vulnerabilities"),
     POLICY_VIOLATION_ANALYSIS("Provides the ability to make analysis decisions on policy violations"),
     ACCESS_MANAGEMENT("Allows the management of users, teams, and API keys"),
@@ -50,6 +51,7 @@ public enum Permissions {
         public static final String BOM_UPLOAD = "BOM_UPLOAD";
         public static final String VIEW_PORTFOLIO = "VIEW_PORTFOLIO";
         public static final String PORTFOLIO_MANAGEMENT = "PORTFOLIO_MANAGEMENT";
+        public static final String VIEW_VULNERABILITY = "VIEW_VULNERABILITY";
         public static final String VULNERABILITY_ANALYSIS = "VULNERABILITY_ANALYSIS";
         public static final String POLICY_VIOLATION_ANALYSIS = "POLICY_VIOLATION_ANALYSIS";
         public static final String ACCESS_MANAGEMENT = "ACCESS_MANAGEMENT";

--- a/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
@@ -72,7 +72,7 @@ public class AnalysisResource extends AlpineResource {
             @ApiResponse(code = 401, message = "Unauthorized"),
             @ApiResponse(code = 404, message = "The project, component, or vulnerability could not be found")
     })
-    @PermissionRequired(Permissions.Constants.VULNERABILITY_ANALYSIS)
+    @PermissionRequired(Permissions.Constants.VIEW_VULNERABILITY)
     public Response retrieveAnalysis(@ApiParam(value = "The UUID of the project")
                                      @QueryParam("project") String projectUuid,
                                      @ApiParam(value = "The UUID of the component", required = true)

--- a/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
@@ -66,7 +66,7 @@ public class FindingResource extends AlpineResource {
             @ApiResponse(code = 403, message = "Access to the specified project is forbidden"),
             @ApiResponse(code = 404, message = "The project could not be found")
     })
-    @PermissionRequired(Permissions.Constants.VULNERABILITY_ANALYSIS)
+    @PermissionRequired(Permissions.Constants.VIEW_VULNERABILITY)
     public Response getFindingsByProject(@PathParam("uuid") String uuid,
                                          @ApiParam(value = "Optionally includes suppressed findings")
                                          @QueryParam("suppressed") boolean suppressed) {
@@ -97,7 +97,7 @@ public class FindingResource extends AlpineResource {
             @ApiResponse(code = 403, message = "Access to the specified project is forbidden"),
             @ApiResponse(code = 404, message = "The project could not be found")
     })
-    @PermissionRequired(Permissions.Constants.VULNERABILITY_ANALYSIS)
+    @PermissionRequired(Permissions.Constants.VIEW_VULNERABILITY)
     public Response exportFindingsByProject(@PathParam("uuid") String uuid) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final Project project = qm.getObjectByUuid(Project.class, uuid);

--- a/src/main/java/org/dependencytrack/upgrade/UpgradeItems.java
+++ b/src/main/java/org/dependencytrack/upgrade/UpgradeItems.java
@@ -29,7 +29,8 @@ class UpgradeItems {
         UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v400.v400Updater.class);
         UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v410.v410Updater.class);
         UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v420.v420Updater.class);
-    };
+        UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v440.v440Updater.class);
+    }
 
     static List<Class<? extends UpgradeItem>> getUpgradeItems() {
         return UPGRADE_ITEMS;

--- a/src/main/java/org/dependencytrack/upgrade/v440/v440Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v440/v440Updater.java
@@ -1,0 +1,62 @@
+package org.dependencytrack.upgrade.v440;
+
+import alpine.logging.Logger;
+import alpine.model.Permission;
+import alpine.persistence.AlpineQueryManager;
+import alpine.upgrade.AbstractUpgradeItem;
+import org.dependencytrack.auth.Permissions;
+
+import java.sql.Connection;
+
+public class v440Updater extends AbstractUpgradeItem {
+
+    private static final Logger LOGGER = Logger.getLogger(v440Updater.class);
+
+    @Override
+    public String getSchemaVersion() {
+        return "4.4.0";
+    }
+
+    @Override
+    public void executeUpgrade(final AlpineQueryManager qm, final Connection connection) throws Exception {
+        LOGGER.info("Creating VIEW_VULNERABILITY permission");
+        final Permission viewVulnPermission = qm.createPermission(Permissions.VIEW_VULNERABILITY.name(), Permissions.VIEW_VULNERABILITY.getDescription());
+
+        LOGGER.info("Granting VIEW_VULNERABILITY permission to managed users with VULNERABILITY_ANALYSIS permission");
+        for (var user : qm.getManagedUsers()) {
+            if (user.getPermissions().stream().map(Permission::getName).anyMatch(Permissions.VULNERABILITY_ANALYSIS.name()::equals)) {
+                LOGGER.info("Granting VIEW_VULNERABILITY permission to managed user " + user.getUsername());
+                user.getPermissions().add(viewVulnPermission);
+                qm.persist(user);
+            }
+        }
+
+        LOGGER.info("Granting VIEW_VULNERABILITY permission to LDAP users with VULNERABILITY_ANALYSIS permission");
+        for (var user : qm.getLdapUsers()) {
+            if (user.getPermissions().stream().map(Permission::getName).anyMatch(Permissions.VULNERABILITY_ANALYSIS.name()::equals)) {
+                LOGGER.info("Granting VIEW_VULNERABILITY permission to LDAP user " + user.getUsername());
+                user.getPermissions().add(viewVulnPermission);
+                qm.persist(user);
+            }
+        }
+
+        LOGGER.info("Granting VIEW_VULNERABILITY permission to OIDC users with VULNERABILITY_ANALYSIS permission");
+        for (var user : qm.getOidcUsers()) {
+            if (user.getPermissions().stream().map(Permission::getName).anyMatch(Permissions.VULNERABILITY_ANALYSIS.name()::equals)) {
+                LOGGER.info("Granting VIEW_VULNERABILITY permission to OIDC user " + user.getUsername());
+                user.getPermissions().add(viewVulnPermission);
+                qm.persist(user);
+            }
+        }
+
+        LOGGER.info("Granting VIEW_VULNERABILITY permission to teams with VULNERABILITY_ANALYSIS permission");
+        for (var team : qm.getTeams()) {
+            if (team.getPermissions().stream().map(Permission::getName).anyMatch(Permissions.VULNERABILITY_ANALYSIS.name()::equals)) {
+                LOGGER.info("Granting VIEW_VULNERABILITY permission to team " + team.getName());
+                team.getPermissions().add(viewVulnPermission);
+                qm.persist(team);
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/dependencytrack/auth/PermissionsTest.java
+++ b/src/test/java/org/dependencytrack/auth/PermissionsTest.java
@@ -27,10 +27,11 @@ public class PermissionsTest {
 
     @Test
     public void testPermissionEnums() {
-        Assert.assertEquals(9, Permissions.values().length);
+        Assert.assertEquals(10, Permissions.values().length);
         Assert.assertEquals("BOM_UPLOAD", Permissions.BOM_UPLOAD.name());
         Assert.assertEquals("VIEW_PORTFOLIO", Permissions.VIEW_PORTFOLIO.name());
         Assert.assertEquals("PORTFOLIO_MANAGEMENT", Permissions.PORTFOLIO_MANAGEMENT.name());
+        Assert.assertEquals("VIEW_VULNERABILITY", Permissions.VIEW_VULNERABILITY.name());
         Assert.assertEquals("VULNERABILITY_ANALYSIS", Permissions.VULNERABILITY_ANALYSIS.name());
         Assert.assertEquals("POLICY_VIOLATION_ANALYSIS", Permissions.POLICY_VIOLATION_ANALYSIS.name());
         Assert.assertEquals("ACCESS_MANAGEMENT", Permissions.ACCESS_MANAGEMENT.name());
@@ -44,6 +45,7 @@ public class PermissionsTest {
         Assert.assertEquals("BOM_UPLOAD", BOM_UPLOAD);
         Assert.assertEquals("VIEW_PORTFOLIO", VIEW_PORTFOLIO);
         Assert.assertEquals("PORTFOLIO_MANAGEMENT", PORTFOLIO_MANAGEMENT);
+        Assert.assertEquals("VIEW_VULNERABILITY", VIEW_VULNERABILITY);
         Assert.assertEquals("VULNERABILITY_ANALYSIS", VULNERABILITY_ANALYSIS);
         Assert.assertEquals("POLICY_VIOLATION_ANALYSIS", POLICY_VIOLATION_ANALYSIS);
         Assert.assertEquals("ACCESS_MANAGEMENT", ACCESS_MANAGEMENT);

--- a/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
+++ b/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
@@ -50,7 +50,7 @@ public class DefaultObjectGeneratorTest extends PersistenceCapableTest {
         Method method = generator.getClass().getDeclaredMethod("loadDefaultPermissions");
         method.setAccessible(true);
         method.invoke(generator);
-        Assert.assertEquals(9, qm.getPermissions().size());
+        Assert.assertEquals(10, qm.getPermissions().size());
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/resources/v1/PermissionResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PermissionResourceTest.java
@@ -68,7 +68,7 @@ public class PermissionResourceTest extends ResourceTest {
         Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals(9, json.size());
+        Assert.assertEquals(10, json.size());
         Assert.assertEquals("ACCESS_MANAGEMENT", json.getJsonObject(0).getString("name"));
         Assert.assertEquals("Allows the management of users, teams, and API keys", json.getJsonObject(0).getString("description"));
     }


### PR DESCRIPTION
This PR addresses #338 by adding the new `VIEW_VULNERABILITY` permission.

`VIEW_VULNERABILITY` grants read access to `/api/v1/analysis` and `/api/v1/finding`.
This enables users to *see* vulnerabilities a project or component is affected by, as well as the audit trail, but no do any audit decisions. A nice side-effect is that this can be used to reduce the permissions granted to CI integrations like the Jenkins plugin.

To ensure compatibility with older DT versions, all users and teams who previously had the `VULNERABILITY_ANALYSIS` permission are automatically granted the `VIEW_VULNERABILITY` permission.

I was torn whether to call this `VIEW_VULNERABILITY` or `VIEW_FINDING`. `VIEW_VULNERABILITY` fits better into the current naming scheme, but `VIEW_FINDING` is more accurate. After all, viewing vulnerabilities is already possible with `VIEW_PORTFOLIO` - it's just the findings (project<->component<->vulnerability relationships) that are hidden.

Also, we may want to implement something similar for policy violations (`VIEW_POLICY_VIOLATION`). I can implement it in this PR if desired, should be fairly straightforward.

CC @msymons