### PR TITLE
Include component repository metadata in component API

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -40,6 +40,8 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentIdentity;
 import org.dependencytrack.model.License;
 import org.dependencytrack.model.Project;
+import org.dependencytrack.model.RepositoryMetaComponent;
+import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.InternalComponentIdentificationUtil;
 
@@ -118,7 +120,11 @@ public class ComponentResource extends AlpineResource {
             if (component != null) {
                 final Project project = component.getProject();
                 if (qm.hasAccess(super.getPrincipal(), project)) {
+                    final PackageURL purl = component.getPurl();
+                    final RepositoryMetaComponent metaComponent = qm.getRepositoryMetaComponent(
+                            RepositoryType.resolve(purl), purl.getNamespace(), purl.getName());
                     final Component detachedComponent = qm.detach(Component.class, component.getId()); // TODO: Force project to be loaded. It should be anyway, but JDO seems to be having issues here.
+                    detachedComponent.setRepositoryMeta(metaComponent);
                     return Response.ok(detachedComponent).build();
                 } else {
                     return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified component is forbidden").build();


### PR DESCRIPTION
I'm developing an application that gives upgrade advice based on Dependency-Track results. I noticed that the project components endpoint returns a list of all components with their repository metadata (latest version), but the endpoint for a specific component doesn't include the repo metadata. The API for a specific component should be at least as detailed (if not more) as the endpoint for a list of components.

Signed-off-by: AbdelH <Abdel.Hajou@infosupport.com>