### PR TITLE
Extend "limit to" functionality for notifications

### DIFF
--- a/src/main/java/org/dependencytrack/notification/NotificationRouter.java
+++ b/src/main/java/org/dependencytrack/notification/NotificationRouter.java
@@ -34,6 +34,7 @@ import org.dependencytrack.notification.vo.NewVulnerabilityIdentified;
 import org.dependencytrack.notification.vo.NewVulnerableDependency;
 import org.dependencytrack.notification.vo.PolicyViolationIdentified;
 import org.dependencytrack.notification.vo.VexConsumedOrProcessed;
+import org.dependencytrack.notification.vo.ViolationAnalysisDecisionChange;
 import org.dependencytrack.persistence.QueryManager;
 
 import javax.jdo.PersistenceManager;
@@ -105,15 +106,9 @@ public class NotificationRouter implements Subscriber {
             restrictedNotification.setContent(initialNotification.getContent());
             restrictedNotification.setTitle(initialNotification.getTitle());
             restrictedNotification.setTimestamp(initialNotification.getTimestamp());
-            if(initialNotification.getSubject() instanceof NewVulnerabilityIdentified) {
-                NewVulnerabilityIdentified subject = (NewVulnerabilityIdentified) initialNotification.getSubject();
+            if(initialNotification.getSubject() instanceof final NewVulnerabilityIdentified subject) {
                 Set<Project> restrictedProjects = subject.getAffectedProjects().stream().filter(project -> ruleProjectsUuids.contains(project.getUuid().toString())).collect(Collectors.toSet());
                 NewVulnerabilityIdentified restrictedSubject = new NewVulnerabilityIdentified(subject.getVulnerability(), subject.getComponent(), restrictedProjects, null);
-                restrictedNotification.setSubject(restrictedSubject);
-            } else if(initialNotification.getSubject() instanceof AnalysisDecisionChange) {
-                AnalysisDecisionChange subject = (AnalysisDecisionChange) initialNotification.getSubject();
-                Set<Project> restrictedProjects = subject.getAffectedProjects().stream().filter(project -> ruleProjectsUuids.contains(project.getUuid().toString())).collect(Collectors.toSet());
-                AnalysisDecisionChange restrictedSubject = new AnalysisDecisionChange(subject.getVulnerability(), subject.getComponent(), restrictedProjects, subject.getAnalysis());
                 restrictedNotification.setSubject(restrictedSubject);
             }
         }
@@ -126,7 +121,6 @@ public class NotificationRouter implements Subscriber {
                 && rule.getProjects().size() > 0;
     }
 
-    @SuppressWarnings("unchecked")
     List<NotificationRule> resolveRules(final Notification notification) {
         // The notification rules to process for this specific notification
         final List<NotificationRule> rules = new ArrayList<>();
@@ -151,18 +145,16 @@ public class NotificationRouter implements Subscriber {
 
             sb.append("enabled == true && scope == :scope"); //todo: improve this - this only works for testing
             query.setFilter(sb.toString());
-            final List<NotificationRule> result = (List<NotificationRule>)query.execute(NotificationScope.valueOf(notification.getScope()));
+            query.setParameters(NotificationScope.valueOf(notification.getScope()));
+            final List<NotificationRule> result = query.executeList();
             pm.detachCopyAll(result);
 
             if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
-                    && notification.getSubject() != null && notification.getSubject() instanceof NewVulnerabilityIdentified) {
-                final NewVulnerabilityIdentified subject = (NewVulnerabilityIdentified) notification.getSubject();
-                /*
-                if the rule specified one or more projects as targets, reduce the execution
-                of the notification down to those projects that the rule matches and which
-                also match project the component is included in.
-                NOTE: This logic is slightly different from what is implemented in limitToProject()
-                 */
+                    && notification.getSubject() instanceof final NewVulnerabilityIdentified subject) {
+                // If the rule specified one or more projects as targets, reduce the execution
+                // of the notification down to those projects that the rule matches and which
+                // also match project the component is included in.
+                // NOTE: This logic is slightly different from what is implemented in limitToProject()
                 for (final NotificationRule rule: result) {
                     if (rule.getNotifyOn().contains(NotificationGroup.valueOf(notification.getGroup()))) {
                         if (rule.getProjects() != null && rule.getProjects().size() > 0
@@ -178,21 +170,23 @@ public class NotificationRouter implements Subscriber {
                     }
                 }
             } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
-                    && notification.getSubject() != null && notification.getSubject() instanceof NewVulnerableDependency) {
-                final NewVulnerableDependency subject = (NewVulnerableDependency) notification.getSubject();
+                    && notification.getSubject() instanceof final NewVulnerableDependency subject) {
                 limitToProject(rules, result, notification, subject.getComponent().getProject());
             } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
-                    && notification.getSubject() != null && notification.getSubject() instanceof BomConsumedOrProcessed) {
-                final BomConsumedOrProcessed subject = (BomConsumedOrProcessed) notification.getSubject();
+                    && notification.getSubject() instanceof final BomConsumedOrProcessed subject) {
                 limitToProject(rules, result, notification, subject.getProject());
             } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
-                    && notification.getSubject() != null && notification.getSubject() instanceof VexConsumedOrProcessed) {
-                final VexConsumedOrProcessed subject = (VexConsumedOrProcessed) notification.getSubject();
+                    && notification.getSubject() instanceof final VexConsumedOrProcessed subject) {
                 limitToProject(rules, result, notification, subject.getProject());
             } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
-                    && notification.getSubject() != null && notification.getSubject() instanceof PolicyViolationIdentified) {
-                final PolicyViolationIdentified subject = (PolicyViolationIdentified) notification.getSubject();
+                    && notification.getSubject() instanceof final PolicyViolationIdentified subject) {
                 limitToProject(rules, result, notification, subject.getProject());
+            } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
+                    && notification.getSubject() instanceof final AnalysisDecisionChange subject) {
+                limitToProject(rules, result, notification, subject.getProject());
+            } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
+                    && notification.getSubject() instanceof final ViolationAnalysisDecisionChange subject) {
+                limitToProject(rules, result, notification, subject.getComponent().getProject());
             } else {
                 for (final NotificationRule rule: result) {
                     if (rule.getNotifyOn().contains(NotificationGroup.valueOf(notification.getGroup()))) {

--- a/src/main/java/org/dependencytrack/notification/vo/AnalysisDecisionChange.java
+++ b/src/main/java/org/dependencytrack/notification/vo/AnalysisDecisionChange.java
@@ -23,20 +23,18 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vulnerability;
 
-import java.util.Set;
-
 public class AnalysisDecisionChange {
 
     private final Vulnerability vulnerability;
     private final Component component;
-    private final Set<Project> affectedProjects;
+    private final Project affectedProject;
     private final Analysis analysis;
 
     public AnalysisDecisionChange(final Vulnerability vulnerability, final Component component,
-                                  final Set<Project> affectedProjects, final Analysis analysis) {
+                                  final Project affectedProject, final Analysis analysis) {
         this.vulnerability = vulnerability;
         this.component = component;
-        this.affectedProjects = affectedProjects;
+        this.affectedProject = affectedProject;
         this.analysis = analysis;
     }
 
@@ -48,18 +46,11 @@ public class AnalysisDecisionChange {
         return component;
     }
 
-    public Set<Project> getAffectedProjects() {
-        return affectedProjects;
-    }
-
     public Analysis getAnalysis() {
         return analysis;
     }
 
     public Project getProject() {
-        if (affectedProjects != null && affectedProjects.size() == 1) {
-            return affectedProjects.iterator().next();
-        }
-        return null;
+        return affectedProject;
     }
 }

--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -65,7 +65,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -130,9 +129,7 @@ public final class NotificationUtil {
                                                    final boolean analysisStateChange, final boolean suppressionChange) {
         if (analysisStateChange || suppressionChange) {
             final NotificationGroup notificationGroup;
-            final Set<Project> affectedProjects = new HashSet<>();
             notificationGroup = NotificationGroup.PROJECT_AUDIT_CHANGE;
-            affectedProjects.add(analysis.getProject());
 
             String title = null;
             if (analysisStateChange) {
@@ -176,7 +173,7 @@ public final class NotificationUtil {
                     .level(NotificationLevel.INFORMATIONAL)
                     .content(generateNotificationContent(analysis))
                     .subject(new AnalysisDecisionChange(analysis.getVulnerability(),
-                            analysis.getComponent(), affectedProjects, analysis))
+                            analysis.getComponent(), analysis.getProject(), analysis))
             );
         }
     }
@@ -382,12 +379,9 @@ public final class NotificationUtil {
         if (vo.getAnalysis() != null) {
             builder.add("analysis", toJson(vo.getAnalysis()));
         }
-        if (vo.getAffectedProjects() != null && vo.getAffectedProjects().size() > 0) {
-            final JsonArrayBuilder projectsBuilder = Json.createArrayBuilder();
-            for (final Project project: vo.getAffectedProjects()) {
-                projectsBuilder.add(toJson(project));
-            }
-            builder.add("affectedProjects", projectsBuilder.build());
+        if (vo.getProject() != null) {
+            // Provide the affected project in the form of an array for backwards-compatibility
+            builder.add("affectedProjects", Json.createArrayBuilder().add(toJson(vo.getProject())));
         }
         return builder.build();
     }

--- a/src/test/java/org/dependencytrack/notification/vo/AnalysisDecisionChangeTest.java
+++ b/src/test/java/org/dependencytrack/notification/vo/AnalysisDecisionChangeTest.java
@@ -34,15 +34,12 @@ public class AnalysisDecisionChangeTest {
     public void testVo() {
         Vulnerability vuln = new Vulnerability();
         Component component = new Component();
-        Set<Project> affectedProjects = new HashSet<>();
         Project project = new Project();
-        affectedProjects.add(project);
         Analysis analysis = new Analysis();
-        AnalysisDecisionChange vo = new AnalysisDecisionChange(vuln, component, affectedProjects, analysis);
+        AnalysisDecisionChange vo = new AnalysisDecisionChange(vuln, component, project, analysis);
         Assert.assertEquals(vuln, vo.getVulnerability());
         Assert.assertEquals(component, vo.getComponent());
-        Assert.assertEquals(1, vo.getAffectedProjects().size());
-        Assert.assertEquals(project, vo.getAffectedProjects().iterator().next());
+        Assert.assertEquals(project, vo.getProject());
         Assert.assertEquals(analysis, vo.getAnalysis());
     }
 }


### PR DESCRIPTION
... to now also include the following subjects:

* `PolicyViolationIdentified`
* `AnalysisDecisionChange`
* `ViolationAnalysisDecisionChange`

Fixes https://github.com/DependencyTrack/dependency-track/issues/975