### PR TITLE
Issue #1565 : new policy tag feature

### DIFF
--- a/src/main/java/org/dependencytrack/model/Policy.java
+++ b/src/main/java/org/dependencytrack/model/Policy.java
@@ -118,6 +118,15 @@ public class Policy implements Serializable {
     private List<Project> projects;
 
     /**
+     * A list of zero-to-n tags
+     */
+    @Persistent(table = "POLICY_TAGS", defaultFetchGroup = "true")
+    @Join(column = "POLICY_ID")
+    @Element(column = "TAG_ID")
+    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
+    private List<Tag> tags;
+
+    /**
      * The unique identifier of the object.
      */
     @Persistent(customValueStrategy = "uuid")
@@ -182,7 +191,15 @@ public class Policy implements Serializable {
     }
 
     public boolean isGlobal() {
-        return (projects == null || projects.size() == 0);
+        return (projects == null || projects.size() == 0) && (tags == null || tags.size() == 0);
+    }
+
+    public List<Tag> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<Tag> tags) {
+        this.tags = tags;
     }
 
     public UUID getUuid() {

--- a/src/main/java/org/dependencytrack/model/Tag.java
+++ b/src/main/java/org/dependencytrack/model/Tag.java
@@ -64,6 +64,7 @@ public class Tag implements Serializable {
     private String name;
 
     @Persistent
+    @JsonIgnore
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
     private List<Project> projects;
 

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -106,6 +106,8 @@ public class QueryManager extends AlpineQueryManager {
     private VulnerabilityQueryManager vulnerabilityQueryManager;
     private VulnerableSoftwareQueryManager vulnerableSoftwareQueryManager;
 
+    private TagQueryManager tagQueryManager;
+
     /**
      * Default constructor.
      */
@@ -148,6 +150,17 @@ public class QueryManager extends AlpineQueryManager {
             projectQueryManager = (request == null) ? new ProjectQueryManager(getPersistenceManager()) : new ProjectQueryManager(getPersistenceManager(), request);
         }
         return projectQueryManager;
+    }
+
+    /**
+     * Lazy instantiation of TagQueryManager.
+     * @return a TagQueryManager object
+     */
+    private TagQueryManager getTagQueryManager() {
+        if (tagQueryManager == null) {
+            tagQueryManager = (request == null) ? new TagQueryManager(getPersistenceManager()) : new TagQueryManager(getPersistenceManager(), request);
+        }
+        return tagQueryManager;
     }
 
     /**
@@ -1087,5 +1100,9 @@ public class QueryManager extends AlpineQueryManager {
 
     public boolean hasAccessManagementPermission(final ApiKey apiKey) {
         return getProjectQueryManager().hasAccessManagementPermission(apiKey);
+    }
+
+    public PaginatedResult getTags(String policyUuid) {
+        return getTagQueryManager().getTags(policyUuid);
     }
 }

--- a/src/main/java/org/dependencytrack/persistence/TagQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/TagQueryManager.java
@@ -1,0 +1,61 @@
+package org.dependencytrack.persistence;
+
+import alpine.common.logging.Logger;
+import alpine.persistence.PaginatedResult;
+import alpine.resources.AlpineRequest;
+import org.dependencytrack.model.Policy;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.Tag;
+
+import javax.jdo.PersistenceManager;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.HashSet;
+
+public class TagQueryManager extends QueryManager implements IQueryManager {
+
+    private static final Logger LOGGER = Logger.getLogger(ProjectQueryManager.class);
+
+    /**
+     * Constructs a new QueryManager.
+     * @param pm a PersistenceManager object
+     */
+    TagQueryManager(final PersistenceManager pm) {
+        super(pm);
+    }
+
+    /**
+     * Constructs a new QueryManager.
+     * @param pm a PersistenceManager object
+     * @param request an AlpineRequest object
+     */
+    TagQueryManager(final PersistenceManager pm, final AlpineRequest request) {
+        super(pm, request);
+    }
+
+    public PaginatedResult getTags(String policyUuid) {
+
+        LOGGER.debug("Retrieving tags under policy " + policyUuid);
+
+        Policy policy = getObjectByUuid(Policy.class, policyUuid);
+        List<Project> projects = policy.getProjects();
+
+        List<Tag> tagsToShow;
+
+        if(projects != null && projects.size() != 0){
+            HashSet<Tag> filteredTags = new HashSet<>();
+            for(Project project : projects) {
+                filteredTags.addAll(project.getTags());
+            }
+            tagsToShow = new ArrayList<>(filteredTags);
+        } else {
+            List<Tag> tagsQueried = pm.newQuery(Tag.class).executeList();
+            tagsToShow = new ArrayList<>(tagsQueried);
+        }
+        tagsToShow.sort(Comparator.comparingInt(tag -> tag.getProjects().size()));
+        Collections.reverse(tagsToShow);
+        return (new PaginatedResult()).objects(tagsToShow).total(tagsToShow.size());
+    }
+}

--- a/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.Project;
+import org.dependencytrack.model.Tag;
 import org.dependencytrack.persistence.QueryManager;
 
 import javax.validation.Validator;
@@ -260,6 +261,83 @@ public class PolicyResource extends AlpineResource {
             final List<Project> projects = policy.getProjects();
             if (projects != null && projects.contains(project)) {
                 policy.getProjects().remove(project);
+                qm.persist(policy);
+                return Response.ok(policy).build();
+            }
+            return Response.status(Response.Status.NOT_MODIFIED).build();
+        }
+    }
+
+    @POST
+    @Path("/{policyUuid}/tag/{tagName}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Adds a tag to a policy",
+            response = Policy.class
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 304, message = "The policy already has the specified tag assigned"),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 404, message = "The policy or tag could not be found")
+    })
+    @PermissionRequired(Permissions.Constants.POLICY_MANAGEMENT)
+    public Response addTagToPolicy(
+            @ApiParam(value = "The UUID of the policy to add a project to", required = true)
+            @PathParam("policyUuid") String policyUuid,
+            @ApiParam(value = "The name of the tag to add to the rule", required = true)
+            @PathParam("tagName") String tagName) {
+        try (QueryManager qm = new QueryManager()) {
+            final Policy policy = qm.getObjectByUuid(Policy.class, policyUuid);
+            if (policy == null) {
+                return Response.status(Response.Status.NOT_FOUND).entity("The policy could not be found.").build();
+            }
+
+            final Tag tag = qm.getTagByName(tagName);
+            if (tag == null) {
+                return Response.status(Response.Status.NOT_FOUND).entity("The tag could not be found.").build();
+            }
+            final List<Tag> tags = policy.getTags();
+            if (tags != null && !tags.contains(tag)) {
+                policy.getTags().add(tag);
+                qm.persist(policy);
+                return Response.ok(policy).build();
+            }
+            return Response.status(Response.Status.NOT_MODIFIED).build();
+        }
+    }
+
+    @DELETE
+    @Path("/{policyUuid}/tag/{tagName}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Removes a tag from a policy",
+            response = Policy.class
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 304, message = "The policy does not have the specified tag assigned"),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 404, message = "The policy or tag could not be found")
+    })
+    @PermissionRequired(Permissions.Constants.POLICY_MANAGEMENT)
+    public Response removeTagFromPolicy(
+            @ApiParam(value = "The UUID of the policy to remove the tag from", required = true)
+            @PathParam("policyUuid") String policyUuid,
+            @ApiParam(value = "The name of the tag to remove from the policy", required = true)
+            @PathParam("tagName") String tagName) {
+        try (QueryManager qm = new QueryManager()) {
+            final Policy policy = qm.getObjectByUuid(Policy.class, policyUuid);
+            if (policy == null) {
+                return Response.status(Response.Status.NOT_FOUND).entity("The policy could not be found.").build();
+            }
+            final Tag tag = qm.getTagByName(tagName);
+            if (tag == null) {
+                return Response.status(Response.Status.NOT_FOUND).entity("The tag could not be found.").build();
+            }
+            final List<Tag> tags = policy.getTags();
+            if (tags != null && tags.contains(tag)) {
+                policy.getTags().remove(tag);
                 qm.persist(policy);
                 return Response.ok(policy).build();
             }

--- a/src/main/java/org/dependencytrack/resources/v1/TagResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/TagResource.java
@@ -1,0 +1,48 @@
+package org.dependencytrack.resources.v1;
+
+import alpine.persistence.PaginatedResult;
+import alpine.server.auth.PermissionRequired;
+import alpine.server.resources.AlpineResource;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.ResponseHeader;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.Tag;
+import org.dependencytrack.persistence.QueryManager;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/v1/tag")
+@Api(value = "tag", authorizations = @Authorization(value = "X-Api-Key"))
+public class TagResource extends AlpineResource {
+
+    @GET
+    @Path("/{policyUuid}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Returns a list of all tags",
+            response = Tag.class,
+            responseContainer = "List",
+            responseHeaders = @ResponseHeader(name = TOTAL_COUNT_HEADER, response = Long.class, description = "The total number of tags")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Unauthorized")
+    })
+    @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
+    public Response getTags(@ApiParam(value = "The UUID of the policy", required = true)
+                            @PathParam("policyUuid") String policyUuid){
+        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+            final PaginatedResult result = qm.getTags(policyUuid);
+            return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
+        }
+    }
+}

