### PR TITLE
Issue 1174: Fix component update due to uppercase hashes

### DIFF
--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -147,49 +147,49 @@ public class Component implements Serializable {
     @Persistent
     @Index(name = "COMPONENT_MD5_IDX")
     @Column(name = "MD5", jdbcType = "VARCHAR", length = 32)
-    @Pattern(regexp = RegexSequence.Definition.HASH_MD5, message = "The MD5 hash must be a valid 32 character HEX number")
+    @Pattern(regexp = "^[0-9a-fA-F]{32}$", message = "The MD5 hash must be a valid 32 character HEX number")
     private String md5;
 
     @Persistent
     @Index(name = "COMPONENT_SHA1_IDX")
     @Column(name = "SHA1", jdbcType = "VARCHAR", length = 40)
-    @Pattern(regexp = RegexSequence.Definition.HASH_SHA1, message = "The SHA1 hash must be a valid 40 character HEX number")
+    @Pattern(regexp = "^[0-9a-fA-F]{40}$", message = "The SHA1 hash must be a valid 40 character HEX number")
     private String sha1;
 
     @Persistent
     @Index(name = "COMPONENT_SHA256_IDX")
     @Column(name = "SHA_256", jdbcType = "VARCHAR", length = 64)
-    @Pattern(regexp = RegexSequence.Definition.HASH_SHA256, message = "The SHA-256 hash must be a valid 64 character HEX number")
+    @Pattern(regexp = "^[0-9a-fA-F]{64}$", message = "The SHA-256 hash must be a valid 64 character HEX number")
     private String sha256;
 
     @Persistent
     @Index(name = "COMPONENT_SHA384_IDX")
     @Column(name = "SHA_384", jdbcType = "VARCHAR", length = 96)
-    @Pattern(regexp = RegexSequence.Definition.HASH_SHA384, message = "The SHA-384 hash must be a valid 96 character HEX number")
+    @Pattern(regexp = "^[0-9a-fA-F]{96}$", message = "The SHA-384 hash must be a valid 96 character HEX number")
     private String sha384;
 
     @Persistent
     @Index(name = "COMPONENT_SHA512_IDX")
     @Column(name = "SHA_512", jdbcType = "VARCHAR", length = 128)
-    @Pattern(regexp = RegexSequence.Definition.HASH_SHA512, message = "The SHA-512 hash must be a valid 128 character HEX number")
+    @Pattern(regexp = "^[0-9a-fA-F]{128}$", message = "The SHA-512 hash must be a valid 128 character HEX number")
     private String sha512;
 
     @Persistent
     @Index(name = "COMPONENT_SHA3_256_IDX")
     @Column(name = "SHA3_256", jdbcType = "VARCHAR", length = 64)
-    @Pattern(regexp = RegexSequence.Definition.HASH_SHA256, message = "The SHA3-256 hash must be a valid 64 character HEX number")
+    @Pattern(regexp = "^[0-9a-fA-F]{64}$", message = "The SHA3-256 hash must be a valid 64 character HEX number")
     private String sha3_256;
 
     @Persistent
     @Index(name = "COMPONENT_SHA3_384_IDX")
     @Column(name = "SHA3_384", jdbcType = "VARCHAR", length = 96)
-    @Pattern(regexp = RegexSequence.Definition.HASH_SHA384, message = "The SHA3-384 hash must be a valid 96 character HEX number")
+    @Pattern(regexp = "^[0-9a-fA-F]{96}$", message = "The SHA3-384 hash must be a valid 96 character HEX number")
     private String sha3_384;
 
     @Persistent
     @Index(name = "COMPONENT_SHA3_512_IDX")
     @Column(name = "SHA3_512", jdbcType = "VARCHAR", length = 128)
-    @Pattern(regexp = RegexSequence.Definition.HASH_SHA512, message = "The SHA3-512 hash must be a valid 128 character HEX number")
+    @Pattern(regexp = "^[0-9a-fA-F]{128}$", message = "The SHA3-512 hash must be a valid 128 character HEX number")
     private String sha3_512;
 
     @Persistent
@@ -410,7 +410,7 @@ public class Component implements Serializable {
     }
 
     public void setMd5(String md5) {
-        this.md5 = md5;
+        this.md5 = md5 == null ? null : md5.toLowerCase();
     }
 
     public String getSha1() {
@@ -418,7 +418,7 @@ public class Component implements Serializable {
     }
 
     public void setSha1(String sha1) {
-        this.sha1 = sha1;
+        this.sha1 = sha1 == null ? null : sha1.toLowerCase();
     }
 
     public String getSha256() {
@@ -426,7 +426,7 @@ public class Component implements Serializable {
     }
 
     public void setSha256(String sha256) {
-        this.sha256 = sha256;
+        this.sha256 = sha256 == null ? null : sha256.toLowerCase();
     }
 
     public String getSha384() {
@@ -434,7 +434,7 @@ public class Component implements Serializable {
     }
 
     public void setSha384(String sha384) {
-        this.sha384 = sha384;
+        this.sha384 = sha384 == null ? null : sha384.toLowerCase();
     }
 
     public String getSha512() {
@@ -442,7 +442,7 @@ public class Component implements Serializable {
     }
 
     public void setSha512(String sha512) {
-        this.sha512 = sha512;
+        this.sha512 = sha512 == null ? null : sha512.toLowerCase();
     }
 
     public String getSha3_256() {
@@ -450,7 +450,7 @@ public class Component implements Serializable {
     }
 
     public void setSha3_256(String sha3_256) {
-        this.sha3_256 = sha3_256;
+        this.sha3_256 = sha3_256 == null ? null : sha3_256.toLowerCase();
     }
 
     public String getSha3_384() {
@@ -458,7 +458,7 @@ public class Component implements Serializable {
     }
 
     public void setSha3_384(String sha3_384) {
-        this.sha3_384 = sha3_384;
+        this.sha3_384 = sha3_384 == null ? null : sha3_384.toLowerCase();
     }
 
     public String getSha3_512() {
@@ -466,7 +466,7 @@ public class Component implements Serializable {
     }
 
     public void setSha3_512(String sha3_512) {
-        this.sha3_512 = sha3_512;
+        this.sha3_512 = sha3_512 == null ? null : sha3_512.toLowerCase();
     }
 
     public String getBlake2b_256() {

--- a/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
@@ -135,6 +135,40 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
+    public void createComponentUpperCaseHashTest() {
+        Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
+        Component component = new Component();
+        component.setProject(project);
+        component.setName("My Component");
+        component.setVersion("1.0");
+        component.setSha1("640ab2bae07bedc4c163f679a746f7ab7fb5d1fa".toUpperCase());
+        component.setSha256("532eaabd9574880dbf76b9b8cc00832c20a6ec113d682299550d7a6e0f345e25".toUpperCase());
+        component.setSha3_256("c0a5cca43b8aa79eb50e3464bc839dd6fd414fae0ddf928ca23dcebf8a8b8dd0".toUpperCase());
+        component.setSha384("7b8f4654076b80eb963911f19cfad1aaf4285ed48e826f6cde1b01a79aa73fadb5446e667fc4f90417782c91270540f3".toUpperCase());
+        component.setSha3_384("da73bfcba560692a019f52c37de4d5e3ab49ca39c6a75594e3c39d805388c4de9d0ff3927eb9e197536f5b0b3a515f0a".toUpperCase());
+        component.setSha512("c6ee9e33cf5c6715a1d148fd73f7318884b41adcb916021e2bc0e800a5c5dd97f5142178f6ae88c8fdd98e1afb0ce4c8d2c54b5f37b30b7da1997bb33b0b8a31".toUpperCase());
+        component.setSha3_512("301bb421c971fbb7ed01dcc3a9976ce53df034022ba982b97d0f27d48c4f03883aabf7c6bc778aa7c383062f6823045a6d41b8a720afbb8a9607690f89fbe1a7".toUpperCase());
+        component.setMd5("0cbc6611f5540bd0809a388dc95a615b".toUpperCase());
+        Response response = target(V1_COMPONENT + "/project/" + project.getUuid().toString()).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(component, MediaType.APPLICATION_JSON));
+        Assert.assertEquals(201, response.getStatus(), 0);
+        JsonObject json = parseJsonObject(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals("My Component", json.getString("name"));
+        Assert.assertEquals("1.0", json.getString("version"));
+        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
+        Assert.assertEquals(component.getSha1(), json.getString("sha1"));
+        Assert.assertEquals(component.getSha256(), json.getString("sha256"));
+        Assert.assertEquals(component.getSha3_256(), json.getString("sha3_256"));
+        Assert.assertEquals(component.getSha384(), json.getString("sha384"));
+        Assert.assertEquals(component.getSha3_384(), json.getString("sha3_384"));
+        Assert.assertEquals(component.getSha512(), json.getString("sha512"));
+        Assert.assertEquals(component.getSha3_512(), json.getString("sha3_512"));
+        Assert.assertEquals(component.getMd5(), json.getString("md5"));
+    }
+
+    @Test
     public void updateComponentTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         Component component = new Component();


### PR DESCRIPTION
Predefined RegexSequences only validate lower case hash notations. While this is usually the case it is not mandatory as hex values can be upper and lower case. Furthermore, tools like cyclonedx-dotnet provide uppercase hash values and boms generated by it can be imported but components can't be changed in UI. API will return an error for failed hash validation

Fixes: #1174, Partially: #1182 

Signed-off-by: awegg <alexander@weggerle.de>