### PR TITLE
Fix NPE when updating an analysis that was created with DT y= 4.3.6

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
@@ -35,6 +35,8 @@ import io.swagger.annotations.Authorization;
 import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Analysis;
+import org.dependencytrack.model.AnalysisJustification;
+import org.dependencytrack.model.AnalysisResponse;
 import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
@@ -155,16 +157,21 @@ public class AnalysisResource extends AlpineResource {
             if (analysis != null) {
                 if (request.getAnalysisState() != null && analysis.getAnalysisState() != request.getAnalysisState()) {
                     analysisStateChange = true;
-                    final String message = "Analysis: " + analysis.getAnalysisState().name() + " → " + request.getAnalysisState().name();
-                    qm.makeAnalysisComment(analysis, message, commenter);
+                    qm.makeAnalysisComment(analysis, String.format("Analysis: %s → %s", analysis.getAnalysisState(), request.getAnalysisState()), commenter);
                 }
-                if (request.getAnalysisJustification() != null && analysis.getAnalysisJustification() != request.getAnalysisJustification()) {
-                    final String message = "Justification: " + analysis.getAnalysisJustification().name() + " → " + request.getAnalysisJustification().name();
-                    qm.makeAnalysisComment(analysis, message, commenter);
+                if (request.getAnalysisJustification() != null) {
+                    if (analysis.getAnalysisJustification() == null && request.getAnalysisJustification() != AnalysisJustification.NOT_SET) {
+                        qm.makeAnalysisComment(analysis, String.format("Justification: %s → %s", AnalysisJustification.NOT_SET, request.getAnalysisJustification()), commenter);
+                    } else {
+                        qm.makeAnalysisComment(analysis, String.format("Justification: %s → %s", analysis.getAnalysisJustification(), request.getAnalysisJustification()), commenter);
+                    }
                 }
-                if (request.getAnalysisResponse() != null && analysis.getAnalysisResponse() != request.getAnalysisResponse()) {
-                    final String message = "Vendor Response: " + analysis.getAnalysisResponse().name() + " → " + request.getAnalysisResponse().name();
-                    qm.makeAnalysisComment(analysis, message, commenter);
+                if (request.getAnalysisResponse() != null) {
+                    if (analysis.getAnalysisResponse() == null && analysis.getAnalysisResponse() != request.getAnalysisResponse()) {
+                        qm.makeAnalysisComment(analysis, String.format("Vendor Response: %s → %s", AnalysisResponse.NOT_SET, request.getAnalysisResponse()), commenter);
+                    } else {
+                        qm.makeAnalysisComment(analysis, String.format("Vendor Response: %s → %s", analysis.getAnalysisResponse(), request.getAnalysisResponse()), commenter);
+                    }
                 }
                 if (request.getAnalysisDetails() != null && !request.getAnalysisDetails().equals(analysis.getAnalysisDetails())) {
                     final String message = "Details: " + request.getAnalysisDetails().trim();
@@ -180,8 +187,7 @@ public class AnalysisResource extends AlpineResource {
                 analysis = qm.makeAnalysis(component, vulnerability, request.getAnalysisState(), request.getAnalysisJustification(), request.getAnalysisResponse(), request.getAnalysisDetails(), request.isSuppressed());
                 analysisStateChange = true; // this is a new analysis - so set to true because it was previously null
                 if (AnalysisState.NOT_SET != request.getAnalysisState()) {
-                    final String message = "Analysis: " + AnalysisState.NOT_SET.name() + " → " + request.getAnalysisState().name();
-                    qm.makeAnalysisComment(analysis, message, commenter);
+                    qm.makeAnalysisComment(analysis, String.format("Analysis: %s → %s", AnalysisState.NOT_SET, request.getAnalysisState()), commenter);
                 }
             }
 


### PR DESCRIPTION
The NPE was caused by calling `.name()` on `null` values. 
I took the chance to add `NOT_SET ->` transitions for *Justification* and *Vendor Response* as well.

Addresses #1409 