### PR TITLE
Make background tasks periodicity configurable

### DIFF
--- a/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
+++ b/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
@@ -71,17 +71,17 @@ public enum ConfigPropertyConstants {
     ACCESS_MANAGEMENT_ACL_ENABLED("access-management", "acl.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable access control to projects in the portfolio"),
     NOTIFICATION_TEMPLATE_BASE_DIR("notification", "template.baseDir", SystemUtils.getEnvironmentVariable("DEFAULT_TEMPLATES_OVERRIDE_BASE_DIRECTORY", System.getProperty("user.home")), PropertyType.STRING, "The base directory to use when searching for notification templates"),
     NOTIFICATION_TEMPLATE_DEFAULT_OVERRIDE_ENABLED("notification", "template.default.override.enabled", SystemUtils.getEnvironmentVariable("DEFAULT_TEMPLATES_OVERRIDE_ENABLED", "false"), PropertyType.BOOLEAN, "Flag to enable/disable override of default notification templates"),
-    TASK_SCHEDULER_LDAP_SYNC_PERIOD("task-scheduler", "ldap.sync.period","21600000", PropertyType.NUMBER, "Sync period (in milliseconds) for LDAP"),
-    TASK_SCHEDULER_GHSA_MIRROR_PERIOD("task-scheduler", "ghsa.mirror.period","86400000", PropertyType.NUMBER, "Mirror period (in milliseconds) for Github Security Advisories"),
-    TASK_SCHEDULER_OSV_MIRROR_PERIOD("task-scheduler", "osv.mirror.period","86400000", PropertyType.NUMBER, "Mirror period (in milliseconds) for OSV database"),
-    TASK_SCHEDULER_NIST_MIRROR_PERIOD("task-scheduler", "nist.mirror.period","86400000", PropertyType.NUMBER, "Mirror period (in milliseconds) for NVD database"),
-    TASK_SCHEDULER_VULNDB_MIRROR_PERIOD("task-scheduler", "vulndb.mirror.period","86400000", PropertyType.NUMBER, "Mirror period (in milliseconds) for VulnDB database"),
-    TASK_SCHEDULER_PORTFOLIO_METRICS_UPDATE_PERIOD("task-scheduler", "portfolio.metrics.update.period","3600000", PropertyType.NUMBER, "Update period (in milliseconds) for portfolio metrics"),
-    TASK_SCHEDULER_VULNERABILITY_METRICS_UPDATE_PERIOD("task-scheduler", "vulnerability.metrics.update.period","3600000", PropertyType.NUMBER, "Update period (in milliseconds) for vulnerability metrics"),
-    TASK_SCHEDULER_PORTFOLIO_VULNERABILITY_ANALYSIS_PERIOD("task-scheduler", "portfolio.vulnerability.analysis.period","86400000", PropertyType.NUMBER, "Launch period (in milliseconds) for portfolio vulnerability analysis"),
-    TASK_SCHEDULER_REPOSITORY_METADATA_FETCH_PERIOD("task-scheduler", "repository.metadata.fetch.period","86400000", PropertyType.NUMBER, "Metadada fetch period (in milliseconds) for package repositories"),
-    TASK_SCHEDULER_INTERNAL_COMPONENT_IDENTIFICATION_PERIOD("task-scheduler", "internal.components.identification.period","21600000", PropertyType.NUMBER, "Internal component identification period (in milliseconds)"),
-    TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_PERIOD("task-scheduler", "component.analysis.cache.clear.period","259200000", PropertyType.NUMBER, "Cleanup period (in milliseconds) for component analysis cache");
+    TASK_SCHEDULER_LDAP_SYNC_CADENCE("task-scheduler", "ldap.sync.cadence","6", PropertyType.INTEGER, "Sync cadence (in hours) for LDAP"),
+    TASK_SCHEDULER_GHSA_MIRROR_CADENCE("task-scheduler", "ghsa.mirror.cadence","24", PropertyType.INTEGER, "Mirror cadence (in hours) for Github Security Advisories"),
+    TASK_SCHEDULER_OSV_MIRROR_CADENCE("task-scheduler", "osv.mirror.cadence","24", PropertyType.INTEGER, "Mirror cadence (in hours) for OSV database"),
+    TASK_SCHEDULER_NIST_MIRROR_CADENCE("task-scheduler", "nist.mirror.cadence","24", PropertyType.INTEGER, "Mirror cadence (in hours) for NVD database"),
+    TASK_SCHEDULER_VULNDB_MIRROR_CADENCE("task-scheduler", "vulndb.mirror.cadence","24", PropertyType.INTEGER, "Mirror cadence (in hours) for VulnDB database"),
+    TASK_SCHEDULER_PORTFOLIO_METRICS_UPDATE_CADENCE("task-scheduler", "portfolio.metrics.update.cadence","1", PropertyType.INTEGER, "Update cadence (in hours) for portfolio metrics"),
+    TASK_SCHEDULER_VULNERABILITY_METRICS_UPDATE_CADENCE("task-scheduler", "vulnerability.metrics.update.cadence","1", PropertyType.INTEGER, "Update cadence (in hours) for vulnerability metrics"),
+    TASK_SCHEDULER_PORTFOLIO_VULNERABILITY_ANALYSIS_CADENCE("task-scheduler", "portfolio.vulnerability.analysis.cadence","24", PropertyType.INTEGER, "Launch cadence (in hours) for portfolio vulnerability analysis"),
+    TASK_SCHEDULER_REPOSITORY_METADATA_FETCH_CADENCE("task-scheduler", "repository.metadata.fetch.cadence","24", PropertyType.INTEGER, "Metadada fetch cadence (in hours) for package repositories"),
+    TASK_SCHEDULER_INTERNAL_COMPONENT_IDENTIFICATION_CADENCE("task-scheduler", "internal.components.identification.cadence","6", PropertyType.INTEGER, "Internal component identification cadence (in hours)"),
+    TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_CADENCE("task-scheduler", "component.analysis.cache.clear.cadence","72", PropertyType.INTEGER, "Cleanup cadence (in hours) for component analysis cache");
 
     private String groupName;
     private String propertyName;

--- a/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
+++ b/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
@@ -46,6 +46,7 @@ public enum ConfigPropertyConstants {
     SCANNER_VULNDB_ENABLED("scanner", "vulndb.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable VulnDB"),
     SCANNER_VULNDB_OAUTH1_CONSUMER_KEY("scanner", "vulndb.api.oauth1.consumerKey", null, PropertyType.STRING, "The OAuth 1.0a consumer key"),
     SCANNER_VULNDB_OAUTH1_CONSUMER_SECRET("scanner", "vulndb.api.oath1.consumerSecret", null, PropertyType.ENCRYPTEDSTRING, "The OAuth 1.0a consumer secret"),
+    SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD("scanner", "analysis.cache.validity.period","864000", PropertyType.NUMBER, "Validity period for individual component analysis cache"),
     VULNERABILITY_SOURCE_NVD_ENABLED("vuln-source", "nvd.enabled", "true", PropertyType.BOOLEAN, "Flag to enable/disable National Vulnerability Database"),
     VULNERABILITY_SOURCE_NVD_FEEDS_URL("vuln-source", "nvd.feeds.url", "https://nvd.nist.gov/feeds", PropertyType.URL, "A base URL pointing to the hostname and path of the NVD feeds"),
     VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED("vuln-source", "github.advisories.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable GitHub Advisories"),
@@ -69,7 +70,18 @@ public enum ConfigPropertyConstants {
     KENNA_CONNECTOR_ID("integrations", "kenna.connector.id", null, PropertyType.STRING, "The Kenna Security connector identifier to upload to"),
     ACCESS_MANAGEMENT_ACL_ENABLED("access-management", "acl.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable access control to projects in the portfolio"),
     NOTIFICATION_TEMPLATE_BASE_DIR("notification", "template.baseDir", SystemUtils.getEnvironmentVariable("DEFAULT_TEMPLATES_OVERRIDE_BASE_DIRECTORY", System.getProperty("user.home")), PropertyType.STRING, "The base directory to use when searching for notification templates"),
-    NOTIFICATION_TEMPLATE_DEFAULT_OVERRIDE_ENABLED("notification", "template.default.override.enabled", SystemUtils.getEnvironmentVariable("DEFAULT_TEMPLATES_OVERRIDE_ENABLED", "false"), PropertyType.BOOLEAN, "Flag to enable/disable override of default notification templates");
+    NOTIFICATION_TEMPLATE_DEFAULT_OVERRIDE_ENABLED("notification", "template.default.override.enabled", SystemUtils.getEnvironmentVariable("DEFAULT_TEMPLATES_OVERRIDE_ENABLED", "false"), PropertyType.BOOLEAN, "Flag to enable/disable override of default notification templates"),
+    TASK_SCHEDULER_LDAP_SYNC_PERIOD("task-scheduler", "ldap.sync.period","21600000", PropertyType.NUMBER, "Sync period (in milliseconds) for LDAP"),
+    TASK_SCHEDULER_GHSA_MIRROR_PERIOD("task-scheduler", "ghsa.mirror.period","86400000", PropertyType.NUMBER, "Mirror period (in milliseconds) for Github Security Advisories"),
+    TASK_SCHEDULER_OSV_MIRROR_PERIOD("task-scheduler", "osv.mirror.period","86400000", PropertyType.NUMBER, "Mirror period (in milliseconds) for OSV database"),
+    TASK_SCHEDULER_NIST_MIRROR_PERIOD("task-scheduler", "nist.mirror.period","86400000", PropertyType.NUMBER, "Mirror period (in milliseconds) for NVD database"),
+    TASK_SCHEDULER_VULNDB_MIRROR_PERIOD("task-scheduler", "vulndb.mirror.period","86400000", PropertyType.NUMBER, "Mirror period (in milliseconds) for VulnDB database"),
+    TASK_SCHEDULER_PORTFOLIO_METRICS_UPDATE_PERIOD("task-scheduler", "portfolio.metrics.update.period","3600000", PropertyType.NUMBER, "Update period (in milliseconds) for portfolio metrics"),
+    TASK_SCHEDULER_VULNERABILITY_METRICS_UPDATE_PERIOD("task-scheduler", "vulnerability.metrics.update.period","3600000", PropertyType.NUMBER, "Update period (in milliseconds) for vulnerability metrics"),
+    TASK_SCHEDULER_PORTFOLIO_VULNERABILITY_ANALYSIS_PERIOD("task-scheduler", "portfolio.vulnerability.analysis.period","86400000", PropertyType.NUMBER, "Launch period (in milliseconds) for portfolio vulnerability analysis"),
+    TASK_SCHEDULER_REPOSITORY_METADATA_FETCH_PERIOD("task-scheduler", "repository.metadata.fetch.period","86400000", PropertyType.NUMBER, "Metadada fetch period (in milliseconds) for package repositories"),
+    TASK_SCHEDULER_INTERNAL_COMPONENT_IDENTIFICATION_PERIOD("task-scheduler", "internal.components.identification.period","21600000", PropertyType.NUMBER, "Internal component identification period (in milliseconds)"),
+    TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_PERIOD("task-scheduler", "component.analysis.cache.clear.period","259200000", PropertyType.NUMBER, "Cleanup period (in milliseconds) for component analysis cache");
 
     private String groupName;
     private String propertyName;

--- a/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
@@ -24,6 +24,7 @@ import alpine.common.util.UuidUtil;
 import alpine.model.IConfigProperty;
 import alpine.security.crypto.DataEncryption;
 import alpine.server.resources.AlpineResource;
+import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.persistence.QueryManager;
 
 import javax.ws.rs.core.Response;
@@ -58,7 +59,11 @@ abstract class AbstractConfigPropertyResource extends AlpineResource {
             property.setPropertyValue(String.valueOf(BooleanUtil.valueOf(json.getPropertyValue())));
         } else if (property.getPropertyType() == IConfigProperty.PropertyType.INTEGER) {
             try {
-                property.setPropertyValue(String.valueOf(Integer.parseInt(json.getPropertyValue())));
+                int propertyValue = Integer.parseInt(json.getPropertyValue());
+                if(ConfigPropertyConstants.TASK_SCHEDULER_LDAP_SYNC_CADENCE.getGroupName().equals(json.getGroupName()) && propertyValue <= 0) {
+                    return Response.status(Response.Status.BAD_REQUEST).entity("A Task scheduler cadence ("+json.getPropertyName()+") cannot be inferior to one hour.A value of "+propertyValue+" was provided.").build();
+                }
+                property.setPropertyValue(String.valueOf(propertyValue));
             } catch (NumberFormatException e) {
                 return Response.status(Response.Status.BAD_REQUEST).entity("The property expected an integer and an integer was not sent.").build();
             }

--- a/src/main/java/org/dependencytrack/tasks/TaskScheduler.java
+++ b/src/main/java/org/dependencytrack/tasks/TaskScheduler.java
@@ -22,19 +22,9 @@ import alpine.common.util.BooleanUtil;
 import alpine.event.LdapSyncEvent;
 import alpine.event.framework.Event;
 import alpine.model.ConfigProperty;
+import alpine.model.IConfigProperty.PropertyType;
 import alpine.server.tasks.AlpineTaskScheduler;
-import org.dependencytrack.event.ClearComponentAnalysisCacheEvent;
-import org.dependencytrack.event.DefectDojoUploadEventAbstract;
-import org.dependencytrack.event.FortifySscUploadEventAbstract;
-import org.dependencytrack.event.GitHubAdvisoryMirrorEvent;
-import org.dependencytrack.event.OsvMirrorEvent;
-import org.dependencytrack.event.InternalComponentIdentificationEvent;
-import org.dependencytrack.event.KennaSecurityUploadEventAbstract;
-import org.dependencytrack.event.MetricsUpdateEvent;
-import org.dependencytrack.event.NistMirrorEvent;
-import org.dependencytrack.event.PortfolioVulnerabilityAnalysisEvent;
-import org.dependencytrack.event.RepositoryMetaEvent;
-import org.dependencytrack.event.VulnDbSyncEvent;
+import org.dependencytrack.event.*;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.persistence.QueryManager;
 
@@ -55,39 +45,40 @@ public final class TaskScheduler extends AlpineTaskScheduler {
      * Private constructor.
      */
     private TaskScheduler() {
+        try (QueryManager qm = new QueryManager()) {
+            // Creates a new event that executes every 6 hours (21600000) by default after an initial 10 second (10000) delay
+            scheduleEvent(new LdapSyncEvent(), 10000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_LDAP_SYNC_PERIOD));
 
-        // Creates a new event that executes every 6 hours (21600000) after an initial 10 second (10000) delay
-        scheduleEvent(new LdapSyncEvent(), 10000, 21600000);
+            // Creates a new event that executes every 24 hours (86400000) by default after an initial 10 second (10000) delay
+            scheduleEvent(new GitHubAdvisoryMirrorEvent(), 10000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_GHSA_MIRROR_PERIOD));
 
-        // Creates a new event that executes every 24 hours (86400000) after an initial 10 second (10000) delay
-        scheduleEvent(new GitHubAdvisoryMirrorEvent(), 10000, 86400000);
+            // Creates a new event that executes every 24 hours (86400000) by default after an initial 10 second (10000) delay
+            scheduleEvent(new OsvMirrorEvent(), 10000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_OSV_MIRROR_PERIOD));
 
-        // Creates a new event that executes every 24 hours (86400000) after an initial 10 second (10000) delay
-        scheduleEvent(new OsvMirrorEvent(), 10000, 86400000);
+            // Creates a new event that executes every 24 hours (86400000) by default after an initial 1 minute (60000) delay
+            scheduleEvent(new NistMirrorEvent(), 60000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_NIST_MIRROR_PERIOD));
 
-        // Creates a new event that executes every 24 hours (86400000) after an initial 1 minute (60000) delay
-        scheduleEvent(new NistMirrorEvent(), 60000, 86400000);
+            // Creates a new event that executes every 24 hours (86400000) by default after an initial 1 minute (60000) delay
+            scheduleEvent(new VulnDbSyncEvent(), 60000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_VULNDB_MIRROR_PERIOD));
 
-        // Creates a new event that executes every 24 hours (86400000) after an initial 1 minute (60000) delay
-        scheduleEvent(new VulnDbSyncEvent(), 60000, 86400000);
+            // Creates a new event that executes every 1 hour (3600000) by default after an initial 10 second (10000) delay
+            scheduleEvent(new MetricsUpdateEvent(MetricsUpdateEvent.Type.PORTFOLIO), 10000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_PORTFOLIO_METRICS_UPDATE_PERIOD));
 
-        // Creates a new event that executes every 1 hour (3600000) after an initial 10 second (10000) delay
-        scheduleEvent(new MetricsUpdateEvent(MetricsUpdateEvent.Type.PORTFOLIO), 10000, 3600000);
+            // Creates a new event that executes every 1 hour (3600000) by default after an initial 10 second (10000) delay
+            scheduleEvent(new MetricsUpdateEvent(MetricsUpdateEvent.Type.VULNERABILITY), 10000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_VULNERABILITY_METRICS_UPDATE_PERIOD));
 
