### PR TITLE
Change NuGet package metadata URL

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/repositories/NugetMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/NugetMetaAnalyzer.java
@@ -45,7 +45,7 @@ public class NugetMetaAnalyzer extends AbstractMetaAnalyzer {
     private static final Logger LOGGER = Logger.getLogger(NugetMetaAnalyzer.class);
     private static final String DEFAULT_BASE_URL = "https://api.nuget.org";
     private static final String VERSION_QUERY_URL = "/v3-flatcontainer/%s/index.json";
-    private static final String REGISTRATION_URL = "/v3/registration3/%s/%s.json";
+    private static final String REGISTRATION_URL = "/v3/registration5-semver1/%s/%s.json";
 
     NugetMetaAnalyzer() {
         this.baseUrl = DEFAULT_BASE_URL;

--- a/src/test/java/org/dependencytrack/tasks/repositories/NugetMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/NugetMetaAnalyzerTest.java
@@ -22,16 +22,11 @@ import com.github.packageurl.PackageURL;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
 import org.junit.Assert;
+import org.junit.Test;
 
 public class NugetMetaAnalyzerTest {
 
-    //@Test
-    /*
-     * Noticed that Microsoft NuGet is broken for package 3.13.0, which as of this moment, is the latest
-     * version available. However, the registration3 API returns a 404 when making queries for it and the call
-     * to index.json for the nuget package returns 3.12.0 as the latest version. This is breaking DT unit tests.
-     * Commenting out for now.
-     */
+    @Test
     public void testAnalyzer() throws Exception {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:nuget/NUnit@3.8.0"));


### PR DESCRIPTION
According to the API index at https://api.nuget.org/v3/index.json, the registration3 endpoint which was used for retrieving package version metadata has been discontinued. This wasn't a big issue for Dependency-Track because this endpoint is only used for retrieving the publish timestamp of the package version. This PR just fixes the failing test and makes sure metadata can be correctly retrieved for newer package versions. The registration5-semver1 is backwards compatible, so this shouldn't cause any issues.