--- a/src/test/java/org/dependencytrack/ResourceTest.java
+++ b/src/test/java/org/dependencytrack/ResourceTest.java
@@ -80,6 +80,8 @@ public abstract class ResourceTest extends JerseyTest {
     protected final String TOTAL_COUNT_HEADER = "X-Total-Count";
     protected final String X_API_KEY = "X-Api-Key";
 
+    protected final String V1_TAG = "/v1/tag";
+
     protected QueryManager qm;
     protected ManagedUser testUser;
     protected String jwt;

--- a/src/test/java/org/dependencytrack/model/PolicyTest.java
+++ b/src/test/java/org/dependencytrack/model/PolicyTest.java
@@ -75,4 +75,15 @@ public class PolicyTest {
         Assert.assertEquals(1, policy.getProjects().size());
         Assert.assertEquals(project, policy.getProjects().get(0));
     }
+
+    @Test
+    public void testTags() {
+        List<Tag> tags = new ArrayList<>();
+        Tag tag = new Tag();
+        tags.add(tag);
+        Policy policy = new Policy();
+        policy.setTags(tags);
+        Assert.assertEquals(1, policy.getTags().size());
+        Assert.assertEquals(tag, policy.getTags().get(0));
+    }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
@@ -1,0 +1,75 @@
+package org.dependencytrack.resources.v1;
+
+import alpine.server.filters.ApiFilter;
+import alpine.server.filters.AuthenticationFilter;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.model.Policy;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.json.JsonArray;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+public class TagResourceTest extends ResourceTest {
+
+    @Override
+    protected DeploymentContext configureDeployment() {
+        return ServletDeploymentContext.forServlet(new ServletContainer(
+                        new ResourceConfig(TagResource.class)
+                                .register(ApiFilter.class)
+                                .register(AuthenticationFilter.class)))
+                .build();
+    }
+
+    @Test
+    public void getAllTagsWithOrderingTest() {
+        for (int i=1; i<5; i++) {
+            qm.createTag("Tag "+i);
+        }
+        qm.createProject("Project A", null, "1", List.of(qm.getTagByName("Tag 1"), qm.getTagByName("Tag 2")), null, null, true, false);
+        qm.createProject("Project B", null, "1", List.of(qm.getTagByName("Tag 2"), qm.getTagByName("Tag 3"), qm.getTagByName("Tag 4")), null, null, true, false);
+        Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+
+        Response response = target(V1_TAG + "/" + policy.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals(String.valueOf(4), response.getHeaderString(TOTAL_COUNT_HEADER));
+        JsonArray json = parseJsonArray(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals(4, json.size());
+        Assert.assertEquals("Tag 2", json.getJsonObject(0).getString("name"));
+    }
+
+    @Test
+    public void getTagsWithPolicyProjectsFilterTest() {
+        for (int i=1; i<5; i++) {
+            qm.createTag("Tag "+i);
+        }
+        qm.createProject("Project A", null, "1", List.of(qm.getTagByName("Tag 1"), qm.getTagByName("Tag 2")), null, null, true, false);
+        qm.createProject("Project B", null, "1", List.of(qm.getTagByName("Tag 1"), qm.getTagByName("Tag 3")), null, null, true, false);
+        qm.createProject("Project C", null, "1", List.of(qm.getTagByName("Tag 1"), qm.getTagByName("Tag 4")), null, null, true, false);
+
+        Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        policy.setProjects(List.of(qm.getProject("Project A", "1"), qm.getProject("Project C", "1")));
+
+        Response response = target(V1_TAG + "/" + policy.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
+        JsonArray json = parseJsonArray(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals(3, json.size());
+        Assert.assertEquals("Tag 1", json.getJsonObject(0).getString("name"));
+    }
+}


### PR DESCRIPTION
Changes for new feature to support 'Limit to Tags' in policy management.
This includes:

endpoint to add new tag/s in a policy
endpoint to remove tag/s from a policy
endpoint to get all tags available in all projects or specific projects under a policy
changes in policy evaluation to limit scanning of components against policies having these tags (if, added in 'Limit to Tags')
Unit tests for above
Issue: https://github.com/DependencyTrack/dependency-track/issues/1565

Frontend changes -> https://github.com/DependencyTrack/frontend/pull/160
https://github.com/DependencyTrack/frontend/pull/162