-        // Creates a new event that executes every 1 hour (3600000) after an initial 10 second (10000) delay
-        scheduleEvent(new MetricsUpdateEvent(MetricsUpdateEvent.Type.VULNERABILITY), 10000, 3600000);
+            // Creates a new event that executes every 24 hours (86400000) by default after an initial 6 hour (21600000) delay
+            scheduleEvent(new PortfolioVulnerabilityAnalysisEvent(), 21600000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_PORTFOLIO_VULNERABILITY_ANALYSIS_PERIOD));
 
-        // Creates a new event that executes every 24 hours (86400000) after an initial 6 hour (21600000) delay
-        scheduleEvent(new PortfolioVulnerabilityAnalysisEvent(), 21600000, 86400000);
+            // Creates a new event that executes every 24 hours (86400000) by default after an initial 1 hour (3600000) delay
+            scheduleEvent(new RepositoryMetaEvent(), 3600000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_REPOSITORY_METADATA_FETCH_PERIOD));
 
-        // Creates a new event that executes every 24 hours (86400000) after an initial 1 hour (3600000) delay
-        scheduleEvent(new RepositoryMetaEvent(), 3600000, 86400000);
+            // Creates a new event that executes every 6 hours (21600000) by default after an initial 1 hour (3600000) delay
+            scheduleEvent(new InternalComponentIdentificationEvent(), 3600000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_INTERNAL_COMPONENT_IDENTIFICATION_PERIOD));
 
