### PR TITLE
grafana: replace heap usage gauage

### DIFF
--- a/docs/files/grafana-dashboard.json
+++ b/docs/files/grafana-dashboard.json
@@ -201,21 +201,24 @@
           "color": {
             "mode": "thresholds"
           },
-          "mappings": [],
+          "decimals": 2,
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
           "thresholds": {
-            "mode": "percentage",
+            "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "rgba(50, 172, 45, 0.97)",
                 "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 65
-              },
-              {
-                "color": "red",
-                "value": 85
               }
             ]
           },
@@ -224,14 +227,19 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 3,
         "w": 5,
         "x": 11,
         "y": 0
       },
       "id": 24,
+      "links": [],
+      "maxDataPoints": 100,
       "options": {
-        "orientation": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -239,8 +247,7 @@
           "fields": "",
           "values": false
         },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "textMode": "auto"
       },
       "pluginVersion": "9.0.3",
       "targets": [
@@ -249,39 +256,18 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
+          "editorMode": "code",
           "expr": "sum(jvm_memory_used_bytes{instance=\"$instance\", area=\"heap\"})",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "sum(jvm_memory_max_bytes{instance=\"$instance\", area=\"heap\"})",
-          "hide": false,
-          "refId": "B"
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "range": true,
+          "refId": "A",
+          "step": 14400
         }
       ],
       "title": "Current Heap Usage",
-      "transformations": [
-        {
-          "id": "configFromData",
-          "options": {
-            "configRefId": "B",
-            "mappings": [
-              {
-                "fieldName": "Time",
-                "handlerKey": "__ignore"
-              },
-              {
-                "fieldName": "sum(jvm_memory_max_bytes{instance=\"apiserver:8080\", area=\"heap\"})",
-                "handlerKey": "max"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "gauge"
+      "type": "stat"
     },
     {
       "datasource": {
@@ -458,6 +444,84 @@
         }
       ],
       "title": "Java Runtime",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 11,
+        "y": 3
+      },
+      "id": 45,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(jvm_memory_max_bytes{instance=\"$instance\", area=\"heap\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "range": true,
+          "refId": "A",
+          "step": 14400
+        }
+      ],
+      "title": "Total Heap Size",
       "type": "stat"
     },
     {


### PR DESCRIPTION
The current heap usage gauge is not working correctly. This is because Grafana doesn't support variables in data transformations.
And we're using a transformation to dynamically set the Max value of the gauge, but this fails when using the $instance variable. It only works if the instance name is hardcoded (or left out). It currently is set hardcoded to `apiserver:8080` which probably won't work for most realworld deployments.

This PR switches from a gauge to two stat panels giving similar information. The colours are always green as again if we wanted thresholds and a max value, we would run into the same problems. 

![image](https://user-images.githubusercontent.com/4426050/197217691-8118e420-cde1-4d36-97a6-35beb53bf23e.png)


If you want colours for heap usage, you can use the micrometer dashboard which shows the percentage of heap used in green - orange - red styles.

Signed-off-by: Valentijn Scholten <valentijnscholten@gmail.com>