### PR TITLE
Documentation fix for export endpoint permissions

### DIFF
--- a/docs/_docs/integrations/file-formats.md
+++ b/docs/_docs/integrations/file-formats.md
@@ -24,7 +24,7 @@ FPF's are json files and have the following sections:
 
 To export findings in the FPF format, the `/api/v1/finding/project/{uuid}/export` API endpoint is used.
 
-The **VULNERABILITY_ANALYSIS** permission is required to use the findings API.
+The **VIEW_VULNERABILITY** permission is required to use the findings API.
 
 > Finding Packaging Format v1.1 was introduced in Dependency-Track v4.5 and supports an array of CWEs per vulnerability.
 > Previous versions of Dependency-Track supported only a single CWE (cweId and cweName fields respectively) per


### PR DESCRIPTION
If you want to export the FPF format findings via the `/api/v1/finding/project/{uuid}/export` API, the documentation says that you need the VULNERABILITY_ANALYSIS permission for the accompanying API key. After some debugging, i found out that the source requires VIEW_VULNERABILITY:

https://github.com/DependencyTrack/dependency-track/blob/beda0ce2a594302b6ef976187967b0c4ea12cd91/src/main/java/org/dependencytrack/resources/v1/FindingResource.java#L111

This is a fix to patch the documentation to state the correct permissions needed.

Signed-off-by: Tonimir Kisasondi <kisasondi@gmail.com>