### PR TITLE
Include `policy` field in `POLICY_VIOLATION` notification

### DIFF
--- a/docs/_docs/integrations/notifications.md
+++ b/docs/_docs/integrations/notifications.md
@@ -31,19 +31,20 @@ Dependency-Track notifications come in two flavors:
 
 Each scope contains a set of notification groups that can be used to subscribe to.
 
-| Scope | Group | Description |
-| ------|-------|-------------|
-| SYSTEM | ANALYZER | Notifications generated as a result of interacting with an external source of vulnerability intelligence |
-| SYSTEM | DATASOURCE_MIRRORING | Notifications generated when performing mirroring of one of the supported datasources such as the NVD |
-| SYSTEM | INDEXING_SERVICE | Notifications generated as a result of performing maintenance on Dependency-Tracks internal index used for global searching |
-| SYSTEM | FILE_SYSTEM | Notifications generated as a result of a file system operation. These are typically only generated on error conditions |
+| Scope | Group | Description                                                                                                                       |
+| ------|-------|-----------------------------------------------------------------------------------------------------------------------------------|
+| SYSTEM | ANALYZER | Notifications generated as a result of interacting with an external source of vulnerability intelligence                          |
+| SYSTEM | DATASOURCE_MIRRORING | Notifications generated when performing mirroring of one of the supported datasources such as the NVD                             |
+| SYSTEM | INDEXING_SERVICE | Notifications generated as a result of performing maintenance on Dependency-Tracks internal index used for global searching       |
+| SYSTEM | FILE_SYSTEM | Notifications generated as a result of a file system operation. These are typically only generated on error conditions            |
 | SYSTEM | REPOSITORY | Notifications generated as a result of interacting with one of the supported repositories such as Maven Central, RubyGems, or NPM |
-| PORTFOLIO | NEW_VULNERABILITY | Notifications generated whenever a new vulnerability is identified |
-| PORTFOLIO | NEW_VULNERABLE_DEPENDENCY | Notifications generated as a result of a vulnerable component becoming a dependency of a project |
-| PORTFOLIO | GLOBAL_AUDIT_CHANGE | Notifications generated whenever an analysis or suppression state has changed on a finding from a component (global) |
-| PORTFOLIO | PROJECT_AUDIT_CHANGE | Notifications generated whenever an analysis or suppression state has changed on a finding from a project |
-| PORTFOLIO | BOM_CONSUMED | Notifications generated whenever a supported BOM is ingested and identified |
-| PORTFOLIO | BOM_PROCESSED | Notifications generated after a supported BOM is ingested, identified, and successfully processed |
+| PORTFOLIO | NEW_VULNERABILITY | Notifications generated whenever a new vulnerability is identified                                                                |
+| PORTFOLIO | NEW_VULNERABLE_DEPENDENCY | Notifications generated as a result of a vulnerable component becoming a dependency of a project                                  |
+| PORTFOLIO | GLOBAL_AUDIT_CHANGE | Notifications generated whenever an analysis or suppression state has changed on a finding from a component (global)              |
+| PORTFOLIO | PROJECT_AUDIT_CHANGE | Notifications generated whenever an analysis or suppression state has changed on a finding from a project                         |
+| PORTFOLIO | BOM_CONSUMED | Notifications generated whenever a supported BOM is ingested and identified                                                       |
+| PORTFOLIO | BOM_PROCESSED | Notifications generated after a supported BOM is ingested, identified, and successfully processed                                 |
+| PORTFOLIO | POLICY_VIOLATION | Notifications generated whenever a policy violation is identified                                                                 |
 
 
 ## Configuring Notifications
@@ -116,10 +117,12 @@ This type of notification will always contain:
         "description": "Apache Axis 1.4 and earlier, as used in PayPal Payments Pro, PayPal Mass Pay, PayPal Transactional Information SOAP, the Java Message Service implementation in Apache ActiveMQ, and other products, does not verify that the server hostname matches a domain name in the subject's Common Name (CN) or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via an arbitrary valid certificate.",
         "cvssv2": 5.8,
         "severity": "MEDIUM",
