### PR TITLE
Restrict notification's affected project list when notification rule is limited to specific projects

### DIFF
--- a/src/main/java/org/dependencytrack/notification/NotificationRouter.java
+++ b/src/main/java/org/dependencytrack/notification/NotificationRouter.java
@@ -22,12 +22,12 @@ import alpine.common.logging.Logger;
 import alpine.notification.Notification;
 import alpine.notification.NotificationLevel;
 import alpine.notification.Subscriber;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.dependencytrack.exception.PublisherException;
 import org.dependencytrack.model.NotificationPublisher;
 import org.dependencytrack.model.NotificationRule;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.notification.publisher.Publisher;
+import org.dependencytrack.notification.vo.AnalysisDecisionChange;
 import org.dependencytrack.notification.vo.BomConsumedOrProcessed;
 import org.dependencytrack.notification.vo.NewVulnerabilityIdentified;
 import org.dependencytrack.notification.vo.NewVulnerableDependency;
@@ -44,6 +44,9 @@ import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class NotificationRouter implements Subscriber {
 
@@ -72,7 +75,7 @@ public class NotificationRouter implements Subscriber {
                                                                  .add(Publisher.CONFIG_TEMPLATE_KEY, notificationPublisher.getTemplate())
                                                                  .addAll(Json.createObjectBuilder(config))
                                                                          .build();
-                    publisher.inform(notification, notificationPublisherConfig);
+                    publisher.inform(restrictNotificationToRuleProjects(notification, rule), notificationPublisherConfig);
                 } else {
                     LOGGER.error("The defined notification publisher is not assignable from " + Publisher.class.getCanonicalName());
                 }
@@ -82,6 +85,38 @@ public class NotificationRouter implements Subscriber {
                 LOGGER.error("An error occured during the publication of the notification", publisherException);
             }
         }
+    }
+
+    public Notification restrictNotificationToRuleProjects(Notification initialNotification, NotificationRule rule) {
+        Notification restrictedNotification = initialNotification;
+        if(canRestrictNotificationToRuleProjects(initialNotification, rule)) {
+            Set<String> ruleProjectsUuids = rule.getProjects().stream().map(Project::getUuid).map(UUID::toString).collect(Collectors.toSet());
+            restrictedNotification = new Notification();
+            restrictedNotification.setGroup(initialNotification.getGroup());
+            restrictedNotification.setLevel(initialNotification.getLevel());
+            restrictedNotification.scope(initialNotification.getScope());
+            restrictedNotification.setContent(initialNotification.getContent());
+            restrictedNotification.setTitle(initialNotification.getTitle());
+            restrictedNotification.setTimestamp(initialNotification.getTimestamp());
+            if(initialNotification.getSubject() instanceof NewVulnerabilityIdentified) {
+                NewVulnerabilityIdentified subject = (NewVulnerabilityIdentified) initialNotification.getSubject();
+                Set<Project> restrictedProjects = subject.getAffectedProjects().stream().filter(project -> ruleProjectsUuids.contains(project.getUuid().toString())).collect(Collectors.toSet());
+                NewVulnerabilityIdentified restrictedSubject = new NewVulnerabilityIdentified(subject.getVulnerability(), subject.getComponent(), restrictedProjects);
+                restrictedNotification.setSubject(restrictedSubject);
+            } else if(initialNotification.getSubject() instanceof AnalysisDecisionChange) {
+                AnalysisDecisionChange subject = (AnalysisDecisionChange) initialNotification.getSubject();
+                Set<Project> restrictedProjects = subject.getAffectedProjects().stream().filter(project -> ruleProjectsUuids.contains(project.getUuid().toString())).collect(Collectors.toSet());
+                AnalysisDecisionChange restrictedSubject = new AnalysisDecisionChange(subject.getVulnerability(), subject.getComponent(), restrictedProjects, subject.getAnalysis());
+                restrictedNotification.setSubject(restrictedSubject);
+            }
+        }
+        return restrictedNotification;
+    }
+
+    private boolean canRestrictNotificationToRuleProjects(Notification initialNotification, NotificationRule rule) {
+        return (initialNotification.getSubject() instanceof NewVulnerabilityIdentified || initialNotification.getSubject() instanceof AnalysisDecisionChange) &&
+                rule.getProjects() != null
+                && rule.getProjects().size() > 0;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Fixes #1866

Signed-off-by: Alioune SY <sy_alioune@yahoo.fr>

Project deduplication in `NotificationUtil` is debatable as we can say it is not Dependency Track job to compensate input data quality (e.g : SBOM merge with duplicates). I agree for the most part (metrics calculation, vulnerability assignment...) but for notification, I feel that it is a sound compromise.