### PR TITLE
Allow cloning of ACL during Project cloning

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -27,6 +27,8 @@ import alpine.model.UserPrincipal;
 import alpine.persistence.PaginatedResult;
 import alpine.resources.AlpineRequest;
 import com.github.packageurl.PackageURL;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.event.IndexEvent;
@@ -49,6 +51,7 @@ import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -536,7 +539,8 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
     }
 
     public Project clone(UUID from, String newVersion, boolean includeTags, boolean includeProperties,
-                         boolean includeComponents, boolean includeServices, boolean includeAuditHistory) {
+                         boolean includeComponents, boolean includeServices, boolean includeAuditHistory,
+                         boolean includeACL) {
         final Project source = getObjectByUuid(Project.class, from, Project.FetchGroup.ALL.name());
         if (source == null) {
             return null;
@@ -624,6 +628,15 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                         }
                     }
                 }
+            }
+        }
+
+        if (includeACL) {
+            //It's possible that the DT instance is being prepared for ACL enabling,
+            //So client can request to includeACL even if ACL is not (yet) enabled
+            List<Team> accessTeams = source.getAccessTeams();
+            if (CollectionUtils.isEmpty(accessTeams)) {
+                project.setAccessTeams(new LinkedList<>(accessTeams));
             }
         }
 

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -632,8 +632,6 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         }
 
         if (includeACL) {
-            //It's possible that the DT instance is being prepared for ACL enabling,
-            //So client can request to includeACL even if ACL is not (yet) enabled
             List<Team> accessTeams = source.getAccessTeams();
             if (CollectionUtils.isEmpty(accessTeams)) {
                 project.setAccessTeams(new LinkedList<>(accessTeams));

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -634,7 +634,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         if (includeACL) {
             List<Team> accessTeams = source.getAccessTeams();
             if (CollectionUtils.isEmpty(accessTeams)) {
-                project.setAccessTeams(new LinkedList<>(accessTeams));
+                project.setAccessTeams(new ArrayList<>(accessTeams));
             }
         }
 

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -398,9 +398,10 @@ public class QueryManager extends AlpineQueryManager {
     }
 
     public Project clone(UUID from, String newVersion, boolean includeTags, boolean includeProperties,
-                         boolean includeComponents, boolean includeServices, boolean includeAuditHistory) {
+                         boolean includeComponents, boolean includeServices, boolean includeAuditHistory,
+                         boolean includeACL) {
         return getProjectQueryManager().clone(from, newVersion, includeTags, includeProperties,
-                includeComponents, includeServices, includeAuditHistory);
+                includeComponents, includeServices, includeAuditHistory, includeACL);
     }
 
     public Project updateLastBomImport(Project p, Date date, String bomFormat) {

--- a/src/main/java/org/dependencytrack/resources/v1/AccessControlResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AccessControlResource.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.resources.v1;
 
 import alpine.common.logging.Logger;
+import alpine.model.ConfigProperty;
 import alpine.model.Team;
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
@@ -30,6 +31,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.v1.vo.AclMappingRequest;
@@ -58,6 +60,25 @@ import java.util.List;
 public class AccessControlResource extends AlpineResource {
 
     private static final Logger LOGGER = Logger.getLogger(AccessControlResource.class);
+
+    @GET
+    @Path("/enabled")
+    @Produces(MediaType.TEXT_PLAIN)
+    @ApiOperation(
+            value = "Returns True if Access Control is Enabled",
+            response = Boolean.class
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Unauthorized"),
+    })
+    @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
+    public Response isEnabled () {
+        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+            final ConfigProperty aclEnabledProperty = qm.getConfigProperty(ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
+                                                                           ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName());
+            return Response.ok(Boolean.valueOf(aclEnabledProperty.getPropertyValue())).build();
+        }
+    }
 
     @GET
     @Path("/team/{uuid}")

--- a/src/main/java/org/dependencytrack/resources/v1/AccessControlResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AccessControlResource.java
@@ -62,25 +62,6 @@ public class AccessControlResource extends AlpineResource {
     private static final Logger LOGGER = Logger.getLogger(AccessControlResource.class);
 
     @GET
-    @Path("/enabled")
-    @Produces(MediaType.TEXT_PLAIN)
-    @ApiOperation(
-            value = "Returns True if Access Control is Enabled",
-            response = Boolean.class
-    )
-    @ApiResponses(value = {
-            @ApiResponse(code = 401, message = "Unauthorized"),
-    })
-    @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
-    public Response isEnabled () {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
-            final ConfigProperty aclEnabledProperty = qm.getConfigProperty(ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
-                                                                           ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName());
-            return Response.ok(Boolean.valueOf(aclEnabledProperty.getPropertyValue())).build();
-        }
-    }
-
-    @GET
     @Path("/team/{uuid}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(

--- a/src/main/java/org/dependencytrack/resources/v1/vo/CloneProjectRequest.java
+++ b/src/main/java/org/dependencytrack/resources/v1/vo/CloneProjectRequest.java
@@ -57,6 +57,8 @@ public class CloneProjectRequest {
 
     private final boolean includeAuditHistory;
 
+    private final boolean includeACL;
+
     @JsonCreator
     public CloneProjectRequest(@JsonProperty(value = "project", required = true) String project,
                                @JsonProperty(value = "version", required = true) String version,
@@ -65,8 +67,9 @@ public class CloneProjectRequest {
                                @JsonProperty(value = "includeDependencies") boolean includeDependencies,
                                @JsonProperty(value = "includeComponents") boolean includeComponents,
                                @JsonProperty(value = "includeServices") boolean includeServices,
-                               @JsonProperty(value = "includeAuditHistory") boolean includeAuditHistory) {
-        if (includeDependencies) { // For backward compatibility
+                               @JsonProperty(value = "includeAuditHistory") boolean includeAuditHistory,
+                               @JsonProperty(value = "includeACL") boolean includeACL) {
+                                    if (includeDependencies) { // For backward compatibility
             includeComponents = true;
         }
         this.project = project;
@@ -77,6 +80,7 @@ public class CloneProjectRequest {
         this.includeComponents = includeComponents;
         this.includeServices = includeServices;
         this.includeAuditHistory = includeAuditHistory;
+        this.includeACL = includeACL;
     }
 
     public String getProject() {
@@ -110,4 +114,9 @@ public class CloneProjectRequest {
     public boolean includeAuditHistory() {
         return includeAuditHistory;
     }
+
+    public boolean includeACL() {
+        return includeACL;
+    }
+
 }

--- a/src/main/java/org/dependencytrack/tasks/CloneProjectTask.java
+++ b/src/main/java/org/dependencytrack/tasks/CloneProjectTask.java
@@ -43,7 +43,7 @@ public class CloneProjectTask implements Subscriber {
             try (QueryManager qm = new QueryManager()) {
                 final Project project = qm.clone(UUID.fromString(request.getProject()),
                         request.getVersion(), request.includeTags(), request.includeProperties(),
-                        request.includeComponents(), request.includeServices(), request.includeAuditHistory());
+                        request.includeComponents(), request.includeServices(), request.includeAuditHistory(), request.includeACL());
                 LOGGER.info("Cloned project: " + request.getProject() + " to " + project.getUuid());
             }
         }

--- a/src/test/java/org/dependencytrack/event/CloneProjectEventTest.java
+++ b/src/test/java/org/dependencytrack/event/CloneProjectEventTest.java
@@ -29,7 +29,7 @@ public class CloneProjectEventTest {
     @Test
     public void testEvent() {
         UUID uuid = UUID.randomUUID();
-        CloneProjectRequest request = new CloneProjectRequest(uuid.toString(), "1.0", true, true, true, true, true, true);
+        CloneProjectRequest request = new CloneProjectRequest(uuid.toString(), "1.0", true, true, true, true, true, true, true);
         CloneProjectEvent event = new CloneProjectEvent(request);
         Assert.assertEquals(request, event.getRequest());
     }


### PR DESCRIPTION
Adds an `includeACL` parameter to the project clone api. And an extra `/acl/enabled` endpoint for the front-end to query ACL enabled status.

Fixes #1534 and option 1 of #1632

Front-end PR linked below.

Signed-off-by: Valentijn Scholten <valentijnscholten@gmail.com>