### PR TITLE
Grafana: Use datasource for dropdown population

### DIFF
--- a/docs/files/grafana-dashboard.json
+++ b/docs/files/grafana-dashboard.json
@@ -1675,6 +1675,10 @@
     "list": [
       {
         "current": {},
+        "datasource": {
+           "type": "prometheus",
+           "uid": "${DS_PROMETHEUS}"
+        },
         "definition": "label_values(jvm_info, instance)",
         "hide": 0,
         "includeAll": false,


### PR DESCRIPTION
The sample Grafana dashboard misses a datasource property for the `instance` dropdownlist. This causes the dropdown (and possible options in the dropdown) to be empty. This results in a (Javascript) error when importing the dashboard. 

This PR fixes this.