-        // Creates a new event that executes every 6 hours (21600000) after an initial 1 hour (3600000) delay
-        scheduleEvent(new InternalComponentIdentificationEvent(), 3600000, 21600000);
-
-        // Creates a new event that executes every 72 hours (259200000) after an initial 10 second (10000) delay
-        scheduleEvent(new ClearComponentAnalysisCacheEvent(), 10000, 259200000);
+            // Creates a new event that executes every 72 hours (259200000) by default after an initial 10 second (10000) delay
+            scheduleEvent(new ClearComponentAnalysisCacheEvent(), 10000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_PERIOD));
+        }
 
         // Configurable tasks
         scheduleConfigurableTask(300000, FORTIFY_SSC_ENABLED, FORTIFY_SSC_SYNC_CADENCE, new FortifySscUploadEventAbstract());
@@ -122,5 +113,14 @@ public final class TaskScheduler extends AlpineTaskScheduler {
                 scheduleEvent(event, initialDelay, (long)minutes * (long)60 * (long)1000);
             }
         }
+    }
+
+    private long getNumberConfigPropertyValue(QueryManager qm, ConfigPropertyConstants configProperty) {
+        long result = 0;
+        ConfigProperty property = qm.getConfigProperty(configProperty.getGroupName(), configProperty.getPropertyName());
+        if(PropertyType.NUMBER.equals(property.getPropertyType()) && property.getPropertyValue() != null) {
+            result = Long.valueOf(property.getPropertyValue());
+        }
+        return result;
     }
 }

