### PR TITLE
Add example OIDC setup for Azure Active Directory

### DIFF
--- a/docs/_docs/getting-started/openidconnect-configuration.md
+++ b/docs/_docs/getting-started/openidconnect-configuration.md
@@ -58,6 +58,23 @@ For a complete overview of available configuration options for both backend and 
 > gitlab.com currently does not set the required CORS headers, see GitLab issue [#209259](https://gitlab.com/gitlab-org/gitlab/-/issues/209259).  
 > For on-premise installations, this could be fixed by setting the required headers via reverse proxy.  
 
+#### Azure Active Directory
+
+| API server                                                                                     | Frontend                                                                                |
+|:-----------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------|
+| alpine.oidc.enabled=true                                                                       |                                                                                         |
+| alpine.oidc.client.id=2e0a07ae-eabd-45d7-a8f5-ca4ad71b48ae                                     | OIDC_CLIENT_ID=2e0a07ae-eabd-45d7-a8f5-ca4ad71b48ae                                     |    
+| alpine.oidc.issuer=https://login.microsoftonline.com/3919df77-d4cd-4772-8b50-cfdb195bcdd6/v2.0 | OIDC_ISSUER=https://login.microsoftonline.com/3919df77-d4cd-4772-8b50-cfdb195bcdd6/v2.0 |
+| alpine.oidc.username.claim=preferred_username                                                  |                                                                                         |
+| alpine.oidc.user.provisioning=true                                                             |                                                                                         |
+| alpine.oidc.teams.claim=groups                                                                 |                                                                                         |
+| alpine.oidc.team.synchronization=true                                                          |                                                                                         |
+
+OIDC integration with Azure Active Directory requires you to register Dependency-Track as an app in your tenant, see [Azure Active Directory app registration](#azure-active-directory-app-registration).
+
+The `alpine.oidc.client.id` contains the Application ID of the app registration, and the `alpine.oidc.issuer` contains the Directory (tenant) ID.
+
+
 #### Keycloak
 
 | API server                                                               | Frontend                                                 |
@@ -170,3 +187,31 @@ $ curl https://auth.example.com/auth/realms/example/protocol/openid-connect/user
 
 > Dependency-Track associates every OpenID Connect user with their subject identifier (`sub` claim of the access token) upon first login.
 > If a user with the same name but a different subject identifier attempts to log in via OIDC, Dependency-Track will refuse to authenticate that user. This is done to prevent account takeovers, as some identity providers allow users to change their usernames. Also, uniqueness of usernames is not always guaranteed, while the uniqueness of subject identifiers is.
+
+### Azure Active Directory app registration
+
+The following steps demonstrate how to setup OpenID Connect with Azure Active Directory.
+
+> This guide assumes that:
+>   * the Dependency-Track frontend has been deployed to `https://dependencytrack.example.com`
+>   * an Azure Active Directory tenant has been created with name `dt-example`
+
+1. Add an app registration for Dependency-Track to your Azure AD tenant:
+   * Name: `Dependency-Track`
+   * Supported account types: `Accounts in this organizational directory only`
+   * Redirect URI (optional): Leave empty for now
+
+
+2. Under Authentication, add two Redirect URIs for Single Page Applications and leave all settings at default:
+   * https://dependencytrack.example.com/static/oidc-callback.html
+   * https://dependencytrack.example.com/static/oidc-callback.html?redirect=%2fdashboard
+
+
+3. Under Token configuration, click Add groups claim and select the group types you'd like to include (check all options if you're not sure).
+
+
+4. Under API permissions, add the following Microsoft Graph API permissions:
+   * OpenId permissions -> email
+   * OpenId permissions -> openid
+   * OpenId permissions -> profile
+   * GroupMember -> GroupMember.Read.All

--- a/docs/_docs/getting-started/openidconnect-configuration.md
+++ b/docs/_docs/getting-started/openidconnect-configuration.md
@@ -194,7 +194,7 @@ The following steps demonstrate how to setup OpenID Connect with Azure Active Di
 
 > This guide assumes that:
 >   * the Dependency-Track frontend has been deployed to `https://dependencytrack.example.com`
->   * an Azure Active Directory tenant has been created with name `dt-example`
+>   * an Azure Active Directory tenant has been created
 
 1. Add an app registration for Dependency-Track to your Azure AD tenant:
    * Name: `Dependency-Track`
@@ -202,9 +202,8 @@ The following steps demonstrate how to setup OpenID Connect with Azure Active Di
    * Redirect URI (optional): Leave empty for now
 
 
-2. Under Authentication, add two Redirect URIs for Single Page Applications and leave all settings at default:
+2. Under Authentication, add the following Redirect URI for a Single Page Application and leave all settings at default:
    * https://dependencytrack.example.com/static/oidc-callback.html
-   * https://dependencytrack.example.com/static/oidc-callback.html?redirect=%2fdashboard
 
 
 3. Under Token configuration, click Add groups claim and select the group types you'd like to include (check all options if you're not sure).


### PR DESCRIPTION
I noticed some people having trouble setting up OIDC for popular cloud providers like GCP and Azure AD. I thought I would add some documentation on how I set up OIDC with my Azure AD tenant. Hopefully, someone will contribute documentation for GCP (#1556) and AWS too.