### PR TITLE
Upgrade to Java 17

### DIFF
--- a/.github/workflows/_meta-build.yaml
+++ b/.github/workflows/_meta-build.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v3.4.1
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'maven'
 
       - name: Build with Maven

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/setup-java@v3.4.1
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'maven'
 
       - name: Set Version

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-java@v3.4.1
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'maven'
 
       - name: Execute unit tests

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -18,7 +18,7 @@ This document primarily covers the API server. Please refer to the frontend repo
 
 There are a few things you'll need on your journey:
 
-* JDK 11+ ([Temurin](https://adoptium.net/temurin/releases) distribution recommended)
+* JDK 17+ ([Temurin](https://adoptium.net/temurin/releases) distribution recommended)
 * Maven (comes bundled with IntelliJ and Eclipse)
 * A Java IDE of your preference (we recommend IntelliJ, but any other IDE is fine as well)
 * Docker (optional)

--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.connectors</groupId>
+            <artifactId>jersey-grizzly-connector</artifactId>
+            <version>${lib.jersey.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${lib.mockito.version}</version>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.15_10-jre-focal@sha256:0e1a237e0ac63c6d8dbc6e172d9ed01a89defbbe339f50a868a866f1804cba1b AS jre-build
+FROM eclipse-temurin:17.0.3_7-jre-focal@sha256:4ca578c1685435b134d228c3631fb94bb3d94567f9bcc4bc2b04f2afcdeabdcf AS jre-build
 
 FROM debian:bullseye-20220801-slim@sha256:a811e62769a642241b168ac34f615fb02da863307a14c4432cea8e5a0f9782b8
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.3_7-jre-focal@sha256:4ca578c1685435b134d228c3631fb94bb3d94567f9bcc4bc2b04f2afcdeabdcf AS jre-build
+FROM eclipse-temurin:17.0.4_8-jre-focal@sha256:b8a6b012d1cc5b51f460b72aa32c4ef76d908e9143bcc367bbfdd0c6348d3673 AS jre-build
 
 FROM debian:bullseye-20220801-slim@sha256:a811e62769a642241b168ac34f615fb02da863307a14c4432cea8e5a0f9782b8
 

--- a/src/test/java/org/dependencytrack/ResourceTest.java
+++ b/src/test/java/org/dependencytrack/ResourceTest.java
@@ -27,6 +27,8 @@ import alpine.server.auth.PasswordService;
 import alpine.server.persistence.PersistenceManagerFactory;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.persistence.QueryManager;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.grizzly.connector.GrizzlyConnectorProvider;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
@@ -113,6 +115,14 @@ public abstract class ResourceTest extends JerseyTest {
     @Override
     protected TestContainerFactory getTestContainerFactory() {
         return new GrizzlyWebTestContainerFactory();
+    }
+
+    @Override
+    protected void configureClient(final ClientConfig config) {
+        // Prevent InaccessibleObjectException with JDK >= 16 when performing PATCH requests
+        // using the default HttpUrlConnection connector provider.
+        // See https://github.com/eclipse-ee4j/jersey/issues/4825
+        config.connectorProvider(new GrizzlyConnectorProvider());
     }
 
     public void initializeWithPermissions(Permissions... permissions) {

--- a/src/test/java/org/dependencytrack/integration/ApiClient.java
+++ b/src/test/java/org/dependencytrack/integration/ApiClient.java
@@ -24,11 +24,11 @@ import kong.unirest.UnirestException;
 import kong.unirest.UnirestInstance;
 import kong.unirest.json.JSONObject;
 import org.apache.commons.io.FileUtils;
-import org.datanucleus.util.Base64;
 import org.dependencytrack.common.UnirestFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Base64;
 import java.util.UUID;
 
 public class ApiClient {
@@ -65,7 +65,7 @@ public class ApiClient {
                 .header("X-API-Key", apiKey)
                 .body(new JSONObject()
                         .put("project", uuid.toString())
-                        .put("bom", Base64.encode(FileUtils.readFileToByteArray(bom)))
+                        .put("bom", Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(bom)))
                 )
                 .asJson();
         return (response.getStatus() == 200);
@@ -78,7 +78,7 @@ public class ApiClient {
                 .header("X-API-Key", apiKey)
                 .body(new JSONObject()
                         .put("project", uuid.toString())
-                        .put("scan", Base64.encode(FileUtils.readFileToByteArray(scan)))
+                        .put("scan", Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(scan)))
                 )
                 .asJson();
         return (response.getStatus() == 200);


### PR DESCRIPTION
Depends on https://github.com/stevespringett/Alpine/pull/410

Note: The compilation target version is defined in Alpine (which is still 11 in `master`). This PR includes the necessary changes to build and run DT with compilation target 17.