--- a/src/main/java/org/dependencytrack/tasks/TaskScheduler.java
+++ b/src/main/java/org/dependencytrack/tasks/TaskScheduler.java
@@ -24,7 +24,18 @@ import alpine.event.framework.Event;
 import alpine.model.ConfigProperty;
 import alpine.model.IConfigProperty.PropertyType;
 import alpine.server.tasks.AlpineTaskScheduler;
-import org.dependencytrack.event.*;
+import org.dependencytrack.event.GitHubAdvisoryMirrorEvent;
+import org.dependencytrack.event.NistMirrorEvent;
+import org.dependencytrack.event.OsvMirrorEvent;
+import org.dependencytrack.event.VulnDbSyncEvent;
+import org.dependencytrack.event.MetricsUpdateEvent;
+import org.dependencytrack.event.PortfolioVulnerabilityAnalysisEvent;
+import org.dependencytrack.event.RepositoryMetaEvent;
+import org.dependencytrack.event.InternalComponentIdentificationEvent;
+import org.dependencytrack.event.ClearComponentAnalysisCacheEvent;
+import org.dependencytrack.event.FortifySscUploadEventAbstract;
+import org.dependencytrack.event.KennaSecurityUploadEventAbstract;
+import org.dependencytrack.event.DefectDojoUploadEventAbstract;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.persistence.QueryManager;
 
