### PR TITLE
Allow notifications to be deactivated

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/NotificationQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/NotificationQueryManager.java
@@ -77,6 +77,7 @@ public class NotificationQueryManager extends QueryManager implements IQueryMana
     public NotificationRule updateNotificationRule(NotificationRule transientRule) {
         final NotificationRule rule = getObjectByUuid(NotificationRule.class, transientRule.getUuid());
         rule.setName(transientRule.getName());
+        rule.setEnabled(transientRule.isEnabled());
         rule.setNotificationLevel(transientRule.getNotificationLevel());
         rule.setPublisherConfig(transientRule.getPublisherConfig());
         rule.setNotifyOn(transientRule.getNotifyOn());


### PR DESCRIPTION
Closes #1173

Signed-off-by: nscuro <nscuro@protonmail.com>

Companion PR to https://github.com/DependencyTrack/frontend/pull/171

It turned out that enabling/disabling notifications was already implemented in the API server, it just wasn't possible to set the `enabled` field via REST API. This is now possible, and disabling notifications works as expected.