### PR TITLE
Refactor `InternalComponentIdentificationTask` to use pagination

### DIFF
--- a/src/main/java/org/dependencytrack/event/InternalComponentIdentificationEvent.java
+++ b/src/main/java/org/dependencytrack/event/InternalComponentIdentificationEvent.java
@@ -19,10 +19,6 @@
 package org.dependencytrack.event;
 
 import alpine.event.framework.Event;
-import org.dependencytrack.model.Component;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Defines an event triggered when internal components should be identified in the entire portfolio.
@@ -32,19 +28,7 @@ import java.util.List;
  */
 public class InternalComponentIdentificationEvent implements Event {
 
-    private List<Component> components = new ArrayList<>();
-
-    public InternalComponentIdentificationEvent() { }
-
-    public InternalComponentIdentificationEvent(final Component component) {
-        this.components.add(component);
+    public InternalComponentIdentificationEvent() {
     }
 
-    public InternalComponentIdentificationEvent(final List<Component> components) {
-        this.components = components;
-    }
-
-    public List<Component> getComponents() {
-        return components;
-    }
 }

--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -70,6 +70,13 @@ import java.util.UUID;
                 @Persistent(name = "parent"),
                 @Persistent(name = "children"),
                 @Persistent(name = "vulnerabilities"),
+        }),
+        @FetchGroup(name = "INTERNAL_IDENTIFICATION", members = {
+                @Persistent(name = "id"),
+                @Persistent(name = "group"),
+                @Persistent(name = "name"),
+                @Persistent(name = "internal"),
+                @Persistent(name = "uuid")
         })
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -81,7 +88,8 @@ public class Component implements Serializable {
      * Defines JDO fetch groups for this class.
      */
     public enum FetchGroup {
-        ALL
+        ALL,
+        INTERNAL_IDENTIFICATION
     }
 
     @PrimaryKey

--- a/src/main/java/org/dependencytrack/tasks/InternalComponentIdentificationTask.java
+++ b/src/main/java/org/dependencytrack/tasks/InternalComponentIdentificationTask.java
@@ -21,11 +21,19 @@ package org.dependencytrack.tasks;
 import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.DateFormatUtils;
+import org.datanucleus.PropertyNames;
 import org.dependencytrack.event.InternalComponentIdentificationEvent;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.InternalComponentIdentificationUtil;
 
+import javax.jdo.PersistenceManager;
+import javax.jdo.Query;
+import javax.jdo.Transaction;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -40,38 +48,90 @@ public class InternalComponentIdentificationTask implements Subscriber {
 
     @Override
     public void inform(final Event e) {
-        if (!(e instanceof InternalComponentIdentificationEvent)) {
-            return;
+        if (e instanceof InternalComponentIdentificationEvent) {
+            LOGGER.info("Starting internal component identification");
+            final Instant startTime = Instant.now();
+            try {
+                analyze();
+            } catch (Exception ex) {
+                LOGGER.error("An unexpected error occurred while identifying internal components", ex);
+            }
+            LOGGER.info("Internal component identification completed in "
+                    + DateFormatUtils.format(Duration.between(startTime, Instant.now()).toMillis(), "mm:ss:SS"));
         }
-        final InternalComponentIdentificationEvent event = (InternalComponentIdentificationEvent)e;
-        LOGGER.info("Starting internal component identification task");
-        if (event.getComponents().size() > 0) {
-            analyze(event.getComponents());
-        } else {
-            analyze(null);
-        }
-        LOGGER.info("Internal component identification task completed");
     }
 
-    private void analyze(final List<Component> components) {
-        try (final QueryManager qm = new QueryManager()) {
-            for (final Component component : components != null ? components : qm.getAllComponents()) {
-                final boolean internal = InternalComponentIdentificationUtil.isInternalComponent(component, qm);
-                if (internal) {
-                    LOGGER.debug("Component " + component + " was identified to be internal");
-                }
-                if (component.isInternal() != internal) { // We want to log changes to a component's internal status.
+    private void analyze() throws Exception {
+        try (final var qm = new QueryManager()) {
+            final PersistenceManager pm = qm.getPersistenceManager();
+
+            // Disable the DataNucleus L2 cache for this persistence manager.
+            // The cache will hold references to the queried objects, preventing them
+            // from being garbage collected. This is not required the case of this task.
+            pm.setProperty(PropertyNames.PROPERTY_CACHE_L2_TYPE, "none");
+
+            List<Component> components = fetchNextComponentsPage(pm, null);
+            while (!components.isEmpty()) {
+                for (final Component component : components) {
+                    String coordinates = component.getName();
+                    if (StringUtils.isNotBlank(component.getGroup())) {
+                        coordinates = component.getGroup() + ":" + coordinates;
+                    }
+
+                    final boolean internal = InternalComponentIdentificationUtil.isInternalComponent(component, qm);
                     if (internal) {
-                        LOGGER.info("Component " + component + " was identified to be internal. It was previously not an internal component.");
-                    } else {
-                        LOGGER.info("Component " + component + " was previously identified as an internal component. It is no longer identified as internal.");
+                        LOGGER.debug("Component " + coordinates + " (" + component.getUuid() + ") was identified to be internal");
+                    }
+
+                    if (component.isInternal() != internal) {
+                        if (internal) {
+                            LOGGER.info("Component " + coordinates + " (" + component.getUuid()
+                                    + ") was identified to be internal. It was previously not an internal component.");
+                        } else {
+                            LOGGER.info("Component " + coordinates + " (" + component.getUuid()
+                                    + ") was previously identified as internal. It is no longer identified as internal.");
+                        }
+                    }
+
+                    if (component.isInternal() != internal) {
+                        final Transaction trx = pm.currentTransaction();
+                        try {
+                            trx.begin();
+                            component.setInternal(internal);
+                            trx.commit();
+                        } finally {
+                            if (trx.isActive()) {
+                                trx.rollback();
+                            }
+                        }
                     }
                 }
-                if (component.isInternal() != internal) {
-                    component.setInternal(internal);
-                    qm.persist(component);
-                }
+
+                final long lastId = components.get(components.size() - 1).getId();
+                components = fetchNextComponentsPage(pm, lastId);
             }
+        }
+    }
+
+    /**
+     * Efficiently page through all components using keyset pagination.
+     *
+     * @param pm     The {@link PersistenceManager} to use
+     * @param lastId ID of the last {@link Component} in the previous result set, or {@code null} if this is the first invocation
+     * @return A {@link List} representing a page of up to {@code 500} {@link Component}s
+     * @throws Exception When closing the query failed
+     * @see <a href="https://use-the-index-luke.com/no-offset">Keyset pagination</a>
+     */
+    private List<Component> fetchNextComponentsPage(final PersistenceManager pm, final Long lastId) throws Exception {
+        try (final Query<Component> query = pm.newQuery(Component.class)) {
+            if (lastId != null) {
+                query.setFilter("id < :lastId");
+                query.setParameters(lastId);
+            }
+            query.setOrdering("id DESC");
+            query.setRange(0, 500);
+            query.getFetchPlan().setGroup(Component.FetchGroup.INTERNAL_IDENTIFICATION.name());
+            return List.copyOf(query.executeList());
         }
     }
 

--- a/src/test/java/org/dependencytrack/tasks/InternalComponentIdentificationTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/InternalComponentIdentificationTaskTest.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.tasks;
+
+import alpine.model.IConfigProperty.PropertyType;
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.event.InternalComponentIdentificationEvent;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.ConfigPropertyConstants;
+import org.dependencytrack.model.Project;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jdo.Query;
+import javax.jdo.Transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InternalComponentIdentificationTaskTest extends PersistenceCapableTest {
+
+    @Before
+    public void setUp() {
+        // Configure internal components to be identified by group "org.acme"
+        // and names starting with "foobar-".
+        qm.createConfigProperty(ConfigPropertyConstants.INTERNAL_COMPONENTS_GROUPS_REGEX.getGroupName(),
+                ConfigPropertyConstants.INTERNAL_COMPONENTS_GROUPS_REGEX.getPropertyName(),
+                "^org\\.acme$", PropertyType.STRING, null);
+        qm.createConfigProperty(ConfigPropertyConstants.INTERNAL_COMPONENTS_NAMES_REGEX.getGroupName(),
+                ConfigPropertyConstants.INTERNAL_COMPONENTS_NAMES_REGEX.getPropertyName(),
+                "^foobar-.*", PropertyType.STRING, null);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        // Batch insert 280 components, 30 of which are supposed to be identified as internal
+        final Transaction trx = qm.getPersistenceManager().currentTransaction();
+        trx.begin();
+        for (int i = 0; i < 10; i++) {
+            for (int j = 0; j < 250; j++) {
+                createComponent("com.example", "example-lib", project);
+            }
+
+            createComponent("org.acme", "acme-lib", project); // Only group matches
+            createComponent("com.example", "foobar-baz", project); // Only name matches
+            createComponent("org.acme", "foobar-baz", project); // Group and name match
+            qm.getPersistenceManager().flush();
+        }
+        trx.commit();
+    }
+
+    @Test
+    public void test() throws Exception {
+        new InternalComponentIdentificationTask().inform(new InternalComponentIdentificationEvent());
+        assertThat(getInternalComponentCount()).isEqualTo(30);
+    }
+
+    private void createComponent(final String group, final String name, final Project project) {
+        final var component = new Component();
+        component.setGroup(group);
+        component.setName(name);
+        component.setProject(project);
+        qm.getPersistenceManager().makePersistent(component);
+    }
+
+    private long getInternalComponentCount() throws Exception {
+        try (final Query<Component> query = qm.getPersistenceManager().newQuery(Component.class)) {
+            query.setFilter("internal == true");
+            query.setResult("count(this)");
+            return query.executeResultUnique(Long.class);
+        }
+    }
+
+}


### PR DESCRIPTION
Instead of loading all components at once. Also use a dedicated fetch group to limit the data being fetched. Remove unused code from `InternalComponentIdentificationEvent`.

Fixes #1947 

Memory usage while the task is running on a portfolio with 466000 components (task execution marked with red arrow):

This PR
![Screenshot 2022-09-12 at 22 34 50](https://user-images.githubusercontent.com/5693141/189754879-119267d2-b7b1-4e82-92d0-245db34c59ec.png)

Current `master` (note that the JVM only has 8GB assigned to it)
![Screenshot 2022-09-12 at 22 38 57](https://user-images.githubusercontent.com/5693141/189754930-6ba9dc2b-46ee-4d68-be1d-c762f66a1d10.png)