@@ -47,37 +58,37 @@ public final class TaskScheduler extends AlpineTaskScheduler {
     private TaskScheduler() {
         try (QueryManager qm = new QueryManager()) {
             // Creates a new event that executes every 6 hours (21600000) by default after an initial 10 second (10000) delay
-            scheduleEvent(new LdapSyncEvent(), 10000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_LDAP_SYNC_PERIOD));
+            scheduleEvent(new LdapSyncEvent(), 10000, getCadenceConfigPropertyValueInMilliseconds(qm, TASK_SCHEDULER_LDAP_SYNC_CADENCE));
 
             // Creates a new event that executes every 24 hours (86400000) by default after an initial 10 second (10000) delay
-            scheduleEvent(new GitHubAdvisoryMirrorEvent(), 10000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_GHSA_MIRROR_PERIOD));
+            scheduleEvent(new GitHubAdvisoryMirrorEvent(), 10000, getCadenceConfigPropertyValueInMilliseconds(qm, TASK_SCHEDULER_GHSA_MIRROR_CADENCE));
 
             // Creates a new event that executes every 24 hours (86400000) by default after an initial 10 second (10000) delay
-            scheduleEvent(new OsvMirrorEvent(), 10000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_OSV_MIRROR_PERIOD));
+            scheduleEvent(new OsvMirrorEvent(), 10000, getCadenceConfigPropertyValueInMilliseconds(qm, TASK_SCHEDULER_OSV_MIRROR_CADENCE));
 
             // Creates a new event that executes every 24 hours (86400000) by default after an initial 1 minute (60000) delay
