### PR TITLE
Include vulnerability aliases in notifications

### DIFF
--- a/docs/_docs/integrations/notifications.md
+++ b/docs/_docs/integrations/notifications.md
@@ -103,6 +103,12 @@ This type of notification will always contain:
         "uuid": "941a93f5-e06b-4304-84de-4d788eeb4969",
         "vulnId": "CVE-2012-5784",
         "source": "NVD",
+        "aliases": [
+          {
+            "vulnId": "GHSA-55w9-c3g2-4rrh",
+            "source": "GITHUB"
+          }
+        ],
         "description": "Apache Axis 1.4 and earlier, as used in PayPal Payments Pro, PayPal Mass Pay, PayPal Transactional Information SOAP, the Java Message Service implementation in Apache ActiveMQ, and other products, does not verify that the server hostname matches a domain name in the subject's Common Name (CN) or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via an arbitrary valid certificate.",
         "cvssv2": 5.8,
         "severity": "MEDIUM",
@@ -167,6 +173,12 @@ This type of notification will always contain:
           "uuid": "941a93f5-e06b-4304-84de-4d788eeb4969",
           "vulnId": "CVE-2012-5784",
           "source": "NVD",
+          "aliases": [
+            {
+              "vulnId": "GHSA-55w9-c3g2-4rrh",
+              "source": "GITHUB"
+            }
+          ],
           "description": "Apache Axis 1.4 and earlier, as used in PayPal Payments Pro, PayPal Mass Pay, PayPal Transactional Information SOAP, the Java Message Service implementation in Apache ActiveMQ, and other products, does not verify that the server hostname matches a domain name in the subject's Common Name (CN) or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via an arbitrary valid certificate.",
           "cvssv2": 5.8,
           "severity": "MEDIUM",
@@ -185,6 +197,7 @@ This type of notification will always contain:
           "uuid": "ca318ca7-616f-4af0-9c6b-15b8e208c586",
           "vulnId": "CVE-2014-3596",
           "source": "NVD",
+          "aliases": [],
           "description": "The getCN function in Apache Axis 1.4 and earlier does not properly verify that the server hostname matches a domain name in the subject's Common Name (CN) or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via a certificate with a subject that specifies a common name in a field that is not the CN field.  NOTE: this issue exists because of an incomplete fix for CVE-2012-5784.\n\n<a href=\"http://cwe.mitre.org/data/definitions/297.html\" target=\"_blank\">CWE-297: Improper Validation of Certificate with Host Mismatch</a>",
           "cvssv2": 5.8,
           "severity": "MEDIUM"
@@ -229,6 +242,12 @@ Audit change notifications are fired whenever the analysis state changes or when
         "uuid": "941a93f5-e06b-4304-84de-4d788eeb4969",
         "vulnId": "CVE-2012-5784",
         "source": "NVD",
+        "aliases": [
+          {
+            "vulnId": "GHSA-55w9-c3g2-4rrh",
+            "source": "GITHUB"
+          }
+        ],
         "description": "Apache Axis 1.4 and earlier, as used in PayPal Payments Pro, PayPal Mass Pay, PayPal Transactional Information SOAP, the Java Message Service implementation in Apache ActiveMQ, and other products, does not verify that the server hostname matches a domain name in the subject's Common Name (CN) or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via an arbitrary valid certificate.",
         "cvssv2": 5.8,
         "severity": "MEDIUM"

--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -22,7 +22,20 @@ import alpine.model.ConfigProperty;
 import alpine.notification.Notification;
 import alpine.notification.NotificationLevel;
 import org.apache.commons.io.FileUtils;
-import org.dependencytrack.model.*;
+import org.dependencytrack.model.Analysis;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.ComponentIdentity;
+import org.dependencytrack.model.ConfigPropertyConstants;
+import org.dependencytrack.model.Cwe;
+import org.dependencytrack.model.NotificationPublisher;
+import org.dependencytrack.model.Policy;
+import org.dependencytrack.model.PolicyCondition;
+import org.dependencytrack.model.PolicyViolation;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.Tag;
+import org.dependencytrack.model.ViolationAnalysis;
+import org.dependencytrack.model.ViolationAnalysisState;
+import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.notification.NotificationConstants;
 import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationScope;
@@ -43,7 +56,6 @@ import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
-import javax.validation.constraints.NotNull;
 import java.io.File;
 import java.io.IOException;
 import java.net.URLDecoder;
@@ -77,6 +89,7 @@ public final class NotificationUtil {
             }
 
             final Vulnerability detachedVuln =  qm.detach(Vulnerability.class, vulnerability.getId());
