### PR TITLE
Prevent event queue saturation when processing BOMs with large component quantities

### DIFF
--- a/src/main/java/org/dependencytrack/event/RepositoryMetaEvent.java
+++ b/src/main/java/org/dependencytrack/event/RepositoryMetaEvent.java
@@ -20,18 +20,56 @@ package org.dependencytrack.event;
 
 import alpine.event.framework.Event;
 import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Project;
+
+import java.util.Optional;
+import java.util.UUID;
 
 public class RepositoryMetaEvent implements Event {
 
-    private Component component;
+    public enum Type {
+        PORTFOLIO,
+        PROJECT,
+        COMPONENT
+    }
 
-    public RepositoryMetaEvent() { }
+    private final Type type;
+    private final UUID target;
+
+    public RepositoryMetaEvent() {
+        this(Type.PORTFOLIO, null);
+    }
+
+    /**
+     * @since 4.6.0
+     */
+    public RepositoryMetaEvent(final Project project) {
+        this(Type.PROJECT, project.getUuid());
+    }
 
     public RepositoryMetaEvent(final Component component) {
-        this.component = component;
+        this(Type.COMPONENT, component.getUuid());
     }
 
-    public Component getComponent() {
-        return component;
+    private RepositoryMetaEvent(final Type type, final UUID target) {
+        this.type = type;
+        this.target = target;
     }
+
+    /**
+     * @return The {@link Type} of the target
+     * @since 4.6.0
+     */
+    public Type getType() {
+        return type;
+    }
+
+    /**
+     * @return The {@link UUID} of the target
+     * @since 4.6.0
+     */
+    public Optional<UUID> getTarget() {
+        return Optional.ofNullable(target);
+    }
+
 }

--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -147,6 +147,7 @@ public class BomUploadProcessingTask implements Subscriber {
                 final VulnerabilityAnalysisEvent vae = new VulnerabilityAnalysisEvent(detachedFlattenedComponent).project(detachedProject);
                 vae.setChainIdentifier(event.getChainIdentifier());
                 Event.dispatch(vae);
+                Event.dispatch(new RepositoryMetaEvent(detachedProject));
                 LOGGER.info("Processed " + flattenedComponents.size() + " components and " + flattenedServices.size() + " services uploaded to project " + event.getProjectUuid());
                 Notification.dispatch(new Notification()
                         .scope(NotificationScope.PORTFOLIO)
@@ -172,7 +173,6 @@ public class BomUploadProcessingTask implements Subscriber {
         final long oid = component.getId();
         // Refreshing the object by querying for it again is preventative
         flattenedComponents.add(qm.getObjectById(Component.class, oid));
-        Event.dispatch(new RepositoryMetaEvent(component));
         if (component.getChildren() != null) {
             for (final Component child : component.getChildren()) {
                 processComponent(qm, bom, child, flattenedComponents);

--- a/src/test/java/org/dependencytrack/event/RepositoryMetaEventTest.java
+++ b/src/test/java/org/dependencytrack/event/RepositoryMetaEventTest.java
@@ -19,21 +19,47 @@
 package org.dependencytrack.event;
 
 import org.dependencytrack.model.Component;
-import org.junit.Assert;
+import org.dependencytrack.model.Project;
 import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RepositoryMetaEventTest {
 
     @Test
     public void testDefaultConstructor() {
-        RepositoryMetaEvent event = new RepositoryMetaEvent();
-        Assert.assertNull(event.getComponent());
+        final var event = new RepositoryMetaEvent();
+        assertThat(event.getType()).isEqualTo(RepositoryMetaEvent.Type.PORTFOLIO);
+        assertThat(event.getTarget()).isNotPresent();
+    }
+
+    @Test
+    public void testProjectConstructor() {
+        final var project = new Project();
+        var event = new RepositoryMetaEvent(project);
+        assertThat(event.getType()).isEqualTo(RepositoryMetaEvent.Type.PROJECT);
+        assertThat(event.getTarget()).isNotPresent();
+
+        final var uuid = UUID.randomUUID();
+        project.setUuid(uuid);
+        event = new RepositoryMetaEvent(project);
+        assertThat(event.getType()).isEqualTo(RepositoryMetaEvent.Type.PROJECT);
+        assertThat(event.getTarget()).contains(uuid);
     }
 
     @Test
     public void testComponentConstructor() {
-        Component component = new Component();
-        RepositoryMetaEvent event = new RepositoryMetaEvent(component);
-        Assert.assertEquals(component, event.getComponent());
+        final var component = new Component();
+        var event = new RepositoryMetaEvent(component);
+        assertThat(event.getType()).isEqualTo(RepositoryMetaEvent.Type.COMPONENT);
+        assertThat(event.getTarget()).isNotPresent();
+
+        final var uuid = UUID.randomUUID();
+        component.setUuid(uuid);
+        event = new RepositoryMetaEvent(component);
+        assertThat(event.getType()).isEqualTo(RepositoryMetaEvent.Type.COMPONENT);
+        assertThat(event.getTarget()).contains(uuid);
     }
 }


### PR DESCRIPTION
Previously, a `RepositoryMetaEvent` was dispatched for every component in the uploaded BOM. For a BOM with 20k components, 20k events were dispatched.

This was done *before* the `VulnerabilityAnalysisTask` is dispatched. Due to the sheer number of `RepositoryMetaEvent`s, vulnerability analysis would be drastically delayed. Even worse, event processing in the entire platform would essentially halt because DT would be busy with processing `RepositoryMetaEvent`s.

To prevent such situations, a single `RepositoryMetaEvent` is now dispatched for the entire project for which the BOM was uploaded. This ensures that the event subsystem remains available for other tasks.

Addresses #1759