-            scheduleEvent(new NistMirrorEvent(), 60000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_NIST_MIRROR_PERIOD));
+            scheduleEvent(new NistMirrorEvent(), 60000, getCadenceConfigPropertyValueInMilliseconds(qm, TASK_SCHEDULER_NIST_MIRROR_CADENCE));
 
             // Creates a new event that executes every 24 hours (86400000) by default after an initial 1 minute (60000) delay
-            scheduleEvent(new VulnDbSyncEvent(), 60000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_VULNDB_MIRROR_PERIOD));
+            scheduleEvent(new VulnDbSyncEvent(), 60000, getCadenceConfigPropertyValueInMilliseconds(qm, TASK_SCHEDULER_VULNDB_MIRROR_CADENCE));
 
             // Creates a new event that executes every 1 hour (3600000) by default after an initial 10 second (10000) delay
-            scheduleEvent(new MetricsUpdateEvent(MetricsUpdateEvent.Type.PORTFOLIO), 10000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_PORTFOLIO_METRICS_UPDATE_PERIOD));
+            scheduleEvent(new MetricsUpdateEvent(MetricsUpdateEvent.Type.PORTFOLIO), 10000, getCadenceConfigPropertyValueInMilliseconds(qm, TASK_SCHEDULER_PORTFOLIO_METRICS_UPDATE_CADENCE));
 
             // Creates a new event that executes every 1 hour (3600000) by default after an initial 10 second (10000) delay
