### PR TITLE
Fix GHSA vulnerabilities not being matched for Go modules

### DIFF
--- a/docs/_posts/2022-xx-xx-v4.5.0.md
+++ b/docs/_posts/2022-xx-xx-v4.5.0.md
@@ -9,6 +9,7 @@ type: major
 **Fixes:**
 * Resolved defect where the `VULNERABILITY_ANALYSIS` permission was required to see policy violations - [#126](https://github.com/DependencyTrack/frontend/issues/126)
 * Resolved defect where audit trail entries were generated for `Justification` and `Response`, even though they didn't actually change - [#1566](https://github.com/DependencyTrack/dependency-track/pull/1566)
+* Resolved defect where vulnerabilities from GitHub Advisories could not be matched with Go modules - [#1574](https://github.com/DependencyTrack/dependency-track/issues/1574)
 
 **Security:**
 

--- a/src/main/java/org/dependencytrack/tasks/GitHubAdvisoryMirrorTask.java
+++ b/src/main/java/org/dependencytrack/tasks/GitHubAdvisoryMirrorTask.java
@@ -289,6 +289,10 @@ public class GitHubAdvisoryMirrorTask implements LoggableSubscriber {
             } else if (PackageURL.StandardTypes.MAVEN.equals(purlType) && vuln.getPackageName().contains(":")) {
                 final String[] parts = vuln.getPackageName().split(":");
                 return PackageURLBuilder.aPackageURL().withType(purlType).withNamespace(parts[0]).withName(parts[1]).build();
+            } else if (PackageURL.StandardTypes.GOLANG.equals(purlType) && vuln.getPackageName().contains("/")) {
+                final String[] parts = vuln.getPackageName().split("/");
+                final String namespace = String.join("/", Arrays.copyOfRange(parts, 0, parts.length - 1));
+                return PackageURLBuilder.aPackageURL().withType(purlType).withNamespace(namespace).withName(parts[parts.length - 1]).build();
             } else {
                 return PackageURLBuilder.aPackageURL().withType(purlType).withName(vuln.getPackageName()).build();
             }

--- a/src/main/java/org/dependencytrack/tasks/scanners/BaseComponentAnalyzerTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/BaseComponentAnalyzerTask.java
@@ -55,7 +55,7 @@ public abstract class BaseComponentAnalyzerTask implements ScanTask {
             final ConfigProperty property = qm.getConfigProperty(
                     configPropertyConstants.getGroupName(), configPropertyConstants.getPropertyName()
             );
-            if (ConfigProperty.PropertyType.BOOLEAN == property.getPropertyType()) {
+            if (property != null && ConfigProperty.PropertyType.BOOLEAN == property.getPropertyType()) {
                 return BooleanUtil.valueOf(property.getPropertyValue());
             }
             return false;

--- a/src/main/java/org/dependencytrack/upgrade/v450/v450Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v450/v450Updater.java
@@ -23,10 +23,10 @@ import alpine.common.logging.Logger;
 import alpine.persistence.AlpineQueryManager;
 import alpine.server.upgrade.AbstractUpgradeItem;
 import alpine.server.upgrade.UpgradeException;
-import org.dependencytrack.auth.Permissions;
 import alpine.server.util.DbUtil;
 import org.apache.commons.io.FileDeleteStrategy;
 import org.dependencytrack.auth.Permissions;
+
 import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
@@ -34,6 +34,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Arrays;
 
 public class v450Updater extends AbstractUpgradeItem {
 
@@ -51,6 +52,8 @@ public class v450Updater extends AbstractUpgradeItem {
     private static final String STMT_10 = "INSERT INTO \"TEAMS_PERMISSIONS\" (\"TEAM_ID\", \"PERMISSION_ID\") VALUES (?, ?)";
     private static final String STMT_11 = "UPDATE \"VULNERABILITY\" SET \"CWE\" = NULL";
     private static final String STMT_12 = "UPDATE \"REPOSITORY\" SET \"URL\" = 'https://packages.atlassian.com/content/repositories/atlassian-public/' WHERE \"TYPE\" = 'MAVEN' AND \"IDENTIFIER\" = 'atlassian-public'";
+    private static final String STMT_13 = "SELECT \"ID\", \"PURL_NAME\" FROM \"VULNERABLESOFTWARE\" WHERE \"PURL_TYPE\" = 'golang' AND \"PURL_NAMESPACE\" IS NULL AND \"PURL_NAME\" LIKE '%/%'";
+    private static final String STMT_14 = "UPDATE \"VULNERABLESOFTWARE\" SET \"PURL_NAMESPACE\" = ?, \"PURL_NAME\" = ? WHERE \"ID\" = ?";
 
     @Override
     public String getSchemaVersion() {
@@ -125,6 +128,23 @@ public class v450Updater extends AbstractUpgradeItem {
 
         LOGGER.info("Updating Atlassian Maven Repository URL");
         DbUtil.executeUpdate(connection, STMT_12);
+
+        LOGGER.info("Updating Package URLs of Go Packages for GHSA Vulnerabilities");
+        try (final Statement stmt = connection.createStatement()) {
+            final ResultSet rs = stmt.executeQuery(STMT_13);
+            while (rs.next()) {
+                final String purlName = rs.getString(2);
+                final String[] purlParts = purlName.split("/");
+
+                final String namespace = String.join("/", Arrays.copyOfRange(purlParts, 0, purlParts.length - 1));
+
+                ps = connection.prepareStatement(STMT_14);
+                ps.setString(1, namespace);
+                ps.setString(2, purlParts[purlParts.length - 1]);
+                ps.setLong(3, rs.getLong(1));
+                ps.executeUpdate();
+            }
+        }
     }
 
     private long getPermissionId(final Connection connection, final Permissions permission) throws SQLException, UpgradeException {

--- a/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskTest.java
@@ -1,0 +1,50 @@
+package org.dependencytrack.tasks.scanners;
+
+import alpine.persistence.PaginatedResult;
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.VulnerableSoftware;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InternalAnalysisTaskTest extends PersistenceCapableTest {
+
+    @Test
+    public void testIssue1574() {
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.createProject(project, List.of(), false);
+        var component = new Component();
+        component.setProject(project);
+        component.setName("github.com/tidwall/gjson");
+        component.setVersion("v1.6.0");
+        component.setPurl("pkg:golang/github.com/tidwall/gjson@v1.6.0?type=module");
+        component = qm.createComponent(component, false);
+
+        var vulnerableSoftware = new VulnerableSoftware();
+        vulnerableSoftware.setPurlType("golang");
+        vulnerableSoftware.setPurlNamespace("github.com/tidwall");
+        vulnerableSoftware.setPurlName("gjson");
+        vulnerableSoftware.setVersionEndExcluding("1.6.5");
+        vulnerableSoftware.setVulnerable(true);
+        vulnerableSoftware = qm.persist(vulnerableSoftware);
+
+        var vulnerability = new Vulnerability();
+        vulnerability.setVulnId("GHSA-wjm3-fq3r-5x46");
+        vulnerability.setSource(Vulnerability.Source.GITHUB);
+        vulnerability.setVulnerableSoftware(List.of(vulnerableSoftware));
+        qm.createVulnerability(vulnerability, false);
+
+        new InternalAnalysisTask().analyze(List.of(component));
+
+        final PaginatedResult vulnerabilities = qm.getVulnerabilities(component);
+        assertThat(vulnerabilities.getTotal()).isEqualTo(1);
+        assertThat(vulnerabilities.getList(Vulnerability.class).get(0).getVulnId()).isEqualTo("GHSA-wjm3-fq3r-5x46");
+    }
+
+}


### PR DESCRIPTION
This PR does two things:

1. Handle component versions prefixed with `v` in `InternalAnalysisTask` when performing lookups in `VULNERABLESOFTWARE`. Both GHSA and NVD do not include this prefix in their versions. As `VULNERABLESOFTWARE` is populated by multiple sources, this change will need to be revisited when another source is added. 
2. Correct the PURL building for Go modules in `GitHubAdvisoryMirrorTask`. See https://github.com/DependencyTrack/dependency-track/issues/1574#issuecomment-1114307576 for details on this issue. Go module names are a little special when it comes to PURL and need extra care.

Additionally, the changes in 2. are applied to existing `VULNERABLESOFTWARE` rows as well during the v4.5.0 upgrade.

Fixes #1574.