### PR TITLE
Add tests for `MetricsUpdateTask` and squash some bugs along the way

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
@@ -58,30 +58,36 @@ public class FindingsQueryManager extends QueryManager implements IQueryManager 
 
     /**
      * Returns the number of audited findings for the portfolio.
+     * Findings that are suppressed or have been assigned the states {@link AnalysisState#NOT_SET} or {@link AnalysisState#IN_TRIAGE}
+     * do not count as audited. Suppressions are tracked separately.
      * @return the total number of analysis decisions
      */
     public long getAuditedCount() {
-        final Query<Analysis> query = pm.newQuery(Analysis.class, "analysisState != null && analysisState != :notSet && analysisState != :inTriage");
+        final Query<Analysis> query = pm.newQuery(Analysis.class, "analysisState != null && suppressed == false && analysisState != :notSet && analysisState != :inTriage");
         return getCount(query, AnalysisState.NOT_SET, AnalysisState.IN_TRIAGE);
     }
 
     /**
      * Returns the number of audited findings for the specified Project.
+     * Findings that are suppressed or have been assigned the states {@link AnalysisState#NOT_SET} or {@link AnalysisState#IN_TRIAGE}
+     * do not count as audited. Suppressions are tracked separately.
      * @param project the Project to retrieve audit counts for
      * @return the total number of analysis decisions for the project
      */
     public long getAuditedCount(Project project) {
-        final Query<Analysis> query = pm.newQuery(Analysis.class, "project == :project && analysisState != null && analysisState != :notSet && analysisState != :inTriage");
+        final Query<Analysis> query = pm.newQuery(Analysis.class, "project == :project && analysisState != null && suppressed == false && analysisState != :notSet && analysisState != :inTriage");
         return getCount(query, project, AnalysisState.NOT_SET, AnalysisState.IN_TRIAGE);
     }
 
     /**
      * Returns the number of audited findings for the specified Component.
+     * Findings that are suppressed or have been assigned the states {@link AnalysisState#NOT_SET} or {@link AnalysisState#IN_TRIAGE}
+     * do not count as audited. Suppressions are tracked separately.
      * @param component the Component to retrieve audit counts for
      * @return the total number of analysis decisions for the component
      */
     public long getAuditedCount(Component component) {
-        final Query<Analysis> query = pm.newQuery(Analysis.class, "project == null && component == :component && analysisState != null && analysisState != :notSet && analysisState != :inTriage");
+        final Query<Analysis> query = pm.newQuery(Analysis.class, "component == :component && analysisState != null && suppressed == false && analysisState != :notSet && analysisState != :inTriage");
         return getCount(query, component, AnalysisState.NOT_SET, AnalysisState.IN_TRIAGE);
     }
 
@@ -121,7 +127,7 @@ public class FindingsQueryManager extends QueryManager implements IQueryManager 
      * @return the total number of suppressed vulnerabilities for the component
      */
     public long getSuppressedCount(Component component) {
-        final Query<Analysis> query = pm.newQuery(Analysis.class, "project == null && component == :component && suppressed == true");
+        final Query<Analysis> query = pm.newQuery(Analysis.class, "component == :component && suppressed == true");
         return getCount(query, component);
     }
 

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -459,6 +459,10 @@ public class QueryManager extends AlpineQueryManager {
         return getPolicyQueryManager().getAllPolicyViolations(component);
     }
 
+    public List<PolicyViolation> getAllPolicyViolations(final Component component, final boolean includeSuppressed) {
+        return getPolicyQueryManager().getAllPolicyViolations(component, includeSuppressed);
+    }
+
     public List<PolicyViolation> getAllPolicyViolations(final Project project) {
         return getPolicyQueryManager().getAllPolicyViolations(project);
     }