-            scheduleEvent(new MetricsUpdateEvent(MetricsUpdateEvent.Type.VULNERABILITY), 10000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_VULNERABILITY_METRICS_UPDATE_PERIOD));
+            scheduleEvent(new MetricsUpdateEvent(MetricsUpdateEvent.Type.VULNERABILITY), 10000, getCadenceConfigPropertyValueInMilliseconds(qm, TASK_SCHEDULER_VULNERABILITY_METRICS_UPDATE_CADENCE));
 
             // Creates a new event that executes every 24 hours (86400000) by default after an initial 6 hour (21600000) delay
-            scheduleEvent(new PortfolioVulnerabilityAnalysisEvent(), 21600000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_PORTFOLIO_VULNERABILITY_ANALYSIS_PERIOD));
+            scheduleEvent(new PortfolioVulnerabilityAnalysisEvent(), 21600000, getCadenceConfigPropertyValueInMilliseconds(qm, TASK_SCHEDULER_PORTFOLIO_VULNERABILITY_ANALYSIS_CADENCE));
 
             // Creates a new event that executes every 24 hours (86400000) by default after an initial 1 hour (3600000) delay
-            scheduleEvent(new RepositoryMetaEvent(), 3600000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_REPOSITORY_METADATA_FETCH_PERIOD));
+            scheduleEvent(new RepositoryMetaEvent(), 3600000, getCadenceConfigPropertyValueInMilliseconds(qm, TASK_SCHEDULER_REPOSITORY_METADATA_FETCH_CADENCE));
 
             // Creates a new event that executes every 6 hours (21600000) by default after an initial 1 hour (3600000) delay
-            scheduleEvent(new InternalComponentIdentificationEvent(), 3600000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_INTERNAL_COMPONENT_IDENTIFICATION_PERIOD));
+            scheduleEvent(new InternalComponentIdentificationEvent(), 3600000, getCadenceConfigPropertyValueInMilliseconds(qm, TASK_SCHEDULER_INTERNAL_COMPONENT_IDENTIFICATION_CADENCE));
 
             // Creates a new event that executes every 72 hours (259200000) by default after an initial 10 second (10000) delay
-            scheduleEvent(new ClearComponentAnalysisCacheEvent(), 10000, getNumberConfigPropertyValue(qm, TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_PERIOD));
+            scheduleEvent(new ClearComponentAnalysisCacheEvent(), 10000, getCadenceConfigPropertyValueInMilliseconds(qm, TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_CADENCE));
         }
 
         // Configurable tasks
@@ -115,11 +126,11 @@ public final class TaskScheduler extends AlpineTaskScheduler {
         }
     }
 
