### PR TITLE
Distinguish state changes in analysis trail comments

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
@@ -156,15 +156,15 @@ public class AnalysisResource extends AlpineResource {
                 if (request.getAnalysisState() != null && analysis.getAnalysisState() != request.getAnalysisState()) {
                     // The analysis state has changed. Add an additional comment to the trail.
                     analysisStateChange = true;
-                    final String message = analysis.getAnalysisState().name() + " → " + request.getAnalysisState().name();
+                    final String message = "Analysis: " + analysis.getAnalysisState().name() + " → " + request.getAnalysisState().name();
                     qm.makeAnalysisComment(analysis, message, commenter);
                 }
                 if (request.getAnalysisJustification() != null && analysis.getAnalysisJustification() != request.getAnalysisJustification()) {
-                    final String message = analysis.getAnalysisJustification().name() + " → " + request.getAnalysisJustification().name();
+                    final String message = "Justification: " + analysis.getAnalysisJustification().name() + " → " + request.getAnalysisJustification().name();
                     qm.makeAnalysisComment(analysis, message, commenter);
                 }
                 if (request.getAnalysisResponse() != null && analysis.getAnalysisResponse() != request.getAnalysisResponse()) {
-                    final String message = analysis.getAnalysisResponse().name() + " → " + request.getAnalysisResponse().name();
+                    final String message = "Vendor Response: " + analysis.getAnalysisResponse().name() + " → " + request.getAnalysisResponse().name();
                     qm.makeAnalysisComment(analysis, message, commenter);
                 }
                 if (request.isSuppressed() != null && analysis.isSuppressed() != request.isSuppressed()) {
@@ -177,7 +177,7 @@ public class AnalysisResource extends AlpineResource {
                 analysis = qm.makeAnalysis(component, vulnerability, request.getAnalysisState(), request.getAnalysisJustification(), request.getAnalysisResponse(), request.getAnalysisDetails(), request.isSuppressed());
                 analysisStateChange = true; // this is a new analysis - so set to true because it was previously null
                 if (AnalysisState.NOT_SET != request.getAnalysisState()) {
-                    final String message = AnalysisState.NOT_SET.name() + " → " + request.getAnalysisState().name();
+                    final String message = "Analysis: " + AnalysisState.NOT_SET.name() + " → " + request.getAnalysisState().name();
                     qm.makeAnalysisComment(analysis, message, commenter);
                 }
             }

--- a/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
@@ -227,7 +227,7 @@ public class AnalysisResourceTest extends ResourceTest {
         qm.createVulnerability(vulnerability, false);
         qm.makeAnalysis(component, vulnerability, AnalysisState.IN_TRIAGE, AnalysisJustification.CODE_NOT_REACHABLE, AnalysisResponse.WILL_NOT_FIX, "Analysis details here", false);
         AnalysisRequest request = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
-                vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE, AnalysisResponse.WILL_NOT_FIX, "Analysis details here", "Not an issue", true);
+                vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.PROTECTED_BY_MITIGATING_CONTROL, AnalysisResponse.UPDATE, "Analysis details here", "Not an issue", true);
         Response response = target(V1_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -238,11 +238,17 @@ public class AnalysisResourceTest extends ResourceTest {
         Assert.assertNotNull(json);
         Assert.assertEquals(AnalysisState.NOT_AFFECTED.name(), json.getString("analysisState"));
         Assert.assertTrue(json.getBoolean("isSuppressed"));
-        Assert.assertEquals(3, json.getJsonArray("analysisComments").size());
+        Assert.assertEquals(5, json.getJsonArray("analysisComments").size());
         Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(0).getJsonNumber("timestamp"));
-        Assert.assertEquals("IN_TRIAGE → NOT_AFFECTED", json.getJsonArray("analysisComments").getJsonObject(0).getString("comment"));
+        Assert.assertEquals("Analysis: IN_TRIAGE → NOT_AFFECTED", json.getJsonArray("analysisComments").getJsonObject(0).getString("comment"));
         Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(1).getJsonNumber("timestamp"));
-        Assert.assertEquals("Not an issue", json.getJsonArray("analysisComments").getJsonObject(2).getString("comment"));
+        Assert.assertEquals("Justification: CODE_NOT_REACHABLE → PROTECTED_BY_MITIGATING_CONTROL", json.getJsonArray("analysisComments").getJsonObject(1).getString("comment"));
+        Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(2).getJsonNumber("timestamp"));
+        Assert.assertEquals("Vendor Response: WILL_NOT_FIX → UPDATE", json.getJsonArray("analysisComments").getJsonObject(2).getString("comment"));
+        Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(3).getJsonNumber("timestamp"));
+        Assert.assertEquals("Suppressed", json.getJsonArray("analysisComments").getJsonObject(3).getString("comment"));
+        Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(4).getJsonNumber("timestamp"));
+        Assert.assertEquals("Not an issue", json.getJsonArray("analysisComments").getJsonObject(4).getString("comment"));
         Analysis analysis = qm.getAnalysis(component, vulnerability);
         Assert.assertEquals(project.getUuid(), analysis.getProject().getUuid());
         Assert.assertEquals(component.getUuid(), analysis.getComponent().getUuid());


### PR DESCRIPTION
This PR enriches the state change comments in the analysis trail with a prefix of which state was changed.
Without this, changes are kinda ambiguous for the untrained eye.

Such a prefix is not added for suppression changes.