### PR TITLE
Tweak `MetricsUpdateTask` performance

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/MetricsUpdateTask.java
+++ b/src/main/java/org/dependencytrack/tasks/MetricsUpdateTask.java
@@ -97,10 +97,12 @@ public class MetricsUpdateTask implements Subscriber {
 
         // Iterate through all projects
         LOGGER.debug("Iterating through active projects");
-        for (final Project project: projects) {
-            try {
+        for (final Project project : projects) {
+            // Due to the large buildup of cached objects, we use a new query manager
+            // for each project. That way, resources are released in reasonable intervals.
+            try (final var pqm = new QueryManager()) {
                 // Update the projects metrics
-                final MetricCounters projectMetrics = updateProjectMetrics(qm, project.getId());
+                final MetricCounters projectMetrics = updateProjectMetrics(pqm, project.getId());
                 projectCountersList.add(projectMetrics);
             } catch (Exception e) {
                 LOGGER.error("An unexpected error occurred while updating portfolio metrics and iterating through projects. The error occurred while updating metrics for project: " + project.getUuid().toString(), e);

--- a/src/main/java/org/dependencytrack/tasks/MetricsUpdateTask.java
+++ b/src/main/java/org/dependencytrack/tasks/MetricsUpdateTask.java
@@ -361,11 +361,13 @@ public class MetricsUpdateTask implements Subscriber {
             last.setLastOccurrence(measuredAt);
             LOGGER.debug("Persisting metrics for project: " + project.getUuid());
             qm.persist(last);
-            LOGGER.debug("Updating Inherited Risk Score for project: " + project.getUuid());
             // Update the convenience fields in the Project object
-            project.setLastInheritedRiskScore(last.getInheritedRiskScore());
-            LOGGER.debug("Persisting metrics for project: " + project.getUuid());
-            qm.persist(project);
+            if (project.getLastInheritedRiskScore() != last.getInheritedRiskScore()) {
+                LOGGER.debug("Updating Inherited Risk Score for project: " + project.getUuid());
+                project.setLastInheritedRiskScore(last.getInheritedRiskScore());
+                LOGGER.debug("Persisting metrics for project: " + project.getUuid());
+                qm.persist(project);
+            }
         } else {
             LOGGER.debug("Metrics have changed (or were never previously measured) for project: " + project.getUuid());
             final ProjectMetrics projectMetrics = new ProjectMetrics();
@@ -402,11 +404,13 @@ public class MetricsUpdateTask implements Subscriber {
             projectMetrics.setLastOccurrence(measuredAt);
             LOGGER.debug("Persisting metrics for project: " + project.getUuid());
             qm.persist(projectMetrics);
-            LOGGER.debug("Updating Inherited Risk Score for project: " + project.getUuid());
             // Update the convenience fields in the Project object
-            project.setLastInheritedRiskScore(projectMetrics.getInheritedRiskScore());
-            LOGGER.debug("Persisting metrics for project: " + project.getUuid());
-            qm.persist(project);
+            if (project.getLastInheritedRiskScore() != projectMetrics.getInheritedRiskScore()) {
+                LOGGER.debug("Updating Inherited Risk Score for project: " + project.getUuid());
+                project.setLastInheritedRiskScore(projectMetrics.getInheritedRiskScore());
+                LOGGER.debug("Persisting metrics for project: " + project.getUuid());
+                qm.persist(project);
+            }
         }
         LOGGER.info("Completed metrics update for project: " + project.getUuid());
         return counters;
@@ -500,11 +504,13 @@ public class MetricsUpdateTask implements Subscriber {
             last.setLastOccurrence(measuredAt);
             LOGGER.debug("Persisting metrics for component: " + component.getUuid());
             qm.persist(last);
-            LOGGER.debug("Updating Inherited Risk Score for component: " + component.getUuid());
             // Update the convenience fields in the Component object
-            component.setLastInheritedRiskScore(last.getInheritedRiskScore());
-            LOGGER.debug("Persisting metrics for component: " + component.getUuid());
-            qm.persist(component);
+            if (component.getLastInheritedRiskScore() != last.getInheritedRiskScore()) {
+                LOGGER.debug("Updating Inherited Risk Score for component: " + component.getUuid());
+                component.setLastInheritedRiskScore(last.getInheritedRiskScore());
+                LOGGER.debug("Persisting metrics for component: " + component.getUuid());
+                qm.persist(component);
+            }
         } else {
             LOGGER.debug("Metrics have changed (or were never previously measured) for component: " + component.getUuid());
             final DependencyMetrics componentMetrics = new DependencyMetrics();
@@ -540,11 +546,13 @@ public class MetricsUpdateTask implements Subscriber {
             componentMetrics.setLastOccurrence(measuredAt);
             LOGGER.debug("Persisting metrics for component: " + component.getUuid());
             qm.persist(componentMetrics);
-            LOGGER.debug("Updating Inherited Risk Score for component: " + component.getUuid());
             // Update the convenience fields in the Component object
-            component.setLastInheritedRiskScore(componentMetrics.getInheritedRiskScore());
-            LOGGER.debug("Persisting metrics for component: " + component.getUuid());
-            qm.persist(component);
+            if (component.getLastInheritedRiskScore() != componentMetrics.getInheritedRiskScore()) {
+                LOGGER.debug("Updating Inherited Risk Score for component: " + component.getUuid());
+                component.setLastInheritedRiskScore(componentMetrics.getInheritedRiskScore());
+                LOGGER.debug("Persisting metrics for component: " + component.getUuid());
+                qm.persist(component);
+            }
         }
         LOGGER.debug("Completed metrics update for component: " + component.getUuid());
         return counters;


### PR DESCRIPTION
I was profiling the `MetricsUpdateTask` class due to some folks reporting performance concerns and managed to identify a few screws we could tighten to make the task more resource efficient.

### Profiling

#### Setup

* DT 4.4.2 running on Temurin 11 on macOS.
* Postgres database running in Docker, using the `postgres:14.2-alpine` image.
* 50 projects, all using the DT API Server 4.4.2 BOM. 7850 components in total.
* `MetricsUpdateTask` running in a `JerseyTest` without any resources deployed. The task is running pretty much isolated.
* Because no other tasks are running, no data is changing, thus the metrics update task won't perform any `INSERT`s, just `UPDATE`s.
* Using *Async Profiler* in IntelliJ.

#### Results

The current implementation is performing a lot of allocations in the `updateComponentMetrics` method. Profiling results showed that the biggest chunk is allocated in [`AbstractAlpineQueryManager.persist`](https://github.com/stevespringett/Alpine/blob/v2-dev/alpine-infra/src/main/java/alpine/persistence/AbstractAlpineQueryManager.java#L425). More specifically, in DataNucleus' [`preCommit`](https://github.com/datanucleus/datanucleus-core/blob/datanucleus-core-5.2.10/src/main/java/org/datanucleus/ExecutionContextImpl.java#L4153) method, where DN maintains its [L1 cache](https://www.datanucleus.org/products/accessplatform_4_1/jdo/pm.html#level1_cache):

<img width="1155" alt="Screenshot 2022-03-19 at 23 17 22" src="https://user-images.githubusercontent.com/5693141/159140615-ff1786c9-9113-4966-8d0e-a7afd1c76557.png">

This is also where a lot of CPU time is spent:

<img width="1155" alt="Screenshot 2022-03-19 at 23 16 20" src="https://user-images.githubusercontent.com/5693141/159140795-71b2c279-bae0-450a-acea-606157ddd425.png">

The DN docs say WRT the L1 cache:

> Each `PersistenceManager` maintains a cache of the objects that it has encountered (or have been "enlisted") during its lifetime. [...]
> Objects are placed in the L1 cache (and updated there) during the course of the transaction. This provides rapid access to the objects in use in the users application and is used to guarantee that there is only one object with a particular identity at any one time for that `PersistenceManager`. **When the `PersistenceManager` is closed the L1 cache is cleared.**

Because DT currently uses a single `PersistenceManager` for the entire portfolio metrics update run, the L1 cache keeps on growing, and DN has to do a lot of work in order to maintain it. Performance deteriorates with every project being processed. So far, this matches what @hostalp was reporting in https://github.com/DependencyTrack/dependency-track/issues/1210#issuecomment-936023060.

Another factor here is what [`AbstractAlpineQueryManager.persist`](https://github.com/stevespringett/Alpine/blob/v2-dev/alpine-infra/src/main/java/alpine/persistence/AbstractAlpineQueryManager.java#L425) does with objects passed to it:

* Start a transaction
* Make the object *persistent* (it may or may not be *transient* until now)
* Commit the transaction (this *detaches* the object again)
* Refresh the detached object, making it *persistent* again

<a href="https://www.datanucleus.org/products/accessplatform_4_2/jdo/object_lifecycle.html"><img width="394" alt="Screenshot 2022-03-19 at 23 49 16" src="https://user-images.githubusercontent.com/5693141/159141069-97130d1b-9e17-463a-9e8b-c309d59859b6.png"></a>

Especially for larger objects, that's quite a bit of work being performed. In cases like metrics updates, we only want to `INSERT` or `UPDATE` something, but we don't care about the object after that, we don't need it to be *persistent*.

There are cases in the current logic where `persist` is called even if it isn't necessary, causing some additional overhead. One of these cases is when updating the `lastInheritedRiskScore` field of `Component`, when the metrics themselves didn't change (see [here](https://github.com/DependencyTrack/dependency-track/blob/4.4.2/src/main/java/org/dependencytrack/tasks/MetricsUpdateTask.java#L502-L505)). Semantically, this is (almost?) always a no-op. But in the background, the persistence layer is producing garbage.

When working on objects that already are *persistent* we could achieve the desired effect using something like this as well:

```java
qm.getPersistenceManager().currentTransaction().begin();
component.setLastInheritedRiskScore(last.getInheritedRiskScore());
qm.getPersistenceManager().currentTransaction();
```

That safes us the unnecessary calls to `makePersistent` and `refresh`.

### Tweaks

I didn't want to change too much here, so I only introduced two changes:

* Every `updateProjectMetrics` method gets its own `QueryManager`. This ensures that resources like the L1 cache are regularly cleared. We *do* want to take advantage of DN's caching to some degree, so using a different `QueryManager` for each `updateComponentMetrics` method is not reasonable. According to [DN's docs](https://www.datanucleus.org/products/accessplatform_4_1/jdo/performance_tuning.html), creating `PersistenceManager` instances is a cheap operation though.
* `lastInheritedRiskScore` fields of projects and components are only updated when they actually changed. In the majority of cases, this won't be the case and we're saving quite a bit of computing power.

#### Results

Allocations are reduced by more than 50%:

<img width="1155" alt="Screenshot 2022-03-19 at 23 22 31" src="https://user-images.githubusercontent.com/5693141/159141286-70f723cf-2cbf-40bf-a163-0551e679d7db.png">

CPU time spent is drastically reduced as well:

<img width="1155" alt="Screenshot 2022-03-19 at 23 21 38" src="https://user-images.githubusercontent.com/5693141/159141319-22f267a0-840f-4ae6-a9ed-8759a7dbb547.png">

With the original code, the task ran for **3m30s**. With the changes outlined above, it finished just under **2m30s**!

There are probably a few more places throughout the codebase where similar minor changes could be made to achieve such results.