### PR TITLE
Run Tests CI only for pushes or PRs to default- or release branches

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -2,9 +2,15 @@ name: Tests CI
 
 on:
   push:
+    branches:
+      - 'master'          # Default branch
+      - '[0-9]+.[0-9]+.x' # Release branches
     paths-ignore:
       - '**/*.md'
   pull_request:
+    branches:
+      - 'master'          # Default branch
+      - '[0-9]+.[0-9]+.x' # Release branches
     paths-ignore:
       - '**/*.md'
   workflow_dispatch:


### PR DESCRIPTION
The workflow is currently run twice for PRs. Tests take quite a while, and we really only care about tests on our main branches.

Signed-off-by: nscuro <nscuro@protonmail.com>