### PR TITLE
Bump Temurin base image to 11.0.15_10

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.14.1_1-jre-focal@sha256:4d7b447eb9e7a4f8c17f2e3ce52d7b9b886c6f458a138ad83602c84e66c3b646 AS jre-build
+FROM eclipse-temurin:11.0.15_10-jre-focal@sha256:f9ee9b3a0a0b0e36ae33256ed13f73df34059f427cfc39ccd43b953f5752e1f2 AS jre-build
 
 FROM debian:bullseye-20220711-slim@sha256:f576b8067b77ff85c70725c976b7b6cde960898e2f19b9abab3fb148407614e2
 


### PR DESCRIPTION
Dependabot can't figure this update out on its own

Signed-off-by: nscuro <nscuro@protonmail.com>