### PR TITLE
Use datastore-native limiting in queries where only a single result is desired

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/CacheQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/CacheQueryManager.java
@@ -50,6 +50,7 @@ public class CacheQueryManager extends QueryManager implements IQueryManager {
         final Query<ComponentAnalysisCache> query = pm.newQuery(ComponentAnalysisCache.class,
                 "cacheType == :cacheType && targetHost == :targetHost && targetType == :targetType && target == :target");
         query.setOrdering("lastOccurrence desc");
+        query.setRange(0, 1);
         return singleResult(query.executeWithArray(cacheType, targetHost, targetType, target));
     }
 

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -441,6 +441,7 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             }
         }
         final Query<Component> query = pm.newQuery(Component.class, "project == :project && ((purl != null && purl == :purl) || (purlCoordinates != null && purlCoordinates == :purlCoordinates) || (swidTagId != null && swidTagId == :swidTagId) || (cpe != null && cpe == :cpe) || (group == :group && name == :name && version == :version))");
+        query.setRange(0, 1);
         return singleResult(query.executeWithArray(project, purlString, purlCoordinates, cid.getSwidTagId(), cid.getCpe(), cid.getGroup(), cid.getName(), cid.getVersion()));
     }
 

--- a/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
@@ -161,6 +161,7 @@ public class FindingsQueryManager extends QueryManager implements IQueryManager 
      */
     public Analysis getAnalysis(Component component, Vulnerability vulnerability) {
         final Query<Analysis> query = pm.newQuery(Analysis.class, "component == :component && vulnerability == :vulnerability");
+        query.setRange(0, 1);
         return singleResult(query.execute(component, vulnerability));
     }
 

