### PR TITLE
ci: improve pull request testing

### DIFF
--- a/.github/workflows/_meta-build.yaml
+++ b/.github/workflows/_meta-build.yaml
@@ -78,6 +78,7 @@ jobs:
 
       - name: Login to Docker.io
         uses: docker/login-action@v2.0.0
+        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           registry: docker.io
           username: ${{ secrets.registry-0-usr }}
@@ -93,7 +94,7 @@ jobs:
             COMMIT_SHA=${{ github.sha }}
             WAR_FILENAME=dependency-track-${{ matrix.distribution }}.jar
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.ref == 'refs/heads/master' }}
           context: .
           file: src/main/docker/Dockerfile
 
@@ -108,7 +109,7 @@ jobs:
           vuln-type: 'os'
 
       - name: Upload Trivy Scan Results to GitHub Security Tab
-        if: github.ref == 'refs/heads/master'
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'master'          # Default branch
       - '[0-9]+.[0-9]+.x' # Release branches
+  pull_request:
+    branches:
+      - 'master'          # Default branch
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Description

A slight oversight on my previous PR resulted in pull requests only triggering the test-ci workflow, and while that sounds alright it ignores the fact that the test-ci wont build and thereby test the full build and the container builds.
This PR aims to fix this oversight.

### Changes

* only run login action and push when triggered on the default branch
* also trigger the build-ci workflow to test the general build and the container files

### Issues

* n/a