### PR TITLE
fix: codacy upload and JRE version

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -56,9 +56,11 @@ jobs:
 
     - name: Publish test coverage
       if: github.ref == 'refs/heads/master' && github.event.inputs.skipTests != 'true'
-      env:
-        CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-      run: java -jar ~/codacy-coverage-reporter-assembly.jar report -l Java -r target/jacoco-ut/jacoco.xml
+      uses: codacy/codacy-coverage-reporter-action@v1
+      with:
+        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        language: Java
+        coverage-reports: target/jacoco-ut/jacoco.xml
 
     - name: Logging into Docker Hub
       if: github.ref == 'refs/heads/master'

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.2_8-jre-focal AS jre-build
+FROM eclipse-temurin:11.0.14.1_1-jre-focal AS jre-build
 
 FROM debian:bullseye-20220125-slim
 


### PR DESCRIPTION
### Description

This PR offers a fix for 2 mistakes I caused with my earlier packaging PR (#1303).
First it fixes the failing Codacy report upload, where I missed that it used to be downloaded in the 'Tool setup' step. It now uses the official Codacy GitHub action instead of the prior downloaded Jar.
Second it fixes a staging mishap that happened likely due to late local time :man_facepalming:, where I already prepared a followup commit to bump the Container JRE to 17 as requested by the original review. With this PR I offer a revert to the 11 JRE.

### Changes

* use codacy GitHub action instead of downloaded jar
* revert Container Image JRE to 11

### Issues

* relates to and fixes #1303 