### PR TITLE
Project (auto)create: Add Team to ACL for ApiKey principals

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.persistence;
 
+import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
 import alpine.model.ApiKey;
 import alpine.model.Permission;
@@ -52,6 +53,8 @@ import java.util.Map;
 import java.util.UUID;
 
 final class ProjectQueryManager extends QueryManager implements IQueryManager {
+
+    private static final Logger LOGGER = Logger.getLogger(ProjectQueryManager.class);
 
     /**
      * Constructs a new QueryManager.
@@ -739,6 +742,32 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         } else if (StringUtils.trimToNull(inputFilter) != null) {
             query.setFilter(inputFilter);
         }
+    }
+
+    /**
+     * Updates a Project ACL to add the principals Team to the AccessTeams
+     * This only happens if Portfolio Access Control is enabled and the @param principal is an ApyKey
+     * For a UserPrincipal we don't know which Team(s) to add to the ACL,
+     * See https://github.com/DependencyTrack/dependency-track/issues/1435
+     * @param project
+     * @param principal
+     * @return True if ACL was updated
+     */
+    public boolean updateNewProjectACL(Project project, Principal principal) {
+        if (isEnabled(ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED) && principal instanceof ApiKey) {
+            ApiKey apiKey = (ApiKey) principal;
+            final var apiTeam = apiKey.getTeams().stream().findFirst();
+            if (apiTeam.isPresent()) {
+                LOGGER.debug("adding Team to ACL of newly created project");
+                final Team team = getObjectByUuid(Team.class, apiTeam.get().getUuid());
+                project.addAccessTeam(team);
+                persist(project);
+                return true;
+            } else {
+                LOGGER.warn("API Key without a Team, unable to assign team ACL to project.");
+            }
+        }
+        return false;
     }
 
     public boolean hasAccessManagementPermission(final UserPrincipal userPrincipal) {

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -314,6 +314,10 @@ public class QueryManager extends AlpineQueryManager {
         return getProjectQueryManager().updateProject(transientProject, commitIndex);
     }
 
+    public boolean updateNewProjectACL(Project transientProject, Principal principal) {
+        return getProjectQueryManager().updateNewProjectACL(transientProject, principal);
+    }
+
     public Project clone(UUID from, String newVersion, boolean includeTags, boolean includeProperties,
                          boolean includeComponents, boolean includeServices, boolean includeAuditHistory) {
         return getProjectQueryManager().clone(from, newVersion, includeTags, includeProperties,

--- a/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -39,6 +39,8 @@ import org.dependencytrack.model.Tag;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.v1.vo.CloneProjectRequest;
 
+import java.security.Principal;
+
 import javax.validation.Validator;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -211,6 +213,8 @@ public class ProjectResource extends AlpineResource {
             Project project = qm.getProject(StringUtils.trimToNull(jsonProject.getName()), StringUtils.trimToNull(jsonProject.getVersion()));
             if (project == null) {
                 project = qm.createProject(jsonProject, jsonProject.getTags(), true);
+                Principal principal = getPrincipal();
+                qm.updateNewProjectACL(project, principal);
                 LOGGER.info("Project " + project.toString() + " created by " + super.getPrincipal().getName());
                 return Response.status(Response.Status.CREATED).entity(project).build();
             } else {


### PR DESCRIPTION
**Changes**
When Project is autocreated during BOM upload and Portfolio Access Control is enabled, the ACL of the new Project should contain the Team that created the Project. fixes #1435 

The same cannot yet be done for Users autocreating a Project as we don't know which Team should be added to the ACL. Users can be in 0 or more Teams.

**Unit tests**
I was planning on updating the unit tests to reflect this scenario. But there are no unit tests around Portfolio Access Control it seems. It would to be too big a change for me here to add them in this PR.

**Notes**
There already was some duplicate code in the `BomResource`. I didn't want to refactor too much, but tried to avoid creating more duplicate code.