### PR TITLE
Include SnykAnalysisTask thread pool in Prometheus metrics

### DIFF
--- a/docs/_docs/getting-started/configuration.md
+++ b/docs/_docs/getting-started/configuration.md
@@ -349,6 +349,13 @@ alpine.oidc.team.synchronization=false
 # When using a customizable / on-demand hosted identity provider, name, content, and inclusion in the userinfo endpoint
 # will most likely need to be configured.
 alpine.oidc.teams.claim=groups
+
+# Required
+# Defines the size of the thread pool used to perform requests to the Snyk API in parallel.
+# The thread pool will only be used when Snyk integration is enabled.
+# A high number may result in a quicker excession of API rate limits, 
+# while a number that is too low may result in vulnerability analyses taking too long.
+snyk.thread.batch.size=10
 ```
 
 #### Proxy Configuration

--- a/docs/_docs/getting-started/deploy-docker.md
+++ b/docs/_docs/getting-started/deploy-docker.md
@@ -155,6 +155,9 @@ services:
     # - DEFAULT_TEMPLATES_OVERRIDE_ENABLED=false
     # - DEFAULT_TEMPLATES_OVERRIDE_BASE_DIRECTORY=/data
     #
+    # Optional configuration for the Snyk analyzer
+    # - SNYK_THREAD_BATCH_SIZE=10
+    #
     # Optional environmental variables to provide more JVM arguments to the API Server JVM, i.e. "-XX:ActiveProcessorCount=8"
     # - EXTRA_JAVA_OPTIONS=
 

--- a/docs/_docs/getting-started/monitoring.md
+++ b/docs/_docs/getting-started/monitoring.md
@@ -41,7 +41,8 @@ alpine_notifications_published_total{group="<NOTIFICATION_GROUP>",level="<NOTIFI
 Events and notifications are processed by [executors]. The executor *Alpine-EventService* corresponds to what is 
 typically referred to as *worker pool*, and is responsible for executing the majority of events in Dependency-Track.
 *Alpine-SingleThreadedEventService* is a dedicated executor for events that can't safely be executed in parallel.
-The following executor metrics are available:
+The *SnykAnalysisTask* executor is used to perform API requests to [Snyk] (if enabled) in parallel, in order to work 
+around the missing batch functionality in Snyk's REST API. The following executor metrics are available:
 
 ```yaml
 # HELP executor_pool_max_threads The maximum allowed number of threads in the pool
@@ -49,36 +50,43 @@ The following executor metrics are available:
 executor_pool_max_threads{name="Alpine-NotificationService",} 4.0
 executor_pool_max_threads{name="Alpine-SingleThreadedEventService",} 1.0
 executor_pool_max_threads{name="Alpine-EventService",} 40.0
+executor_pool_max_threads{name="SnykAnalysisTask",} 10.0
 # HELP executor_pool_core_threads The core number of threads for the pool
 # TYPE executor_pool_core_threads gauge
 executor_pool_core_threads{name="Alpine-NotificationService",} 4.0
 executor_pool_core_threads{name="Alpine-SingleThreadedEventService",} 1.0
 executor_pool_core_threads{name="Alpine-EventService",} 40.0
+executor_pool_core_threads{name="SnykAnalysisTask",} 10.0
 # HELP executor_pool_size_threads The current number of threads in the pool
 # TYPE executor_pool_size_threads gauge
 executor_pool_size_threads{name="Alpine-NotificationService",} 0.0
 executor_pool_size_threads{name="Alpine-SingleThreadedEventService",} 1.0
 executor_pool_size_threads{name="Alpine-EventService",} 7.0
+executor_pool_size_threads{name="SnykAnalysisTask",} 10.0
 # HELP executor_active_threads The approximate number of threads that are actively executing tasks
 # TYPE executor_active_threads gauge
 executor_active_threads{name="Alpine-NotificationService",} 0.0
 executor_active_threads{name="Alpine-SingleThreadedEventService",} 1.0
 executor_active_threads{name="Alpine-EventService",} 2.0