@@ -522,6 +526,10 @@ public class QueryManager extends AlpineQueryManager {
 
     void deletePolicyViolations(Project project) {
         getPolicyQueryManager().deletePolicyViolations(project);
+    }
+
+    public long getAuditedCount(final Component component, final PolicyViolation.Type type) {
+        return getPolicyQueryManager().getAuditedCount(component, type);
     }
 
     public void deletePolicyCondition(PolicyCondition policyCondition) {

--- a/src/main/java/org/dependencytrack/tasks/MetricsUpdateTask.java
+++ b/src/main/java/org/dependencytrack/tasks/MetricsUpdateTask.java
@@ -83,7 +83,7 @@ public class MetricsUpdateTask implements Subscriber {
      * Performs high-level metric updates on the portfolio.
      * @param qm a QueryManager instance
      */
-    private void updatePortfolioMetrics(final QueryManager qm) {
+    MetricCounters updatePortfolioMetrics(final QueryManager qm) {
         LOGGER.info("Executing portfolio metrics update");
         final Date measuredAt = new Date();
 
@@ -246,6 +246,7 @@ public class MetricsUpdateTask implements Subscriber {
             qm.persist(portfolioMetrics);
         }
         LOGGER.info("Completed portfolio metrics update");
+        return portfolioCounters;
     }
 
     /**
@@ -254,7 +255,7 @@ public class MetricsUpdateTask implements Subscriber {
      * @param oid the object ID of the project
      * @return MetricCounters
      */
-    private MetricCounters updateProjectMetrics(final QueryManager qm, final long oid) {
+    MetricCounters updateProjectMetrics(final QueryManager qm, final long oid) {
         final Project project = qm.getObjectById(Project.class, oid);
         LOGGER.info("Executing metrics update for project: " + project.getUuid());
         final Date measuredAt = new Date();
@@ -424,7 +425,7 @@ public class MetricsUpdateTask implements Subscriber {
      * @param oid object ID of the component to perform metric updates on
      * @return MetricCounters
      */
-    private MetricCounters updateComponentMetrics(final QueryManager qm, final long oid) {
+    MetricCounters updateComponentMetrics(final QueryManager qm, final long oid) {
         final Component component = qm.getObjectById(Component.class, oid);
         LOGGER.debug("Executing metrics update for component: " + component.getUuid());
         final Date measuredAt = new Date();
@@ -439,12 +440,13 @@ public class MetricsUpdateTask implements Subscriber {
 
         // For the time being finding and vulnerability counts are the same.
         // However, vulns may be defined as 'confirmed' in a future release.
-        counters.findingsTotal = counters.severitySum();
+        counters.vulnerabilities = counters.severitySum();
+        counters.findingsTotal = counters.vulnerabilities;
         LOGGER.debug("Retrieving existing audited count for component: " + component.getUuid());
         counters.findingsAudited = toIntExact(qm.getAuditedCount(component));
         counters.findingsUnaudited = counters.findingsTotal - counters.findingsAudited;
 
-        for (final PolicyViolation violation: qm.getAllPolicyViolations(component)) {
+        for (final PolicyViolation violation: qm.getAllPolicyViolations(component, false)) {
             counters.policyViolationsTotal++;
 
             // Assign violation states
@@ -458,18 +460,33 @@ public class MetricsUpdateTask implements Subscriber {
             // Assign violation types
             if (PolicyViolation.Type.LICENSE == violation.getType()) {
                 counters.policyViolationsLicenseTotal++;
-                //counters.policyViolationsLicenseAudited = qm.getAuditedCount(violation, component);
-                counters.policyViolationsLicenseUnaudited = counters.policyViolationsLicenseTotal - counters.policyViolationsLicenseAudited;
             } else if (PolicyViolation.Type.SECURITY == violation.getType()) {
                 counters.policyViolationsSecurityTotal++;
-                //counters.policyViolationsSecurityAudited = qm.getAuditedCount(violation, component);
-                counters.policyViolationsSecurityUnaudited = counters.policyViolationsSecurityTotal - counters.policyViolationsSecurityAudited;
             } else if (PolicyViolation.Type.OPERATIONAL == violation.getType()) {
                 counters.policyViolationsOperationalTotal++;
-                //counters.policyViolationsOperationalAudited = qm.getAuditedCount(violation, component);
-                counters.policyViolationsOperationalUnaudited = counters.policyViolationsOperationalTotal - counters.policyViolationsOperationalAudited;
             }
         }
+
+        // Calculate audit counts per violation type.
+        // Only do this if there are any violations at all, otherwise we'll be performing unnecessary database operations.
+        if (counters.policyViolationsLicenseTotal > 0) {
+            counters.policyViolationsLicenseAudited = toIntExact(qm.getAuditedCount(component, PolicyViolation.Type.LICENSE));
+            counters.policyViolationsLicenseUnaudited = counters.policyViolationsLicenseTotal - counters.policyViolationsLicenseAudited;
+        }
+        if (counters.policyViolationsOperationalTotal > 0) {
+            counters.policyViolationsOperationalAudited = toIntExact(qm.getAuditedCount(component, PolicyViolation.Type.OPERATIONAL));
+            counters.policyViolationsOperationalUnaudited = counters.policyViolationsOperationalTotal - counters.policyViolationsOperationalAudited;
+        }
+        if (counters.policyViolationsSecurityTotal > 0) {
+            counters.policyViolationsSecurityAudited = toIntExact(qm.getAuditedCount(component, PolicyViolation.Type.SECURITY));
+            counters.policyViolationsSecurityUnaudited = counters.policyViolationsSecurityTotal - counters.policyViolationsSecurityAudited;
+        }
+
+        // Calculate total audit counts across all violation types.
+        counters.policyViolationsAudited = counters.policyViolationsLicenseAudited +
+                counters.policyViolationsOperationalAudited +
+                counters.policyViolationsSecurityAudited;
+        counters.policyViolationsUnaudited = counters.policyViolationsTotal - counters.policyViolationsAudited;
 
         // Query for an existing ComponentMetrics
         final DependencyMetrics last = qm.getMostRecentDependencyMetrics(component);
@@ -647,10 +664,10 @@ public class MetricsUpdateTask implements Subscriber {
     /**
      * A value object that holds various counters returned by the updating of metrics.
      */
-    private class MetricCounters {
+    static class MetricCounters {
 
-        private int critical, high, medium, low, unassigned;
-        private int projects, vulnerableProjects, components, vulnerableComponents,
+        int critical, high, medium, low, unassigned;
+        int projects, vulnerableProjects, components, vulnerableComponents,
                 vulnerabilities, suppressions, findingsTotal, findingsAudited, findingsUnaudited,
                 policyViolationsFail, policyViolationsWarn, policyViolationsInfo, policyViolationsTotal,
                 policyViolationsAudited, policyViolationsUnaudited, policyViolationsSecurityTotal,

--- a/src/main/java/org/dependencytrack/tasks/MetricsUpdateTask.java
+++ b/src/main/java/org/dependencytrack/tasks/MetricsUpdateTask.java
@@ -362,7 +362,8 @@ public class MetricsUpdateTask implements Subscriber {
             LOGGER.debug("Persisting metrics for project: " + project.getUuid());
             qm.persist(last);
             // Update the convenience fields in the Project object
-            if (project.getLastInheritedRiskScore() != last.getInheritedRiskScore()) {
+            if (project.getLastInheritedRiskScore() == null ||
+                    project.getLastInheritedRiskScore() != last.getInheritedRiskScore()) {
                 LOGGER.debug("Updating Inherited Risk Score for project: " + project.getUuid());
                 project.setLastInheritedRiskScore(last.getInheritedRiskScore());
                 LOGGER.debug("Persisting metrics for project: " + project.getUuid());
@@ -405,7 +406,8 @@ public class MetricsUpdateTask implements Subscriber {
             LOGGER.debug("Persisting metrics for project: " + project.getUuid());
             qm.persist(projectMetrics);
             // Update the convenience fields in the Project object
-            if (project.getLastInheritedRiskScore() != projectMetrics.getInheritedRiskScore()) {
+            if (project.getLastInheritedRiskScore() == null ||
+                    project.getLastInheritedRiskScore() != projectMetrics.getInheritedRiskScore()) {
                 LOGGER.debug("Updating Inherited Risk Score for project: " + project.getUuid());
                 project.setLastInheritedRiskScore(projectMetrics.getInheritedRiskScore());
                 LOGGER.debug("Persisting metrics for project: " + project.getUuid());
@@ -505,7 +507,8 @@ public class MetricsUpdateTask implements Subscriber {
             LOGGER.debug("Persisting metrics for component: " + component.getUuid());
             qm.persist(last);
             // Update the convenience fields in the Component object
-            if (component.getLastInheritedRiskScore() != last.getInheritedRiskScore()) {
+            if (component.getLastInheritedRiskScore() == null ||
+                    component.getLastInheritedRiskScore() != last.getInheritedRiskScore()) {
                 LOGGER.debug("Updating Inherited Risk Score for component: " + component.getUuid());
                 component.setLastInheritedRiskScore(last.getInheritedRiskScore());
                 LOGGER.debug("Persisting metrics for component: " + component.getUuid());
@@ -547,7 +550,8 @@ public class MetricsUpdateTask implements Subscriber {
             LOGGER.debug("Persisting metrics for component: " + component.getUuid());
             qm.persist(componentMetrics);
             // Update the convenience fields in the Component object
-            if (component.getLastInheritedRiskScore() != componentMetrics.getInheritedRiskScore()) {
+            if (component.getLastInheritedRiskScore() == null ||
+                    component.getLastInheritedRiskScore() != componentMetrics.getInheritedRiskScore()) {
                 LOGGER.debug("Updating Inherited Risk Score for component: " + component.getUuid());
                 component.setLastInheritedRiskScore(componentMetrics.getInheritedRiskScore());
                 LOGGER.debug("Persisting metrics for component: " + component.getUuid());

--- a/src/test/java/org/dependencytrack/TaskTest.java
+++ b/src/test/java/org/dependencytrack/TaskTest.java
@@ -1,0 +1,48 @@
+package org.dependencytrack;
+
+import alpine.Config;
+import org.dependencytrack.persistence.QueryManager;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import static org.dependencytrack.PersistenceCapableTest.dbReset;
+
+public abstract class TaskTest extends JerseyTest {
+
+    protected QueryManager qm;
+
+    @BeforeClass
+    public static void init() {
+        Config.enableUnitTests();
+    }
+
+    @Override
+    protected TestContainerFactory getTestContainerFactory() {
+        return new GrizzlyWebTestContainerFactory();
+    }
+
+    @Override
+    protected DeploymentContext configureDeployment() {
+        return ServletDeploymentContext.forServlet(new ServletContainer()).build();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        dbReset();
+        qm = new QueryManager();
+    }
+
+    @After
+    public void after() throws Exception {
+        dbReset();
+        qm.close();
+    }
+
+}

--- a/src/test/java/org/dependencytrack/tasks/MetricsUpdateTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/MetricsUpdateTaskTest.java
@@ -1,0 +1,543 @@
+package org.dependencytrack.tasks;
+
+import org.dependencytrack.TaskTest;
+import org.dependencytrack.model.AnalysisState;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Policy;
+import org.dependencytrack.model.Policy.ViolationState;
+import org.dependencytrack.model.PolicyCondition;
+import org.dependencytrack.model.PolicyCondition.Subject;
+import org.dependencytrack.model.PolicyViolation;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.Severity;
+import org.dependencytrack.model.ViolationAnalysisState;
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.tasks.MetricsUpdateTask.MetricCounters;
+import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MetricsUpdateTaskTest extends TaskTest {
+
+    @Test
+    public void testUpdatePortfolioMetricsEmpty() {
+        final MetricCounters counters = new MetricsUpdateTask().updatePortfolioMetrics(qm);
+        assertThat(counters.critical).isZero();
+        assertThat(counters.high).isZero();
+        assertThat(counters.medium).isZero();
+        assertThat(counters.low).isZero();
+        assertThat(counters.unassigned).isZero();
+        assertThat(counters.projects).isZero();
+        assertThat(counters.vulnerableProjects).isZero();
+        assertThat(counters.components).isZero();
+        assertThat(counters.vulnerableComponents).isZero();
+        assertThat(counters.vulnerabilities).isZero();
+        assertThat(counters.suppressions).isZero();
+        assertThat(counters.findingsTotal).isZero();
+        assertThat(counters.findingsAudited).isZero();
+        assertThat(counters.findingsUnaudited).isZero();
+        assertThat(counters.policyViolationsFail).isZero();
+        assertThat(counters.policyViolationsWarn).isZero();
+        assertThat(counters.policyViolationsInfo).isZero();
+        assertThat(counters.policyViolationsTotal).isZero();
+        assertThat(counters.policyViolationsAudited).isZero();
+        assertThat(counters.policyViolationsUnaudited).isZero();
+        assertThat(counters.policyViolationsSecurityTotal).isZero();
+        assertThat(counters.policyViolationsSecurityAudited).isZero();
+        assertThat(counters.policyViolationsSecurityUnaudited).isZero();
+        assertThat(counters.policyViolationsLicenseTotal).isZero();
+        assertThat(counters.policyViolationsLicenseAudited).isZero();
+        assertThat(counters.policyViolationsLicenseUnaudited).isZero();
+        assertThat(counters.policyViolationsOperationalTotal).isZero();
+        assertThat(counters.policyViolationsOperationalAudited).isZero();
+        assertThat(counters.policyViolationsOperationalUnaudited).isZero();
+    }
+
+    @Test
+    public void testUpdatePortfolioMetricsVulnerabilities() {
+        var vuln = new Vulnerability();
+        vuln.setVulnId("INTERNAL-001");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        vuln = qm.createVulnerability(vuln, false);
+
+        // Create a project with an unaudited vulnerability.
+        var projectUnaudited = new Project();
+        projectUnaudited.setName("acme-app-a");
+        projectUnaudited = qm.createProject(projectUnaudited, List.of(), false);
+        var componentUnaudited = new Component();
+        componentUnaudited.setProject(projectUnaudited);
+        componentUnaudited.setName("acme-lib-a");
+        componentUnaudited = qm.createComponent(componentUnaudited, false);
+        qm.addVulnerability(vuln, componentUnaudited, AnalyzerIdentity.NONE);
+
+        // Create a project with an audited vulnerability.
+        var projectAudited = new Project();
+        projectAudited.setName("acme-app-b");
+        projectAudited = qm.createProject(projectAudited, List.of(), false);
+        var componentAudited = new Component();
+        componentAudited.setProject(projectAudited);
+        componentAudited.setName("acme-lib-b");
+        componentAudited = qm.createComponent(componentAudited, false);
+        qm.addVulnerability(vuln, componentAudited, AnalyzerIdentity.NONE);
+        qm.makeAnalysis(componentAudited, vuln, AnalysisState.NOT_AFFECTED, null, null, null, false);
+
+        // Create a project with a suppressed vulnerability.
+        var projectSuppressed = new Project();
+        projectSuppressed.setName("acme-app-c");
+        projectSuppressed = qm.createProject(projectSuppressed, List.of(), false);
+        var componentSuppressed = new Component();
+        componentSuppressed.setProject(projectSuppressed);
+        componentSuppressed.setName("acme-lib-c");
+        componentSuppressed = qm.createComponent(componentSuppressed, false);
+        qm.addVulnerability(vuln, componentSuppressed, AnalyzerIdentity.NONE);
+        qm.makeAnalysis(componentSuppressed, vuln, AnalysisState.FALSE_POSITIVE, null, null, null, true);
+
+        final MetricCounters counters = new MetricsUpdateTask().updatePortfolioMetrics(qm);
+        assertThat(counters.critical).isZero();
+        assertThat(counters.high).isEqualTo(2); // One is suppressed
+        assertThat(counters.medium).isZero();
+        assertThat(counters.low).isZero();
+        assertThat(counters.unassigned).isZero();
+        assertThat(counters.projects).isEqualTo(3);
+        assertThat(counters.vulnerableProjects).isEqualTo(2); // Finding for one project is suppressed
+        assertThat(counters.components).isEqualTo(3);
+        assertThat(counters.vulnerableComponents).isEqualTo(2); // Finding for one component is suppressed
+        assertThat(counters.vulnerabilities).isEqualTo(2); // One is suppressed
+        assertThat(counters.suppressions).isEqualTo(1);
+        assertThat(counters.findingsTotal).isEqualTo(2); // One is suppressed
+        assertThat(counters.findingsAudited).isEqualTo(1);
+        assertThat(counters.findingsUnaudited).isEqualTo(1);
+        assertThat(counters.policyViolationsFail).isZero();
+        assertThat(counters.policyViolationsWarn).isZero();
+        assertThat(counters.policyViolationsInfo).isZero();
+        assertThat(counters.policyViolationsTotal).isZero();
+        assertThat(counters.policyViolationsAudited).isZero();
+        assertThat(counters.policyViolationsUnaudited).isZero();
+        assertThat(counters.policyViolationsSecurityTotal).isZero();
+        assertThat(counters.policyViolationsSecurityAudited).isZero();
+        assertThat(counters.policyViolationsSecurityUnaudited).isZero();
+        assertThat(counters.policyViolationsLicenseTotal).isZero();
+        assertThat(counters.policyViolationsLicenseAudited).isZero();
+        assertThat(counters.policyViolationsLicenseUnaudited).isZero();
+        assertThat(counters.policyViolationsOperationalTotal).isZero();
+        assertThat(counters.policyViolationsOperationalAudited).isZero();
+        assertThat(counters.policyViolationsOperationalUnaudited).isZero();
+    }
+
+    @Test
+    public void testUpdatePortfolioMetricsPolicyViolations() {
+        // Create a project with an unaudited violation.
+        var projectUnaudited = new Project();
+        projectUnaudited.setName("acme-app-a");
+        projectUnaudited = qm.createProject(projectUnaudited, List.of(), false);
+        var componentUnaudited = new Component();
+        componentUnaudited.setProject(projectUnaudited);
+        componentUnaudited.setName("acme-lib-a");
+        componentUnaudited = qm.createComponent(componentUnaudited, false);
+        createPolicyViolation(componentUnaudited, ViolationState.FAIL, PolicyViolation.Type.LICENSE);
+
+        // Create a project with an audited violation.
+        var projectAudited = new Project();
+        projectAudited.setName("acme-app-b");
+        projectAudited = qm.createProject(projectAudited, List.of(), false);
+        var componentAudited = new Component();
+        componentAudited.setProject(projectAudited);
+        componentAudited.setName("acme-lib-b");
+        componentAudited = qm.createComponent(componentAudited, false);
+        final var violationAudited = createPolicyViolation(componentAudited, ViolationState.WARN, PolicyViolation.Type.OPERATIONAL);
+        qm.makeViolationAnalysis(componentAudited, violationAudited, ViolationAnalysisState.APPROVED, false);
+
+        // Create a project with a suppressed violation.
+        var projectSuppressed = new Project();
+        projectSuppressed.setName("acme-app-c");
+        projectSuppressed = qm.createProject(projectSuppressed, List.of(), false);
+        var componentSuppressed = new Component();
+        componentSuppressed.setProject(projectSuppressed);
+        componentSuppressed.setName("acme-lib-c");
+        componentSuppressed = qm.createComponent(componentSuppressed, false);
+        final var violationSuppressed = createPolicyViolation(componentSuppressed, ViolationState.INFO, PolicyViolation.Type.SECURITY);
+        qm.makeViolationAnalysis(componentSuppressed, violationSuppressed, ViolationAnalysisState.REJECTED, true);
+
+        final MetricCounters counters = new MetricsUpdateTask().updatePortfolioMetrics(qm);
+        assertThat(counters.critical).isZero();
+        assertThat(counters.high).isZero();
+        assertThat(counters.medium).isZero();
+        assertThat(counters.low).isZero();
+        assertThat(counters.unassigned).isZero();
+        assertThat(counters.projects).isEqualTo(3);
+        assertThat(counters.vulnerableProjects).isZero();
+        assertThat(counters.components).isEqualTo(3);
+        assertThat(counters.vulnerableComponents).isZero();
+        assertThat(counters.vulnerabilities).isZero();
+        assertThat(counters.suppressions).isZero();
+        assertThat(counters.findingsTotal).isZero();
+        assertThat(counters.findingsAudited).isZero();
+        assertThat(counters.findingsUnaudited).isZero();
+        assertThat(counters.policyViolationsFail).isEqualTo(1);
+        assertThat(counters.policyViolationsWarn).isEqualTo(1);
+        assertThat(counters.policyViolationsInfo).isZero(); // Suppressed
+        assertThat(counters.policyViolationsTotal).isEqualTo(2);
+        assertThat(counters.policyViolationsAudited).isEqualTo(1);
+        assertThat(counters.policyViolationsUnaudited).isEqualTo(1);
+        assertThat(counters.policyViolationsSecurityTotal).isZero(); // Suppressed
+        assertThat(counters.policyViolationsSecurityAudited).isZero();
+        assertThat(counters.policyViolationsSecurityUnaudited).isZero();
+        assertThat(counters.policyViolationsLicenseTotal).isEqualTo(1);
+        assertThat(counters.policyViolationsLicenseAudited).isZero();
+        assertThat(counters.policyViolationsLicenseUnaudited).isEqualTo(1);
+        assertThat(counters.policyViolationsOperationalTotal).isEqualTo(1);
+        assertThat(counters.policyViolationsOperationalAudited).isEqualTo(1);
+        assertThat(counters.policyViolationsOperationalUnaudited).isEqualTo(0);
+    }
+
+    @Test
+    public void testUpdateProjectMetricsEmpty() {
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.createProject(project, List.of(), false);
+
+        final MetricCounters counters = new MetricsUpdateTask().updateProjectMetrics(qm, project.getId());
+        assertThat(counters.critical).isZero();
+        assertThat(counters.high).isZero();
+        assertThat(counters.medium).isZero();
+        assertThat(counters.low).isZero();
+        assertThat(counters.unassigned).isZero();
+        assertThat(counters.projects).isZero();
+        assertThat(counters.vulnerableProjects).isZero();
+        assertThat(counters.components).isZero();
+        assertThat(counters.vulnerableComponents).isZero();
+        assertThat(counters.vulnerabilities).isZero();
+        assertThat(counters.suppressions).isZero();
+        assertThat(counters.findingsTotal).isZero();
+        assertThat(counters.findingsAudited).isZero();
+        assertThat(counters.findingsUnaudited).isZero();
+        assertThat(counters.policyViolationsFail).isZero();
+        assertThat(counters.policyViolationsWarn).isZero();
+        assertThat(counters.policyViolationsInfo).isZero();
+        assertThat(counters.policyViolationsTotal).isZero();
+        assertThat(counters.policyViolationsAudited).isZero();
+        assertThat(counters.policyViolationsUnaudited).isZero();
+        assertThat(counters.policyViolationsSecurityTotal).isZero();
+        assertThat(counters.policyViolationsSecurityAudited).isZero();
+        assertThat(counters.policyViolationsSecurityUnaudited).isZero();
+        assertThat(counters.policyViolationsLicenseTotal).isZero();
+        assertThat(counters.policyViolationsLicenseAudited).isZero();
+        assertThat(counters.policyViolationsLicenseUnaudited).isZero();
+        assertThat(counters.policyViolationsOperationalTotal).isZero();
+        assertThat(counters.policyViolationsOperationalAudited).isZero();
+        assertThat(counters.policyViolationsOperationalUnaudited).isZero();
+    }
+
+    @Test
+    public void testUpdateProjectMetricsVulnerabilities() {
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.createProject(project, List.of(), false);
+
+        var vuln = new Vulnerability();
+        vuln.setVulnId("INTERNAL-001");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        vuln = qm.createVulnerability(vuln, false);
+
+        // Create a component with an unaudited vulnerability.
+        var componentUnaudited = new Component();
+        componentUnaudited.setProject(project);
+        componentUnaudited.setName("acme-lib-a");
+        componentUnaudited = qm.createComponent(componentUnaudited, false);
+        qm.addVulnerability(vuln, componentUnaudited, AnalyzerIdentity.NONE);
+
+        // Create a project with an audited vulnerability.
+        var componentAudited = new Component();
+        componentAudited.setProject(project);
+        componentAudited.setName("acme-lib-b");
+        componentAudited = qm.createComponent(componentAudited, false);
+        qm.addVulnerability(vuln, componentAudited, AnalyzerIdentity.NONE);
+        qm.makeAnalysis(componentAudited, vuln, AnalysisState.NOT_AFFECTED, null, null, null, false);
+
+        // Create a project with a suppressed vulnerability.
+        var componentSuppressed = new Component();
+        componentSuppressed.setProject(project);
+        componentSuppressed.setName("acme-lib-c");
+        componentSuppressed = qm.createComponent(componentSuppressed, false);
+        qm.addVulnerability(vuln, componentSuppressed, AnalyzerIdentity.NONE);
+        qm.makeAnalysis(componentSuppressed, vuln, AnalysisState.FALSE_POSITIVE, null, null, null, true);
+
+        final MetricCounters counters = new MetricsUpdateTask().updateProjectMetrics(qm, project.getId());
+        assertThat(counters.critical).isZero();
+        assertThat(counters.high).isEqualTo(2); // One is suppressed
+        assertThat(counters.medium).isZero();
+        assertThat(counters.low).isZero();
+        assertThat(counters.unassigned).isZero();
+        assertThat(counters.projects).isZero();
+        assertThat(counters.vulnerableProjects).isZero();
+        assertThat(counters.components).isEqualTo(3);
+        assertThat(counters.vulnerableComponents).isEqualTo(2); // Finding for one component is suppressed
+        assertThat(counters.vulnerabilities).isEqualTo(2); // One is suppressed
+        assertThat(counters.suppressions).isEqualTo(1);
+        assertThat(counters.findingsTotal).isEqualTo(2); // One is suppressed
+        assertThat(counters.findingsAudited).isEqualTo(1);
+        assertThat(counters.findingsUnaudited).isEqualTo(1);
+        assertThat(counters.policyViolationsFail).isZero();
+        assertThat(counters.policyViolationsWarn).isZero();
+        assertThat(counters.policyViolationsInfo).isZero();
+        assertThat(counters.policyViolationsTotal).isZero();
+        assertThat(counters.policyViolationsAudited).isZero();
+        assertThat(counters.policyViolationsUnaudited).isZero();
+        assertThat(counters.policyViolationsSecurityTotal).isZero();
+        assertThat(counters.policyViolationsSecurityAudited).isZero();
+        assertThat(counters.policyViolationsSecurityUnaudited).isZero();
+        assertThat(counters.policyViolationsLicenseTotal).isZero();
+        assertThat(counters.policyViolationsLicenseAudited).isZero();
+        assertThat(counters.policyViolationsLicenseUnaudited).isZero();
+        assertThat(counters.policyViolationsOperationalTotal).isZero();
+        assertThat(counters.policyViolationsOperationalAudited).isZero();
+        assertThat(counters.policyViolationsOperationalUnaudited).isZero();
+    }
+
+    @Test
+    public void testUpdateProjectMetricsPolicyViolations() {
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.createProject(project, List.of(), false);
+
+        // Create a component with an unaudited violation.
+        var componentUnaudited = new Component();
+        componentUnaudited.setProject(project);
+        componentUnaudited.setName("acme-lib-a");
+        componentUnaudited = qm.createComponent(componentUnaudited, false);
+        createPolicyViolation(componentUnaudited, ViolationState.FAIL, PolicyViolation.Type.LICENSE);
+
+        // Create a component with an audited violation.
+        var componentAudited = new Component();
+        componentAudited.setProject(project);
+        componentAudited.setName("acme-lib-b");
+        componentAudited = qm.createComponent(componentAudited, false);
+        final var violationAudited = createPolicyViolation(componentAudited, ViolationState.WARN, PolicyViolation.Type.OPERATIONAL);
+        qm.makeViolationAnalysis(componentAudited, violationAudited, ViolationAnalysisState.APPROVED, false);
+
+        // Create a component with a suppressed violation.
+        var componentSuppressed = new Component();
+        componentSuppressed.setProject(project);
+        componentSuppressed.setName("acme-lib-c");
+        componentSuppressed = qm.createComponent(componentSuppressed, false);
+        final var violationSuppressed = createPolicyViolation(componentSuppressed, ViolationState.INFO, PolicyViolation.Type.SECURITY);
+        qm.makeViolationAnalysis(componentSuppressed, violationSuppressed, ViolationAnalysisState.REJECTED, true);
+
+        final MetricCounters counters = new MetricsUpdateTask().updateProjectMetrics(qm, project.getId());
+        assertThat(counters.critical).isZero();
+        assertThat(counters.high).isZero();
+        assertThat(counters.medium).isZero();
+        assertThat(counters.low).isZero();
+        assertThat(counters.unassigned).isZero();
+        assertThat(counters.projects).isZero();
+        assertThat(counters.vulnerableProjects).isZero();
+        assertThat(counters.components).isEqualTo(3);
+        assertThat(counters.vulnerableComponents).isZero();
+        assertThat(counters.vulnerabilities).isZero();
+        assertThat(counters.suppressions).isZero();
+        assertThat(counters.findingsTotal).isZero();
+        assertThat(counters.findingsAudited).isZero();
+        assertThat(counters.findingsUnaudited).isZero();
+        assertThat(counters.policyViolationsFail).isEqualTo(1);
+        assertThat(counters.policyViolationsWarn).isEqualTo(1);
+        assertThat(counters.policyViolationsInfo).isZero(); // Suppressed
+        assertThat(counters.policyViolationsTotal).isEqualTo(2);
+        assertThat(counters.policyViolationsAudited).isEqualTo(1);
+        assertThat(counters.policyViolationsUnaudited).isEqualTo(1);
+        assertThat(counters.policyViolationsSecurityTotal).isZero(); // Suppressed
+        assertThat(counters.policyViolationsSecurityAudited).isZero();
+        assertThat(counters.policyViolationsSecurityUnaudited).isZero();
+        assertThat(counters.policyViolationsLicenseTotal).isEqualTo(1);
+        assertThat(counters.policyViolationsLicenseAudited).isZero();
+        assertThat(counters.policyViolationsLicenseUnaudited).isEqualTo(1);
+        assertThat(counters.policyViolationsOperationalTotal).isEqualTo(1);
+        assertThat(counters.policyViolationsOperationalAudited).isEqualTo(1);
+        assertThat(counters.policyViolationsOperationalUnaudited).isZero();
+    }
+
+    @Test
+    public void testUpdateComponentMetricsEmpty() {
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.createProject(project, List.of(), false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component = qm.createComponent(component, false);
+
+        final MetricCounters counters = new MetricsUpdateTask().updateComponentMetrics(qm, component.getId());
+        assertThat(counters.critical).isZero();
+        assertThat(counters.high).isZero();
+        assertThat(counters.medium).isZero();
+        assertThat(counters.low).isZero();
+        assertThat(counters.unassigned).isZero();
+        assertThat(counters.projects).isZero();
+        assertThat(counters.vulnerableProjects).isZero();
+        assertThat(counters.components).isZero();
+        assertThat(counters.vulnerableComponents).isZero();
+        assertThat(counters.vulnerabilities).isZero();
+        assertThat(counters.suppressions).isZero();
+        assertThat(counters.findingsTotal).isZero();
+        assertThat(counters.findingsAudited).isZero();
+        assertThat(counters.findingsUnaudited).isZero();
+        assertThat(counters.policyViolationsFail).isZero();
+        assertThat(counters.policyViolationsWarn).isZero();
+        assertThat(counters.policyViolationsInfo).isZero();
+        assertThat(counters.policyViolationsTotal).isZero();
+        assertThat(counters.policyViolationsAudited).isZero();
+        assertThat(counters.policyViolationsUnaudited).isZero();
+        assertThat(counters.policyViolationsSecurityTotal).isZero();
+        assertThat(counters.policyViolationsSecurityAudited).isZero();
+        assertThat(counters.policyViolationsSecurityUnaudited).isZero();
+        assertThat(counters.policyViolationsLicenseTotal).isZero();
+        assertThat(counters.policyViolationsLicenseAudited).isZero();
+        assertThat(counters.policyViolationsLicenseUnaudited).isZero();
+        assertThat(counters.policyViolationsOperationalTotal).isZero();
+        assertThat(counters.policyViolationsOperationalAudited).isZero();
+        assertThat(counters.policyViolationsOperationalUnaudited).isZero();
+    }
+
+    @Test
+    public void testUpdateComponentMetricsVulnerabilities() {
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.createProject(project, List.of(), false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component = qm.createComponent(component, false);
+
+        // Create an unaudited vulnerability.
+        var vulnUnaudited = new Vulnerability();
+        vulnUnaudited.setVulnId("INTERNAL-001");
+        vulnUnaudited.setSource(Vulnerability.Source.INTERNAL);
+        vulnUnaudited.setSeverity(Severity.HIGH);
+        vulnUnaudited = qm.createVulnerability(vulnUnaudited, false);
+        qm.addVulnerability(vulnUnaudited, component, AnalyzerIdentity.NONE);
+
+        // Create an audited vulnerability.
+        var vulnAudited = new Vulnerability();
+        vulnAudited.setVulnId("INTERNAL-002");
+        vulnAudited.setSource(Vulnerability.Source.INTERNAL);
+        vulnAudited.setSeverity(Severity.MEDIUM);
+        vulnAudited = qm.createVulnerability(vulnAudited, false);
+        qm.addVulnerability(vulnAudited, component, AnalyzerIdentity.NONE);
+        qm.makeAnalysis(component, vulnAudited, AnalysisState.NOT_AFFECTED, null, null, null, false);
+
+        // Create a suppressed vulnerability.
+        var vulnSuppressed = new Vulnerability();
+        vulnSuppressed.setVulnId("INTERNAL-003");
+        vulnSuppressed.setSource(Vulnerability.Source.INTERNAL);
+        vulnSuppressed.setSeverity(Severity.MEDIUM);
+        vulnSuppressed = qm.createVulnerability(vulnSuppressed, false);
+        qm.addVulnerability(vulnSuppressed, component, AnalyzerIdentity.NONE);
+        qm.makeAnalysis(component, vulnSuppressed, AnalysisState.FALSE_POSITIVE, null, null, null, true);
+
+        final MetricCounters counters = new MetricsUpdateTask().updateComponentMetrics(qm, component.getId());
+        assertThat(counters.critical).isZero();
+        assertThat(counters.high).isEqualTo(1);
+        assertThat(counters.medium).isEqualTo(1); // One is suppressed
+        assertThat(counters.low).isZero();
+        assertThat(counters.unassigned).isZero();
+        assertThat(counters.projects).isZero();
+        assertThat(counters.vulnerableProjects).isZero();
+        assertThat(counters.components).isZero();
+        assertThat(counters.vulnerableComponents).isZero();
+        assertThat(counters.vulnerabilities).isEqualTo(2); // One is suppressed
+        assertThat(counters.suppressions).isEqualTo(1);
+        assertThat(counters.findingsTotal).isEqualTo(2); // One is suppressed
+        assertThat(counters.findingsAudited).isEqualTo(1);
+        assertThat(counters.findingsUnaudited).isEqualTo(1);
+        assertThat(counters.policyViolationsFail).isZero();
+        assertThat(counters.policyViolationsWarn).isZero();
+        assertThat(counters.policyViolationsInfo).isZero();
+        assertThat(counters.policyViolationsTotal).isZero();
+        assertThat(counters.policyViolationsAudited).isZero();
+        assertThat(counters.policyViolationsUnaudited).isZero();
+        assertThat(counters.policyViolationsSecurityTotal).isZero();
+        assertThat(counters.policyViolationsSecurityAudited).isZero();
+        assertThat(counters.policyViolationsSecurityUnaudited).isZero();
+        assertThat(counters.policyViolationsLicenseTotal).isZero();
+        assertThat(counters.policyViolationsLicenseAudited).isZero();
+        assertThat(counters.policyViolationsLicenseUnaudited).isZero();
+        assertThat(counters.policyViolationsOperationalTotal).isZero();
+        assertThat(counters.policyViolationsOperationalAudited).isZero();
+        assertThat(counters.policyViolationsOperationalUnaudited).isZero();
+    }
+
+    @Test
+    public void testUpdateComponentMetricsPolicyViolations() {
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.createProject(project, List.of(), false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component = qm.createComponent(component, false);
+
+        // Create an unaudited violation.
+        createPolicyViolation(component, ViolationState.FAIL, PolicyViolation.Type.LICENSE);
+
+        // Create an audited violation.
+        final PolicyViolation auditedViolation = createPolicyViolation(component, ViolationState.WARN, PolicyViolation.Type.OPERATIONAL);
+        qm.makeViolationAnalysis(component, auditedViolation, ViolationAnalysisState.APPROVED, false);
+
+        // Create a suppressed violation.
+        final PolicyViolation suppressedViolation = createPolicyViolation(component, ViolationState.INFO, PolicyViolation.Type.SECURITY);
+        qm.makeViolationAnalysis(component, suppressedViolation, ViolationAnalysisState.REJECTED, true);
+
+        final MetricCounters counters = new MetricsUpdateTask().updateComponentMetrics(qm, component.getId());
+        assertThat(counters.critical).isZero();
+        assertThat(counters.high).isZero();
+        assertThat(counters.medium).isZero();
+        assertThat(counters.low).isZero();
+        assertThat(counters.unassigned).isZero();
+        assertThat(counters.projects).isZero();
+        assertThat(counters.vulnerableProjects).isZero();
+        assertThat(counters.components).isZero();
+        assertThat(counters.vulnerableComponents).isZero();
+        assertThat(counters.vulnerabilities).isZero();
+        assertThat(counters.suppressions).isZero();
+        assertThat(counters.findingsTotal).isZero();
+        assertThat(counters.findingsAudited).isZero();
+        assertThat(counters.findingsUnaudited).isZero();
+        assertThat(counters.policyViolationsFail).isEqualTo(1);
+        assertThat(counters.policyViolationsWarn).isEqualTo(1);
+        assertThat(counters.policyViolationsInfo).isZero(); // Suppressed
+        assertThat(counters.policyViolationsTotal).isEqualTo(2);
+        assertThat(counters.policyViolationsAudited).isEqualTo(1);
+        assertThat(counters.policyViolationsUnaudited).isEqualTo(1);
+        assertThat(counters.policyViolationsSecurityTotal).isZero(); // Suppressed
+        assertThat(counters.policyViolationsSecurityAudited).isZero();
+        assertThat(counters.policyViolationsSecurityUnaudited).isZero();
+        assertThat(counters.policyViolationsLicenseTotal).isEqualTo(1);
+        assertThat(counters.policyViolationsLicenseAudited).isZero();
+        assertThat(counters.policyViolationsLicenseUnaudited).isEqualTo(1);
+        assertThat(counters.policyViolationsOperationalTotal).isEqualTo(1);
+        assertThat(counters.policyViolationsOperationalAudited).isEqualTo(1);
+        assertThat(counters.policyViolationsOperationalUnaudited).isZero();
+    }
+
+    private PolicyViolation createPolicyViolation(final Component component, final Policy.ViolationState violationState, final PolicyViolation.Type type) {
+        final var policy = qm.createPolicy(UUID.randomUUID().toString(), Policy.Operator.ALL, violationState);
+        final var policyCondition = qm.createPolicyCondition(policy, Subject.COORDINATES, PolicyCondition.Operator.MATCHES, "");
+        final var policyViolation = new PolicyViolation();
+
+        policyViolation.setComponent(component);
+        policyViolation.setPolicyCondition(policyCondition);
+        policyViolation.setTimestamp(new Date());
+        policyViolation.setType(type);
+        return qm.addPolicyViolationIfNotExist(policyViolation);
+    }
+
+}


### PR DESCRIPTION
This PR adds tests for `MetricsUpdateTask`, making it easier to debug and verify its functionality when stuff gets changed.

* The count of audited and suppressed findings was off, as their queries still included `project == null` expressions. Probably leftovers from the global component model before v4.
* The count of audited findings was off, because it didn't account for suppressed findings. If a finding is suppressed, the overall finding count is reduced as well. Until now however, suppressed findings were considered "audited" as well, which could result in situations where more findings are audited than even exist.
* The audited/unaudited counts of policy violations were off, because the count of audited violations was never populated.
* Suppressed policy violations were not reflected in the metrics.

This PR also includes #1526.