### PR TITLE
Change type of analysis details column to `CLOB`

### DIFF
--- a/src/main/java/org/dependencytrack/model/Analysis.java
+++ b/src/main/java/org/dependencytrack/model/Analysis.java
@@ -83,7 +83,7 @@ public class Analysis implements Serializable {
     private AnalysisResponse analysisResponse;
 
     @Persistent(defaultFetchGroup = "true")
-    @Column(name = "DETAILS", jdbcType = "VARCHAR", allowsNull = "true")
+    @Column(name = "DETAILS", jdbcType = "CLOB", allowsNull = "true")
     @NotNull
     private String analysisDetails;
 

--- a/src/main/java/org/dependencytrack/upgrade/UpgradeItems.java
+++ b/src/main/java/org/dependencytrack/upgrade/UpgradeItems.java
@@ -32,6 +32,7 @@ class UpgradeItems {
         UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v420.v420Updater.class);
         UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v440.v440Updater.class);
         UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v450.v450Updater.class);
+        UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v460.v460Updater.class);
     }
 
     static List<Class<? extends UpgradeItem>> getUpgradeItems() {

--- a/src/main/java/org/dependencytrack/upgrade/v460/v460Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v460/v460Updater.java
@@ -1,0 +1,39 @@
+package org.dependencytrack.upgrade.v460;
+
+import alpine.common.logging.Logger;
+import alpine.persistence.AlpineQueryManager;
+import alpine.server.upgrade.AbstractUpgradeItem;
+import alpine.server.util.DbUtil;
+
+import java.sql.Connection;
+
+public class v460Updater extends AbstractUpgradeItem {
+
+    private static final Logger LOGGER = Logger.getLogger(v460Updater.class);
+
+    @Override
+    public String getSchemaVersion() {
+        return "4.6.0";
+    }
+
+    @Override
+    public void executeUpgrade(final AlpineQueryManager qm, final Connection connection) throws Exception {
+        // Fixes https://github.com/DependencyTrack/dependency-track/issues/1661
+        // The JDBC type "CLOB" is mapped to the type CLOB for H2, MEDIUMTEXT for MySQL, and TEXT for PostgreSQL and SQL Server.
+        // - https://github.com/datanucleus/datanucleus-rdbms/blob/datanucleus-rdbms-5.2.11/src/main/java/org/datanucleus/store/rdbms/adapter/H2Adapter.java#L484
+        // - https://github.com/datanucleus/datanucleus-rdbms/blob/datanucleus-rdbms-5.2.11/src/main/java/org/datanucleus/store/rdbms/adapter/MySQLAdapter.java#L185-L186
+        // - https://github.com/datanucleus/datanucleus-rdbms/blob/datanucleus-rdbms-5.2.11/src/main/java/org/datanucleus/store/rdbms/adapter/PostgreSQLAdapter.java#L144
+        // - https://github.com/datanucleus/datanucleus-rdbms/blob/datanucleus-rdbms-5.2.11/src/main/java/org/datanucleus/store/rdbms/adapter/SQLServerAdapter.java#L168-L169
+        LOGGER.info("Changing JDBC type of \"ANALYSIS\".\"DETAILS\" from VARCHAR to CLOB");
+        if (DbUtil.isH2()) {
+            DbUtil.executeUpdate(connection, "ALTER TABLE \"ANALYSIS\" ADD \"DETAILS_V46\" CLOB");
+        } else if (DbUtil.isMysql()) {
+            DbUtil.executeUpdate(connection, "ALTER TABLE \"ANALYSIS\" ADD \"DETAILS_V46\" MEDIUMTEXT");
+        } else {
+            DbUtil.executeUpdate(connection, "ALTER TABLE \"ANALYSIS\" ADD \"DETAILS_V46\" TEXT");
+        }
+        DbUtil.executeUpdate(connection, "UPDATE \"ANALYSIS\" SET \"DETAILS_V46\" = \"DETAILS\"");
+        DbUtil.executeUpdate(connection, "ALTER TABLE \"ANALYSIS\" DROP COLUMN \"DETAILS\"");
+        DbUtil.executeUpdate(connection, "ALTER TABLE \"ANALYSIS\" RENAME COLUMN \"DETAILS_V46\" TO \"DETAILS\"");
+    }
+}


### PR DESCRIPTION
Fixes #1661

Signed-off-by: nscuro <nscuro@protonmail.com>

Tested by:

1. Launching a new DT instance (built from `master`)
2. Creating a new project, uploading a BOM with vulnerable components
3. Recording analysis for some findings, including the *Details* field
4. Stop the instance
5. Manually change `"SCHEMAVERSION"."VERSION"` in the DB to `4.5.0`
6. Rebuild DT from the `issue-1661` branch
7. Start DT again
8. Verify that the `"ANALYSIS"."DETAILS"` column was correctly updated

Tested with:

- [x] H2
- [x] PostgreSQL 14
- [x] SQL Server 2019, 2022
- [x] MySQL 5.7