-        "cwe": {
-          "cweId": 20,
-          "name": "Improper Input Validation"
-        }
+        "cwe": [
+          {
+            "cweId": 20,
+            "name": "Improper Input Validation"
+          }
+        ]
       },
       "affectedProjects": [
         {
@@ -172,10 +175,12 @@ This type of notification will always contain:
           "description": "Apache Axis 1.4 and earlier, as used in PayPal Payments Pro, PayPal Mass Pay, PayPal Transactional Information SOAP, the Java Message Service implementation in Apache ActiveMQ, and other products, does not verify that the server hostname matches a domain name in the subject's Common Name (CN) or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via an arbitrary valid certificate.",
           "cvssv2": 5.8,
           "severity": "MEDIUM",
-          "cwe": {
-            "cweId": 20,
-            "name": "Improper Input Validation"
-          }
+          "cwe": [
+            {
+              "cweId": 20,
+              "name": "Improper Input Validation"
+            }
+          ]
         },
         {
           "uuid": "ca318ca7-616f-4af0-9c6b-15b8e208c586",
@@ -270,6 +275,50 @@ This type of notification will always contain:
         "content": "<base64 encoded bom>",
         "format": "CycloneDX",
         "specVersion": "1.1"
+      }
+    }
+  }
+}
+```
+
+#### POLICY_VIOLATION
+
+```json
+{
+  "notification": {
+    "level": "INFORMATIONAL",
+    "scope": "PORTFOLIO",
+    "group": "POLICY_VIOLATION",
+    "timestamp": "2022-05-12T23:07:59.611303",
+    "title": "Policy Violation",
+    "content": "A operational policy violation occurred",
+    "subject": {
+      "project": {
+        "uuid": "7a36e5c0-9f09-42dd-b401-360da56c2abe",
+        "name": "Acme Example",
+        "version": "1.0.0"
+      },
+      "component": {
+        "uuid": "4e04c695-9acd-46fc-9bf6-ed23d7eb551e",
+        "group": "apache",
+        "name": "axis",
+        "version": "1.4"
+      },
+      "policyViolation": {
+        "uuid": "c82fcb50-029a-4636-a657-96242b20680e",
+        "type": "OPERATIONAL",
+        "timestamp": "2022-05-12T20:34:46Z",
+        "policyCondition": {
+          "uuid": "8e5c0a5b-71fb-45c5-afac-6c6a99742cbe",
+          "subject": "COORDINATES",
+          "operator": "MATCHES",
+          "value": "{\"group\":\"apache\",\"name\":\"axis\",\"version\":\"*\"}",
+          "policy": {
+            "uuid": "6d4c7398-689a-4ec7-b5c5-9abb6b5393e9",
+            "name": "Banned Components",
+            "violationState": "FAIL"
+          }
+        }
       }
     }
   }

--- a/docs/_posts/2022-xx-xx-v4.5.0.md
+++ b/docs/_posts/2022-xx-xx-v4.5.0.md
@@ -8,7 +8,7 @@ type: major
 * Added support for management of internal vulnerabilities - [#96](https://github.com/DependencyTrack/dependency-track/issues/96)
   * Added new `VULNERABILITY_MANAGEMENT` permission, which is required to create, edit and delete internal vulnerabilities
 * Added support for [EPSS](https://www.first.org/epss/model) - [#1178](https://github.com/DependencyTrack/dependency-track/issues/1178)
-* Added support for policy violation alerts - [#1396](https://github.com/DependencyTrack/dependency-track/issues/1396)
+* Added support for notifications on policy violations - [#1396](https://github.com/DependencyTrack/dependency-track/issues/1396)
 * Added support for fetching projects by classifier - [#1185](https://github.com/DependencyTrack/dependency-track/issues/1185)
 * Added support for multiple CWEs being assigned to vulnerabilities - [#1467](https://github.com/DependencyTrack/dependency-track/issues/1467)
   * Breaking change for API consumers: The `cwe` field for vulnerabilities and findings is now an array
@@ -25,7 +25,7 @@ type: major
 * Resolved defect where audit trail entries were generated for `Justification` and `Response`, even though they didn't actually change - [#1566](https://github.com/DependencyTrack/dependency-track/pull/1566)
 * Resolved defect where vulnerabilities from GitHub Advisories could not be matched with Go modules - [#1574](https://github.com/DependencyTrack/dependency-track/issues/1574)
 * Resolved defect where filtering projects by tag would ignore the active / inactive filter - [#1501](https://github.com/DependencyTrack/dependency-track/issues/1501)
-* Resolved defect where enabling NVD mirroring could not be enabled - [#1576](https://github.com/DependencyTrack/dependency-track/issues/1576) 
+* Resolved defect where NVD mirroring could not be enabled - [#1576](https://github.com/DependencyTrack/dependency-track/issues/1576) 
 * Updated URL of the Atlassian package repository - [#1568](https://github.com/DependencyTrack/dependency-track/pull/1568)
 * Resolved multiple defects in calculation of portfolio metrics - [#1530](https://github.com/DependencyTrack/dependency-track/pull/1530)
 * Resolved defect where incomplete NVD data could be mirrored - [#1480](https://github.com/DependencyTrack/dependency-track/pull/1480)


### PR DESCRIPTION
Signed-off-by: nscuro <nscuro@protonmail.com>

Example notification:

```json
{
  "notification": {
    "level": "INFORMATIONAL",
    "scope": "PORTFOLIO",
    "group": "POLICY_VIOLATION",
    "timestamp": "2022-05-12T23:07:59.611303",
    "title": "Policy Violation",
    "content": "A operational policy violation occurred",
    "subject": {
      "project": {
        "uuid": "7a36e5c0-9f09-42dd-b401-360da56c2abe",
        "name": "Acme Example",
        "version": "1.0.0"
      },
      "component": {
        "uuid": "4e04c695-9acd-46fc-9bf6-ed23d7eb551e",
        "group": "apache",
        "name": "axis",
        "version": "1.4"
      },
      "policyViolation": {
        "uuid": "c82fcb50-029a-4636-a657-96242b20680e",
        "type": "OPERATIONAL",
        "timestamp": "2022-05-12T20:34:46Z",
        "policyCondition": {
          "uuid": "8e5c0a5b-71fb-45c5-afac-6c6a99742cbe",
          "subject": "COORDINATES",
          "operator": "MATCHES",
          "value": "{\"group\":\"apache\",\"name\":\"axis\",\"version\":\"*\"}",
          "policy": {
            "uuid": "6d4c7398-689a-4ec7-b5c5-9abb6b5393e9",
            "name": "Banned Components",
            "violationState": "FAIL"
          }
        }
      }
    }
  }
}
```