### PR TITLE
Ensure backwards-compatibility by including an additional `cwe` field in API objects and notifications

### DIFF
--- a/docs/_docs/integrations/file-formats.md
+++ b/docs/_docs/integrations/file-formats.md
@@ -63,7 +63,11 @@ The **VIEW_VULNERABILITY** permission is required to use the findings API.
       "subtitle": "timespan",
       "severity": "LOW",
       "severityRank": 3,
-      "cwe": [
+      "cwe": {
+        "cweId": 400,
+        "name": "Uncontrolled Resource Consumption ('Resource Exhaustion')"
+      },
+      "cwes": [
         {
           "cweId": 400,
           "name": "Uncontrolled Resource Consumption ('Resource Exhaustion')"
@@ -93,7 +97,11 @@ The **VIEW_VULNERABILITY** permission is required to use the findings API.
       "subtitle": "uglify-js",
       "severity": "LOW",
       "severityRank": 3,
-      "cwe": [
+      "cwe": {
+        "cweId": 400,
+        "name": "Uncontrolled Resource Consumption ('Resource Exhaustion')"
+      },
+      "cwes": [
         {
           "cweId": 400,
           "name": "Uncontrolled Resource Consumption ('Resource Exhaustion')"
@@ -109,3 +117,5 @@ The **VIEW_VULNERABILITY** permission is required to use the findings API.
   }]
 }
 ```
+
+> The `cwe` field is deprecated and will be removed in a later version. Please use `cwes` instead.

--- a/docs/_docs/integrations/notifications.md
+++ b/docs/_docs/integrations/notifications.md
@@ -117,7 +117,11 @@ This type of notification will always contain:
         "description": "Apache Axis 1.4 and earlier, as used in PayPal Payments Pro, PayPal Mass Pay, PayPal Transactional Information SOAP, the Java Message Service implementation in Apache ActiveMQ, and other products, does not verify that the server hostname matches a domain name in the subject's Common Name (CN) or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via an arbitrary valid certificate.",
         "cvssv2": 5.8,
         "severity": "MEDIUM",
-        "cwe": [
+        "cwe": {
+          "cweId": 20,
+          "name": "Improper Input Validation"
+        },
+        "cwes": [
           {
             "cweId": 20,
             "name": "Improper Input Validation"
@@ -135,6 +139,8 @@ This type of notification will always contain:
   }
 }
 ```
+
+> The `cwe` field is deprecated and will be removed in a later version. Please use `cwes` instead.
 
 #### NEW_VULNERABLE_DEPENDENCY
 This type of notification will always contain:
@@ -175,7 +181,11 @@ This type of notification will always contain:
           "description": "Apache Axis 1.4 and earlier, as used in PayPal Payments Pro, PayPal Mass Pay, PayPal Transactional Information SOAP, the Java Message Service implementation in Apache ActiveMQ, and other products, does not verify that the server hostname matches a domain name in the subject's Common Name (CN) or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via an arbitrary valid certificate.",
           "cvssv2": 5.8,
           "severity": "MEDIUM",
-          "cwe": [
+          "cwe": {
+            "cweId": 20,
+            "name": "Improper Input Validation"
+          },
+          "cwes": [
             {
               "cweId": 20,
               "name": "Improper Input Validation"
@@ -195,6 +205,8 @@ This type of notification will always contain:
   }
 }
 ```
+
+> The `cwe` field is deprecated and will be removed in a later version. Please use `cwes` instead.
 
 #### PROJECT_AUDIT_CHANGE and GLOBAL_AUDIT_CHANGE
 This type of notification will always contain:

--- a/docs/_posts/2022-xx-xx-v4.5.0.md
+++ b/docs/_posts/2022-xx-xx-v4.5.0.md
@@ -11,7 +11,8 @@ type: major
 * Added support for notifications on policy violations - [#1396](https://github.com/DependencyTrack/dependency-track/issues/1396)
 * Added support for fetching projects by classifier - [#1185](https://github.com/DependencyTrack/dependency-track/issues/1185)
 * Added support for multiple CWEs being assigned to vulnerabilities - [#1467](https://github.com/DependencyTrack/dependency-track/issues/1467)
-  * Breaking change for API consumers: The `cwe` field for vulnerabilities and findings is now an array
+  * API, FPF and notifications now include an additional JSON array field `cwes`
+  * The `cwe` field is still supported, but deprecated, and will be removed in a later release
 * Added new `VIEW_POLICY_VIOLATION` permission that grants read-only access to policy violations and the audit trail - [#1433](https://github.com/DependencyTrack/dependency-track/issues/1433)
 * Added ability to modify specific project fields via `PATCH` requests - [#1586](https://github.com/DependencyTrack/dependency-track/pull/1586)
 * Grant access to the team that created a project via BOM upload when portfolio ACL is enabled - [#1529](https://github.com/DependencyTrack/dependency-track/pull/1529)

--- a/src/main/java/org/dependencytrack/model/Finding.java
+++ b/src/main/java/org/dependencytrack/model/Finding.java
@@ -115,7 +115,12 @@ public class Finding implements Serializable {
         optValue(vulnerability, "severityRank", severity.ordinal());
         optValue(vulnerability, "epssScore", o[16]);
         optValue(vulnerability, "epssPercentile", o[17]);
-        optValue(vulnerability, "cwe", getCwes(o[18]));
+        final List<Cwe> cwes = getCwes(o[18]);
+        if (cwes != null && !cwes.isEmpty()) {
+            // Ensure backwards-compatibility with DT < 4.5.0. Remove this in v5!
+            optValue(vulnerability, "cwe", cwes.get(0));
+        }
+        optValue(vulnerability, "cwes", cwes);
         optValue(attribution, "analyzerIdentity", o[19]);
         optValue(attribution, "attributedOn", o[20]);
         optValue(attribution, "alternateIdentifier", o[21]);

--- a/src/main/java/org/dependencytrack/model/Vulnerability.java
+++ b/src/main/java/org/dependencytrack/model/Vulnerability.java
@@ -20,11 +20,13 @@ package org.dependencytrack.model;
 
 import alpine.common.validation.RegexSequence;
 import alpine.server.json.TrimmedStringDeserializer;
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.dependencytrack.parser.common.resolver.CweResolver;
 import org.dependencytrack.persistence.CollectionIntegerConverter;
 import org.dependencytrack.resources.v1.serializers.CweDeserializer;
 import org.dependencytrack.resources.v1.serializers.CweSerializer;
@@ -189,7 +191,6 @@ public class Vulnerability implements Serializable {
     @Persistent(defaultFetchGroup = "true")
     @Column(name = "CWES")
     @Convert(CollectionIntegerConverter.class)
-    @JsonProperty(value = "cwe")
     @JsonSerialize(using = CweSerializer.class)
     @JsonDeserialize(using = CweDeserializer.class)
     private List<Integer> cwes;
@@ -442,6 +443,36 @@ public class Vulnerability implements Serializable {
 
     public void setSubTitle(String subTitle) {
         this.subTitle = subTitle;
+    }
+
+    /**
+     * Setter for keeping the REST API backwards-compatible.
+     * Will be removed in v5.
+     *
+     * @deprecated Use {@link #getCwes()} instead
+     * @return The first {@link Cwe} returned by {@link #getCwes()}, or {@code null} if no {@link Cwe}s are set.
+     */
+    @JsonGetter("cwe")
+    public Cwe getCwe() {
+        if (cwes == null || cwes.isEmpty()) {
+            return null;
+        }
+
+        return CweResolver.getInstance().lookup(cwes.get(0));
+    }
+
+    /**
+     * Setter for keeping the REST API backwards-compatible.
+     * Will be removed in v5.
+     *
+     * @deprecated Use {@link #setCwes(List)} instead
+     * @param cwe The {@link Cwe} to set
+     */
+    @JsonSetter("cwe")
+    public void setCwe(final Cwe cwe) {
+        if (cwe != null) {
+            setCwes(List.of(cwe.getCweId()));
+        }
     }
 
     public List<Integer> getCwes() {

--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -47,6 +47,7 @@ import org.dependencytrack.persistence.QueryManager;
 
 import javax.jdo.FetchPlan;
 import javax.json.Json;
+import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
@@ -281,7 +282,12 @@ public final class NotificationUtil {
                 }
             }
         }
-        vulnerabilityBuilder.add("cwes", cwesBuilder.build());
+        final JsonArray cwes = cwesBuilder.build();
+        if (cwes != null && !cwes.isEmpty()) {
+            // Ensure backwards-compatibility with DT < 4.5.0. Remove this in v5!
+            vulnerabilityBuilder.add("cwe", cwes.getJsonObject(0));
+        }
+        vulnerabilityBuilder.add("cwes", cwes);
         return vulnerabilityBuilder.build();
     }
 

--- a/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -26,17 +26,20 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.persistence.CweImporter;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.glassfish.jersey.test.DeploymentContext;
 import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.ws.rs.core.Response;
+import java.util.List;
 import java.util.UUID;
 
 public class FindingResourceTest extends ResourceTest {
@@ -48,6 +51,12 @@ public class FindingResourceTest extends ResourceTest {
                         .register(ApiFilter.class)
                         .register(AuthenticationFilter.class)))
                 .build();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        new CweImporter().processCweDefinitions();
     }
 
     @Test
@@ -80,18 +89,33 @@ public class FindingResourceTest extends ResourceTest {
         Assert.assertEquals("1.0", json.getJsonObject(0).getJsonObject("component").getString("version"));
         Assert.assertEquals("Vuln-1", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
         Assert.assertEquals(Severity.CRITICAL.name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
+        Assert.assertNotNull(json.getJsonObject(0).getJsonObject("vulnerability").getJsonObject("cwe"));
+        Assert.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getJsonObject("cwe").getInt("cweId"));
+        Assert.assertEquals(2, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assert.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assert.assertEquals(666, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
         Assert.assertFalse(json.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
         Assert.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v1.getUuid().toString(), json.getJsonObject(0).getString("matrix"));
         Assert.assertEquals("Component A", json.getJsonObject(1).getJsonObject("component").getString("name"));
         Assert.assertEquals("1.0", json.getJsonObject(1).getJsonObject("component").getString("version"));
         Assert.assertEquals("Vuln-2", json.getJsonObject(1).getJsonObject("vulnerability").getString("vulnId"));
         Assert.assertEquals(Severity.HIGH.name(), json.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
+        Assert.assertNotNull(json.getJsonObject(1).getJsonObject("vulnerability").getJsonObject("cwe"));
+        Assert.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getJsonObject("cwe").getInt("cweId"));
+        Assert.assertEquals(2, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assert.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assert.assertEquals(666, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
         Assert.assertFalse(json.getJsonObject(1).getJsonObject("analysis").getBoolean("isSuppressed"));
         Assert.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v2.getUuid().toString(), json.getJsonObject(1).getString("matrix"));
         Assert.assertEquals("Component B", json.getJsonObject(2).getJsonObject("component").getString("name"));
         Assert.assertEquals("1.0", json.getJsonObject(2).getJsonObject("component").getString("version"));
         Assert.assertEquals("Vuln-3", json.getJsonObject(2).getJsonObject("vulnerability").getString("vulnId"));
         Assert.assertEquals(Severity.MEDIUM.name(), json.getJsonObject(2).getJsonObject("vulnerability").getString("severity"));
+        Assert.assertNotNull(json.getJsonObject(2).getJsonObject("vulnerability").getJsonObject("cwe"));
+        Assert.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getJsonObject("cwe").getInt("cweId"));
+        Assert.assertEquals(2, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assert.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assert.assertEquals(666, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
         Assert.assertFalse(json.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
         Assert.assertEquals(p1.getUuid().toString() + ":" + c2.getUuid().toString() + ":" + v3.getUuid().toString(), json.getJsonObject(2).getString("matrix"));
     }
@@ -145,18 +169,33 @@ public class FindingResourceTest extends ResourceTest {
         Assert.assertEquals("1.0", findings.getJsonObject(0).getJsonObject("component").getString("version"));
         Assert.assertEquals("Vuln-1", findings.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
         Assert.assertEquals(Severity.CRITICAL.name(), findings.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
+        Assert.assertNotNull(findings.getJsonObject(1).getJsonObject("vulnerability").getJsonObject("cwe"));
+        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonObject("cwe").getInt("cweId"));
+        Assert.assertEquals(2, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assert.assertEquals(666, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
         Assert.assertFalse(findings.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
         Assert.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v1.getUuid().toString(), findings.getJsonObject(0).getString("matrix"));
         Assert.assertEquals("Component A", findings.getJsonObject(1).getJsonObject("component").getString("name"));
         Assert.assertEquals("1.0", findings.getJsonObject(1).getJsonObject("component").getString("version"));
         Assert.assertEquals("Vuln-2", findings.getJsonObject(1).getJsonObject("vulnerability").getString("vulnId"));
         Assert.assertEquals(Severity.HIGH.name(), findings.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
+        Assert.assertNotNull(findings.getJsonObject(1).getJsonObject("vulnerability").getJsonObject("cwe"));
+        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonObject("cwe").getInt("cweId"));
+        Assert.assertEquals(2, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assert.assertEquals(666, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
         Assert.assertFalse(findings.getJsonObject(1).getJsonObject("analysis").getBoolean("isSuppressed"));
         Assert.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v2.getUuid().toString(), findings.getJsonObject(1).getString("matrix"));
         Assert.assertEquals("Component B", findings.getJsonObject(2).getJsonObject("component").getString("name"));
         Assert.assertEquals("1.0", findings.getJsonObject(2).getJsonObject("component").getString("version"));
         Assert.assertEquals("Vuln-3", findings.getJsonObject(2).getJsonObject("vulnerability").getString("vulnId"));
         Assert.assertEquals(Severity.MEDIUM.name(), findings.getJsonObject(2).getJsonObject("vulnerability").getString("severity"));
+        Assert.assertNotNull(findings.getJsonObject(1).getJsonObject("vulnerability").getJsonObject("cwe"));
+        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonObject("cwe").getInt("cweId"));
+        Assert.assertEquals(2, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assert.assertEquals(666, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
         Assert.assertFalse(findings.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
         Assert.assertEquals(p1.getUuid().toString() + ":" + c2.getUuid().toString() + ":" + v3.getUuid().toString(), findings.getJsonObject(2).getString("matrix"));
     }
@@ -185,6 +224,7 @@ public class FindingResourceTest extends ResourceTest {
         vulnerability.setVulnId(vulnId);
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(severity);
+        vulnerability.setCwes(List.of(80, 666));
         return qm.createVulnerability(vulnerability, false);
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -72,11 +72,15 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Assert.assertEquals("INTERNAL", json.getJsonObject(0).getString("source"));
         Assert.assertEquals("Description 1", json.getJsonObject(0).getString("description"));
         Assert.assertEquals("CRITICAL", json.getJsonObject(0).getString("severity"));
+        Assert.assertNull(json.getJsonObject(0).getJsonObject("cwe"));
+        Assert.assertNull(json.getJsonObject(0).getJsonArray("cwes"));
         Assert.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(0).getString("uuid")));
         Assert.assertEquals("INT-2", json.getJsonObject(1).getString("vulnId"));
         Assert.assertEquals("INTERNAL", json.getJsonObject(1).getString("source"));
         Assert.assertEquals("Description 2", json.getJsonObject(1).getString("description"));
         Assert.assertEquals("HIGH", json.getJsonObject(1).getString("severity"));
+        Assert.assertNull(json.getJsonObject(1).getJsonObject("cwe"));
+        Assert.assertNull(json.getJsonObject(1).getJsonArray("cwes"));
         Assert.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(1).getString("uuid")));
     }
 
@@ -284,7 +288,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         JsonObject payload = Json.createObjectBuilder()
                 .add("vulnId", "ACME-1")
                 .add("description", "Something is vulnerable")
-                .add("cwe", Json.createArrayBuilder().add(Json.createObjectBuilder().add("cweId", 80)))
+                .add("cwes", Json.createArrayBuilder().add(Json.createObjectBuilder().add("cweId", 80)))
                 .add("cvssV2Vector", "(AV:N/AC:M/Au:S/C:P/I:P/A:P)")
                 .add("cvssV3Vector", "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L")
                 .build();
@@ -306,9 +310,39 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Assert.assertEquals(2.8, json.getJsonNumber("cvssV3ExploitabilitySubScore").doubleValue(), 0);
         Assert.assertEquals("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L", json.getString("cvssV3Vector"));
         Assert.assertEquals("MEDIUM", json.getString("severity"));
-        Assert.assertEquals(1, json.getJsonArray("cwe").size());
-        Assert.assertEquals(80, json.getJsonArray("cwe").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonArray("cwe").getJsonObject(0).getString("name"));
+        Assert.assertNotNull(json.getJsonObject("cwe"));
+        Assert.assertEquals(80, json.getJsonObject("cwe").getInt("cweId"));
+        Assert.assertEquals(1, json.getJsonArray("cwes").size());
+        Assert.assertEquals(80, json.getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assert.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonArray("cwes").getJsonObject(0).getString("name"));
+        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
+    }
+
+    /**
+     * Ensure that pre-v4.5.0 behavior of setting CWE via a single object
+     * still works, and both "cwe" and "cwes" fields are returned in the response.
+     */
+    @Test
+    public void createVulnerabilityCwePreV450CompatTest() throws Exception {
+        new CweImporter().processCweDefinitions();
+        JsonObject payload = Json.createObjectBuilder()
+                .add("vulnId", "ACME-1")
+                .add("cwe", Json.createObjectBuilder().add("cweId", 80))
+                .build();
+        Response response = target(V1_VULNERABILITY).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(payload.toString()));
+        Assert.assertEquals(201, response.getStatus(), 0);
+        JsonObject json = parseJsonObject(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals("ACME-1", json.getString("vulnId"));
+        Assert.assertEquals("INTERNAL", json.getString("source"));
+        Assert.assertNotNull(json.getJsonObject("cwe"));
+        Assert.assertEquals(80, json.getJsonObject("cwe").getInt("cweId"));
+        Assert.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonObject("cwe").getString("name"));
+        Assert.assertEquals(1, json.getJsonArray("cwes").size());
+        Assert.assertEquals(80, json.getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assert.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonArray("cwes").getJsonObject(0).getString("name"));
         Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
     }
 
@@ -321,7 +355,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         JsonObject payload = Json.createObjectBuilder()
                 .add("vulnId", "ACME-1")
                 .add("description", "Something is vulnerable")
-                .add("cwe", Json.createArrayBuilder().add(Json.createObjectBuilder().add("cweId", 80)))
+                .add("cwes", Json.createArrayBuilder().add(Json.createObjectBuilder().add("cweId", 80)))
                 .add("cvssV2Vector", "(AV:N/AC:M/Au:S/C:P/I:P/A:P)")
                 .add("cvssV3Vector", "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L")
                 .build();
@@ -345,7 +379,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                 .add("vulnId", "ACME-1")
                 .add("source", "INTERNAL")
                 .add("description", "Something is vulnerable")
-                .add("cwe", Json.createArrayBuilder().add(Json.createObjectBuilder().add("cweId", 80)))
+                .add("cwes", Json.createArrayBuilder().add(Json.createObjectBuilder().add("cweId", 80)))
                 .add("cvssV2Vector", "(AV:N/AC:M/Au:S/C:P/I:P/A:P)")
                 .add("cvssV3Vector", "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L")
                 .add("uuid", vuln.getUuid().toString())
@@ -368,9 +402,9 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Assert.assertEquals(2.8, json.getJsonNumber("cvssV3ExploitabilitySubScore").doubleValue(), 0);
         Assert.assertEquals("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L", json.getString("cvssV3Vector"));
         Assert.assertEquals("MEDIUM", json.getString("severity"));
-        Assert.assertEquals(1, json.getJsonArray("cwe").size());
-        Assert.assertEquals(80, json.getJsonArray("cwe").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonArray("cwe").getJsonObject(0).getString("name"));
+        Assert.assertEquals(1, json.getJsonArray("cwes").size());
+        Assert.assertEquals(80, json.getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assert.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonArray("cwes").getJsonObject(0).getString("name"));
         Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
     }
 
@@ -379,7 +413,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         JsonObject payload = Json.createObjectBuilder()
                 .add("vulnId", "ACME-1")
                 .add("description", "Something is vulnerable")
-                .add("cwe", Json.createArrayBuilder().add(Json.createObjectBuilder().add("cweId", 80)))
+                .add("cwes", Json.createArrayBuilder().add(Json.createObjectBuilder().add("cweId", 80)))
                 .add("cvssV2Vector", "(AV:N/AC:M/Au:S/C:P/I:P/A:P)")
                 .add("cvssV3Vector", "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L")
                 .add("uuid", UUID.randomUUID().toString())
@@ -402,7 +436,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         JsonObject payload = Json.createObjectBuilder()
                 .add("vulnId", "ACME-2")
                 .add("description", "Something is vulnerable")
-                .add("cwe", Json.createArrayBuilder().add(Json.createObjectBuilder().add("cweId", 80)))
+                .add("cwes", Json.createArrayBuilder().add(Json.createObjectBuilder().add("cweId", 80)))
                 .add("cvssV2Vector", "(AV:N/AC:M/Au:S/C:P/I:P/A:P)")
                 .add("cvssV3Vector", "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L")
                 .add("uuid", vuln.getUuid().toString())


### PR DESCRIPTION
Addresses concerns with 3rd party integrations, e.g. https://github.com/DependencyTrack/dependency-track/issues/1467#issuecomment-1128161152

Signed-off-by: nscuro <nscuro@protonmail.com>