+executor_active_threads{name="SnykAnalysisTask",} 0.0
 # HELP executor_completed_tasks_total The approximate total number of tasks that have completed execution
 # TYPE executor_completed_tasks_total counter
 executor_completed_tasks_total{name="Alpine-NotificationService",} 0.0
 executor_completed_tasks_total{name="Alpine-SingleThreadedEventService",} 0.0
 executor_completed_tasks_total{name="Alpine-EventService",} 5.0
+executor_completed_tasks_total{name="SnykAnalysisTask",} 132.0
 # HELP executor_queued_tasks The approximate number of tasks that are queued for execution
 # TYPE executor_queued_tasks gauge
 executor_queued_tasks{name="Alpine-NotificationService",} 0.0
 executor_queued_tasks{name="Alpine-SingleThreadedEventService",} 160269.0
 executor_queued_tasks{name="Alpine-EventService",} 0.0
+executor_queued_tasks{name="SnykAnalysisTask",} 0.0
 # HELP executor_queue_remaining_tasks The number of additional elements that this queue can ideally accept without blocking
 # TYPE executor_queue_remaining_tasks gauge
 executor_queue_remaining_tasks{name="Alpine-NotificationService",} 2.147483647E9
 executor_queue_remaining_tasks{name="Alpine-SingleThreadedEventService",} 2.147323378E9
 executor_queue_remaining_tasks{name="Alpine-EventService",} 2.147483647E9
