### PR TITLE
Automatically discover NuGet server endpoints

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/repositories/NugetMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/NugetMetaAnalyzer.java
@@ -25,6 +25,7 @@ import kong.unirest.JsonNode;
 import kong.unirest.UnirestException;
 import kong.unirest.UnirestInstance;
 import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
 import org.dependencytrack.common.UnirestFactory;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
@@ -44,11 +45,26 @@ public class NugetMetaAnalyzer extends AbstractMetaAnalyzer {
 
     private static final Logger LOGGER = Logger.getLogger(NugetMetaAnalyzer.class);
     private static final String DEFAULT_BASE_URL = "https://api.nuget.org";
-    private static final String VERSION_QUERY_URL = "/v3-flatcontainer/%s/index.json";
-    private static final String REGISTRATION_URL = "/v3/registration3/%s/%s.json";
+
+    private static final String INDEX_URL = "/v3/index.json";
+
+    private static final String DEFAULT_VERSION_QUERY_ENDPOINT = "/v3-flatcontainer/%s/index.json";
+
+    private static final String DEFAULT_REGISTRATION_ENDPOINT = "/v3/registration5-semver1/%s/%s.json";
+
+    private String versionQueryUrl;
+
+    private String registrationUrl;
 
     NugetMetaAnalyzer() {
-        this.baseUrl = DEFAULT_BASE_URL;
+        setRepositoryBaseUrl(DEFAULT_BASE_URL);
+    }
+
+    @Override
+    public void setRepositoryBaseUrl(String baseUrl) {
+        super.setRepositoryBaseUrl(baseUrl);
+
+        initializeEndpoints();
     }
 
     /**
@@ -80,7 +96,7 @@ public class NugetMetaAnalyzer extends AbstractMetaAnalyzer {
 
     private boolean performVersionCheck(final MetaModel meta, final Component component) {
         final UnirestInstance ui = UnirestFactory.getUnirestInstance();
-        final String url = String.format(baseUrl + VERSION_QUERY_URL, component.getPurl().getName().toLowerCase());
+        final String url = String.format(versionQueryUrl, component.getPurl().getName().toLowerCase());
         try {
             final HttpResponse<JsonNode> response = ui.get(url)
                     .header("accept", "application/json")
@@ -103,7 +119,7 @@ public class NugetMetaAnalyzer extends AbstractMetaAnalyzer {
 
     private boolean performLastPublishedCheck(final MetaModel meta, final Component component) {
         final UnirestInstance ui = UnirestFactory.getUnirestInstance();
-        final String url = String.format(baseUrl + REGISTRATION_URL, component.getPurl().getName().toLowerCase(), meta.getLatestVersion());
+        final String url = String.format(registrationUrl, component.getPurl().getName().toLowerCase(), meta.getLatestVersion());
         try {
             final HttpResponse<JsonNode> response = ui.get(url)
                     .header("accept", "application/json")
@@ -129,5 +145,42 @@ public class NugetMetaAnalyzer extends AbstractMetaAnalyzer {
             handleRequestException(LOGGER, e);
         }
         return false;
+    }
+
+    private void initializeEndpoints() {
+        // Set defaults that work with NuGet.org just in case the index endpoint is not available
+        versionQueryUrl = baseUrl + DEFAULT_VERSION_QUERY_ENDPOINT;
+        registrationUrl = baseUrl + DEFAULT_REGISTRATION_ENDPOINT;
+
+        final UnirestInstance ui = UnirestFactory.getUnirestInstance();
+        final String url = baseUrl + INDEX_URL;
+        try {
+            final HttpResponse<JsonNode> response = ui
+                    .get(url)
+                    .header("accept", "application/json")
+                    .asJson();
+            if (response.getStatus() == 200 && response.getBody() != null && response.getBody().getObject() != null) {
+                final JSONArray resources = response.getBody().getObject().getJSONArray("resources");
+                final JSONObject packageBaseResource = findResourceByType(resources, "PackageBaseAddress");
+                final JSONObject registrationsBaseResource = findResourceByType(resources, "RegistrationsBaseUrl");
+                if (packageBaseResource != null && registrationsBaseResource != null) {
+                    versionQueryUrl = packageBaseResource.getString("@id") + "%s/index.json";
+                    registrationUrl = registrationsBaseResource.getString("@id") + "%s/%s.json";
+                }
+            }
+        } catch (UnirestException e) {
+            handleRequestException(LOGGER, e);
+        }
+    }
+
+    private JSONObject findResourceByType(JSONArray resources, String type) {
+        for (int i = 0; i < resources.length(); i++) {
+            String resourceType = resources.getJSONObject(i).getString("@type");
+            if (resourceType != null && resourceType.toLowerCase().startsWith(type.toLowerCase())) {
+                return resources.getJSONObject(i);
+            }
+        }
+
+        return null;
     }
 }

--- a/src/test/java/org/dependencytrack/tasks/repositories/NugetMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/NugetMetaAnalyzerTest.java
@@ -22,16 +22,11 @@ import com.github.packageurl.PackageURL;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
 import org.junit.Assert;
+import org.junit.Test;
 
 public class NugetMetaAnalyzerTest {
 
-    //@Test
-    /*
-     * Noticed that Microsoft NuGet is broken for package 3.13.0, which as of this moment, is the latest
-     * version available. However, the registration3 API returns a 404 when making queries for it and the call
-     * to index.json for the nuget package returns 3.12.0 as the latest version. This is breaking DT unit tests.
-     * Commenting out for now.
-     */
+    @Test
     public void testAnalyzer() throws Exception {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:nuget/NUnit@3.8.0"));


### PR DESCRIPTION
The NugetMetaAnalyzer currently assumes default hard-coded query endpoints that used to work with an older version of NuGet.org. The registration3 endpoint is now discontinued and no longer works for newer package versions. I've changed this default version to the endpoint used by NuGet.org (registration5-semver1) and added a mechanism for automatically determining the endpoints to use based on the index.json file of the NuGet repository. This allows support for different NuGet package repositories, like Azure Artifacts and Artifactory. 