### PR TITLE
Use bot account to create releases

### DIFF
--- a/.github/workflows/ci-publish.yaml
+++ b/.github/workflows/ci-publish.yaml
@@ -68,8 +68,7 @@ jobs:
 
       - name: Update Release
         env:
-          # or change it to a custom PAT that should be credited for the release
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_RELEASE_TOKEN }}
         run: |-
           cat << EOF >> .github/default-release-notes.md
           \`\`\`text

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -59,8 +59,7 @@ jobs:
 
       - name: Commit Version
         env:
-          # or change it to a custom PAT that has push rights to the branch
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_RELEASE_TOKEN }}
         run: |-
           MESSAGE="prepare-release: set version to ${VERSION}"
           CONTENT=$(base64 -i pom.xml)
@@ -94,8 +93,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          # or change it to a custom PAT that should be credited for the release
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_RELEASE_TOKEN }}
         run: |-
           gh release create "${{ needs.prepare-release.outputs.version }}" \
             --target "${{ needs.prepare-release.outputs.release-branch }}" \
@@ -123,8 +121,7 @@ jobs:
 
       - name: Commit SNAPSHOT Version
         env:
-          # or change it to a custom PAT that has push rights to the branch
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_RELEASE_TOKEN }}
         run: |-
           MESSAGE="prepare-iteration: set version to ${NEXT_VERSION}"
           CONTENT=$(base64 -i pom.xml)


### PR DESCRIPTION
Builds upon https://github.com/DependencyTrack/dependency-track/pull/1645. `Publish CI` is not triggered automatically when creating releases with `GITHUB_TOKEN`. The bot account needs write access to the repository. The bot's PAT (`BOT_RELEASE_TOKEN`) only requires the `public_repo` scope.

Signed-off-by: nscuro <nscuro@protonmail.com>