### PR TITLE
flips level logic to mirror root logger

### DIFF
--- a/src/main/java/org/dependencytrack/notification/NotificationRouter.java
+++ b/src/main/java/org/dependencytrack/notification/NotificationRouter.java
@@ -89,11 +89,11 @@ public class NotificationRouter implements Subscriber {
 
             final NotificationLevel level = notification.getLevel();
             if (NotificationLevel.INFORMATIONAL == level) {
-                sb.append("(notificationLevel == 'INFORMATIONAL' || notificationLevel == 'WARNING' || notificationLevel == 'ERROR') && ");
+                sb.append("notificationLevel == 'INFORMATIONAL' && ");
             } else if (NotificationLevel.WARNING == level) {
-                sb.append("(notificationLevel == 'WARNING' || notificationLevel == 'ERROR') && ");
+                sb.append("(notificationLevel == 'WARNING' || notificationLevel == 'INFORMATIONAL') && ");
             } else if (NotificationLevel.ERROR == level) {
-                sb.append("notificationLevel == 'ERROR' && ");
+                sb.append("(notificationLevel == 'INFORMATIONAL' || notificationLevel == 'WARNING' || notificationLevel == 'ERROR') && ");
             }
 
             sb.append("enabled == true && scope == :scope"); //todo: improve this - this only works for testing


### PR DESCRIPTION
 #1429 
* An INFORMATIONAL sink/publisher will receive INFO, WARN, ERROR events
* A WARNING sink/publisher will receive WARN, ERROR events
* An ERROR sink/publisher will receive ERROR events

This creates the ablitity to publish mirror events only when in error as
opposed the the current "everything is okay" alarms we now get daily on ERROR scoped
Alerts.

Signed-off-by: Drew Thompson <drew.michael.thompson+ghdco@gmail.com>