### PR TITLE
Fix `v440Updater.java` for MS SQL compatibility.

### DIFF
--- a/src/main/java/org/dependencytrack/upgrade/v440/v440Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v440/v440Updater.java
@@ -16,7 +16,7 @@ public class v440Updater extends AbstractUpgradeItem {
 
     private static final Logger LOGGER = Logger.getLogger(v440Updater.class);
     private static final String STMT_1 = "INSERT INTO \"PERMISSION\" (\"NAME\", \"DESCRIPTION\") VALUES (?, ?)";
-    private static final String STMT_2 = "SELECT \"ID\" FROM \"PERMISSION\" WHERE \"NAME\" = ? LIMIT 1";
+    private static final String STMT_2 = "SELECT TOP 1 \"ID\" FROM \"PERMISSION\" WHERE \"NAME\" = ?";
     private static final String STMT_3 = "SELECT \"u\".\"ID\" FROM \"MANAGEDUSER\" AS \"u\" INNER JOIN \"MANAGEDUSERS_PERMISSIONS\" AS \"up\" ON \"up\".\"MANAGEDUSER_ID\" = \"u\".\"ID\" WHERE \"up\".\"PERMISSION_ID\" = %d";
     private static final String STMT_4 = "INSERT INTO \"MANAGEDUSERS_PERMISSIONS\" (\"MANAGEDUSER_ID\", \"PERMISSION_ID\") VALUES (?, ?)";
     private static final String STMT_5 = "SELECT \"u\".\"ID\" FROM \"LDAPUSER\" AS \"u\" INNER JOIN \"LDAPUSERS_PERMISSIONS\" AS \"up\" ON \"up\".\"LDAPUSER_ID\" = \"u\".\"ID\" WHERE \"up\".\"PERMISSION_ID\" = %d";


### PR DESCRIPTION
MS SQL does not support `LIMIT n` syntax; the alternatives are `TOP n` or [`OFFSET x ROWS FETCH NEXT y ROWS ONLY`](https://docs.microsoft.com/en-us/sql/t-sql/queries/select-order-by-clause-transact-sql?view=sql-server-ver15#using-offset-and-fetch-to-limit-the-rows-returned).

The goal of this query appears to be to select a single row, hence `TOP 1` is a simple alternative to `LIMIT 1`.

Tested locally, this change helps perform the upgrade correctly on MS SQL 2019. The upgrade failed with `LIMIT 1`:

```
2022-02-18 07:09:34,692 INFO [UpgradeExecutor] Upgrade class org.dependencytrack.upgrade.v440.v440Updater about to run.
2022-02-18 07:09:34,692 INFO [v440Updater] Creating VIEW_VULNERABILITY permission
2022-02-18 07:09:34,715 ERROR [UpgradeExecutor] Error in executing upgrade class: org.dependencytrack.upgrade.v440.v440Updater
com.microsoft.sqlserver.jdbc.SQLServerException: Incorrect syntax near 'LIMIT'.
```

And passed with `TOP 1`:

```
2022-02-18 07:49:38,225 INFO [UpgradeExecutor] Upgrade class org.dependencytrack.upgrade.v440.v440Updater about to run.
2022-02-18 07:49:38,225 INFO [v440Updater] Creating VIEW_VULNERABILITY permission
2022-02-18 07:49:38,230 INFO [v440Updater] Granting VIEW_VULNERABILITY permission to managed users with VULNERABILITY_ANALYSIS permission
2022-02-18 07:49:38,234 INFO [v440Updater] Granting VIEW_VULNERABILITY permission to LDAP users with VULNERABILITY_ANALYSIS permission
2022-02-18 07:49:38,236 INFO [v440Updater] Granting VIEW_VULNERABILITY permission to OIDC users with VULNERABILITY_ANALYSIS permission
2022-02-18 07:49:38,238 INFO [v440Updater] Granting VIEW_VULNERABILITY permission to teams with VULNERABILITY_ANALYSIS permission
2022-02-18 07:49:38,263 INFO [UpgradeExecutor] Completed running upgrade class org.dependencytrack.upgrade.v440.v440Updater in 17 ms.

```

This change fixes #1402 for MS SQL users. However, I could not test or evaluate the impact it would have on other supported DBs. 