### PR TITLE
Fix cwe field names for findings API and FPF

### DIFF
--- a/docs/_docs/integrations/file-formats.md
+++ b/docs/_docs/integrations/file-formats.md
@@ -27,8 +27,9 @@ To export findings in the FPF format, the `/api/v1/finding/project/{uuid}/export
 The **VIEW_VULNERABILITY** permission is required to use the findings API.
 
 > Finding Packaging Format v1.1 was introduced in Dependency-Track v4.5 and supports an array of CWEs per vulnerability.
-> Previous versions of Dependency-Track supported only a single CWE (cweId and cweName fields respectively) per
+> Previous versions of Dependency-Track supported only a single CWE (`cweId` and `cweName` fields respectively) per
 > vulnerability.
+> The `cweId` and `cweName` fields are deprecated and will be removed in a later version. Please use `cwes` instead.
 
 #### Example
 
@@ -63,10 +64,8 @@ The **VIEW_VULNERABILITY** permission is required to use the findings API.
       "subtitle": "timespan",
       "severity": "LOW",
       "severityRank": 3,
-      "cwe": {
-        "cweId": 400,
-        "name": "Uncontrolled Resource Consumption ('Resource Exhaustion')"
-      },
+      "cweId": 400,
+      "cweName": "Uncontrolled Resource Consumption ('Resource Exhaustion')",
       "cwes": [
         {
           "cweId": 400,
@@ -97,10 +96,8 @@ The **VIEW_VULNERABILITY** permission is required to use the findings API.
       "subtitle": "uglify-js",
       "severity": "LOW",
       "severityRank": 3,
-      "cwe": {
-        "cweId": 400,
-        "name": "Uncontrolled Resource Consumption ('Resource Exhaustion')"
-      },
+      "cweId": 400,
+      "cweName": "Uncontrolled Resource Consumption ('Resource Exhaustion')",
       "cwes": [
         {
           "cweId": 400,
@@ -117,5 +114,3 @@ The **VIEW_VULNERABILITY** permission is required to use the findings API.
   }]
 }
 ```
-
-> The `cwe` field is deprecated and will be removed in a later version. Please use `cwes` instead.

--- a/src/main/java/org/dependencytrack/model/Finding.java
+++ b/src/main/java/org/dependencytrack/model/Finding.java
@@ -118,7 +118,8 @@ public class Finding implements Serializable {
         final List<Cwe> cwes = getCwes(o[18]);
         if (cwes != null && !cwes.isEmpty()) {
             // Ensure backwards-compatibility with DT < 4.5.0. Remove this in v5!
-            optValue(vulnerability, "cwe", cwes.get(0));
+            optValue(vulnerability, "cweId", cwes.get(0).getCweId());
+            optValue(vulnerability, "cweName", cwes.get(0).getName());
         }
         optValue(vulnerability, "cwes", cwes);
         optValue(attribution, "analyzerIdentity", o[19]);

--- a/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -89,8 +89,7 @@ public class FindingResourceTest extends ResourceTest {
         Assert.assertEquals("1.0", json.getJsonObject(0).getJsonObject("component").getString("version"));
         Assert.assertEquals("Vuln-1", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
         Assert.assertEquals(Severity.CRITICAL.name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertNotNull(json.getJsonObject(0).getJsonObject("vulnerability").getJsonObject("cwe"));
-        Assert.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getJsonObject("cwe").getInt("cweId"));
+        Assert.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getInt("cweId"));
         Assert.assertEquals(2, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").size());
         Assert.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
         Assert.assertEquals(666, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
@@ -100,8 +99,7 @@ public class FindingResourceTest extends ResourceTest {
         Assert.assertEquals("1.0", json.getJsonObject(1).getJsonObject("component").getString("version"));
         Assert.assertEquals("Vuln-2", json.getJsonObject(1).getJsonObject("vulnerability").getString("vulnId"));
         Assert.assertEquals(Severity.HIGH.name(), json.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertNotNull(json.getJsonObject(1).getJsonObject("vulnerability").getJsonObject("cwe"));
-        Assert.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getJsonObject("cwe").getInt("cweId"));
+        Assert.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getInt("cweId"));
         Assert.assertEquals(2, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
         Assert.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
         Assert.assertEquals(666, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
@@ -111,8 +109,7 @@ public class FindingResourceTest extends ResourceTest {
         Assert.assertEquals("1.0", json.getJsonObject(2).getJsonObject("component").getString("version"));
         Assert.assertEquals("Vuln-3", json.getJsonObject(2).getJsonObject("vulnerability").getString("vulnId"));
         Assert.assertEquals(Severity.MEDIUM.name(), json.getJsonObject(2).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertNotNull(json.getJsonObject(2).getJsonObject("vulnerability").getJsonObject("cwe"));
-        Assert.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getJsonObject("cwe").getInt("cweId"));
+        Assert.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getInt("cweId"));
         Assert.assertEquals(2, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").size());
         Assert.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
         Assert.assertEquals(666, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
@@ -169,8 +166,7 @@ public class FindingResourceTest extends ResourceTest {
         Assert.assertEquals("1.0", findings.getJsonObject(0).getJsonObject("component").getString("version"));
         Assert.assertEquals("Vuln-1", findings.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
         Assert.assertEquals(Severity.CRITICAL.name(), findings.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertNotNull(findings.getJsonObject(1).getJsonObject("vulnerability").getJsonObject("cwe"));
-        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonObject("cwe").getInt("cweId"));
+        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getInt("cweId"));
         Assert.assertEquals(2, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
         Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
         Assert.assertEquals(666, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
@@ -180,8 +176,7 @@ public class FindingResourceTest extends ResourceTest {
         Assert.assertEquals("1.0", findings.getJsonObject(1).getJsonObject("component").getString("version"));
         Assert.assertEquals("Vuln-2", findings.getJsonObject(1).getJsonObject("vulnerability").getString("vulnId"));
         Assert.assertEquals(Severity.HIGH.name(), findings.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertNotNull(findings.getJsonObject(1).getJsonObject("vulnerability").getJsonObject("cwe"));
-        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonObject("cwe").getInt("cweId"));
+        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getInt("cweId"));
         Assert.assertEquals(2, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
         Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
         Assert.assertEquals(666, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
@@ -191,8 +186,7 @@ public class FindingResourceTest extends ResourceTest {
         Assert.assertEquals("1.0", findings.getJsonObject(2).getJsonObject("component").getString("version"));
         Assert.assertEquals("Vuln-3", findings.getJsonObject(2).getJsonObject("vulnerability").getString("vulnId"));
         Assert.assertEquals(Severity.MEDIUM.name(), findings.getJsonObject(2).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertNotNull(findings.getJsonObject(1).getJsonObject("vulnerability").getJsonObject("cwe"));
-        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonObject("cwe").getInt("cweId"));
+        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getInt("cweId"));
         Assert.assertEquals(2, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
         Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
         Assert.assertEquals(666, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));


### PR DESCRIPTION
It was `cweId` and `cweName` before, instead of a `cwe` object.

Signed-off-by: nscuro <nscuro@protonmail.com>