+executor_queue_remaining_tasks{name="SnykAnalysisTask",} 2.147483647E9
 ```
 
 Executor metrics are a good way to monitor how busy an API server instance is, and how good of a job it's
@@ -109,5 +117,6 @@ An [example dashboard] is provided as a quickstart. Refer to the [Grafana docume
 [Grafana]: https://grafana.com/
 [Grafana documentation]: https://grafana.com/docs/grafana/latest/dashboards/export-import/#import-dashboard
 [Prometheus]: https://prometheus.io/
+[Snyk]: {{ site.baseurl }}{% link _docs/datasources/snyk.md %}
 [text-based exposition format]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
 [thread states]: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Thread.State.html

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -86,6 +86,9 @@ services:
     # - DEFAULT_TEMPLATES_OVERRIDE_ENABLED=false
     # - DEFAULT_TEMPLATES_OVERRIDE_BASE_DIRECTORY=/data
     #
+    # Optional configuration for the Snyk analyzer
+    # - SNYK_THREAD_BATCH_SIZE=10
+    #
     # Optional environmental variables to provide more JVM arguments to the API Server JVM, i.e. "-XX:ActiveProcessorCount=8"
     # - EXTRA_JAVA_OPTIONS=
     deploy:

--- a/src/main/java/org/dependencytrack/tasks/scanners/SnykAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/SnykAnalysisTask.java
@@ -18,22 +18,25 @@
  */
 package org.dependencytrack.tasks.scanners;
 
-import alpine.common.logging.Logger;
 import alpine.Config;
-import org.dependencytrack.common.ConfigKey;
+import alpine.common.logging.Logger;
+import alpine.common.metrics.Metrics;
 import alpine.event.framework.Event;
+import alpine.event.framework.LoggableUncaughtExceptionHandler;
 import alpine.event.framework.Subscriber;
 import alpine.model.ConfigProperty;
 import alpine.security.crypto.DataEncryption;
-import kong.unirest.UnirestInstance;
 import kong.unirest.GetRequest;
+import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
 import kong.unirest.UnirestException;
-import kong.unirest.HttpResponse;
+import kong.unirest.UnirestInstance;
 import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.apache.http.HttpHeaders;
+import org.dependencytrack.common.ConfigKey;
 import org.dependencytrack.common.UnirestFactory;
 import org.dependencytrack.event.IndexEvent;
 import org.dependencytrack.event.SnykAnalysisEvent;
@@ -51,25 +54,38 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_SNYK_BASE_URL;
 
 /**
  * Subscriber task that performs an analysis of component using Snyk vulnerability REST API.
+ *
+ * @since 4.7.0
  */
 public class SnykAnalysisTask extends BaseComponentAnalyzerTask implements Subscriber {
 
-    private String apiBaseUrl;
-    private static String apiEndPoint = "/issues?";
-
-    //number of threads to be used for snyk analyzer are configurable. Default is 10. Can be set based on user requirements.
-    private static final ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(Config.getInstance().getPropertyAsInt(ConfigKey.SNYK_THREAD_BATCH_SIZE));
     private static final Logger LOGGER = Logger.getLogger(SnykAnalysisTask.class);
+    private static final ExecutorService EXECUTOR;
+
+    static {
+        // The number of threads to be used for Snyk analyzer are configurable.
+        // Default is 10. Can be set based on user requirements.
+        final int threadPoolSize = Config.getInstance().getPropertyAsInt(ConfigKey.SNYK_THREAD_BATCH_SIZE);
+        final var threadFactory = new BasicThreadFactory.Builder()
+                .namingPattern(SnykAnalysisTask.class.getSimpleName() + "-%d")
+                .uncaughtExceptionHandler(new LoggableUncaughtExceptionHandler())
+                .build();
+        EXECUTOR = Executors.newFixedThreadPool(threadPoolSize, threadFactory);
+        Metrics.registerExecutorService(EXECUTOR, SnykAnalysisTask.class.getSimpleName());
+    }
+
+    private String apiBaseUrl;
+    private String apiEndPoint = "/issues?";
     private String apiToken;
-    private static int duration = 0;
+    private int duration = 0;
     private VulnerabilityAnalysisLevel vulnerabilityAnalysisLevel;
 
     public AnalyzerIdentity getAnalyzerIdentity() {
@@ -81,7 +97,7 @@ public class SnykAnalysisTask extends BaseComponentAnalyzerTask implements Subsc
      */
     public void inform(final Event e) {
         Instant start = Instant.now();
-        if (e instanceof SnykAnalysisEvent) {
+        if (e instanceof final SnykAnalysisEvent event) {
             if (!super.isEnabled(ConfigPropertyConstants.SCANNER_SNYK_ENABLED)) {
                 return;
             }
@@ -126,7 +142,6 @@ public class SnykAnalysisTask extends BaseComponentAnalyzerTask implements Subsc
                     return;
                 }
             }
-            final SnykAnalysisEvent event = (SnykAnalysisEvent) e;
             vulnerabilityAnalysisLevel = event.getVulnerabilityAnalysisLevel();
             LOGGER.info("Starting Snyk vulnerability analysis task");
             if (!event.getComponents().isEmpty()) {
@@ -194,7 +209,7 @@ public class SnykAnalysisTask extends BaseComponentAnalyzerTask implements Subsc
                     }
                 };
                 Instant startThread = Instant.now();
-                executor.execute(analysisUtil);
+                EXECUTOR.execute(analysisUtil);
 
                 Instant endThread = Instant.now();
                 duration += Duration.between(startThread, endThread).toMillis();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -316,3 +316,10 @@ alpine.oidc.team.synchronization=false
 # When using a customizable / on-demand hosted identity provider, name, content, and inclusion in the userinfo endpoint
 # will most likely need to be configured.
 alpine.oidc.teams.claim=groups
+
+# Required
+# Defines the size of the thread pool used to perform requests to the Snyk API in parallel.
+# The thread pool will only be used when Snyk integration is enabled.
+# A high number may result in a quicker excession of API rate limits,
+# while a number that is too low may result in vulnerability analyses taking too long.
+snyk.thread.batch.size=10


### PR DESCRIPTION
Also, give it a name and provide the same `uncaughtExceptionHandler` that is used by Alpine's event services.

Signed-off-by: nscuro <nscuro@protonmail.com>