### PR TITLE
Updated Atlassian package repository address

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
+++ b/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
@@ -238,7 +238,7 @@ public class DefaultObjectGenerator implements ServletContextListener {
             qm.createRepository(RepositoryType.GEM, "rubygems.org", "https://rubygems.org/", true, false);
             qm.createRepository(RepositoryType.HEX, "hex.pm", "https://hex.pm/", true, false);
             qm.createRepository(RepositoryType.MAVEN, "central", "https://repo1.maven.org/maven2/", true, false);
-            qm.createRepository(RepositoryType.MAVEN, "atlassian-public", "https://maven.atlassian.com/content/repositories/atlassian-public/", true, false);
+            qm.createRepository(RepositoryType.MAVEN, "atlassian-public", "https://packages.atlassian.com/content/repositories/atlassian-public/", true, false);
             qm.createRepository(RepositoryType.MAVEN, "jboss-releases", "https://repository.jboss.org/nexus/content/repositories/releases/", true, false);
             qm.createRepository(RepositoryType.MAVEN, "clojars", "https://repo.clojars.org/", true, false);
             qm.createRepository(RepositoryType.MAVEN, "google-android", "https://maven.google.com/", true, false);

--- a/src/main/java/org/dependencytrack/upgrade/v450/v450Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v450/v450Updater.java
@@ -50,6 +50,7 @@ public class v450Updater extends AbstractUpgradeItem {
     private static final String STMT_9 = "SELECT \"t\".\"ID\" FROM \"TEAM\" AS \"t\" INNER JOIN \"TEAMS_PERMISSIONS\" AS \"tp\" ON \"tp\".\"TEAM_ID\" = \"t\".\"ID\" WHERE \"tp\".\"PERMISSION_ID\" = %d";
     private static final String STMT_10 = "INSERT INTO \"TEAMS_PERMISSIONS\" (\"TEAM_ID\", \"PERMISSION_ID\") VALUES (?, ?)";
     private static final String STMT_11 = "UPDATE \"VULNERABILITY\" SET \"CWE\" = NULL";
+    private static final String STMT_12 = "UPDATE \"REPOSITORY\" SET \"URL\" = 'https://packages.atlassian.com/content/repositories/atlassian-public/' WHERE \"TYPE\" = 'MAVEN' AND \"IDENTIFIER\" = 'atlassian-public'";
 
     @Override
     public String getSchemaVersion() {
@@ -121,6 +122,9 @@ public class v450Updater extends AbstractUpgradeItem {
                 ps.executeUpdate();
             }
         }
+
+        LOGGER.info("Updating Atlassian Maven Repository URL");
+        DbUtil.executeUpdate(connection, STMT_12);
     }
 
     private long getPermissionId(final Connection connection, final Permissions permission) throws SQLException, UpgradeException {

--- a/src/main/resources/services.bom.json
+++ b/src/main/resources/services.bom.json
@@ -285,7 +285,7 @@
       "name": "Atlassian Public",
       "description": "Package repository for the Java ecosystem.",
       "endpoints": [
-        "https://maven.atlassian.com/content/repositories/atlassian-public/"
+        "https://packages.atlassian.com/content/repositories/atlassian-public/"
       ],
       "authenticated": false,
       "x-trust-boundary": true,


### PR DESCRIPTION
The Atlassian package repository has been moved.  While this address still works with a 301 permanent redirection, anyone using this file as documentation for allow-listing egress to these endpoints (like me) needs the accurate addresses.  Since this one has been moved by Atlassian, I thought I'd send this PR to update it at source.
 

```shell
curl -v  "https://maven.atlassian.com/content/repositories/atlassian-public/"
*   Trying 104.192.143.13:443...
* Connected to maven.atlassian.com (104.192.143.13) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-ECDSA-AES128-GCM-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=AU; ST=New South Wales; L=Sydney; O=Atlassian Pty Ltd; CN=*.atlassian.com
*  start date: Apr  8 00:00:00 2020 GMT
*  expire date: Jun 10 12:00:00 2022 GMT
*  subjectAltName: host "maven.atlassian.com" matched cert's "*.atlassian.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert SHA2 High Assurance Server CA
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fa6bb012200)
> GET /content/repositories/atlassian-public/ HTTP/2
> Host: maven.atlassian.com
> user-agent: curl/7.77.0
> accept: */*
> 
< HTTP/2 301 
< date: Tue, 26 Apr 2022 06:24:00 GMT
< content-type: text/html
< content-length: 169
< server: globaledge-envoy
< location: https://packages.atlassian.com/content/repositories/atlassian-public/
< x-envoy-upstream-service-time: 811
< expect-ct: report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/artifactory", max-age=86400
< strict-transport-security: max-age=63072000; preload
< x-content-type-options: nosniff
< x-xss-protection: 1; mode=block
< atl-traceid: 377b6acbbd651d6b
< report-to: {"group": "endpoint-1", "max_age": 600, "endpoints": [{"url": "https://dj9s4kmieytgz.cloudfront.net"}], "include_subdomains": true}
< nel: {"report_to": "endpoint-1", "max_age": 600, "include_subdomains": true, "failure_fraction": 0.001}
< 
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx/1.18.0</center>
</body>
</html>
* Connection #0 to host maven.atlassian.com left intact
```