### PR TITLE
Docker: Add optional EXTRA_JAVA_OPTIONS environment variable

### DIFF
--- a/docs/_docs/getting-started/deploy-docker.md
+++ b/docs/_docs/getting-started/deploy-docker.md
@@ -155,7 +155,7 @@ services:
     # - DEFAULT_TEMPLATES_OVERRIDE_ENABLED=false
     # - DEFAULT_TEMPLATES_OVERRIDE_BASE_DIRECTORY=/data
     #
-    # Optional environmental variables to provide more JVM arguments to the API Server JVM, i.e. "-XX:ActiveProcessorCount=8
+    # Optional environmental variables to provide more JVM arguments to the API Server JVM, i.e. "-XX:ActiveProcessorCount=8"
     # - EXTRA_JAVA_OPTIONS=
 
     deploy:

--- a/docs/_docs/getting-started/deploy-docker.md
+++ b/docs/_docs/getting-started/deploy-docker.md
@@ -150,10 +150,14 @@ services:
     # - ALPINE_METRICS_ENABLED=true
     # - ALPINE_METRICS_AUTH_USERNAME=
     # - ALPINE_METRICS_AUTH_PASSWORD=
-    # 
+    #
     # Optional environmental variables to enable default notification publisher templates override and set the base directory to search for templates
     # - DEFAULT_TEMPLATES_OVERRIDE_ENABLED=false
     # - DEFAULT_TEMPLATES_OVERRIDE_BASE_DIRECTORY=/data
+    #
+    # Optional environmental variables to provide more JVM arguments to the API Server JVM, i.e. "-XX:ActiveProcessorCount=8
+    # - EXTRA_JAVA_OPTIONS=
+
     deploy:
       resources:
         limits:
@@ -166,7 +170,7 @@ services:
       - '8081:8080'
     volumes:
     # Optional volume mount to override default notification publisher templates
-    # - "/host/path/to/template/base/dir:/data/templates" 
+    # - "/host/path/to/template/base/dir:/data/templates"
       - 'dependency-track:/data'
     restart: unless-stopped
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -15,8 +15,10 @@ ARG WAR_FILENAME=dependency-track-apiserver.jar
 ENV TZ=Etc/UTC \
     # Dependency-Track's default logging level
     LOGGING_LEVEL=INFO \
-    # Environment variables that can be passed at runtime
+    # JVM Options that are passed at runtime by default
     JAVA_OPTIONS="-XX:+UseParallelGC -XX:MaxRAMPercentage=90.0" \
+    # JVM Options that can be passed at runtime, while maintaining also those set in JAVA_OPTIONS
+    EXTRA_JAVA_OPTIONS="" \
     # The web context defaults to the root. To override, supply an alternative context which starts with a / but does not end with one
     # Example: /dtrack
     CONTEXT="/" \
@@ -59,7 +61,7 @@ USER ${UID}
 WORKDIR ${APP_DIR}
 
 # Launch Dependency-Track
-CMD java ${JAVA_OPTIONS} --add-opens java.base/java.util.concurrent=ALL-UNNAMED -DdependencyTrack.logging.level=${LOGGING_LEVEL} -jar ${WAR_FILENAME} -context ${CONTEXT}
+CMD java ${JAVA_OPTIONS} ${EXTRA_JAVA_OPTIONS} --add-opens java.base/java.util.concurrent=ALL-UNNAMED -DdependencyTrack.logging.level=${LOGGING_LEVEL} -jar ${WAR_FILENAME} -context ${CONTEXT}
 
 # Specify which port Dependency-Track listens on
 EXPOSE 8080

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -86,7 +86,7 @@ services:
     # - DEFAULT_TEMPLATES_OVERRIDE_ENABLED=false
     # - DEFAULT_TEMPLATES_OVERRIDE_BASE_DIRECTORY=/data
     #
-    # Optional environmental variables to provide more JVM arguments to the API Server JVM, i.e. "-XX:ActiveProcessorCount=8
+    # Optional environmental variables to provide more JVM arguments to the API Server JVM, i.e. "-XX:ActiveProcessorCount=8"
     # - EXTRA_JAVA_OPTIONS=
     deploy:
       resources:

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -81,6 +81,13 @@ services:
     # - ALPINE_METRICS_ENABLED=true
     # - ALPINE_METRICS_AUTH_USERNAME=
     # - ALPINE_METRICS_AUTH_PASSWORD=
+    #
+    # Optional environmental variables to enable default notification publisher templates override and set the base directory to search for templates
+    # - DEFAULT_TEMPLATES_OVERRIDE_ENABLED=false
+    # - DEFAULT_TEMPLATES_OVERRIDE_BASE_DIRECTORY=/data
+    #
+    # Optional environmental variables to provide more JVM arguments to the API Server JVM, i.e. "-XX:ActiveProcessorCount=8
+    # - EXTRA_JAVA_OPTIONS=
     deploy:
       resources:
         limits:
@@ -116,4 +123,3 @@ services:
     ports:
       - "8080:8080"
     restart: unless-stopped
-


### PR DESCRIPTION
Sometimes it's useful to pass extra JVM options into the DT Java process.

While it is possible to override the `JAVA_OPTIONS`, this would mean the existing default value from `Dockerfile` has to be copied and maintained.

This PR adds a `EXTRA_JAVA_OPTIONS` environment variable that can be specified at runtime, while benefitting from the existing defaults in the `Dockerfile`.