### PR TITLE
Add Dependency-Track as default project

### DIFF
--- a/.github/workflows/_meta-build.yaml
+++ b/.github/workflows/_meta-build.yaml
@@ -31,12 +31,20 @@ jobs:
           java-version: '17'
           cache: 'maven'
 
+      - name: Setup CycloneDX CLI
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          wget -O "$HOME/.local/bin/cyclonedx" https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-x64
+          echo "ef0d3b31d176e02bc594f83e19cfcea053c6bc5b197351f71696e189390f851d $HOME/.local/bin/cyclonedx" | sha256sum -c
+          chmod +x "$HOME/.local/bin/cyclonedx"
+
       - name: Build with Maven
         run: |-
           mvn clean
-          mvn package -Dmaven.test.skip=true -P enhance -P embedded-jetty -Dlogback.configuration.file=src/main/docker/logback.xml
+          mvn package -Dmaven.test.skip=true -P enhance -P embedded-jetty -Dbom-merge.skip=false -Dlogback.configuration.file=src/main/docker/logback.xml
           mvn clean -P clean-exclude-wars
-          mvn package -Dmaven.test.skip=true -P enhance -P embedded-jetty -P bundle-ui -Dlogback.configuration.file=src/main/docker/logback.xml
+          mvn package -Dmaven.test.skip=true -P enhance -P embedded-jetty -P bundle-ui -Dbom-merge.skip=false -Dlogback.configuration.file=src/main/docker/logback.xml
           mvn clean -P clean-exclude-wars
           mvn cyclonedx:makeBom
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,9 @@
         <plugin.retirejs.breakOnFailure>false</plugin.retirejs.breakOnFailure>
         <!-- SonarCloud properties -->
         <sonar.exclusions>src/main/webapp/**</sonar.exclusions>
+        <!-- BOM merging -->
+        <bom-merge.cyclonedx-cli.path>cyclonedx</bom-merge.cyclonedx-cli.path>
+        <bom-merge.skip>true</bom-merge.skip>
     </properties>
 
     <repositories>
@@ -365,6 +368,31 @@
         </testResources>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>merge-bom</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${bom-merge.cyclonedx-cli.path}</executable>
+                            <arguments>
+                                <argument>merge</argument>
+                                <argument>--input-files</argument>
+                                <argument>${project.build.directory}/bom.json</argument>
+                                <argument>${project.basedir}/src/main/resources/services.bom.json</argument>
+                                <argument>--output-file</argument>
+                                <argument>${project.build.directory}/bom.json</argument>
+                            </arguments>
+                            <skip>${bom-merge.skip}</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>3.1.0</version>
                 <executions>
@@ -391,8 +419,6 @@
                     <webApp>
                         <contextPath>/</contextPath>
                     </webApp>
-                    <reload>manual</reload>
-                    <scanIntervalSeconds>10</scanIntervalSeconds>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -5,6 +5,8 @@ import alpine.Config;
 import java.time.Duration;
 
 public enum ConfigKey implements Config.Key {
+    DEFAULT_PROJECT_DISABLE("default.project.disable", false),
+    DEFAULT_PROJECT_TAGS("default.project.tags", null),
     SNYK_THREAD_BATCH_SIZE("snyk.thread.batch.size", 10),
     SNYK_LIMIT_FOR_PERIOD("snyk.limit.for.period", 1500),
     SNYK_THREAD_TIMEOUT_DURATION("snyk.thread.timeout.duration", 60),

--- a/src/main/java/org/dependencytrack/persistence/defaults/DefaultProjectImporter.java
+++ b/src/main/java/org/dependencytrack/persistence/defaults/DefaultProjectImporter.java
@@ -1,0 +1,122 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.defaults;
+
+import alpine.Config;
+import alpine.common.logging.Logger;
+import alpine.event.framework.Event;
+import org.apache.commons.io.IOUtils;
+import org.cyclonedx.BomParserFactory;
+import org.cyclonedx.exception.ParseException;
+import org.cyclonedx.parsers.Parser;
+import org.dependencytrack.common.ConfigKey;
+import org.dependencytrack.event.BomUploadEvent;
+import org.dependencytrack.model.Classifier;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.Tag;
+import org.dependencytrack.persistence.QueryManager;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @since 4.7.0
+ */
+public class DefaultProjectImporter implements ServletContextListener {
+
+    private static final Logger LOGGER = Logger.getLogger(DefaultProjectImporter.class);
+    private static final String DEFAULT_SBOM_PATH = ".well-known/sbom";
+
+    private final Config config;
+    private final String sbomPath;
+
+    public DefaultProjectImporter() {
+        this(Config.getInstance(), DEFAULT_SBOM_PATH);
+    }
+
+    DefaultProjectImporter(final Config config, final String sbomPath) {
+        this.config = config;
+        this.sbomPath = sbomPath;
+    }
+
+    @Override
+    public void contextInitialized(final ServletContextEvent event) {
+        if (config.getPropertyAsBoolean(ConfigKey.DEFAULT_PROJECT_DISABLE)) {
+            LOGGER.debug("Default project creation is disabled");
+            return;
+        }
+
+        final URL sbomUrl = getClass().getClassLoader().getResource(sbomPath);
+        if (sbomUrl == null) {
+            LOGGER.warn("Cannot create default project because the SBOM %s was not found".formatted(sbomPath));
+            return;
+        }
+
+        final byte[] bomBytes;
+        final org.cyclonedx.model.Component bomComponent;
+        try {
+            bomBytes = IOUtils.toByteArray(sbomUrl);
+            final Parser bomParser = BomParserFactory.createParser(bomBytes);
+            bomComponent = bomParser.parse(bomBytes).getMetadata().getComponent();
+        } catch (IOException | ParseException e) {
+            LOGGER.error("An unexpected error occurred while parsing the default project SBOM", e);
+            return;
+        }
+
+        try (final var qm = new QueryManager()) {
+            Project project = qm.getProject(bomComponent.getName(), bomComponent.getVersion());
+            if (project != null) {
+                LOGGER.info("Default project already exists");
+                return;
+            }
+
+            LOGGER.info("Creating default project %s %s".formatted(bomComponent.getName(), bomComponent.getVersion()));
+            project = new Project();
+            project.setPublisher(bomComponent.getPublisher());
+            project.setGroup(bomComponent.getGroup());
+            project.setName(bomComponent.getName());
+            project.setVersion(bomComponent.getVersion());
+            project.setClassifier(Classifier.APPLICATION);
+            project.setDescription(bomComponent.getDescription());
+            project.setPurl(bomComponent.getPurl());
+            project.setActive(true);
+            project = qm.createProject(project, getConfiguredTags(), true);
+
+            LOGGER.info("Dispatching BOM upload event for default project");
+            Event.dispatch(new BomUploadEvent(project.getUuid(), bomBytes));
+        }
+    }
+
+    private List<Tag> getConfiguredTags() {
+        return Optional.ofNullable(config.getProperty(ConfigKey.DEFAULT_PROJECT_TAGS)).stream()
+                .flatMap(tagNames -> Arrays.stream(tagNames.split(",")))
+                .map(tagName -> {
+                    final var tag = new Tag();
+                    tag.setName(tagName);
+                    return tag;
+                })
+                .toList();
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -318,6 +318,17 @@ alpine.oidc.team.synchronization=false
 alpine.oidc.teams.claim=groups
 
 # Optional
+# Defines whether creation of the default project upon application startup shall be disabled.
+# Unless disabled, Dependency-Track will create a default project representing itself, based
+# on the SBOM shipped with it.
+default.project.disable=false
+
+# Optional
+# Defines the tags to apply to the default project upon creation.
+# Multiple tags can be provided by separating them with commas (e.g. foo,bar,baz).
+default.project.tags=
+
+# Optional
 # Defines the size of the thread pool used to perform requests to the Snyk API in parallel.
 # The thread pool will only be used when Snyk integration is enabled.
 # A high number may result in a quicker excession of API rate limits,

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -47,6 +47,10 @@
     <listener>
         <listener-class>org.dependencytrack.notification.NotificationSubsystemInitializer</listener-class>
     </listener>
+    <listener>
+        <!-- Separated from DefaultObjectGenerator because it needs the event subsystem to be initialized -->
+        <listener-class>org.dependencytrack.persistence.defaults.DefaultProjectImporter</listener-class>
+    </listener>
 
     <filter>
         <filter-name>WhitelistUrlFilter</filter-name>


### PR DESCRIPTION
Draft PR to get the discussion going as to how this feature should behave.

When building, the BOM generated at build-time (`target/bom.json`) is merged with the manually-maintained service BOM (`src/main/resources/services.bom.json`) using the CycloneDX CLI. Because this build step requires the CLI to be present, it is disabled by default, and must be enabled by passing the `-Dbom-merge.skip=false` property to the Maven command.

The BOM is moved to `.well-known/sbom` inside the final JAR (this has been the case for a while already). During startup, we try to locate and parse the BOM from there, map the `metadata/component` node to a DT project, create the project if it doesn't already exist, and emit a `BomUploadEvent` for it. This will trigger the usual analysis tasks.

The entire behavior is enabled by default, but can be disabled via `default.project.disable=true` (`DEFAULT_PROJECT_DISABLE=true`). Additionally, tags for the default project may be provided using the `default.project.tags` (`DEFAULT_PROJECT_TAGS`) property.

As it is now, the project will only be created if it doesn't already exist. Upgrading to a newer DT version will cause a new project version to be created (based on the version of the embedded BOM). It will behave like a poor-man's version of subscribing to a service from which the DT BOM would be acquired automatically.

Looking for input and opinions of all sorts. Will add documentation and tests once we agree on how to proceed.

Closes #1559 