### PR TITLE
Perform policy evaluation during portfolio analysis

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
@@ -87,6 +87,7 @@ public class VulnerabilityAnalysisTask implements Subscriber {
                     final List<Component> components = qm.getAllComponents(project);
                     LOGGER.info("Analyzing " + components.size() + " components in project: " + project.getUuid());
                     analyzeComponents(qm, components);
+                    performPolicyEvaluation(project, components);
                     LOGGER.info("Completed analysis of " + components.size() + " components in project: " + project.getUuid());
                 }
             }


### PR DESCRIPTION
According to this [post](https://github.com/DependencyTrack/dependency-track/issues/249#issuecomment-754725274), I have added a call to performPolicyEvaluation during the portfolio analysis. Otherwise, policy analysis is not done every 24 hours