### PR TITLE
Fix unnecessary creation of audit trail entries for `Justification` and `Response`

### DIFF
--- a/docs/_posts/2022-xx-xx-v4.5.0.md
+++ b/docs/_posts/2022-xx-xx-v4.5.0.md
@@ -8,7 +8,7 @@ type: major
 
 **Fixes:**
 * Resolved defect where the `VULNERABILITY_ANALYSIS` permission was required to see policy violations - [#126](https://github.com/DependencyTrack/frontend/issues/126)
-* Resolved defect where audit trail entries were generated for `Justification` and `Response`, even though they didn't actually change
+* Resolved defect where audit trail entries were generated for `Justification` and `Response`, even though they didn't actually change - [#1566](https://github.com/DependencyTrack/dependency-track/pull/1566)
 
 **Security:**
 

--- a/docs/_posts/2022-xx-xx-v4.5.0.md
+++ b/docs/_posts/2022-xx-xx-v4.5.0.md
@@ -8,6 +8,7 @@ type: major
 
 **Fixes:**
 * Resolved defect where the `VULNERABILITY_ANALYSIS` permission was required to see policy violations - [#126](https://github.com/DependencyTrack/frontend/issues/126)
+* Resolved defect where audit trail entries were generated for `Justification` and `Response`, even though they didn't actually change
 
 **Security:**
 

--- a/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
@@ -165,7 +165,7 @@ public class FindingsQueryManager extends QueryManager implements IQueryManager 
     }
 
     /**
-     * Documents a new analysis. Creates a new Analysis object if one doesn't already exists and appends
+     * Documents a new analysis. Creates a new Analysis object if one doesn't already exist and appends
      * the specified comment along with a timestamp in the AnalysisComment trail.
      * @param component the Component
      * @param vulnerability the Vulnerability
@@ -174,9 +174,6 @@ public class FindingsQueryManager extends QueryManager implements IQueryManager 
     public Analysis makeAnalysis(Component component, Vulnerability vulnerability, AnalysisState analysisState,
                                  AnalysisJustification analysisJustification, AnalysisResponse analysisResponse,
                                  String analysisDetails, Boolean isSuppressed) {
-        if (analysisState == null) {
-            analysisState = AnalysisState.NOT_SET;
-        }
         Analysis analysis = getAnalysis(component, vulnerability);
         if (analysis == null) {
             analysis = new Analysis();
@@ -186,10 +183,18 @@ public class FindingsQueryManager extends QueryManager implements IQueryManager 
         if (isSuppressed != null) {
             analysis.setSuppressed(isSuppressed);
         }
-        analysis.setAnalysisState(analysisState);
-        analysis.setAnalysisJustification(analysisJustification);
-        analysis.setAnalysisResponse(analysisResponse);
-        analysis.setAnalysisDetails(analysisDetails);
+        if (analysisState != null) {
+            analysis.setAnalysisState(analysisState);
+        }
+        if (analysisJustification != null) {
+            analysis.setAnalysisJustification(analysisJustification);
+        }
+        if (analysisResponse != null) {
+            analysis.setAnalysisResponse(analysisResponse);
+        }
+        if (analysisDetails != null) {
+            analysis.setAnalysisDetails(analysisDetails);
+        }
         analysis = persist(analysis);
         return getAnalysis(analysis.getComponent(), analysis.getVulnerability());
     }

--- a/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
@@ -180,9 +180,11 @@ public class FindingsQueryManager extends QueryManager implements IQueryManager 
             analysis.setComponent(component);
             analysis.setVulnerability(vulnerability);
         }
-        if (isSuppressed != null) {
-            analysis.setSuppressed(isSuppressed);
-        }
+
+        // In case we're updating an existing analysis, setting any of the fields
+        // to null will wipe them. That is not the expected behavior when an AnalysisRequest
+        // has some fields unset (so they're null). If fields are not set, there shouldn't
+        // be any modifications to the existing data.
         if (analysisState != null) {
             analysis.setAnalysisState(analysisState);
         }
@@ -195,6 +197,10 @@ public class FindingsQueryManager extends QueryManager implements IQueryManager 
         if (analysisDetails != null) {
             analysis.setAnalysisDetails(analysisDetails);
         }
+        if (isSuppressed != null) {
+            analysis.setSuppressed(isSuppressed);
+        }
+
         analysis = persist(analysis);
         return getAnalysis(analysis.getComponent(), analysis.getVulnerability());
     }

--- a/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
@@ -88,7 +88,7 @@ public class AnalysisResource extends AlpineResource {
                 new ValidationTask(RegexSequence.Pattern.UUID, vulnerabilityUuid, "Vulnerability is not a valid UUID")
         );
         try (QueryManager qm = new QueryManager()) {
-            Project project = null;
+            final Project project;
             if (StringUtils.trimToNull(projectUuid) != null) {
                 project = qm.getObjectByUuid(Project.class, projectUuid);
                 if (project == null) {
@@ -163,14 +163,14 @@ public class AnalysisResource extends AlpineResource {
                 if (request.getAnalysisJustification() != null) {
                     if (analysis.getAnalysisJustification() == null && request.getAnalysisJustification() != AnalysisJustification.NOT_SET) {
                         qm.makeAnalysisComment(analysis, String.format("Justification: %s → %s", AnalysisJustification.NOT_SET, request.getAnalysisJustification()), commenter);
-                    } else {
+                    } else if (analysis.getAnalysisJustification() != null && request.getAnalysisJustification() != analysis.getAnalysisJustification()) {
                         qm.makeAnalysisComment(analysis, String.format("Justification: %s → %s", analysis.getAnalysisJustification(), request.getAnalysisJustification()), commenter);
                     }
                 }
                 if (request.getAnalysisResponse() != null) {
                     if (analysis.getAnalysisResponse() == null && analysis.getAnalysisResponse() != request.getAnalysisResponse()) {
                         qm.makeAnalysisComment(analysis, String.format("Vendor Response: %s → %s", AnalysisResponse.NOT_SET, request.getAnalysisResponse()), commenter);
-                    } else {
+                    } else if (analysis.getAnalysisResponse() != null && request.getAnalysisResponse() != analysis.getAnalysisResponse()) {
                         qm.makeAnalysisComment(analysis, String.format("Vendor Response: %s → %s", analysis.getAnalysisResponse(), request.getAnalysisResponse()), commenter);
                     }
                 }

--- a/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
@@ -18,9 +18,17 @@
  */
 package org.dependencytrack.resources.v1;
 
+import alpine.notification.Notification;
+import alpine.notification.NotificationLevel;
+import alpine.notification.NotificationService;
+import alpine.notification.Subscriber;
+import alpine.notification.Subscription;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import alpine.server.filters.AuthorizationFilter;
+import org.apache.http.HttpStatus;
 import org.dependencytrack.ResourceTest;
+import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Analysis;
 import org.dependencytrack.model.AnalysisJustification;
 import org.dependencytrack.model.AnalysisResponse;
@@ -29,233 +37,640 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.notification.NotificationConstants;
+import org.dependencytrack.notification.NotificationGroup;
+import org.dependencytrack.notification.NotificationScope;
 import org.dependencytrack.resources.v1.vo.AnalysisRequest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.ServletDeploymentContext;
-import org.junit.Assert;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import javax.json.Json;
+import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AnalysisResourceTest extends ResourceTest {
 
     @Override
     protected DeploymentContext configureDeployment() {
         return ServletDeploymentContext.forServlet(new ServletContainer(
-                new ResourceConfig(AnalysisResource.class)
-                        .register(ApiFilter.class)
-                        .register(AuthenticationFilter.class)))
+                        new ResourceConfig(AnalysisResource.class)
+                                .register(ApiFilter.class)
+                                .register(AuthenticationFilter.class)
+                                .register(AuthorizationFilter.class)))
                 .build();
+    }
+
+    public static class NotificationSubscriber implements Subscriber {
+
+        @Override
+        public void inform(final Notification notification) {
+            AnalysisResourceTest.NOTIFICATIONS.add(notification);
+        }
+
+    }
+
+    private static final ConcurrentLinkedQueue<Notification> NOTIFICATIONS = new ConcurrentLinkedQueue<>();
+
+    @BeforeClass
+    public static void setUpClass() {
+        NotificationService.getInstance().subscribe(new Subscription(NotificationSubscriber.class));
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        NotificationService.getInstance().unsubscribe(new Subscription(NotificationSubscriber.class));
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        NOTIFICATIONS.clear();
+        super.tearDown();
     }
 
     @Test
     public void retrieveAnalysisTest() {
-        Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
-        Component component = new Component();
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        var component = new Component();
         component.setProject(project);
         component.setName("Acme Component");
         component.setVersion("1.0");
-        qm.createComponent(component, false);
-        List<Component> components = new ArrayList<>();
-        components.add(component);
-        Vulnerability vulnerability = new Vulnerability();
+        component = qm.createComponent(component, false);
+
+        var vulnerability = new Vulnerability();
         vulnerability.setVulnId("INT-001");
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
-        vulnerability.setComponents(components);
-        qm.createVulnerability(vulnerability, false);
-        qm.makeAnalysis(component, vulnerability, AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE, AnalysisResponse.WILL_NOT_FIX, "Analysis details here", true);
-        Response response = target(V1_ANALYSIS)
+        vulnerability.setComponents(List.of(component));
+        vulnerability = qm.createVulnerability(vulnerability, false);
+
+        final Analysis analysis = qm.makeAnalysis(component, vulnerability, AnalysisState.NOT_AFFECTED,
+                AnalysisJustification.CODE_NOT_REACHABLE, AnalysisResponse.WILL_NOT_FIX, "Analysis details here", true);
+        qm.makeAnalysisComment(analysis, "Analysis comment here", "Jane Doe");
+
+        final Response response = target(V1_ANALYSIS)
                 .queryParam("project", project.getUuid())
                 .queryParam("component", component.getUuid())
                 .queryParam("vulnerability", vulnerability.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
-        JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(AnalysisState.NOT_AFFECTED.name(), json.getString("analysisState"));
-        Assert.assertTrue(json.getBoolean("isSuppressed"));
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+
+        final JsonObject responseJson = parseJsonObject(response);
+        assertThat(responseJson).isNotNull();
+        assertThat(responseJson.getString("analysisState")).isEqualTo(AnalysisState.NOT_AFFECTED.name());
+        assertThat(responseJson.getString("analysisJustification")).isEqualTo(AnalysisJustification.CODE_NOT_REACHABLE.name());
+        assertThat(responseJson.getString("analysisResponse")).isEqualTo(AnalysisResponse.WILL_NOT_FIX.name());
+        assertThat(responseJson.getString("analysisDetails")).isEqualTo("Analysis details here");
+        assertThat(responseJson.getJsonArray("analysisComments")).hasSize(1);
+        assertThat(responseJson.getJsonArray("analysisComments").getJsonObject(0))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Analysis comment here"))
+                .hasFieldOrPropertyWithValue("commenter", Json.createValue("Jane Doe"));
+        assertThat(responseJson.getBoolean("isSuppressed")).isTrue();
     }
 
     @Test
-    public void retrieveAnalysisInvalidProjectUuidTest() {
-        Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
-        Component component = new Component();
+    public void retrieveAnalysisWithoutExistingAnalysisTest() {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        var component = new Component();
         component.setProject(project);
         component.setName("Acme Component");
         component.setVersion("1.0");
-        qm.createComponent(component, false);
-        List<Component> components = new ArrayList<>();
-        components.add(component);
-        Vulnerability vulnerability = new Vulnerability();
+        component = qm.createComponent(component, false);
+
+        var vulnerability = new Vulnerability();
         vulnerability.setVulnId("INT-001");
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
-        vulnerability.setComponents(components);
-        qm.createVulnerability(vulnerability, false);
-        Response response = target(V1_ANALYSIS)
+        vulnerability.setComponents(List.of(component));
+        vulnerability = qm.createVulnerability(vulnerability, false);
+
+        final Response response = target(V1_ANALYSIS)
+                .queryParam("project", project.getUuid())
+                .queryParam("component", component.getUuid())
+                .queryParam("vulnerability", vulnerability.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+        assertThat(getPlainTextBody(response)).isEmpty();
+    }
+
+    @Test
+    public void retrieveAnalysisWithProjectNotFoundTest() {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("Acme Component");
+        component.setVersion("1.0");
+        component = qm.createComponent(component, false);
+
+        var vulnerability = new Vulnerability();
+        vulnerability.setVulnId("INT-001");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.HIGH);
+        vulnerability.setComponents(List.of(component));
+        vulnerability = qm.createVulnerability(vulnerability, false);
+
+        final Response response = target(V1_ANALYSIS)
                 .queryParam("project", UUID.randomUUID())
                 .queryParam("component", component.getUuid())
                 .queryParam("vulnerability", vulnerability.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
-        String body = getPlainTextBody(response);
-        Assert.assertEquals("The project could not be found.", body);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+        assertThat(getPlainTextBody(response)).isEqualTo("The project could not be found.");
     }
 
     @Test
-    public void retrieveAnalysisInvalidComponentUuidTest() {
-        Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
-        Component component = new Component();
+    public void retrieveAnalysisWithComponentNotFoundTest() {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        var component = new Component();
         component.setProject(project);
         component.setName("Acme Component");
         component.setVersion("1.0");
-        qm.createComponent(component, false);
-        List<Component> components = new ArrayList<>();
-        components.add(component);
-        Vulnerability vulnerability = new Vulnerability();
+        component = qm.createComponent(component, false);
+
+        var vulnerability = new Vulnerability();
         vulnerability.setVulnId("INT-001");
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
-        vulnerability.setComponents(components);
-        qm.createVulnerability(vulnerability, false);
-        Response response = target(V1_ANALYSIS)
+        vulnerability.setComponents(List.of(component));
+        vulnerability = qm.createVulnerability(vulnerability, false);
+
+        final Response response = target(V1_ANALYSIS)
                 .queryParam("project", project.getUuid())
                 .queryParam("component", UUID.randomUUID())
                 .queryParam("vulnerability", vulnerability.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
-        String body = getPlainTextBody(response);
-        Assert.assertEquals("The component could not be found.", body);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+        assertThat(getPlainTextBody(response)).isEqualTo("The component could not be found.");
     }
 
     @Test
-    public void retrieveAnalysisInvalidVulnerabilityUuidTest() {
-        Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
-        Component component = new Component();
+    public void retrieveAnalysisWithVulnerabilityNotFoundTest() {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        var component = new Component();
         component.setProject(project);
         component.setName("Acme Component");
         component.setVersion("1.0");
-        qm.createComponent(component, false);
-        List<Component> components = new ArrayList<>();
-        components.add(component);
-        Vulnerability vulnerability = new Vulnerability();
+        component = qm.createComponent(component, false);
+
+        final var vulnerability = new Vulnerability();
         vulnerability.setVulnId("INT-001");
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
-        vulnerability.setComponents(components);
+        vulnerability.setComponents(List.of(component));
         qm.createVulnerability(vulnerability, false);
-        Response response = target(V1_ANALYSIS)
+
+        final Response response = target(V1_ANALYSIS)
                 .queryParam("project", project.getUuid())
                 .queryParam("component", component.getUuid())
                 .queryParam("vulnerability", UUID.randomUUID())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
-        String body = getPlainTextBody(response);
-        Assert.assertEquals("The vulnerability could not be found.", body);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+        assertThat(getPlainTextBody(response)).isEqualTo("The vulnerability could not be found.");
     }
 
     @Test
-    public void updateAnalysisTest() {
-        Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
-        Component component = new Component();
-        component.setProject(project);
-        component.setName("Acme Component");
-        component.setVersion("1.0");
-        qm.createComponent(component, false);
-        List<Component> components = new ArrayList<>();
-        components.add(component);
-        Vulnerability vulnerability = new Vulnerability();
-        vulnerability.setVulnId("INT-001");
-        vulnerability.setSource(Vulnerability.Source.INTERNAL);
-        vulnerability.setSeverity(Severity.HIGH);
-        vulnerability.setComponents(components);
-        qm.createVulnerability(vulnerability, false);
-        qm.makeAnalysis(component, vulnerability, AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE, AnalysisResponse.WILL_NOT_FIX, "Analysis details here", true);
-        AnalysisRequest request = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
-                vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE, AnalysisResponse.WILL_NOT_FIX, "Analysis details here", "Not an issue", true);
-        Response response = target(V1_ANALYSIS)
+    public void retrieveAnalysisUnauthorizedTest() {
+        final Response response = target(V1_ANALYSIS)
+                .queryParam("project", UUID.randomUUID())
+                .queryParam("component", UUID.randomUUID())
+                .queryParam("vulnerability", UUID.randomUUID())
                 .request()
                 .header(X_API_KEY, apiKey)
-                .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
-        JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(AnalysisState.NOT_AFFECTED.name(), json.getString("analysisState"));
-        Assert.assertTrue(json.getBoolean("isSuppressed"));
-        Analysis analysis = qm.getAnalysis(component, vulnerability);
-        Assert.assertEquals(project.getUuid(), analysis.getProject().getUuid());
-        Assert.assertEquals(component.getUuid(), analysis.getComponent().getUuid());
-        Assert.assertEquals(vulnerability.getUuid(), analysis.getVulnerability().getUuid());
+                .get();
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_FORBIDDEN);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
     }
 
     @Test
-    public void updateAnalysisChangeStateTest() {
-        Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
-        Component component = new Component();
+    public void updateAnalysisCreateNewTest() {
+        initializeWithPermissions(Permissions.VULNERABILITY_ANALYSIS);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        var component = new Component();
         component.setProject(project);
         component.setName("Acme Component");
         component.setVersion("1.0");
-        qm.createComponent(component, false);
-        List<Component> components = new ArrayList<>();
-        components.add(component);
-        Vulnerability vulnerability = new Vulnerability();
+        component = qm.createComponent(component, false);
+
+        var vulnerability = new Vulnerability();
         vulnerability.setVulnId("INT-001");
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
-        vulnerability.setComponents(components);
-        qm.createVulnerability(vulnerability, false);
-        qm.makeAnalysis(component, vulnerability, AnalysisState.IN_TRIAGE, AnalysisJustification.CODE_NOT_REACHABLE, AnalysisResponse.WILL_NOT_FIX, "Analysis details here", false);
-        AnalysisRequest request = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
-                vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.PROTECTED_BY_MITIGATING_CONTROL, AnalysisResponse.UPDATE, "Updated analysis details here", "Not an issue", true);
-        Response response = target(V1_ANALYSIS)
+        vulnerability.setComponents(List.of(component));
+        vulnerability = qm.createVulnerability(vulnerability, false);
+
+        final var analysisRequest = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
+                vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE,
+                AnalysisResponse.WILL_NOT_FIX, "Analysis details here", "Analysis comment here", true);
+
+        final Response response = target(V1_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
-                .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
-        JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(AnalysisState.NOT_AFFECTED.name(), json.getString("analysisState"));
-        Assert.assertTrue(json.getBoolean("isSuppressed"));
-        Assert.assertEquals(6, json.getJsonArray("analysisComments").size());
-        Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(0).getJsonNumber("timestamp"));
-        Assert.assertEquals("Analysis: IN_TRIAGE → NOT_AFFECTED", json.getJsonArray("analysisComments").getJsonObject(0).getString("comment"));
-        Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(1).getJsonNumber("timestamp"));
-        Assert.assertEquals("Justification: CODE_NOT_REACHABLE → PROTECTED_BY_MITIGATING_CONTROL", json.getJsonArray("analysisComments").getJsonObject(1).getString("comment"));
-        Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(2).getJsonNumber("timestamp"));
-        Assert.assertEquals("Vendor Response: WILL_NOT_FIX → UPDATE", json.getJsonArray("analysisComments").getJsonObject(2).getString("comment"));
-        Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(3).getJsonNumber("timestamp"));
-        Assert.assertEquals("Details: Updated analysis details here", json.getJsonArray("analysisComments").getJsonObject(3).getString("comment"));
-        Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(4).getJsonNumber("timestamp"));
-        Assert.assertEquals("Suppressed", json.getJsonArray("analysisComments").getJsonObject(4).getString("comment"));
-        Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(5).getJsonNumber("timestamp"));
-        Assert.assertEquals("Not an issue", json.getJsonArray("analysisComments").getJsonObject(5).getString("comment"));
-        Analysis analysis = qm.getAnalysis(component, vulnerability);
-        Assert.assertEquals(project.getUuid(), analysis.getProject().getUuid());
-        Assert.assertEquals(component.getUuid(), analysis.getComponent().getUuid());
-        Assert.assertEquals(vulnerability.getUuid(), analysis.getVulnerability().getUuid());
+                .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+
+        final JsonObject responseJson = parseJsonObject(response);
+        assertThat(responseJson).isNotNull();
+        assertThat(responseJson.getString("analysisState")).isEqualTo(AnalysisState.NOT_AFFECTED.name());
+        assertThat(responseJson.getString("analysisJustification")).isEqualTo(AnalysisJustification.CODE_NOT_REACHABLE.name());
+        assertThat(responseJson.getString("analysisResponse")).isEqualTo(AnalysisResponse.WILL_NOT_FIX.name());
+        assertThat(responseJson.getString("analysisDetails")).isEqualTo("Analysis details here");
+        assertThat(responseJson.getJsonArray("analysisComments")).hasSize(2);
+        assertThat(responseJson.getJsonArray("analysisComments").getJsonObject(0))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Analysis: NOT_SET → NOT_AFFECTED"))
+                .doesNotContainKey("commenter"); // Not set when authenticating via API key
+        assertThat(responseJson.getJsonArray("analysisComments").getJsonObject(1))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Analysis comment here"))
+                .doesNotContainKey("commenter"); // Not set when authenticating via API key
+        assertThat(responseJson.getBoolean("isSuppressed")).isTrue();
+
+        assertThat(NOTIFICATIONS.size()).isEqualTo(1);
+        final Notification notification = NOTIFICATIONS.poll();
+        assertThat(notification).isNotNull();
+        assertThat(notification.getScope()).isEqualTo(NotificationScope.PORTFOLIO.name());
+        assertThat(notification.getGroup()).isEqualTo(NotificationGroup.PROJECT_AUDIT_CHANGE.name());
+        assertThat(notification.getLevel()).isEqualTo(NotificationLevel.INFORMATIONAL);
+        assertThat(notification.getTitle()).isEqualTo(NotificationConstants.Title.ANALYSIS_DECISION_NOT_AFFECTED);
+        assertThat(notification.getContent()).isEqualTo("An analysis decision was made to a finding affecting a project");
+    }
+
+    @Test
+    public void updateAnalysisCreateNewWithEmptyRequestTest() {
+        initializeWithPermissions(Permissions.VULNERABILITY_ANALYSIS);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("Acme Component");
+        component.setVersion("1.0");
+        component = qm.createComponent(component, false);
+
+        var vulnerability = new Vulnerability();
+        vulnerability.setVulnId("INT-001");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.HIGH);
+        vulnerability.setComponents(List.of(component));
+        vulnerability = qm.createVulnerability(vulnerability, false);
+
+        final var analysisRequest = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
+                vulnerability.getUuid().toString(), null, null, null, null, null, null);
+
+        final Response response = target(V1_ANALYSIS)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+
+        final JsonObject responseJson = parseJsonObject(response);
+        assertThat(responseJson).isNotNull();
+        assertThat(responseJson.getString("analysisState")).isEqualTo(AnalysisState.NOT_SET.name());
+        assertThat(responseJson.getString("analysisJustification")).isEqualTo(AnalysisJustification.NOT_SET.name());
+        assertThat(responseJson.getString("analysisResponse")).isEqualTo(AnalysisResponse.NOT_SET.name());
+        assertThat(responseJson.getJsonString("analysisDetails")).isNull();
+        assertThat(responseJson.getJsonArray("analysisComments")).isEmpty();
+        assertThat(responseJson.getBoolean("isSuppressed")).isFalse();
+
+        assertThat(NOTIFICATIONS.size()).isEqualTo(1);
+        final Notification notification = NOTIFICATIONS.poll();
+        assertThat(notification).isNotNull();
+        assertThat(notification.getScope()).isEqualTo(NotificationScope.PORTFOLIO.name());
+        assertThat(notification.getGroup()).isEqualTo(NotificationGroup.PROJECT_AUDIT_CHANGE.name());
+        assertThat(notification.getLevel()).isEqualTo(NotificationLevel.INFORMATIONAL);
+        assertThat(notification.getTitle()).isEqualTo(NotificationConstants.Title.ANALYSIS_DECISION_NOT_SET);
+        assertThat(notification.getContent()).isEqualTo("An analysis decision was made to a finding affecting a project");
+    }
+
+    @Test
+    public void updateAnalysisUpdateExistingTest() {
+        initializeWithPermissions(Permissions.VULNERABILITY_ANALYSIS);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("Acme Component");
+        component.setVersion("1.0");
+        component = qm.createComponent(component, false);
+
+        var vulnerability = new Vulnerability();
+        vulnerability.setVulnId("INT-001");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.HIGH);
+        vulnerability.setComponents(List.of(component));
+        vulnerability = qm.createVulnerability(vulnerability, false);
+
+        final Analysis analysis = qm.makeAnalysis(component, vulnerability, AnalysisState.NOT_AFFECTED,
+                AnalysisJustification.CODE_NOT_REACHABLE, AnalysisResponse.WILL_NOT_FIX, "Analysis details here", true);
+        qm.makeAnalysisComment(analysis, "Analysis comment here", "Jane Doe");
+
+        final var analysisRequest = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
+                vulnerability.getUuid().toString(), AnalysisState.EXPLOITABLE, AnalysisJustification.NOT_SET,
+                AnalysisResponse.UPDATE, "New analysis details here", "New analysis comment here", false);
+
+        final Response response = target(V1_ANALYSIS)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+
+        final JsonObject responseJson = parseJsonObject(response);
+        assertThat(responseJson).isNotNull();
+        assertThat(responseJson.getString("analysisState")).isEqualTo(AnalysisState.EXPLOITABLE.name());
+        assertThat(responseJson.getString("analysisJustification")).isEqualTo(AnalysisJustification.NOT_SET.name());
+        assertThat(responseJson.getString("analysisResponse")).isEqualTo(AnalysisResponse.UPDATE.name());
+        assertThat(responseJson.getString("analysisDetails")).isEqualTo("New analysis details here");
+
+        final JsonArray analysisComments = responseJson.getJsonArray("analysisComments");
+        assertThat(analysisComments).hasSize(7);
+        assertThat(analysisComments.getJsonObject(0))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Analysis comment here"))
+                .hasFieldOrPropertyWithValue("commenter", Json.createValue("Jane Doe"));
+        assertThat(analysisComments.getJsonObject(1))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Analysis: NOT_AFFECTED → EXPLOITABLE"))
+                .doesNotContainKey("commenter"); // Not set when authenticating via API key
+        assertThat(analysisComments.getJsonObject(2))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Justification: CODE_NOT_REACHABLE → NOT_SET"))
+                .doesNotContainKey("commenter"); // Not set when authenticating via API key
+        assertThat(analysisComments.getJsonObject(3))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Vendor Response: WILL_NOT_FIX → UPDATE"))
+                .doesNotContainKey("commenter"); // Not set when authenticating via API key
+        assertThat(analysisComments.getJsonObject(4))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Details: New analysis details here"))
+                .doesNotContainKey("commenter"); // Not set when authenticating via API key
+        assertThat(analysisComments.getJsonObject(5))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Unsuppressed"))
+                .doesNotContainKey("commenter"); // Not set when authenticating via API key
+        assertThat(analysisComments.getJsonObject(6))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("New analysis comment here"))
+                .doesNotContainKey("commenter"); // Not set when authenticating via API key
+        assertThat(responseJson.getBoolean("isSuppressed")).isFalse();
+
+        assertThat(NOTIFICATIONS.size()).isEqualTo(1);
+        final Notification notification = NOTIFICATIONS.poll();
+        assertThat(notification).isNotNull();
+        assertThat(notification.getScope()).isEqualTo(NotificationScope.PORTFOLIO.name());
+        assertThat(notification.getGroup()).isEqualTo(NotificationGroup.PROJECT_AUDIT_CHANGE.name());
+        assertThat(notification.getLevel()).isEqualTo(NotificationLevel.INFORMATIONAL);
+        assertThat(notification.getTitle()).isEqualTo(NotificationConstants.Title.ANALYSIS_DECISION_EXPLOITABLE);
+        assertThat(notification.getContent()).isEqualTo("An analysis decision was made to a finding affecting a project");
+    }
+
+    @Test
+    public void updateAnalysisWithNoChangesTest() {
+        initializeWithPermissions(Permissions.VULNERABILITY_ANALYSIS);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("Acme Component");
+        component.setVersion("1.0");
+        component = qm.createComponent(component, false);
+
+        var vulnerability = new Vulnerability();
+        vulnerability.setVulnId("INT-001");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.HIGH);
+        vulnerability.setComponents(List.of(component));
+        vulnerability = qm.createVulnerability(vulnerability, false);
+
+        final Analysis analysis = qm.makeAnalysis(component, vulnerability, AnalysisState.NOT_AFFECTED,
+                AnalysisJustification.CODE_NOT_REACHABLE, AnalysisResponse.WILL_NOT_FIX, "Analysis details here", true);
+        qm.makeAnalysisComment(analysis, "Analysis comment here", "Jane Doe");
+
+        final var analysisRequest = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
+                vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE,
+                AnalysisResponse.WILL_NOT_FIX, "Analysis details here", null, true);
+
+        final Response response = target(V1_ANALYSIS)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+
+        final JsonObject responseJson = parseJsonObject(response);
+        assertThat(responseJson).isNotNull();
+        assertThat(responseJson.getString("analysisState")).isEqualTo(AnalysisState.NOT_AFFECTED.name());
+        assertThat(responseJson.getString("analysisJustification")).isEqualTo(AnalysisJustification.CODE_NOT_REACHABLE.name());
+        assertThat(responseJson.getString("analysisResponse")).isEqualTo(AnalysisResponse.WILL_NOT_FIX.name());
+        assertThat(responseJson.getString("analysisDetails")).isEqualTo("Analysis details here");
+
+        final JsonArray analysisComments = responseJson.getJsonArray("analysisComments");
+        assertThat(analysisComments).hasSize(1);
+        assertThat(analysisComments.getJsonObject(0))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Analysis comment here"))
+                .hasFieldOrPropertyWithValue("commenter", Json.createValue("Jane Doe"));
+
+        assertThat(NOTIFICATIONS).isEmpty();
+    }
+
+    @Test
+    public void updateAnalysisUpdateExistingWithEmptyRequestTest() {
+        initializeWithPermissions(Permissions.VULNERABILITY_ANALYSIS);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("Acme Component");
+        component.setVersion("1.0");
+        component = qm.createComponent(component, false);
+
+        var vulnerability = new Vulnerability();
+        vulnerability.setVulnId("INT-001");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.HIGH);
+        vulnerability.setComponents(List.of(component));
+        vulnerability = qm.createVulnerability(vulnerability, false);
+
+        final Analysis analysis = qm.makeAnalysis(component, vulnerability, AnalysisState.NOT_AFFECTED,
+                AnalysisJustification.CODE_NOT_REACHABLE, AnalysisResponse.WILL_NOT_FIX, "Analysis details here", true);
+        qm.makeAnalysisComment(analysis, "Analysis comment here", "Jane Doe");
+
+        final var analysisRequest = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
+                vulnerability.getUuid().toString(), null, null, null, null, null, null);
+
+        final Response response = target(V1_ANALYSIS)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+
+        final JsonObject responseJson = parseJsonObject(response);
+        assertThat(responseJson).isNotNull();
+        assertThat(responseJson.getString("analysisState")).isEqualTo(AnalysisState.NOT_SET.name());
+        assertThat(responseJson.getString("analysisJustification")).isEqualTo(AnalysisJustification.NOT_SET.name());
+        assertThat(responseJson.getString("analysisResponse")).isEqualTo(AnalysisResponse.NOT_SET.name());
+        assertThat(responseJson.getString("analysisDetails")).isEqualTo("Analysis details here");
+
+        final JsonArray analysisComments = responseJson.getJsonArray("analysisComments");
+        assertThat(analysisComments).hasSize(4);
+        assertThat(analysisComments.getJsonObject(0))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Analysis comment here"))
+                .hasFieldOrPropertyWithValue("commenter", Json.createValue("Jane Doe"));
+        assertThat(analysisComments.getJsonObject(1))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Analysis: NOT_AFFECTED → NOT_SET"))
+                .doesNotContainKey("commenter"); // Not set when authenticating via API key
+        assertThat(analysisComments.getJsonObject(2))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Justification: CODE_NOT_REACHABLE → NOT_SET"))
+                .doesNotContainKey("commenter"); // Not set when authenticating via API key
+        assertThat(analysisComments.getJsonObject(3))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Vendor Response: WILL_NOT_FIX → NOT_SET"))
+                .doesNotContainKey("commenter"); // Not set when authenticating via API key
+
+        assertThat(NOTIFICATIONS.size()).isEqualTo(1);
+        final Notification notification = NOTIFICATIONS.poll();
+        assertThat(notification).isNotNull();
+        assertThat(notification.getScope()).isEqualTo(NotificationScope.PORTFOLIO.name());
+        assertThat(notification.getGroup()).isEqualTo(NotificationGroup.PROJECT_AUDIT_CHANGE.name());
+        assertThat(notification.getLevel()).isEqualTo(NotificationLevel.INFORMATIONAL);
+        assertThat(notification.getTitle()).isEqualTo(NotificationConstants.Title.ANALYSIS_DECISION_NOT_SET);
+        assertThat(notification.getContent()).isEqualTo("An analysis decision was made to a finding affecting a project");
+    }
+
+    @Test
+    public void updateAnalysisWithProjectNotFoundTest() {
+        initializeWithPermissions(Permissions.VULNERABILITY_ANALYSIS);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("Acme Component");
+        component.setVersion("1.0");
+        component = qm.createComponent(component, false);
+
+        var vulnerability = new Vulnerability();
+        vulnerability.setVulnId("INT-001");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.HIGH);
+        vulnerability.setComponents(List.of(component));
+        vulnerability = qm.createVulnerability(vulnerability, false);
+
+        final var analysisRequest = new AnalysisRequest(UUID.randomUUID().toString(), component.getUuid().toString(),
+                vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE,
+                AnalysisResponse.WILL_NOT_FIX, "Analysis details here", "Analysis comment here", true);
+
+        final Response response = target(V1_ANALYSIS)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+        assertThat(getPlainTextBody(response)).isEqualTo("The project could not be found.");
+    }
+
+    @Test
+    public void updateAnalysisWithComponentNotFoundTest() {
+        initializeWithPermissions(Permissions.VULNERABILITY_ANALYSIS);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("Acme Component");
+        component.setVersion("1.0");
+        component = qm.createComponent(component, false);
+
+        var vulnerability = new Vulnerability();
+        vulnerability.setVulnId("INT-001");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.HIGH);
+        vulnerability.setComponents(List.of(component));
+        vulnerability = qm.createVulnerability(vulnerability, false);
+
+        final var analysisRequest = new AnalysisRequest(project.getUuid().toString(), UUID.randomUUID().toString(),
+                vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE,
+                AnalysisResponse.WILL_NOT_FIX, "Analysis details here", "Analysis comment here", true);
+
+        final Response response = target(V1_ANALYSIS)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+        assertThat(getPlainTextBody(response)).isEqualTo("The component could not be found.");
+    }
+
+    @Test
+    public void updateAnalysisWithVulnerabilityNotFoundTest() {
+        initializeWithPermissions(Permissions.VULNERABILITY_ANALYSIS);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("Acme Component");
+        component.setVersion("1.0");
+        component = qm.createComponent(component, false);
+
+        final var vulnerability = new Vulnerability();
+        vulnerability.setVulnId("INT-001");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.HIGH);
+        vulnerability.setComponents(List.of(component));
+        qm.createVulnerability(vulnerability, false);
+
+        final var analysisRequest = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
+                UUID.randomUUID().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE,
+                AnalysisResponse.WILL_NOT_FIX, "Analysis details here", "Analysis comment here", true);
+
+        final Response response = target(V1_ANALYSIS)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+        assertThat(getPlainTextBody(response)).isEqualTo("The vulnerability could not be found.");
     }
 
     // Test the scenario where an analysis was created with Dependency-Track <= 4.3.6,
