### PR TITLE
Bugfix/mirror contention

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/NistMirrorTask.java
+++ b/src/main/java/org/dependencytrack/tasks/NistMirrorTask.java
@@ -188,7 +188,7 @@ public class NistMirrorTask implements LoggableSubscriber {
             filename = filename.substring(filename.lastIndexOf('/') + 1);
             file = new File(outputDir, filename).getAbsoluteFile();
             if (file.exists()) {
-                if (false && System.currentTimeMillis() < ((86400000 * 5) + file.lastModified())) {
+                if (System.currentTimeMillis() < ((86400000 * 5) + file.lastModified())) {
                     if (ResourceType.CVE_YEAR_DATA == resourceType) {
                         LOGGER.info("Retrieval of " + filename + " not necessary. Will use modified feed for updates.");
                         return;

--- a/src/main/java/org/dependencytrack/tasks/NistMirrorTask.java
+++ b/src/main/java/org/dependencytrack/tasks/NistMirrorTask.java
@@ -47,6 +47,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.zip.GZIPInputStream;
@@ -187,7 +188,7 @@ public class NistMirrorTask implements LoggableSubscriber {
             filename = filename.substring(filename.lastIndexOf('/') + 1);
             file = new File(outputDir, filename).getAbsoluteFile();
             if (file.exists()) {
-                if (System.currentTimeMillis() < ((86400000 * 5) + file.lastModified())) {
+                if (false && System.currentTimeMillis() < ((86400000 * 5) + file.lastModified())) {
                     if (ResourceType.CVE_YEAR_DATA == resourceType) {
                         LOGGER.info("Retrieval of " + filename + " not necessary. Will use modified feed for updates.");
                         return;
@@ -212,8 +213,10 @@ public class NistMirrorTask implements LoggableSubscriber {
                 if (status.getStatusCode() == 200) {
                     LOGGER.info("Downloading...");
                     try (InputStream in = response.getEntity().getContent()) {
+                        File temp = File.createTempFile(filename, null);
                         file = new File(outputDir, filename);
-                        FileUtils.copyInputStreamToFile(in, file);
+                        FileUtils.copyInputStreamToFile(in, temp);
+                        Files.move(temp.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
                         if (ResourceType.CVE_YEAR_DATA == resourceType || ResourceType.CVE_MODIFIED_DATA == resourceType) {
                             // Sets the last modified date to 0. Upon a successful parse, it will be set back to its original date.
                             file.setLastModified(0);


### PR DESCRIPTION
When NVD is slow our internal process that uses the dependency-track mirror experiences issues cause by corrupted/incomplete files being downloaded when the mirroring process is taking place.  This PR improves* the chances of getting a good file by downloading to a temp location and then moving it into place.  

*The filesystem is stable but we still are running into issues with the alpine StaticResourceServlet.  Our solution is to provide the mirror via nginx for now as I don't understand alpine ins and outs. The following script is similar to what we are using to discover inconsistent mirror state if run while Mirror is updating.

` while true;  curl http://dependency-track/mirror/nvdcve-1.1-2020.json.gz |  zcat  | jq . 2>&1 > /dev/null; done`