--- a/src/main/java/org/dependencytrack/persistence/LicenseQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/LicenseQueryManager.java
@@ -88,6 +88,7 @@ final class LicenseQueryManager extends QueryManager implements IQueryManager {
     public License getLicense(String licenseId) {
         final Query<License> query = pm.newQuery(License.class, "licenseId == :licenseId");
         query.getFetchPlan().addGroup(License.FetchGroup.ALL.name());
+        query.setRange(0, 1);
         return singleResult(query.execute(licenseId));
     }
 

--- a/src/main/java/org/dependencytrack/persistence/MetricsQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/MetricsQueryManager.java
@@ -69,6 +69,7 @@ public class MetricsQueryManager extends QueryManager implements IQueryManager {
     public PortfolioMetrics getMostRecentPortfolioMetrics() {
         final Query<PortfolioMetrics> query = pm.newQuery(PortfolioMetrics.class);
         query.setOrdering("lastOccurrence desc");
+        query.setRange(0, 1);
         return singleResult(query.execute());
     }
 
@@ -101,6 +102,7 @@ public class MetricsQueryManager extends QueryManager implements IQueryManager {
     public ProjectMetrics getMostRecentProjectMetrics(Project project) {
         final Query<ProjectMetrics> query = pm.newQuery(ProjectMetrics.class, "project == :project");
         query.setOrdering("lastOccurrence desc");
+        query.setRange(0, 1);
         return singleResult(query.execute(project));
     }
 
@@ -134,6 +136,7 @@ public class MetricsQueryManager extends QueryManager implements IQueryManager {
     public DependencyMetrics getMostRecentDependencyMetrics(Component component) {
         final Query<DependencyMetrics> query = pm.newQuery(DependencyMetrics.class, "component == :component");
         query.setOrdering("lastOccurrence desc");
+        query.setRange(0, 1);
         return singleResult(query.execute(component));
     }
 

--- a/src/main/java/org/dependencytrack/persistence/NotificationQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/NotificationQueryManager.java
@@ -122,6 +122,7 @@ public class NotificationQueryManager extends QueryManager implements IQueryMana
      */
     public NotificationPublisher getNotificationPublisher(final String name) {
         final Query<NotificationPublisher> query = pm.newQuery(NotificationPublisher.class, "name == :name");
+        query.setRange(0, 1);
         return singleResult(query.execute(name));
     }
 
@@ -142,6 +143,7 @@ public class NotificationQueryManager extends QueryManager implements IQueryMana
     private NotificationPublisher getDefaultNotificationPublisher(final String clazz) {
         final Query<NotificationPublisher> query = pm.newQuery(NotificationPublisher.class, "publisherClass == :publisherClass && defaultPublisher == true");
         query.getFetchPlan().addGroup(NotificationPublisher.FetchGroup.ALL.name());
+        query.setRange(0, 1);
         return singleResult(query.execute(clazz));
     }
 

--- a/src/main/java/org/dependencytrack/persistence/PolicyQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/PolicyQueryManager.java
@@ -93,6 +93,7 @@ final class PolicyQueryManager extends QueryManager implements IQueryManager {
      */
     public Policy getPolicy(final String name) {
         final Query<Policy> query = pm.newQuery(Policy.class, "name == :name");
+        query.setRange(0, 1);
         return singleResult(query.execute(name));
     }
 
@@ -174,6 +175,7 @@ final class PolicyQueryManager extends QueryManager implements IQueryManager {
      */
     public synchronized PolicyViolation addPolicyViolationIfNotExist(final PolicyViolation pv) {
         final Query<PolicyViolation> query = pm.newQuery(PolicyViolation.class, "type == :type && component == :component && policyCondition == :policyCondition");
+        query.setRange(0, 1);
         PolicyViolation result = singleResult(query.execute(pv.getType(), pv.getComponent(), pv.getPolicyCondition()));
         if (result == null) {
             result = persist(pv);
@@ -339,6 +341,7 @@ final class PolicyQueryManager extends QueryManager implements IQueryManager {
      */
     public ViolationAnalysis getViolationAnalysis(Component component, PolicyViolation policyViolation) {
         final Query<ViolationAnalysis> query = pm.newQuery(ViolationAnalysis.class, "component == :component && policyViolation == :policyViolation");
+        query.setRange(0, 1);
         return singleResult(query.execute(component, policyViolation));
     }
 
@@ -438,6 +441,7 @@ final class PolicyQueryManager extends QueryManager implements IQueryManager {
      */
     public LicenseGroup getLicenseGroup(final String name) {
         final Query<LicenseGroup> query = pm.newQuery(LicenseGroup.class, "name == :name");
+        query.setRange(0, 1);
         return singleResult(query.execute(name));
     }
 
@@ -461,6 +465,7 @@ final class PolicyQueryManager extends QueryManager implements IQueryManager {
     public boolean doesLicenseGroupContainLicense(final LicenseGroup lg, final License license) {
         final License l = getObjectById(License.class, license.getId());
         final Query<LicenseGroup> query = pm.newQuery(LicenseGroup.class, "id == :id && licenses.contains(:license)");
+        query.setRange(0, 1);
         return singleResult(query.execute(lg.getId(), l)) != null;
     }
 

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -194,6 +194,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
 
         preprocessACLs(query, queryFilter, params, false);
         query.setFilter(queryFilter);
+        query.setRange(0, 1);
         return singleResult(query.executeWithMap(params));
     }
 
@@ -332,6 +333,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
     public Tag getTagByName(final String name) {
         final String trimmedTag = StringUtils.trimToNull(name);
         final Query<Tag> query = pm.newQuery(Tag.class, "name == :name");
+        query.setRange(0, 1);
         return singleResult(query.execute(trimmedTag));
     }
 
@@ -641,6 +643,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
      */
     public ProjectProperty getProjectProperty(final Project project, final String groupName, final String propertyName) {
         final Query<ProjectProperty> query = this.pm.newQuery(ProjectProperty.class, "project == :project && groupName == :groupName && propertyName == :propertyName");
+        query.setRange(0, 1);
         return singleResult(query.execute(project, groupName, propertyName));
     }
 

--- a/src/main/java/org/dependencytrack/persistence/RepositoryQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/RepositoryQueryManager.java
@@ -112,6 +112,7 @@ public class RepositoryQueryManager extends QueryManager implements IQueryManage
      */
     public boolean repositoryExist(RepositoryType type, String identifier) {
         final Query<Repository> query = pm.newQuery(Repository.class, "type == :type && identifier == :identifier");
+        query.setRange(0, 1);
         return singleResult(query.execute(type, identifier)) != null;
     }
 
@@ -185,6 +186,7 @@ public class RepositoryQueryManager extends QueryManager implements IQueryManage
     public RepositoryMetaComponent getRepositoryMetaComponent(RepositoryType repositoryType, String namespace, String name) {
         final Query<RepositoryMetaComponent> query = pm.newQuery(RepositoryMetaComponent.class);
         query.setFilter("repositoryType == :repositoryType && namespace == :namespace && name == :name");
+        query.setRange(0, 1);
         return singleResult(query.execute(repositoryType, namespace, name));
     }
 

--- a/src/main/java/org/dependencytrack/persistence/ServiceComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ServiceComponentQueryManager.java
@@ -59,6 +59,7 @@ final class ServiceComponentQueryManager extends QueryManager implements IQueryM
      */
     public ServiceComponent matchServiceIdentity(final Project project, final ComponentIdentity cid) {
         final Query<ServiceComponent> query = pm.newQuery(ServiceComponent.class, "project == :project && group == :group && name == :name && version == :version");
+        query.setRange(0, 1);
         return singleResult(query.executeWithArray(project, cid.getGroup(), cid.getName(), cid.getVersion()));
     }
 

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -149,6 +149,7 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
         if (includeVulnerableSoftware) {
             query.getFetchPlan().addGroup(Vulnerability.FetchGroup.VULNERABLE_SOFTWARE.name());
         }
+        query.setRange(0, 1);
         return singleResult(query.execute(source, vulnId));
     }
 
@@ -228,6 +229,7 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
      */
     public FindingAttribution getFindingAttribution(Vulnerability vulnerability, Component component) {
         final Query<FindingAttribution> query = pm.newQuery(FindingAttribution.class, "vulnerability == :vulnerability && component == :component");
+        query.setRange(0, 1);
         return singleResult(query.execute(vulnerability, component));
     }
 

--- a/src/main/java/org/dependencytrack/persistence/VulnerableSoftwareQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerableSoftwareQueryManager.java
@@ -75,6 +75,7 @@ final class VulnerableSoftwareQueryManager extends QueryManager implements IQuer
      */
     public Cpe getCpeBy23(String cpe23) {
         final Query<Cpe> query = pm.newQuery(Cpe.class, "cpe23 == :cpe23");
+        query.setRange(0, 1);
         return singleResult(query.execute(cpe23));
     }
 
@@ -126,6 +127,7 @@ final class VulnerableSoftwareQueryManager extends QueryManager implements IQuer
                                                            String versionStartExcluding, String versionStartIncluding) {
         final Query<VulnerableSoftware> query = pm.newQuery(VulnerableSoftware.class);
         query.setFilter("cpe23 == :cpe23 && versionEndExcluding == :versionEndExcluding && versionEndIncluding == :versionEndIncluding && versionStartExcluding == :versionStartExcluding && versionStartIncluding == :versionStartIncluding");
+        query.setRange(0, 1);
         return singleResult(query.executeWithArray(cpe23, versionEndExcluding, versionEndIncluding, versionStartExcluding, versionStartIncluding));
     }
 
@@ -165,6 +167,7 @@ final class VulnerableSoftwareQueryManager extends QueryManager implements IQuer
                                                                    String versionEndExcluding, String versionEndIncluding,
                                                                    String versionStartExcluding, String versionStartIncluding) {
         final Query<VulnerableSoftware> query = pm.newQuery(VulnerableSoftware.class, "purlType == :purlType && purlNamespace == :purlNamespace && purlName == :purlName && versionEndExcluding == :versionEndExcluding && versionEndIncluding == :versionEndIncluding && versionStartExcluding == :versionStartExcluding && versionStartIncluding == :versionStartIncluding");
+        query.setRange(0, 1);
         return singleResult(query.executeWithArray(purlType, purlNamespace, purlName, versionEndExcluding, versionEndIncluding, versionStartExcluding, versionStartIncluding));
     }
 
@@ -245,6 +248,7 @@ final class VulnerableSoftwareQueryManager extends QueryManager implements IQuer
      */
     public Cwe getCweById(int cweId) {
         final Query<Cwe> query = pm.newQuery(Cwe.class, "cweId == :cweId");
+        query.setRange(0, 1);
         return singleResult(query.execute(cweId));
     }
 


### PR DESCRIPTION
Translates into `LIMIT 1`, `TOP 1` etc. depending on the datastore.

Results in queries being executed faster in the datastore (at least when no index is used), reduces the amount of unnecessary data being loaded into RAM.

Signed-off-by: nscuro <nscuro@protonmail.com>