### PR TITLE
Fix portfolio changes not being reflected in search API results

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -579,16 +579,18 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
     /**
      * Deletes a Project and all objects dependant on the project.
      * @param project the Project to delete
+     * @param commitIndex specifies if the search index should be committed (an expensive operation)
      */
-    public void recursivelyDelete(Project project) {
+    public void recursivelyDelete(final Project project, final boolean commitIndex) {
         if (project.getChildren() != null) {
             for (final Project child: project.getChildren()) {
-                recursivelyDelete(child);
+                recursivelyDelete(child, false);
             }
         }
         pm.getFetchPlan().setDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS);
         final Project result = pm.getObjectById(Project.class, project.getId());
         Event.dispatch(new IndexEvent(IndexEvent.Action.DELETE, pm.detachCopy(result)));
+        commitSearchIndex(commitIndex, Project.class);
 
         deleteAnalysisTrail(project);
         deleteViolationAnalysisTrail(project);

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -382,8 +382,8 @@ public class QueryManager extends AlpineQueryManager {
         return getProjectQueryManager().updateLastBomImport(p, date, bomFormat);
     }
 
-    public void recursivelyDelete(Project project) {
-        getProjectQueryManager().recursivelyDelete(project);
+    public void recursivelyDelete(final Project project, final boolean commitIndex) {
+        getProjectQueryManager().recursivelyDelete(project, commitIndex);
     }
 
     public ProjectProperty createProjectProperty(final Project project, final String groupName, final String propertyName,

--- a/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -422,8 +422,8 @@ public class ProjectResource extends AlpineResource {
             final Project project = qm.getObjectByUuid(Project.class, uuid, Project.FetchGroup.ALL.name());
             if (project != null) {
                 if (qm.hasAccess(super.getPrincipal(), project)) {
-                    LOGGER.info("Project " + project.toString() + " deletion request by " + super.getPrincipal().getName());
-                    qm.recursivelyDelete(project);
+                    LOGGER.info("Project " + project + " deletion request by " + super.getPrincipal().getName());
+                    qm.recursivelyDelete(project, true);
                     return Response.status(Response.Status.NO_CONTENT).build();
                 } else {
                     return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();

--- a/src/main/java/org/dependencytrack/search/IndexManager.java
+++ b/src/main/java/org/dependencytrack/search/IndexManager.java
@@ -65,7 +65,6 @@ public abstract class IndexManager implements AutoCloseable {
 
     private static final Logger LOGGER = Logger.getLogger(IndexManager.class);
     private IndexWriter iwriter;
-    private IndexSearcher isearcher;
     private MultiFieldQueryParser qparser;
     private final IndexType indexType;
 
@@ -160,17 +159,20 @@ public abstract class IndexManager implements AutoCloseable {
     }
 
     /**
-     * Returns an IndexSearcher by opening the index directory first, if necessary.
-     * @return an IndexSearcher
+     * Returns an {@link IndexSearcher}.
+     * <p>
+     * A new instance is created on every invocation. This is necessary because
+     * searchers operate on the state of the index they've been given upon construction.
+     * If the index changed, a new searcher must be created in order to have those changes
+     * being reflected in search results. See {@link IndexSearcher} documentation.
+     *
+     * @return an {@link IndexSearcher}
      * @throws IOException when the index directory cannot be opened
      * @since 3.0.0
      */
     protected IndexSearcher getIndexSearcher() throws IOException {
-        if (isearcher == null) {
-            final IndexReader reader = DirectoryReader.open(getDirectory());
-            isearcher = new IndexSearcher(reader);
-        }
-        return isearcher;
+        final IndexReader reader = DirectoryReader.open(getDirectory());
+        return new IndexSearcher(reader);
     }
 
     /**


### PR DESCRIPTION
Upon project deletion, the search index was updated but never committed, preventing the change from taking effect immediately.

While debugging, I noticed that `/api/v1/search` worked once, shortly after restarting DT, but then didn't update anymore, regardless of whether resources would be added, updated or deleted. This turned out to be caused by DT reusing the same `IndexSearcher` instance. The `IndexSearcher` documentation says:

> For performance reasons, if your index is unchanging, you should share a single IndexSearcher instance across multiple searches instead of creating a new one per-search. **If your index has changed and you wish to see the changes reflected in searching, you should use DirectoryReader.openIfChanged(DirectoryReader) to obtain a new reader and then create a new IndexSearcher from that**.

Fixes #1605 