### PR TITLE
Fix vulnerability aliases not being considered during metrics calculation

### DIFF
--- a/src/main/java/org/dependencytrack/model/Vulnerability.java
+++ b/src/main/java/org/dependencytrack/model/Vulnerability.java
@@ -68,6 +68,8 @@ import java.util.UUID;
                 @Persistent(name = "components")
         }),
         @FetchGroup(name = "COMPONENT_METRICS_UPDATE", members = {
+                @Persistent(name = "vulnId"),
+                @Persistent(name = "source"),
                 @Persistent(name = "severity"),
                 @Persistent(name = "cvssV2BaseScore"),
                 @Persistent(name = "cvssV3BaseScore")

--- a/src/main/java/org/dependencytrack/model/VulnerabilityAlias.java
+++ b/src/main/java/org/dependencytrack/model/VulnerabilityAlias.java
@@ -23,6 +23,7 @@ import alpine.server.json.TrimmedStringDeserializer;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.nimbusds.jose.util.Pair;
 
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.IdGeneratorStrategy;
@@ -34,7 +35,10 @@ import javax.jdo.annotations.Unique;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Model for tracking alias for vulnerabilities.
@@ -177,4 +181,25 @@ public class VulnerabilityAlias implements Serializable {
     public void setUuid(UUID uuid) {
         this.uuid = uuid;
     }
+
+    private String getBySource(final Vulnerability.Source source) {
+        return switch (source) {
+            case GITHUB -> getGhsaId();
+            case INTERNAL -> getInternalId();
+            case NVD -> getCveId();
+            case OSSINDEX -> getSonatypeId();
+            case OSV -> getOsvId();
+            case VULNDB -> getVulnDbId();
+            default -> null;
+        };
+    }
+
+    @JsonIgnore
+    public Map<Vulnerability.Source, String> getAllBySource() {
+        return Arrays.stream(Vulnerability.Source.values())
+                .map(source -> Pair.of(source, getBySource(source)))
+                .filter(pair -> pair.getRight() != null)
+                .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+    }
+
 }


### PR DESCRIPTION
This functionality got lost when resolving merge conflicts in #1912. It has now been adapted to the new metrics calculation method.

Signed-off-by: nscuro <nscuro@protonmail.com>