+            detachedVuln.setAliases(qm.detach(qm.getVulnerabilityAliases(vulnerability))); // Aliases are lost during detach above
             final Component detachedComponent = qm.detach(Component.class, component.getId());
 
             Notification.dispatch(new Notification()
@@ -95,6 +108,11 @@ public final class NotificationUtil {
         if (vulnerabilities != null && !vulnerabilities.isEmpty()) {
             component = qm.detach(Component.class, component.getId());
             vulnerabilities = qm.detach(vulnerabilities);
+            for (final Vulnerability vulnerability : vulnerabilities) {
+                // Because aliases is a transient field, it's lost when detaching the vulnerability.
+                // Repopulating here as a workaround, ultimately we need a better way to handle them.
+                vulnerability.setAliases(qm.detach(qm.getVulnerabilityAliases(vulnerability)));
+            }
 
             Notification.dispatch(new Notification()
                     .scope(NotificationScope.PORTFOLIO)
@@ -146,6 +164,10 @@ public final class NotificationUtil {
             }
 
             analysis = qm.detach(Analysis.class, analysis.getId());
+
+            // Aliases are lost during the detach above
+            analysis.getVulnerability().setAliases(qm.detach(qm.getVulnerabilityAliases(analysis.getVulnerability())));
+
             Notification.dispatch(new Notification()
                     .scope(NotificationScope.PORTFOLIO)
                     .group(notificationGroup)
@@ -258,6 +280,16 @@ public final class NotificationUtil {
         vulnerabilityBuilder.add("uuid", vulnerability.getUuid().toString());
         JsonUtil.add(vulnerabilityBuilder, "vulnId", vulnerability.getVulnId());
         JsonUtil.add(vulnerabilityBuilder, "source", vulnerability.getSource());
+        final JsonArrayBuilder aliasesBuilder = Json.createArrayBuilder();
+        if (vulnerability.getAliases() != null) {
+            for (final Map.Entry<Vulnerability.Source, String> vulnIdBySource : VulnerabilityUtil.getUniqueAliases(vulnerability)) {
+                aliasesBuilder.add(Json.createObjectBuilder()
+                        .add("source", vulnIdBySource.getKey().name())
+                        .add("vulnId", vulnIdBySource.getValue())
+                        .build());
+            }
+        }
+        vulnerabilityBuilder.add("aliases", aliasesBuilder.build());
         JsonUtil.add(vulnerabilityBuilder, "title", vulnerability.getTitle());
         JsonUtil.add(vulnerabilityBuilder, "subtitle", vulnerability.getSubTitle());
         JsonUtil.add(vulnerabilityBuilder, "description", vulnerability.getDescription());

--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -36,6 +36,7 @@ import org.dependencytrack.model.Tag;
 import org.dependencytrack.model.ViolationAnalysis;
 import org.dependencytrack.model.ViolationAnalysisState;
 import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.VulnerabilityAnalysisLevel;
 import org.dependencytrack.notification.NotificationConstants;
 import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationScope;

--- a/src/main/java/org/dependencytrack/util/VulnerabilityUtil.java
+++ b/src/main/java/org/dependencytrack/util/VulnerabilityUtil.java
@@ -19,10 +19,16 @@
 package org.dependencytrack.util;
 
 import org.dependencytrack.model.Severity;
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.VulnerabilityAlias;
 
 import java.math.BigDecimal;
 import java.security.SecureRandom;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 
 public final class VulnerabilityUtil {
 
@@ -167,4 +173,32 @@ public final class VulnerabilityUtil {
             }
         }
     }
+
+    /**
+     * Computes a {@link Set} of unique source-to-vulnId combinations that alias the given {@link Vulnerability}.
+     * The result does not include the source and ID of the {@link Vulnerability} itself.
+     * <p>
+     * The result can not be a {@link Map}, because a {@link Vulnerability} may be aliased by
+     * multiple vulnerabilities from the same source. Using a {@link Map} would make such constellations impossible.
+     *
+     * @param vulnerability The {@link Vulnerability} to compute unique aliases for
+     * @return Unique aliases, or {@code null} when either the vulnerability itself or its aliases are {@code null}
+     */
+    public static Set<Map.Entry<Vulnerability.Source, String>> getUniqueAliases(final Vulnerability vulnerability) {
+        if (vulnerability == null || vulnerability.getAliases() == null) {
+            return Collections.emptySet();
+        }
+
+        final Set<Map.Entry<Vulnerability.Source, String>> uniqueAliases = new HashSet<>();
+        for (final VulnerabilityAlias alias : vulnerability.getAliases()) {
+            alias.getAllBySource().entrySet().stream()
+                    .filter(vulnIdBySource ->
+                            !vulnIdBySource.getKey().name().equals(vulnerability.getSource())
+                                || !vulnIdBySource.getValue().equals(vulnerability.getVulnId()))
+                    .forEach(uniqueAliases::add);
+        }
+
+        return uniqueAliases;
+    }
+
 }

--- a/src/main/resources/templates/notification/publisher/email.peb
+++ b/src/main/resources/templates/notification/publisher/email.peb
@@ -31,12 +31,6 @@ Vulnerability ID:  {{ vulnerability.vulnId }}
 Vulnerability URL: {{ baseUrl }}/vulnerability/?source={{ vulnerability.source }}&vulnId={{ vulnerability.vulnId }}
 Severity:          {{ vulnerability.severity }}
 Source:            {{ vulnerability.source }}
-{% if vulnerability.aliases is not empty %}
-Aliases:
-{% for alias in vulnerability.aliases %}
-  - {{ alias.vulnId }} ({{ alias.source }})
-{% endfor %}
-{% endif %}
 Description:
 {{ vulnerability.description }}
 
@@ -49,12 +43,6 @@ Vulnerability ID:  {{ subject.vulnerability.vulnId }}
 Vulnerability URL: {{ baseUrl }}/vulnerability/?source={{ subject.vulnerability.source }}&vulnId={{ subject.vulnerability.vulnId }}
 Severity:          {{ subject.vulnerability.severity }}
 Source:            {{ subject.vulnerability.source }}
-{% if vulnerability.aliases is not empty %}
-Aliases:
-{% for alias in vulnerability.aliases %}
-  - {{ alias.vulnId }} ({{ alias.source }})
-{% endfor %}
-{% endif %}
 Component:         {{ subject.component.toString }}
 Component URL:     {{ baseUrl }}/component/?uuid={{ subject.component.uuid }}
 Project:           {{ subject.component.project.name }}

--- a/src/main/resources/templates/notification/publisher/email.peb
+++ b/src/main/resources/templates/notification/publisher/email.peb
@@ -31,6 +31,12 @@ Vulnerability ID:  {{ vulnerability.vulnId }}
 Vulnerability URL: {{ baseUrl }}/vulnerability/?source={{ vulnerability.source }}&vulnId={{ vulnerability.vulnId }}
 Severity:          {{ vulnerability.severity }}
 Source:            {{ vulnerability.source }}
+{% if vulnerability.aliases is not empty %}
+Aliases:
+{% for alias in vulnerability.aliases %}
+  - {{ alias.vulnId }} ({{ alias.source }})
+{% endfor %}
+{% endif %}
 Description:
 {{ vulnerability.description }}
 
@@ -43,6 +49,12 @@ Vulnerability ID:  {{ subject.vulnerability.vulnId }}
 Vulnerability URL: {{ baseUrl }}/vulnerability/?source={{ subject.vulnerability.source }}&vulnId={{ subject.vulnerability.vulnId }}
 Severity:          {{ subject.vulnerability.severity }}
 Source:            {{ subject.vulnerability.source }}
+{% if vulnerability.aliases is not empty %}
+Aliases:
+{% for alias in vulnerability.aliases %}
+  - {{ alias.vulnId }} ({{ alias.source }})
+{% endfor %}
+{% endif %}
 Component:         {{ subject.component.toString }}
 Component URL:     {{ baseUrl }}/component/?uuid={{ subject.component.uuid }}
 Project:           {{ subject.component.project.name }}

--- a/src/test/java/org/dependencytrack/util/VulnerabilityUtilTest.java
+++ b/src/test/java/org/dependencytrack/util/VulnerabilityUtilTest.java
@@ -1,0 +1,58 @@
+package org.dependencytrack.util;
+
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.VulnerabilityAlias;
+import org.junit.Test;
+
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VulnerabilityUtilTest {
+
+    @Test
+    public void testGetUniqueAliases() {
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("INTERNAL-001");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setAliases(List.of(
+                createAlias(alias -> {
+                    alias.setInternalId("INTERNAL-001");
+                    alias.setGhsaId("GHSA-002");
+                    alias.setSonatypeId("SONATYPE-003");
+                }),
+                createAlias(alias -> {
+                    alias.setInternalId("INTERNAL-001");
+                    alias.setOsvId("OSV-004");
+                    alias.setSonatypeId("SONATYPE-003");
+                })
+        ));
+
+        final Set<Map.Entry<Vulnerability.Source, String>> uniqueAliases = VulnerabilityUtil.getUniqueAliases(vuln);
+        assertThat(uniqueAliases).hasSize(3);
+        assertThat(uniqueAliases).contains(new AbstractMap.SimpleEntry<>(Vulnerability.Source.GITHUB, "GHSA-002"));
+        assertThat(uniqueAliases).contains(new AbstractMap.SimpleEntry<>(Vulnerability.Source.OSSINDEX, "SONATYPE-003"));
+        assertThat(uniqueAliases).contains(new AbstractMap.SimpleEntry<>(Vulnerability.Source.OSV, "OSV-004"));
+    }
+
+    @Test
+    public void testGetUniqueAliasesWhenVulnerabilityIsNull() {
+        assertThat(VulnerabilityUtil.getUniqueAliases(null)).isEmpty();
+    }
+
+    @Test
+    public void testGetUniqueAliasesWhenAliasesAreNull() {
+        assertThat(VulnerabilityUtil.getUniqueAliases(new Vulnerability())).isEmpty();
+    }
+
+    private VulnerabilityAlias createAlias(final Consumer<VulnerabilityAlias> customizer) {
+        final var alias = new VulnerabilityAlias();
+        customizer.accept(alias);
+        return alias;
+    }
+
+}


### PR DESCRIPTION
Based on #2011 because I needed some methods introduced in that PR.

Note: I've ran into an issue where aliases would be discarded when detaching the vulnerability "owning" them. Because the `Vulnerability#aliases` field is transient, DataNucleus just drops it during detachment. I worked around this for now by refreshing the aliases again whenever it's needed, but ultimately a more general solution would be good.