### PR TITLE
Ensure that policy is part of policy violations API response

### DIFF
--- a/docs/_posts/2022-10-13-v4.6.1.md
+++ b/docs/_posts/2022-10-13-v4.6.1.md
@@ -1,0 +1,32 @@
+---
+title: v4.6.1
+type: patch
+---
+
+**Fixes:**
+
+* Resolved defect that caused policy name and violation state to not be displayed in the violations audit tab - [#2043]
+
+For a complete list of changes, refer to the respective GitHub milestones:
+
+* [API server milestone 4.6.1](https://github.com/DependencyTrack/dependency-track/milestone/28?closed=1)
+
+###### dependency-track-apiserver.jar
+
+| Algorithm | Checksum |
+|:----------|:---------|
+| SHA-1     |          |
+| SHA-256   |          |
+
+###### dependency-track-bundled.jar
+
+| Algorithm | Checksum |
+|:----------|:---------|
+| SHA-1     |          |
+| SHA-256   |          |
+
+###### Software Bill of Materials (SBOM)
+
+* API Server: [bom.json](https://github.com/DependencyTrack/dependency-track/releases/download/4.6.1/bom.json)
+
+[#2043]: https://github.com/DependencyTrack/dependency-track/issues/2043

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyViolationResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyViolationResourceTest.java
@@ -89,6 +89,11 @@ public class PolicyViolationResourceTest extends ResourceTest {
         final JsonObject jsonObject = jsonArray.getJsonObject(0);
         assertThat(jsonObject.getString("uuid")).isEqualTo(violation.getUuid().toString());
         assertThat(jsonObject.getString("type")).isEqualTo(PolicyViolation.Type.OPERATIONAL.name());
+        assertThat(jsonObject.getJsonObject("policyCondition")).isNotNull();
+        assertThat(jsonObject.getJsonObject("policyCondition").getJsonObject("policy")).isNotNull();
+        assertThat(jsonObject.getJsonObject("policyCondition").getJsonObject("policy").getString("name")).isEqualTo("Blacklisted Version");
+        assertThat(jsonObject.getJsonObject("policyCondition").getJsonObject("policy").getString("violationState")).isEqualTo("FAIL");
+
     }
 
     @Test
@@ -137,6 +142,10 @@ public class PolicyViolationResourceTest extends ResourceTest {
         final JsonObject jsonObject = jsonArray.getJsonObject(0);
         assertThat(jsonObject.getString("uuid")).isEqualTo(violation.getUuid().toString());
         assertThat(jsonObject.getString("type")).isEqualTo(PolicyViolation.Type.OPERATIONAL.name());
+        assertThat(jsonObject.getJsonObject("policyCondition")).isNotNull();
+        assertThat(jsonObject.getJsonObject("policyCondition").getJsonObject("policy")).isNotNull();
+        assertThat(jsonObject.getJsonObject("policyCondition").getJsonObject("policy").getString("name")).isEqualTo("Blacklisted Version");
+        assertThat(jsonObject.getJsonObject("policyCondition").getJsonObject("policy").getString("violationState")).isEqualTo("FAIL");
     }
 
     @Test
@@ -200,6 +209,10 @@ public class PolicyViolationResourceTest extends ResourceTest {
         final JsonObject jsonObject = jsonArray.getJsonObject(0);
         assertThat(jsonObject.getString("uuid")).isEqualTo(violation.getUuid().toString());
         assertThat(jsonObject.getString("type")).isEqualTo(PolicyViolation.Type.OPERATIONAL.name());
+        assertThat(jsonObject.getJsonObject("policyCondition")).isNotNull();
+        assertThat(jsonObject.getJsonObject("policyCondition").getJsonObject("policy")).isNotNull();
+        assertThat(jsonObject.getJsonObject("policyCondition").getJsonObject("policy").getString("name")).isEqualTo("Blacklisted Version");
+        assertThat(jsonObject.getJsonObject("policyCondition").getJsonObject("policy").getString("violationState")).isEqualTo("FAIL");
     }
 
     @Test


### PR DESCRIPTION
DataNucleus would (in some, not all cases) falsely assume that the `violation.policyCondition.policy` field has already been loaded, and would not attempt to fetch it again. This then caused API responses to not contain the `policy` field (#2043).

The scenario is not reproducible in unit tests, even with regular cache eviction. It is reliably reproducible in running instances using the steps listed in #2043 though.

Instead of detachment like it's introduced in this PR, another cheap fix would've been to call `violation.getPolicyCondition().getPolicy().getName()` instead of `violation.getPolicyCondition().getPolicy()` in `PolicyQueryManager#getPolicyViolations`. That would force DN to fetch all fields of `Policy`, but I felt like that was too hacky to rely on it.

Fixes #2043 

Signed-off-by: nscuro <nscuro@protonmail.com>