### PR TITLE
Notification email with 'null' subject when 'PROJECT_AUDIT_CHANGE' is enabled and analysis state is 'RESOLVED'

### DIFF
--- a/src/main/java/org/dependencytrack/notification/NotificationConstants.java
+++ b/src/main/java/org/dependencytrack/notification/NotificationConstants.java
@@ -48,6 +48,7 @@ public class NotificationConstants {
         public static final String ANALYSIS_DECISION_NOT_SET = "Analysis Decision: Marking Finding as NOT SET";
         public static final String ANALYSIS_DECISION_SUPPRESSED = "Analysis Decision: Finding Suppressed";
         public static final String ANALYSIS_DECISION_UNSUPPRESSED = "Analysis Decision: Finding UnSuppressed";
+        public static final String ANALYSIS_DECISION_RESOLVED = "Analysis Decision: Finding Resolved";
         public static final String VIOLATIONANALYSIS_DECISION_APPROVED = "Violation Analysis Decision: Approved";
         public static final String VIOLATIONANALYSIS_DECISION_REJECTED = "Violation Analysis Decision: Rejected";
         public static final String VIOLATIONANALYSIS_DECISION_NOT_SET = "Violation Analysis Decision: Marking Finding as NOT SET";

--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -139,6 +139,9 @@ public final class NotificationUtil {
                     case NOT_SET:
                         title = NotificationConstants.Title.ANALYSIS_DECISION_NOT_SET;
                         break;
+                    case RESOLVED:
+                        title = NotificationConstants.Title.ANALYSIS_DECISION_RESOLVED;
+                        break;
                 }
             } else if (suppressionChange) {
                 if (analysis.isSuppressed()) {

--- a/src/test/java/org/dependencytrack/notification/NotificationConstantsTest.java
+++ b/src/test/java/org/dependencytrack/notification/NotificationConstantsTest.java
@@ -46,5 +46,6 @@ public class NotificationConstantsTest {
         Assert.assertEquals("Analysis Decision: Marking Finding as NOT SET", NotificationConstants.Title.ANALYSIS_DECISION_NOT_SET);
         Assert.assertEquals("Analysis Decision: Finding Suppressed", NotificationConstants.Title.ANALYSIS_DECISION_SUPPRESSED);
         Assert.assertEquals("Analysis Decision: Finding UnSuppressed", NotificationConstants.Title.ANALYSIS_DECISION_UNSUPPRESSED);
+        Assert.assertEquals("Analysis Decision: Finding Resolved", NotificationConstants.Title.ANALYSIS_DECISION_RESOLVED);
     }
 }


### PR DESCRIPTION
Fixes #1818

Resolved finding case was missing in NotificationUtil logic.

Signed-off-by: Alioune SY <sy_alioune@yahoo.fr>