-    private long getNumberConfigPropertyValue(QueryManager qm, ConfigPropertyConstants configProperty) {
+    private long getCadenceConfigPropertyValueInMilliseconds(QueryManager qm, ConfigPropertyConstants configProperty) {
         long result = 0;
         ConfigProperty property = qm.getConfigProperty(configProperty.getGroupName(), configProperty.getPropertyName());
-        if(PropertyType.NUMBER.equals(property.getPropertyType()) && property.getPropertyValue() != null) {
-            result = Long.valueOf(property.getPropertyValue());
+        if(PropertyType.INTEGER.equals(property.getPropertyType()) && property.getPropertyValue() != null) {
+            result = Long.valueOf(property.getPropertyValue()) * 3600 * 1000;
         }
         return result;
     }

--- a/src/main/java/org/dependencytrack/tasks/scanners/BaseComponentAnalyzerTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/BaseComponentAnalyzerTask.java
@@ -65,12 +65,14 @@ public abstract class BaseComponentAnalyzerTask implements ScanTask {
     protected boolean isCacheCurrent(Vulnerability.Source source, String targetHost, String target) {
         try (QueryManager qm = new QueryManager()) {
             boolean isCacheCurrent = false;
+            ConfigProperty cacheClearPeriod = qm.getConfigProperty(ConfigPropertyConstants.SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD.getGroupName(), ConfigPropertyConstants.SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD.getPropertyName());
+            long cacheValidityPeriod = Long.valueOf(cacheClearPeriod.getPropertyValue());
             ComponentAnalysisCache cac = qm.getComponentAnalysisCache(ComponentAnalysisCache.CacheType.VULNERABILITY, targetHost, source.name(), target);
             if (cac != null) {
                 final Date now = new Date();
                 if (now.getTime() > cac.getLastOccurrence().getTime()) {
                     final long delta = now.getTime() - cac.getLastOccurrence().getTime();
-                    isCacheCurrent = delta <= 86400000; // TODO: Default to 24 hours. Make this configurable in a future release
+                    isCacheCurrent = delta <= cacheValidityPeriod;
                 }
             }
             if (isCacheCurrent) {

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -39,10 +39,10 @@
         <listener-class>alpine.server.persistence.PersistenceManagerFactory</listener-class>
     </listener>
     <listener>
-        <listener-class>org.dependencytrack.event.EventSubsystemInitializer</listener-class>
+        <listener-class>org.dependencytrack.persistence.DefaultObjectGenerator</listener-class>
     </listener>
     <listener>
-        <listener-class>org.dependencytrack.persistence.DefaultObjectGenerator</listener-class>
+        <listener-class>org.dependencytrack.event.EventSubsystemInitializer</listener-class>
     </listener>
     <listener>
         <listener-class>org.dependencytrack.notification.NotificationSubsystemInitializer</listener-class>


### PR DESCRIPTION
Enhancement request described in #1542.

Signed-off-by: Alioune SY <sy_alioune@yahoo.fr>

Please find below related PRs to review :

- Frontend : [PR 214](https://github.com/DependencyTrack/frontend/pull/214)

**Design decisions :**

- Task are not rescheduled after period update because it would require updates on Alpine framework to be able to cancel a given task. It is also tricky because, if the task ran 5min ago, we don't want to run it again after a reschedule. With a restart, we don't have to handle all those edge cases
- I've introduced _scanner.analysis.cache.validity.period_ configuration property used in [BaseComponentAnalyzerTask](https://github.com/syalioune/dependency-track/blob/feature/configurable_period_for_tasks/src/main/java/org/dependencytrack/tasks/scanners/BaseComponentAnalyzerTask.java#L68) instead of the previous hard coded value. It can be configured through API by experienced users but not through the new UI as it is not really related to task scheduling
- For now, I haven't add a check that _scanner.analysis.cache.validity.period_ is strictly inferior to _task-scheduler.component.analysis.cache.clear.period_  as the first one is not really exposed to the end users
- No specific documentation update as the UI seems self-descriptive

Please find a sneak peak of the UI below

![image](https://user-images.githubusercontent.com/6144741/181718903-08d1f7c6-578f-4a0f-ace3-59a52488197b.png)