@@ -263,51 +678,85 @@ public class AnalysisResourceTest extends ResourceTest {
     // Performing an analysis with those request fields set in >= 4.4.0 then resulted in NPEs,
     // see https://github.com/DependencyTrack/dependency-track/issues/1409
     @Test
-    public void testIssue1409() {
-        Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
-        Component component = new Component();
+    public void updateAnalysisIssue1409Test() {
+        initializeWithPermissions(Permissions.VULNERABILITY_ANALYSIS);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        var component = new Component();
         component.setProject(project);
         component.setName("Acme Component");
         component.setVersion("1.0");
-        qm.createComponent(component, false);
-        List<Component> components = new ArrayList<>();
-        components.add(component);
-        Vulnerability vulnerability = new Vulnerability();
+        component = qm.createComponent(component, false);
+
+        var vulnerability = new Vulnerability();
         vulnerability.setVulnId("INT-001");
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
-        vulnerability.setComponents(components);
-        qm.createVulnerability(vulnerability, false);
+        vulnerability.setComponents(List.of(component));
+        vulnerability = qm.createVulnerability(vulnerability, false);
+
         qm.makeAnalysis(component, vulnerability, AnalysisState.IN_TRIAGE, null, null, null, false);
-        AnalysisRequest request = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
-                vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.PROTECTED_BY_MITIGATING_CONTROL, AnalysisResponse.UPDATE, "Updated analysis details here", "Not an issue", true);
-        Response response = target(V1_ANALYSIS)
+
+        final var analysisRequest = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
+                vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.PROTECTED_BY_MITIGATING_CONTROL,
+                AnalysisResponse.UPDATE, "New analysis details here", "New analysis comment here", false);
+
+        final Response response = target(V1_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
-                .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
-        JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(AnalysisState.NOT_AFFECTED.name(), json.getString("analysisState"));
-        Assert.assertTrue(json.getBoolean("isSuppressed"));
-        Assert.assertEquals(6, json.getJsonArray("analysisComments").size());
-        Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(0).getJsonNumber("timestamp"));
-        Assert.assertEquals("Analysis: IN_TRIAGE → NOT_AFFECTED", json.getJsonArray("analysisComments").getJsonObject(0).getString("comment"));
-        Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(1).getJsonNumber("timestamp"));
-        Assert.assertEquals("Justification: NOT_SET → PROTECTED_BY_MITIGATING_CONTROL", json.getJsonArray("analysisComments").getJsonObject(1).getString("comment"));
-        Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(2).getJsonNumber("timestamp"));
-        Assert.assertEquals("Vendor Response: NOT_SET → UPDATE", json.getJsonArray("analysisComments").getJsonObject(2).getString("comment"));
-        Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(3).getJsonNumber("timestamp"));
-        Assert.assertEquals("Details: Updated analysis details here", json.getJsonArray("analysisComments").getJsonObject(3).getString("comment"));
-        Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(4).getJsonNumber("timestamp"));
-        Assert.assertEquals("Suppressed", json.getJsonArray("analysisComments").getJsonObject(4).getString("comment"));
-        Assert.assertNotNull(json.getJsonArray("analysisComments").getJsonObject(5).getJsonNumber("timestamp"));
-        Assert.assertEquals("Not an issue", json.getJsonArray("analysisComments").getJsonObject(5).getString("comment"));
-        Analysis analysis = qm.getAnalysis(component, vulnerability);
-        Assert.assertEquals(project.getUuid(), analysis.getProject().getUuid());
-        Assert.assertEquals(component.getUuid(), analysis.getComponent().getUuid());
-        Assert.assertEquals(vulnerability.getUuid(), analysis.getVulnerability().getUuid());
+                .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+
+        final JsonObject responseJson = parseJsonObject(response);
+        assertThat(responseJson).isNotNull();
+        assertThat(responseJson.getString("analysisState")).isEqualTo(AnalysisState.NOT_AFFECTED.name());
+        assertThat(responseJson.getString("analysisJustification")).isEqualTo(AnalysisJustification.PROTECTED_BY_MITIGATING_CONTROL.name());
+        assertThat(responseJson.getString("analysisResponse")).isEqualTo(AnalysisResponse.UPDATE.name());
+        assertThat(responseJson.getString("analysisDetails")).isEqualTo("New analysis details here");
+
+        final JsonArray analysisComments = responseJson.getJsonArray("analysisComments");
+        assertThat(analysisComments).hasSize(5);
+        assertThat(analysisComments.getJsonObject(0))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Analysis: IN_TRIAGE → NOT_AFFECTED"))
+                .doesNotContainKey("commenter"); // Not set when authenticating via API key
+        assertThat(analysisComments.getJsonObject(1))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Justification: NOT_SET → PROTECTED_BY_MITIGATING_CONTROL"))
+                .doesNotContainKey("commenter"); // Not set when authenticating via API key
+        assertThat(analysisComments.getJsonObject(2))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Vendor Response: NOT_SET → UPDATE"))
+                .doesNotContainKey("commenter"); // Not set when authenticating via API key
+        assertThat(analysisComments.getJsonObject(3))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("Details: New analysis details here"))
+                .doesNotContainKey("commenter"); // Not set when authenticating via API key
+        assertThat(analysisComments.getJsonObject(4))
+                .hasFieldOrPropertyWithValue("comment", Json.createValue("New analysis comment here"))
+                .doesNotContainKey("commenter"); // Not set when authenticating via API key
+        assertThat(responseJson.getBoolean("isSuppressed")).isFalse();
+
+        assertThat(NOTIFICATIONS.size()).isEqualTo(1);
+        final Notification notification = NOTIFICATIONS.poll();
+        assertThat(notification).isNotNull();
+        assertThat(notification.getScope()).isEqualTo(NotificationScope.PORTFOLIO.name());
+        assertThat(notification.getGroup()).isEqualTo(NotificationGroup.PROJECT_AUDIT_CHANGE.name());
+        assertThat(notification.getLevel()).isEqualTo(NotificationLevel.INFORMATIONAL);
+        assertThat(notification.getTitle()).isEqualTo(NotificationConstants.Title.ANALYSIS_DECISION_NOT_AFFECTED);
+        assertThat(notification.getContent()).isEqualTo("An analysis decision was made to a finding affecting a project");
+    }
+
+    @Test
+    public void updateAnalysisUnauthorizedTest() {
+        final var analysisRequest = new AnalysisRequest(UUID.randomUUID().toString(), UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.PROTECTED_BY_MITIGATING_CONTROL,
+                AnalysisResponse.UPDATE, "Analysis details here", "Analysis comment here", false);
+
+        final Response response = target(V1_ANALYSIS)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_FORBIDDEN);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
     }
 
 }


### PR DESCRIPTION
Also add more tests for `AnalysisResource` and `ViolationAnalysisResource`. Additionally test notifications being sent.

Signed-off-by: nscuro <nscuro@protonmail.com>

Before (in v4.4.2):

![Before](https://user-images.githubusercontent.com/5693141/165164842-1cf9411d-81ef-4014-aac3-a6b63d370aac.gif)

After (this PR):

![After](https://user-images.githubusercontent.com/5693141/165164913-e1443145-8d90-4a32-903e-e3481a82f93c.gif)

