### PR TITLE
Feature: Implementing caching for Repository metadata analyzer

### DIFF
--- a/docs/_docs/getting-started/configuration.md
+++ b/docs/_docs/getting-started/configuration.md
@@ -393,6 +393,23 @@ ossindex.retry.backoff.multiplier=2
 #Defines the maximum duration used by Resilience4J for exponential backoff retry regarding OSSIndex calls. This value is in milliseconds
 # The default value is 10 minutes.
 ossindex.retry.backoff.max.duration=600000
+
+# Optional
+#This flag activate the cache stampede blocker for the repository meta analyzer allowing to handle high concurrency workloads when there
+#is a high ratio of duplicate components which can cause unnecessary external calls and index violation on PUBLIC.REPOSITORY_META_COMPONENT_COMPOUND_IDX during cache population.
+# The default value is false as enabling the cache stampede blocker can create useless locking if the portfolio does not have a high ratio of duplicate components.
+repo.meta.analyzer.cacheStampedeBlocker.enabled=false
+
+# Optional
+#The cache stampede blocker uses a striped (partitioned) lock to distribute locks across keys.
+#This parameter defines the number of buckets used by the striped lock. The lock used for a given key is derived from the key hashcode and number of buckets.
+# The default value is 1000.
+repo.meta.analyzer.cacheStampedeBlocker.lock.buckets=1000
+
+# Optional
+#Defines the maximum number of attempts used by Resilience4J for exponential backoff retry regarding repo meta analyzer cache loading per key.
+# The default value is 10.
+repo.meta.analyzer.cacheStampedeBlocker.max.attempts=10
 ```
 
 #### Proxy Configuration

--- a/docs/_docs/getting-started/deploy-docker.md
+++ b/docs/_docs/getting-started/deploy-docker.md
@@ -168,7 +168,7 @@ services:
     # - OSSINDEX_RETRY_BACKOFF_MAX_DURATION=600000
     #
     # Optional configuration for the repository metadata analyzer cache stampede for high concurrency workloads
-    # - REPO_META_ANALYZER_CACHESTAMPEDEBLOCKER_ENABLED=false
+    # - REPO_META_ANALYZER_CACHESTAMPEDEBLOCKER_ENABLED=true
     # - REPO_META_ANALYZER_CACHESTAMPEDEBLOCKER_LOCK_BUCKETS=1000
     # - REPO_META_ANALYZER_CACHESTAMPEDEBLOCKER_MAX_ATTEMPTS=10
     #

--- a/docs/_docs/getting-started/deploy-docker.md
+++ b/docs/_docs/getting-started/deploy-docker.md
@@ -166,6 +166,12 @@ services:
     # - OSSINDEX_RETRY_BACKOFF_MAX_ATTEMPTS=50
     # - OSSINDEX_RETRY_BACKOFF_MULTIPLIER=2
     # - OSSINDEX_RETRY_BACKOFF_MAX_DURATION=600000
+    #
+    # Optional configuration for the repository metadata analyzer cache stampede for high concurrency workloads
+    # - REPO_META_ANALYZER_CACHESTAMPEDEBLOCKER_ENABLED=false
+    # - REPO_META_ANALYZER_CACHESTAMPEDEBLOCKER_LOCK_BUCKETS=1000
+    # - REPO_META_ANALYZER_CACHESTAMPEDEBLOCKER_MAX_ATTEMPTS=10
+    #
     # Optional environmental variables to provide more JVM arguments to the API Server JVM, i.e. "-XX:ActiveProcessorCount=8"
     # - EXTRA_JAVA_OPTIONS=
 

--- a/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -14,7 +14,7 @@ public enum ConfigKey implements Config.Key {
     OSSINDEX_RETRY_EXPONENTIAL_BACKOFF_MAX_ATTEMPTS("ossindex.retry.backoff.max.attempts", 10),
     OSSINDEX_RETRY_EXPONENTIAL_BACKOFF_MULTIPLIER("ossindex.retry.backoff.multiplier", 2),
     OSSINDEX_RETRY_EXPONENTIAL_BACKOFF_MAX_DURATION("ossindex.retry.backoff.max.duration", Duration.ofMinutes(10).toMillis()),
-    REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_ENABLED("repo.meta.analyzer.cacheStampedeBlocker.enabled", false),
+    REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_ENABLED("repo.meta.analyzer.cacheStampedeBlocker.enabled", true),
     REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_LOCK_BUCKETS("repo.meta.analyzer.cacheStampedeBlocker.lock.buckets", 1000),
     REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_MAX_ATTEMPTS("repo.meta.analyzer.cacheStampedeBlocker.max.attempts", 10);
 

--- a/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -5,6 +5,7 @@ import alpine.Config;
 import java.time.Duration;
 
 public enum ConfigKey implements Config.Key {
+
     SNYK_THREAD_BATCH_SIZE("snyk.thread.batch.size", 10),
     SNYK_LIMIT_FOR_PERIOD("snyk.limit.for.period", 1500),
     SNYK_THREAD_TIMEOUT_DURATION("snyk.thread.timeout.duration", 60),
@@ -12,7 +13,10 @@ public enum ConfigKey implements Config.Key {
     OSSINDEX_REQUEST_MAX_PURL("ossindex.request.max.purl", 128),
     OSSINDEX_RETRY_EXPONENTIAL_BACKOFF_MAX_ATTEMPTS("ossindex.retry.backoff.max.attempts", 10),
     OSSINDEX_RETRY_EXPONENTIAL_BACKOFF_MULTIPLIER("ossindex.retry.backoff.multiplier", 2),
-    OSSINDEX_RETRY_EXPONENTIAL_BACKOFF_MAX_DURATION("ossindex.retry.backoff.max.duration", Duration.ofMinutes(10).toMillis());
+    OSSINDEX_RETRY_EXPONENTIAL_BACKOFF_MAX_DURATION("ossindex.retry.backoff.max.duration", Duration.ofMinutes(10).toMillis()),
+    REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_ENABLED("repo.meta.analyzer.cacheStampedeBlocker.enabled", false),
+    REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_LOCK_BUCKETS("repo.meta.analyzer.cacheStampedeBlocker.lock.buckets", 1000),
+    REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_MAX_ATTEMPTS("repo.meta.analyzer.cacheStampedeBlocker.max.attempts", 10);
 
     private final String propertyName;
     private final Object defaultValue;

--- a/src/main/java/org/dependencytrack/event/RepositoryMetaEvent.java
+++ b/src/main/java/org/dependencytrack/event/RepositoryMetaEvent.java
@@ -21,17 +21,21 @@ package org.dependencytrack.event;
 import alpine.event.framework.Event;
 import org.dependencytrack.model.Component;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
 public class RepositoryMetaEvent implements Event {
 
-    private Component component;
+    private Optional<List<Component>> components = Optional.empty();
 
     public RepositoryMetaEvent() { }
 
-    public RepositoryMetaEvent(final Component component) {
-        this.component = component;
+    public RepositoryMetaEvent(final List<Component> components) {
+        this.components = Optional.of(Collections.unmodifiableList(components));
     }
 
-    public Component getComponent() {
-        return component;
+    public Optional<List<Component>> getComponents() {
+        return components;
     }
 }

--- a/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
+++ b/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
@@ -90,7 +90,7 @@ public enum ConfigPropertyConstants {
     TASK_SCHEDULER_PORTFOLIO_VULNERABILITY_ANALYSIS_CADENCE("task-scheduler", "portfolio.vulnerability.analysis.cadence", "24", PropertyType.INTEGER, "Launch cadence (in hours) for portfolio vulnerability analysis"),
     TASK_SCHEDULER_REPOSITORY_METADATA_FETCH_CADENCE("task-scheduler", "repository.metadata.fetch.cadence", "24", PropertyType.INTEGER, "Metadada fetch cadence (in hours) for package repositories"),
     TASK_SCHEDULER_INTERNAL_COMPONENT_IDENTIFICATION_CADENCE("task-scheduler", "internal.components.identification.cadence", "6", PropertyType.INTEGER, "Internal component identification cadence (in hours)"),
-    TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_CADENCE("task-scheduler", "component.analysis.cache.clear.cadence", "72", PropertyType.INTEGER, "Cleanup cadence (in hours) for component analysis cache");
+    TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_CADENCE("task-scheduler", "component.analysis.cache.clear.cadence", "24", PropertyType.INTEGER, "Cleanup cadence (in hours) for component analysis cache");
 
     private String groupName;
     private String propertyName;

--- a/src/main/java/org/dependencytrack/persistence/CacheQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/CacheQueryManager.java
@@ -26,6 +26,7 @@ import javax.jdo.Query;
 import javax.json.JsonObject;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 public class CacheQueryManager extends QueryManager implements IQueryManager {
 
@@ -59,7 +60,8 @@ public class CacheQueryManager extends QueryManager implements IQueryManager {
         final Query<ComponentAnalysisCache> query = pm.newQuery(ComponentAnalysisCache.class,
                 "cacheType == :cacheType && targetType == :targetType && target == :target");
         query.setOrdering("lastOccurrence desc");
-        return (List<ComponentAnalysisCache>) query.executeWithArray(cacheType, targetType, target);
+        query.setNamedParameters(Map.of("cacheType", cacheType, "targetType", targetType, "target", target));
+        return query.executeList();
     }
 
     public synchronized void updateComponentAnalysisCache(ComponentAnalysisCache.CacheType cacheType, String targetHost, String targetType, String target, Date lastOccurrence, JsonObject result) {
@@ -80,6 +82,12 @@ public class CacheQueryManager extends QueryManager implements IQueryManager {
 
     public void clearComponentAnalysisCache() {
         final Query<ComponentAnalysisCache> query = pm.newQuery(ComponentAnalysisCache.class);
+        query.deletePersistentAll();
+    }
+
+    public void clearComponentAnalysisCache(Date threshold) {
+        final Query<ComponentAnalysisCache> query = pm.newQuery(ComponentAnalysisCache.class, "lastOccurrence < :threshold");
+        query.setNamedParameters(Map.of("threshold", threshold));
         query.deletePersistentAll();
     }
 }

--- a/src/main/java/org/dependencytrack/persistence/CacheQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/CacheQueryManager.java
@@ -25,6 +25,7 @@ import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import javax.json.JsonObject;
 import java.util.Date;
+import java.util.List;
 
 public class CacheQueryManager extends QueryManager implements IQueryManager {
 
@@ -52,6 +53,13 @@ public class CacheQueryManager extends QueryManager implements IQueryManager {
         query.setOrdering("lastOccurrence desc");
         query.setRange(0, 1);
         return singleResult(query.executeWithArray(cacheType, targetHost, targetType, target));
+    }
+
+    public List<ComponentAnalysisCache> getComponentAnalysisCache(ComponentAnalysisCache.CacheType cacheType, String targetType, String target) {
+        final Query<ComponentAnalysisCache> query = pm.newQuery(ComponentAnalysisCache.class,
+                "cacheType == :cacheType && targetType == :targetType && target == :target");
+        query.setOrdering("lastOccurrence desc");
+        return (List<ComponentAnalysisCache>) query.executeWithArray(cacheType, targetType, target);
     }
 
     public synchronized void updateComponentAnalysisCache(ComponentAnalysisCache.CacheType cacheType, String targetHost, String targetType, String target, Date lastOccurrence, JsonObject result) {

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1147,6 +1147,10 @@ public class QueryManager extends AlpineQueryManager {
         return getCacheQueryManager().getComponentAnalysisCache(cacheType, targetHost, targetType, target);
     }
 
+    public List<ComponentAnalysisCache> getComponentAnalysisCache(ComponentAnalysisCache.CacheType cacheType, String targetType, String target) {
+        return getCacheQueryManager().getComponentAnalysisCache(cacheType, targetType, target);
+    }
+
     public synchronized void updateComponentAnalysisCache(ComponentAnalysisCache.CacheType cacheType, String targetHost, String targetType, String target, Date lastOccurrence, JsonObject result) {
         getCacheQueryManager().updateComponentAnalysisCache(cacheType, targetHost, targetType, target, lastOccurrence,  result);
     }

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1159,6 +1159,10 @@ public class QueryManager extends AlpineQueryManager {
         getCacheQueryManager().clearComponentAnalysisCache();
     }
 
+    public void clearComponentAnalysisCache(Date threshold) {
+        getCacheQueryManager().clearComponentAnalysisCache(threshold);
+    }
+
     public void bind(Project project, List<Tag> tags) {
         getProjectQueryManager().bind(project, tags);
     }

--- a/src/main/java/org/dependencytrack/persistence/RepositoryQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/RepositoryQueryManager.java
@@ -197,7 +197,7 @@ public class RepositoryQueryManager extends QueryManager implements IQueryManage
      */
     public synchronized RepositoryMetaComponent synchronizeRepositoryMetaComponent(final RepositoryMetaComponent transientRepositoryMetaComponent) {
         final RepositoryMetaComponent metaComponent = getRepositoryMetaComponent(transientRepositoryMetaComponent.getRepositoryType(),
-                transientRepositoryMetaComponent.getNamespace(), transientRepositoryMetaComponent.getName());;
+                transientRepositoryMetaComponent.getNamespace(), transientRepositoryMetaComponent.getName());
         if (metaComponent != null) {
             metaComponent.setRepositoryType(transientRepositoryMetaComponent.getRepositoryType());
             metaComponent.setNamespace(transientRepositoryMetaComponent.getNamespace());

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -55,6 +55,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.List;
 
 /**
  * JAX-RS resources for processing components.
@@ -284,7 +285,7 @@ public class ComponentResource extends AlpineResource {
 
             component = qm.createComponent(component, true);
             Event.dispatch(new VulnerabilityAnalysisEvent(component));
-            Event.dispatch(new RepositoryMetaEvent(component));
+            Event.dispatch(new RepositoryMetaEvent(List.of(component)));
             return Response.status(Response.Status.CREATED).entity(component).build();
         }
     }
@@ -366,7 +367,7 @@ public class ComponentResource extends AlpineResource {
 
                 component = qm.updateComponent(component, true);
                 Event.dispatch(new VulnerabilityAnalysisEvent(component));
-                Event.dispatch(new RepositoryMetaEvent(component));
+                Event.dispatch(new RepositoryMetaEvent(List.of(component)));
                 return Response.ok(component).build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the component could not be found.").build();

--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -155,6 +155,7 @@ public class BomUploadProcessingTask implements Subscriber {
                     vae.onSuccess(new NewVulnerableDependencyAnalysisEvent(newComponents));
                 }
                 Event.dispatch(vae);
+                Event.dispatch(new RepositoryMetaEvent(detachedFlattenedComponent));
                 LOGGER.info("Processed " + flattenedComponents.size() + " components and " + flattenedServices.size() + " services uploaded to project " + event.getProjectUuid());
                 Notification.dispatch(new Notification()
                         .scope(NotificationScope.PORTFOLIO)
@@ -186,7 +187,6 @@ public class BomUploadProcessingTask implements Subscriber {
         if (isNew) {
             newComponents.add(qm.detach(Component.class, component.getId()));
         }
-        Event.dispatch(new RepositoryMetaEvent(component));
         if (component.getChildren() != null) {
             for (final Component child : component.getChildren()) {
                 processComponent(qm, child, flattenedComponents, newComponents);

--- a/src/main/java/org/dependencytrack/tasks/repositories/RepositoryMetaAnalyzerTask.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/RepositoryMetaAnalyzerTask.java
@@ -21,21 +21,35 @@ package org.dependencytrack.tasks.repositories;
 import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
+import alpine.model.ConfigProperty;
 import alpine.security.crypto.DataEncryption;
 import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.event.RepositoryMetaEvent;
 import org.dependencytrack.model.Component;
+import org.dependencytrack.model.ComponentAnalysisCache;
+import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Repository;
 import org.dependencytrack.model.RepositoryMetaComponent;
+import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.persistence.QueryManager;
 
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import java.time.Instant;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class RepositoryMetaAnalyzerTask implements Subscriber {
 
     private static final Logger LOGGER = Logger.getLogger(RepositoryMetaAnalyzerTask.class);
+
+    private static final String LATEST_VERSION = "latestVersion";
+
+    private static final String PUBLISHED_TIMESTAMP = "publishedTimestamp";
 
     /**
      * {@inheritDoc}
@@ -71,48 +85,119 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
     private void analyze(final QueryManager qm, final Component component) {
         LOGGER.debug("Analyzing component: " + component.getUuid());
         final IMetaAnalyzer analyzer = IMetaAnalyzer.build(component);
-        for (final Repository repository: qm.getAllRepositoriesOrdered(analyzer.supportedRepositoryType())) {
-            // Moved the identification of internal components from the isApplicable() method from the Meta Analyzers
-            // themselves (which was introduced in https://github.com/DependencyTrack/dependency-track/pull/512)
-            // and made a global decision here instead. Internal components should only be analyzed using internal
-            // repositories. Non-internal components should only be analyzed with non-internal repositories. We do not
-            // want non-internal components being analyzed with internal repositories as internal repositories are not
-            // the source of truth for these components, even if the repository acts as a proxy to the source of truth.
-            // This cannot be assumed.
-            if (repository.isEnabled() && ((component.isInternal() && repository.isInternal()) || (!component.isInternal() && !repository.isInternal()))) {
-                LOGGER.debug("Analyzing component: " + component.getUuid() + " using repository: "
-                        + repository.getIdentifier() + " (" + repository.getType() + ")");
-
-                if (repository.isInternal()) {
-                    try {
-                        analyzer.setRepositoryUsernameAndPassword(repository.getUsername(), DataEncryption.decryptAsString(repository.getPassword()));
-                    } catch (Exception e) {
-                        LOGGER.error("Failed decrypting password for repository: " + repository.getIdentifier(), e);
-                    }
-                }
-
-                analyzer.setRepositoryBaseUrl(repository.getUrl());
-                final MetaModel model = analyzer.analyze(component);
-                if (StringUtils.trimToNull(model.getLatestVersion()) != null) {
-                    // Resolution from repository was successful. Update meta model
-                    final RepositoryMetaComponent metaComponent = new RepositoryMetaComponent();
-                    metaComponent.setRepositoryType(repository.getType());
-                    metaComponent.setNamespace(component.getPurl().getNamespace());
-                    metaComponent.setName(component.getPurl().getName());
-                    metaComponent.setPublished(model.getPublishedTimestamp());
-                    metaComponent.setLatestVersion(model.getLatestVersion());
-                    metaComponent.setLastCheck(new Date());
-                    qm.synchronizeRepositoryMetaComponent(metaComponent);
-                    // Since the component metadata found and captured from this repository, return from this
-                    // method without attempting to query additional repositories.
-                    LOGGER.debug("Found component metadata for: " + component.getUuid() + " using repository: "
-                            + repository.getIdentifier() + " (" + repository.getType() + ")");
-                    return;
-                }
-            } else {
-                LOGGER.debug("Skipping analysis of component: " + component.getUuid() + " using repository: "
-                        + repository.getIdentifier() + " (" + repository.getType() + ")");
+        if(RepositoryType.UNSUPPORTED != analyzer.supportedRepositoryType() && !isRepositoryMetaComponentStillValid(qm, analyzer.supportedRepositoryType(), component.getPurl().getNamespace(), component.getPurl().getName())) {
+            // Retrieve existing Component Analysis Cache in one query :- There will be either no cac or cac without "latestVersion" (otherwise a RepositoryMetaModel would have already been created).
+            // Caching cac without "latestVersion" allow avoiding performing the same call to repository over and over.
+            final Map<String, ComponentAnalysisCache> cacByHost = new HashMap<>();
+            List<ComponentAnalysisCache> cacList = qm.getComponentAnalysisCache(ComponentAnalysisCache.CacheType.REPOSITORY, analyzer.supportedRepositoryType().name(), component.getPurl().toString());
+            if (cacList != null && cacList.size() > 0) {
+                cacList.stream().forEach(cac -> cacByHost.put(cac.getTargetHost(), cac));
             }
+            for (final Repository repository: qm.getAllRepositoriesOrdered(analyzer.supportedRepositoryType())) {
+                // Moved the identification of internal components from the isApplicable() method from the Meta Analyzers
+                // themselves (which was introduced in https://github.com/DependencyTrack/dependency-track/pull/512)
+                // and made a global decision here instead. Internal components should only be analyzed using internal
+                // repositories. Non-internal components should only be analyzed with non-internal repositories. We do not
+                // want non-internal components being analyzed with internal repositories as internal repositories are not
+                // the source of truth for these components, even if the repository acts as a proxy to the source of truth.
+                // This cannot be assumed.
+                if (repository.isEnabled() && ((component.isInternal() && repository.isInternal()) || (!component.isInternal() && !repository.isInternal()))) {
+                    String purl = component.getPurl().toString();
+                    ComponentAnalysisCache cac = cacByHost.get(repository.getUrl());
+                    MetaModel model = new MetaModel(component);
+                    if (cac != null && isCacheCurrent(cac, component.getPurl().toString())) {
+                        LOGGER.debug("Building repository Metamodel from cache for "+purl);
+                        model.setLatestVersion(StringUtils.trimToNull(cac.getResult().getString(LATEST_VERSION)));
+                        model.setPublishedTimestamp(Date.from(Instant.ofEpochMilli(cac.getResult().getJsonNumber(PUBLISHED_TIMESTAMP).longValue())));
+                    } else {
+                        LOGGER.debug("Analyzing component: " + component.getUuid() + " using repository: "
+                                + repository.getIdentifier() + " (" + repository.getType() + ")");
+
+                        if (repository.isInternal()) {
+                            try {
+                                analyzer.setRepositoryUsernameAndPassword(repository.getUsername(), DataEncryption.decryptAsString(repository.getPassword()));
+                            } catch (Exception e) {
+                                LOGGER.error("Failed decrypting password for repository: " + repository.getIdentifier(), e);
+                            }
+                        }
+
+                        analyzer.setRepositoryBaseUrl(repository.getUrl());
+                        model = analyzer.analyze(component);
+                        qm.updateComponentAnalysisCache(ComponentAnalysisCache.CacheType.REPOSITORY, repository.getUrl(), repository.getType().name(), component.getPurl().toString(), new Date(), buildRepositoryComponentAnalysisCacheResult(model));
+                    }
+
+                    if (StringUtils.trimToNull(model.getLatestVersion()) != null) {
+                        // Resolution from repository was successful. Update meta model
+                        final RepositoryMetaComponent metaComponent = new RepositoryMetaComponent();
+                        metaComponent.setRepositoryType(repository.getType());
+                        metaComponent.setNamespace(component.getPurl().getNamespace());
+                        metaComponent.setName(component.getPurl().getName());
+                        metaComponent.setPublished(model.getPublishedTimestamp());
+                        metaComponent.setLatestVersion(model.getLatestVersion());
+                        metaComponent.setLastCheck(new Date());
+                        qm.synchronizeRepositoryMetaComponent(metaComponent);
+                        // Since the component metadata found and captured from this repository, return from this
+                        // method without attempting to query additional repositories.
+                        LOGGER.debug("Found component metadata for: " + component.getUuid() + " using repository: "
+                                + repository.getIdentifier() + " (" + repository.getType() + ")");
+                        return;
+                    }
+                } else {
+                    LOGGER.debug("Skipping analysis of component: " + component.getUuid() + " using repository: "
+                            + repository.getIdentifier() + " (" + repository.getType() + ")");
+                }
+            }
+        }
+    }
+
+    private JsonObject buildRepositoryComponentAnalysisCacheResult(MetaModel model) {
+        JsonObjectBuilder builder = Json.createObjectBuilder();
+        String latestVersion = model.getLatestVersion() != null ? model.getLatestVersion() : "";
+        builder.add(LATEST_VERSION, Json.createValue(latestVersion));
+        builder.add(PUBLISHED_TIMESTAMP, Json.createValue(model.getPublishedTimestamp().getTime()));
+        return builder.build();
+    }
+
+    protected boolean isRepositoryMetaComponentStillValid(final QueryManager qm, final RepositoryType repositoryType, final String namespace, final String name) {
+        boolean isRepositoryMetaComponentStillValid = false;
+        ConfigProperty cacheClearPeriod = qm.getConfigProperty(ConfigPropertyConstants.SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD.getGroupName(), ConfigPropertyConstants.SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD.getPropertyName());
+        long cacheValidityPeriod = Long.parseLong(cacheClearPeriod.getPropertyValue());
+        RepositoryMetaComponent metaComponent = qm.getRepositoryMetaComponent(repositoryType, namespace, name);
+        long delta = 0L;
+        if (metaComponent != null) {
+            final Date now = new Date();
+            if (now.getTime() > metaComponent.getLastCheck().getTime()) {
+                delta = now.getTime() - metaComponent.getLastCheck().getTime();
+                isRepositoryMetaComponentStillValid = delta <= cacheValidityPeriod;
+            }
+        }
+        if (isRepositoryMetaComponentStillValid) {
+            LOGGER.debug("RepositoryMetaComponent has been checked in the last "+cacheValidityPeriod+" ms (precisely "+delta+" ms ago). Skipping analysis. (source: " + repositoryType.name() + " / Namespace: " + namespace + " / Name: " + name + ")");
+        } else {
+            LOGGER.debug("RepositoryMetaComponent has not been checked since "+cacheValidityPeriod+" ms. Analysis should be performed (source: " + repositoryType.name() + " / Namespace: " + namespace + " / Name: " + name + ")");
+        }
+        return isRepositoryMetaComponentStillValid;
+    }
+
+    protected boolean isCacheCurrent(ComponentAnalysisCache cac, String target) {
+        try (QueryManager qm = new QueryManager()) {
+            boolean isCacheCurrent = false;
+            ConfigProperty cacheClearPeriod = qm.getConfigProperty(ConfigPropertyConstants.SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD.getGroupName(), ConfigPropertyConstants.SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD.getPropertyName());
+            long cacheValidityPeriod = Long.parseLong(cacheClearPeriod.getPropertyValue());
+            long delta = 0L;
+            if (cac != null) {
+                final Date now = new Date();
+                if (now.getTime() > cac.getLastOccurrence().getTime()) {
+                    delta = now.getTime() - cac.getLastOccurrence().getTime();
+                    isCacheCurrent = delta <= cacheValidityPeriod;
+                }
+            }
+            if (isCacheCurrent) {
+                LOGGER.debug("Cache is current. External repository call was made in the last "+cacheValidityPeriod+" ms (precisely "+delta+" ms ago). Skipping analysis. (target: " + target + ")");
+            } else {
+                LOGGER.debug("Cache is not current. External repository call was not made in the last "+cacheValidityPeriod+" ms. Analysis should be performed (target: " + target + ")");
+            }
+            return isCacheCurrent;
         }
     }
 }

--- a/src/main/java/org/dependencytrack/tasks/repositories/RepositoryMetaAnalyzerTask.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/RepositoryMetaAnalyzerTask.java
@@ -18,12 +18,16 @@
  */
 package org.dependencytrack.tasks.repositories;
 
+import alpine.Config;
 import alpine.common.logging.Logger;
+import alpine.common.metrics.Metrics;
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
 import alpine.model.ConfigProperty;
 import alpine.security.crypto.DataEncryption;
+import io.micrometer.core.instrument.Timer;
 import org.apache.commons.lang3.StringUtils;
+import org.dependencytrack.common.ConfigKey;
 import org.dependencytrack.event.RepositoryMetaEvent;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentAnalysisCache;
@@ -33,6 +37,8 @@ import org.dependencytrack.model.Repository;
 import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.util.CacheStampedeBlocker;
+import org.dependencytrack.util.PurlUtil;
 
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -42,6 +48,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 public class RepositoryMetaAnalyzerTask implements Subscriber {
 
@@ -51,6 +58,17 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
 
     private static final String PUBLISHED_TIMESTAMP = "publishedTimestamp";
 
+    private static final CacheStampedeBlocker<String, Void> cacheStampedeBlocker;
+
+    static {
+        cacheStampedeBlocker = new CacheStampedeBlocker<>(
+                "repositoryMetaCache",
+                Config.getInstance().getPropertyAsInt(ConfigKey.REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_LOCK_BUCKETS),
+                false,
+                Config.getInstance().getPropertyAsInt(ConfigKey.REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_MAX_ATTEMPTS)
+        );
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -59,10 +77,21 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
         if (e instanceof RepositoryMetaEvent) {
             LOGGER.debug("Analyzing component repository metadata");
             final RepositoryMetaEvent event = (RepositoryMetaEvent)e;
-            if (event.getComponent() != null) {
+            // TODO - Remove when https://github.com/DependencyTrack/dependency-track/issues/2110 is implemented
+            Timer timer = Timer.builder("repository_meta_analyzer_task")
+                    .description("Repository meta analyzer task timer")
+                    .tags("event", event.getClass().getName(), "publisher", this.getClass().getName())
+                    .register(Metrics.getRegistry());
+            Timer.Sample recording = Timer.start();
+            if (event.getComponents().isPresent()) {
                 try (QueryManager qm = new QueryManager()) {
+                    final List<Component> components = event.getComponents().get();
                     // Refreshing the object by querying for it again is preventative
-                    analyze(qm, qm.getObjectById(Component.class, event.getComponent().getId()));
+                    LOGGER.info("Performing component repository metadata analysis against " + components.size() + " components");
+                    for (final Component component: components) {
+                        analyze(qm, qm.getObjectById(Component.class, component.getId()));
+                    }
+                    LOGGER.info("Completed component repository metadata analysis against " + components.size() + " components");
                 }
             } else {
                 try (final QueryManager qm = new QueryManager()) {
@@ -78,6 +107,7 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
                 }
                 LOGGER.info("Portfolio component repository metadata analysis complete");
             }
+            recording.stop(timer);
             LOGGER.debug("Component repository metadata analysis complete");
         }
     }
@@ -89,62 +119,75 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
             // Retrieve existing Component Analysis Cache in one query :- There will be either no cac or cac without "latestVersion" (otherwise a RepositoryMetaModel would have already been created).
             // Caching cac without "latestVersion" allow avoiding performing the same call to repository over and over.
             final Map<String, ComponentAnalysisCache> cacByHost = new HashMap<>();
-            List<ComponentAnalysisCache> cacList = qm.getComponentAnalysisCache(ComponentAnalysisCache.CacheType.REPOSITORY, analyzer.supportedRepositoryType().name(), component.getPurl().toString());
+            List<ComponentAnalysisCache> cacList = qm.getComponentAnalysisCache(ComponentAnalysisCache.CacheType.REPOSITORY, analyzer.supportedRepositoryType().name(), PurlUtil.silentPurlCoordinatesOnly(component.getPurl()).toString());
             if (cacList != null && cacList.size() > 0) {
                 cacList.stream().forEach(cac -> cacByHost.put(cac.getTargetHost(), cac));
             }
-            for (final Repository repository: qm.getAllRepositoriesOrdered(analyzer.supportedRepositoryType())) {
-                // Moved the identification of internal components from the isApplicable() method from the Meta Analyzers
-                // themselves (which was introduced in https://github.com/DependencyTrack/dependency-track/pull/512)
-                // and made a global decision here instead. Internal components should only be analyzed using internal
-                // repositories. Non-internal components should only be analyzed with non-internal repositories. We do not
-                // want non-internal components being analyzed with internal repositories as internal repositories are not
-                // the source of truth for these components, even if the repository acts as a proxy to the source of truth.
-                // This cannot be assumed.
-                if (repository.isEnabled() && ((component.isInternal() && repository.isInternal()) || (!component.isInternal() && !repository.isInternal()))) {
-                    String purl = component.getPurl().toString();
-                    ComponentAnalysisCache cac = cacByHost.get(repository.getUrl());
-                    MetaModel model = new MetaModel(component);
-                    if (cac != null && isCacheCurrent(cac, component.getPurl().toString())) {
-                        LOGGER.debug("Building repository Metamodel from cache for "+purl);
-                        model.setLatestVersion(StringUtils.trimToNull(cac.getResult().getString(LATEST_VERSION)));
-                        model.setPublishedTimestamp(Date.from(Instant.ofEpochMilli(cac.getResult().getJsonNumber(PUBLISHED_TIMESTAMP).longValue())));
-                    } else {
-                        LOGGER.debug("Analyzing component: " + component.getUuid() + " using repository: "
-                                + repository.getIdentifier() + " (" + repository.getType() + ")");
+            Callable<Void> cacheLoader = () -> {
+                for (final Repository repository: qm.getAllRepositoriesOrdered(analyzer.supportedRepositoryType())) {
+                    // Moved the identification of internal components from the isApplicable() method from the Meta Analyzers
+                    // themselves (which was introduced in https://github.com/DependencyTrack/dependency-track/pull/512)
+                    // and made a global decision here instead. Internal components should only be analyzed using internal
+                    // repositories. Non-internal components should only be analyzed with non-internal repositories. We do not
+                    // want non-internal components being analyzed with internal repositories as internal repositories are not
+                    // the source of truth for these components, even if the repository acts as a proxy to the source of truth.
+                    // This cannot be assumed.
+                    if (repository.isEnabled() && ((component.isInternal() && repository.isInternal()) || (!component.isInternal() && !repository.isInternal()))) {
+                        String purl = component.getPurl().toString();
+                        ComponentAnalysisCache cac = cacByHost.get(repository.getUrl());
+                        MetaModel model = new MetaModel(component);
+                        if (cac != null && isCacheCurrent(cac, component.getPurl().toString())) {
+                            LOGGER.debug("Building repository Metamodel from cache for "+purl);
+                            model.setLatestVersion(StringUtils.trimToNull(cac.getResult().getString(LATEST_VERSION)));
+                            model.setPublishedTimestamp(Date.from(Instant.ofEpochMilli(cac.getResult().getJsonNumber(PUBLISHED_TIMESTAMP).longValue())));
+                        } else {
+                            LOGGER.debug("Analyzing component: " + component.getUuid() + " using repository: "
+                                    + repository.getIdentifier() + " (" + repository.getType() + ")");
 
-                        if (repository.isInternal()) {
-                            try {
-                                analyzer.setRepositoryUsernameAndPassword(repository.getUsername(), DataEncryption.decryptAsString(repository.getPassword()));
-                            } catch (Exception e) {
-                                LOGGER.error("Failed decrypting password for repository: " + repository.getIdentifier(), e);
+                            if (repository.isInternal()) {
+                                try {
+                                    analyzer.setRepositoryUsernameAndPassword(repository.getUsername(), DataEncryption.decryptAsString(repository.getPassword()));
+                                } catch (Exception e) {
+                                    LOGGER.error("Failed decrypting password for repository: " + repository.getIdentifier(), e);
+                                }
                             }
+
+                            analyzer.setRepositoryBaseUrl(repository.getUrl());
+                            model = analyzer.analyze(component);
+                            qm.updateComponentAnalysisCache(ComponentAnalysisCache.CacheType.REPOSITORY, repository.getUrl(), repository.getType().name(), PurlUtil.silentPurlCoordinatesOnly(component.getPurl()).toString(), new Date(), buildRepositoryComponentAnalysisCacheResult(model));
                         }
 
-                        analyzer.setRepositoryBaseUrl(repository.getUrl());
-                        model = analyzer.analyze(component);
-                        qm.updateComponentAnalysisCache(ComponentAnalysisCache.CacheType.REPOSITORY, repository.getUrl(), repository.getType().name(), component.getPurl().toString(), new Date(), buildRepositoryComponentAnalysisCacheResult(model));
-                    }
-
-                    if (StringUtils.trimToNull(model.getLatestVersion()) != null) {
-                        // Resolution from repository was successful. Update meta model
-                        final RepositoryMetaComponent metaComponent = new RepositoryMetaComponent();
-                        metaComponent.setRepositoryType(repository.getType());
-                        metaComponent.setNamespace(component.getPurl().getNamespace());
-                        metaComponent.setName(component.getPurl().getName());
-                        metaComponent.setPublished(model.getPublishedTimestamp());
-                        metaComponent.setLatestVersion(model.getLatestVersion());
-                        metaComponent.setLastCheck(new Date());
-                        qm.synchronizeRepositoryMetaComponent(metaComponent);
-                        // Since the component metadata found and captured from this repository, return from this
-                        // method without attempting to query additional repositories.
-                        LOGGER.debug("Found component metadata for: " + component.getUuid() + " using repository: "
+                        if (StringUtils.trimToNull(model.getLatestVersion()) != null) {
+                            // Resolution from repository was successful. Update meta model
+                            final RepositoryMetaComponent metaComponent = new RepositoryMetaComponent();
+                            metaComponent.setRepositoryType(repository.getType());
+                            metaComponent.setNamespace(component.getPurl().getNamespace());
+                            metaComponent.setName(component.getPurl().getName());
+                            metaComponent.setPublished(model.getPublishedTimestamp());
+                            metaComponent.setLatestVersion(model.getLatestVersion());
+                            metaComponent.setLastCheck(new Date());
+                            qm.synchronizeRepositoryMetaComponent(metaComponent);
+                            // Since the component metadata found and captured from this repository, return from this
+                            // method without attempting to query additional repositories.
+                            LOGGER.debug("Found component metadata for: " + component.getUuid() + " using repository: "
+                                    + repository.getIdentifier() + " (" + repository.getType() + ")");
+                            break;
+                        }
+                    } else {
+                        LOGGER.debug("Skipping analysis of component: " + component.getUuid() + " using repository: "
                                 + repository.getIdentifier() + " (" + repository.getType() + ")");
-                        return;
                     }
-                } else {
-                    LOGGER.debug("Skipping analysis of component: " + component.getUuid() + " using repository: "
-                            + repository.getIdentifier() + " (" + repository.getType() + ")");
+                }
+                return null;
+            };
+            boolean cacheStampedeBlockerEnabled = Config.getInstance().getPropertyAsBoolean(ConfigKey.REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_ENABLED);
+            if(cacheStampedeBlockerEnabled) {
+                cacheStampedeBlocker.readThroughOrPopulateCache(PurlUtil.silentPurlCoordinatesOnly(component.getPurl()).toString(), cacheLoader);
+            } else {
+                try {
+                    cacheLoader.call();
+                } catch (Exception e) {
+                    LOGGER.error("Error while fetching component meta model for component(id="+component.getId()+"; purl="+component.getPurl()+") : "+e.getMessage());
                 }
             }
         }
@@ -153,8 +196,9 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
     private JsonObject buildRepositoryComponentAnalysisCacheResult(MetaModel model) {
         JsonObjectBuilder builder = Json.createObjectBuilder();
         String latestVersion = model.getLatestVersion() != null ? model.getLatestVersion() : "";
+        Long published = model.getPublishedTimestamp() != null ? model.getPublishedTimestamp().getTime() : 0L;
         builder.add(LATEST_VERSION, Json.createValue(latestVersion));
-        builder.add(PUBLISHED_TIMESTAMP, Json.createValue(model.getPublishedTimestamp().getTime()));
+        builder.add(PUBLISHED_TIMESTAMP, Json.createValue(published));
         return builder.build();
     }
 

--- a/src/main/java/org/dependencytrack/upgrade/UpgradeItems.java
+++ b/src/main/java/org/dependencytrack/upgrade/UpgradeItems.java
@@ -19,7 +19,6 @@
 package org.dependencytrack.upgrade;
 
 import alpine.server.upgrade.UpgradeItem;
-import org.dependencytrack.upgrade.v470.v470Updater;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +33,7 @@ class UpgradeItems {
         UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v440.v440Updater.class);
         UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v450.v450Updater.class);
         UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v460.v460Updater.class);
+        UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v463.v463Updater.class);
         UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v470.v470Updater.class);
     }
 

--- a/src/main/java/org/dependencytrack/upgrade/UpgradeItems.java
+++ b/src/main/java/org/dependencytrack/upgrade/UpgradeItems.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.upgrade;
 
 import alpine.server.upgrade.UpgradeItem;
+import org.dependencytrack.upgrade.v470.v470Updater;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +34,7 @@ class UpgradeItems {
         UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v440.v440Updater.class);
         UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v450.v450Updater.class);
         UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v460.v460Updater.class);
-        UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v463.v463Updater.class);
+        UPGRADE_ITEMS.add(org.dependencytrack.upgrade.v470.v470Updater.class);
     }
 
     static List<Class<? extends UpgradeItem>> getUpgradeItems() {

--- a/src/main/java/org/dependencytrack/upgrade/v463/v463Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v463/v463Updater.java
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) Steve Springett. All Rights Reserved.
  */
-package org.dependencytrack.upgrade.v470;
+package org.dependencytrack.upgrade.v463;
 
 import alpine.common.logging.Logger;
 import alpine.persistence.AlpineQueryManager;
@@ -25,27 +25,27 @@ import alpine.server.upgrade.AbstractUpgradeItem;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 
-import static org.dependencytrack.model.ConfigPropertyConstants.TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_CADENCE;
+import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD;
 
-public class v470Updater extends AbstractUpgradeItem {
+public class v463Updater extends AbstractUpgradeItem {
 
-    private static final Logger LOGGER = Logger.getLogger(v470Updater.class);
+    private static final Logger LOGGER = Logger.getLogger(v463Updater.class);
 
     @Override
     public String getSchemaVersion() {
-        return "4.7.0";
+        return "4.6.3";
     }
 
     @Override
     public void executeUpgrade(final AlpineQueryManager qm, final Connection connection) throws Exception {
-        LOGGER.info("Setting component analysis cache clear cadence to 24H");
+        LOGGER.info("Resetting scanner cache validity period to 12h");
         final PreparedStatement ps = connection.prepareStatement("""
                 UPDATE "CONFIGPROPERTY" SET "PROPERTYVALUE" = ?
                 WHERE "GROUPNAME" = ? AND "PROPERTYNAME" = ?
                 """);
-        ps.setString(1, TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_CADENCE.getDefaultPropertyValue());
-        ps.setString(2, TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_CADENCE.getGroupName());
-        ps.setString(3, TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_CADENCE.getPropertyName());
+        ps.setString(1, SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD.getDefaultPropertyValue());
+        ps.setString(2, SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD.getGroupName());
+        ps.setString(3, SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD.getPropertyName());
         ps.executeUpdate();
     }
 

--- a/src/main/java/org/dependencytrack/upgrade/v470/v470Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v470/v470Updater.java
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) Steve Springett. All Rights Reserved.
  */
-package org.dependencytrack.upgrade.v463;
+package org.dependencytrack.upgrade.v470;
 
 import alpine.common.logging.Logger;
 import alpine.persistence.AlpineQueryManager;
@@ -27,9 +27,9 @@ import java.sql.PreparedStatement;
 
 import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD;
 
-public class v463Updater extends AbstractUpgradeItem {
+public class v470Updater extends AbstractUpgradeItem {
 
-    private static final Logger LOGGER = Logger.getLogger(v463Updater.class);
+    private static final Logger LOGGER = Logger.getLogger(v470Updater.class);
 
     @Override
     public String getSchemaVersion() {

--- a/src/main/java/org/dependencytrack/util/CacheStampedeBlocker.java
+++ b/src/main/java/org/dependencytrack/util/CacheStampedeBlocker.java
@@ -1,0 +1,260 @@
+package org.dependencytrack.util;
+
+import alpine.common.logging.Logger;
+import alpine.common.metrics.Metrics;
+import com.google.common.util.concurrent.Striped;
+import io.github.resilience4j.core.IntervalFunction;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import io.github.resilience4j.retry.RetryRegistry;
+import io.micrometer.core.instrument.Counter;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.locks.ReadWriteLock;
+
+/**
+ * The purpose of this class is to prevent so called Cache-Stampede (see https://en.wikipedia.org/wiki/Cache_stampede).
+ * It uses a partitioned read write lock to detect all threads trying to populate the cache for a given key, let a single key perform the computation and return the result for all threads.
+ *
+ * This stampede blocker allow configuring :
+ *
+ * - The number of partitions used by the striped lock to handle various degree of parallel workloads
+ * - The waiting behavior of competing threads. In case, the loader directly populate the cache and returns no value, there is no need for competing threads to wait
+ * - The number of retries to perform in case of any exception during cache loader execution
+ *
+ * @param <K>
+ *          Key type
+ *
+ * @param <V>
+ *          Value type
+ */
+public class CacheStampedeBlocker<K, V> {
+
+    /**
+     * Default TTL for cache loader entries.
+     */
+    private static final long DEFAULT_CACHE_LOADER_ENTRY_TTL_MS = Duration.ofMinutes(10).toMillis();
+
+    /**
+     * Maximum duration for retries.
+     */
+    private static final long MAX_RETRY_DURATION_MS = Duration.ofMinutes(10).toMillis();
+
+    /**
+     * Maximum number of retries.
+     */
+    private static final int MAX_RETRY_NUMBER = 3;
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(CacheStampedeBlocker.class);
+
+    /**
+     * Cache name.
+     */
+    private String cacheName;
+
+    /**
+     * Striped lock to have a fine-grain lock to reduce contention created by competing threads.
+     */
+    private Striped<ReadWriteLock> stripedLock;
+
+    /**
+     * Cache loaders map.
+     */
+    private Map<K, ExpirableCompletableFuture<V>> cacheLoaders;
+
+    /**
+     * Cache Loader entry TTL.
+     */
+    private long cacheLoaderEntryTTL;
+
+    /**
+     * Flag to block competing threads if computation is ongoing.
+     *  False is helpful for loaders returning no value. As long as a thread pass through, there is no need for competing threads to wait.
+     *  True is helpful for loaders returning a value.
+     */
+    private boolean blockCompetingThreads;
+
+    /**
+     * Maximum number of retry.
+     */
+    private int nbRetryMax;
+
+    /**
+     * Retry instance.
+     */
+    private Retry retry;
+
+    /**
+     * Timer instance.
+     */
+    private Timer timer = new Timer();
+
+    public CacheStampedeBlocker(String cacheName, int nbBuckets, boolean blockCompetingThreads) {
+        this(cacheName, nbBuckets, blockCompetingThreads, MAX_RETRY_NUMBER, DEFAULT_CACHE_LOADER_ENTRY_TTL_MS);
+    }
+
+
+    public CacheStampedeBlocker(String cacheName, int nbBuckets, boolean blockCompetingThreads, int nbRetryMax) {
+        this(cacheName, nbBuckets, blockCompetingThreads, nbRetryMax, DEFAULT_CACHE_LOADER_ENTRY_TTL_MS);
+    }
+
+    public CacheStampedeBlocker(String cacheName, int nbBuckets, boolean blockCompetingThreads, int nbRetryMax, long cacheLoaderEntryTTL) {
+        LOGGER.debug("Striped Lock is configured with "+nbBuckets+" buckets");
+        this.cacheName = cacheName;
+        stripedLock = Striped.lazyWeakReadWriteLock(nbBuckets);
+        cacheLoaders = new ConcurrentHashMap<>();
+        this.blockCompetingThreads = blockCompetingThreads;
+        this.nbRetryMax = nbRetryMax;
+        IntervalFunction intervalWithCustomExponentialBackoff = IntervalFunction
+                .ofExponentialBackoff(IntervalFunction.DEFAULT_INITIAL_INTERVAL, 2d, MAX_RETRY_DURATION_MS);
+        RetryConfig config = RetryConfig.custom()
+                .maxAttempts(this.nbRetryMax)
+                .intervalFunction(intervalWithCustomExponentialBackoff)
+                .failAfterMaxAttempts(true)
+                .build();
+        RetryRegistry registry = RetryRegistry.of(config);
+        retry = registry.retry("cacheStampedeBlocker");
+        this.cacheLoaderEntryTTL = cacheLoaderEntryTTL;
+        timer.schedule(
+                new TimerTask() {
+                    @Override
+                    public void run() {
+                        cleanupExpirableFutureMap();
+                    }
+                },
+                600_000,
+                600_000
+        );
+    }
+
+    /**
+     * Read through/Populate the cache.
+     *
+     * @param key
+     *          Cache key
+     *
+     * @param cacheLoader
+     *          Callable to read through/populate the cache
+     *
+     * @return An optional containing the computed value or Optional.empty in case of any non transient exception
+     */
+    public Optional<V> readThroughOrPopulateCache(K key, Callable<V> cacheLoader) {
+        LOGGER.debug("Trying to read through/populate cache "+cacheName+" for key "+key);
+        ReadWriteLock rwLock = stripedLock.get(key);
+        ExpirableCompletableFuture<V> cachePopulationFuture = null;
+
+        LOGGER.debug("Acquiring readLock for cache "+cacheName+" and key "+key);
+        rwLock.readLock().lock();
+        LOGGER.debug("ReadLock acquired for cache "+cacheName+" and key "+key);
+        cachePopulationFuture = cacheLoaders.get(key);
+        rwLock.readLock().unlock();
+
+        if (cachePopulationFuture == null || (System.currentTimeMillis() - cachePopulationFuture.getTimestamp()) > cacheLoaderEntryTTL) {
+            LOGGER.debug("No ongoing population for cache "+cacheName+" and key "+key+" or entry has expired ! Trying to acquire writeLock");
+            boolean locked = true;
+            try {
+                rwLock.writeLock().lock();
+                LOGGER.debug("WriteLock acquired for cache "+cacheName+" and key "+key);
+                cachePopulationFuture = cacheLoaders.get(key);
+                if(cachePopulationFuture == null) {
+                    LOGGER.debug("Populating cache "+cacheName+" for key "+key+" and returning value");
+                    cachePopulationFuture = new ExpirableCompletableFuture(System.currentTimeMillis(), new CompletableFuture<V>());
+                    cacheLoaders.put(key, cachePopulationFuture);
+                    rwLock.writeLock().unlock();
+                    locked = false;
+                    V result = retry.executeCallable(cacheLoader);
+                    cachePopulationFuture.getFuture().complete(result);
+                    Counter.builder("cache_stampede_blocker_load")
+                            .description("Total number of load event")
+                            .tags("cache", cacheName)
+                            .register(Metrics.getRegistry())
+                            .increment();
+                    // The completable future is not directly removed to account for the threads that detected that the cache
+                    // should be (re)loaded but will be scheduled a bit later. We don't want them to go through the locking-loading phase again.
+                    // Cleanup will be done by a dedicated thread
+                    return Optional.ofNullable(result);
+                }
+            } catch (Exception e) {
+                LOGGER.error("An error occurred while populating cache "+cacheName+" for key "+key+" : "+e.getMessage());
+                if (cachePopulationFuture != null && !cachePopulationFuture.future.isDone()) {
+                    cachePopulationFuture.getFuture().completeExceptionally(e);
+                    cacheLoaders.remove(key);
+                }
+                return Optional.empty();
+            } finally {
+                if(locked) {
+                    rwLock.writeLock().unlock();
+                }
+            }
+        }
+
+        if (cachePopulationFuture != null && blockCompetingThreads) {
+            LOGGER.debug("Cache "+cacheName+" population is ongoing or already finished for key "+key+" - Waiting patiently completion to return the value");
+            Counter.builder("cache_stampede_blocker_wait")
+                    .description("Total number of wait event")
+                    .tags("cache", cacheName)
+                    .register(Metrics.getRegistry())
+                    .increment();
+            try {
+                return Optional.ofNullable(cachePopulationFuture.getFuture().get());
+            } catch (InterruptedException| ExecutionException e) {
+                LOGGER.error("An error occurred while populating cache "+cacheName+" for key "+key+" : "+e.getMessage());
+                return Optional.empty();
+            }
+        } else {
+            LOGGER.debug("Cache "+cacheName+" population is ongoing or already finished for key "+key+" and stampede blocker configured to return immediately in this situation");
+            return Optional.empty();
+        }
+    }
+
+    public void cleanupExpirableFutureMap() {
+        LOGGER.debug("Starting to cleanup "+cacheName+"'s loader map");
+        List<K> keysToDelete =  cacheLoaders.entrySet().stream()
+                .filter(entry -> (System.currentTimeMillis() - entry.getValue().getTimestamp()) > cacheLoaderEntryTTL)
+                .map(entry -> entry.getKey())
+                .toList();
+        keysToDelete.forEach(key -> cacheLoaders.remove(key));
+        LOGGER.debug("Cleanup of "+cacheName+"'s loader map finished");
+    }
+
+    class ExpirableCompletableFuture<V> {
+
+        private Long timestamp;
+
+        private CompletableFuture<V> future;
+
+        public ExpirableCompletableFuture(Long timestamp, CompletableFuture<V> future) {
+            this.timestamp = timestamp;
+            this.future = future;
+        }
+
+        public Long getTimestamp() {
+            return timestamp;
+        }
+
+        public void setTimestamp(Long timestamp) {
+            this.timestamp = timestamp;
+        }
+
+        public CompletableFuture<V> getFuture() {
+            return future;
+        }
+
+        public void setFuture(CompletableFuture<V> future) {
+            this.future = future;
+        }
+    }
+
+}

--- a/src/main/java/org/dependencytrack/util/CacheStampedeBlocker.java
+++ b/src/main/java/org/dependencytrack/util/CacheStampedeBlocker.java
@@ -62,44 +62,44 @@ public class CacheStampedeBlocker<K, V> {
     /**
      * Cache name.
      */
-    private String cacheName;
+    private final String cacheName;
 
     /**
      * Striped lock to have a fine-grain lock to reduce contention created by competing threads.
      */
-    private Striped<ReadWriteLock> stripedLock;
+    private final Striped<ReadWriteLock> stripedLock;
 
     /**
      * Cache loaders map.
      */
-    private Map<K, ExpirableCompletableFuture<V>> cacheLoaders;
+    private final Map<K, ExpirableCompletableFuture<V>> cacheLoaders;
 
     /**
      * Cache Loader entry TTL.
      */
-    private long cacheLoaderEntryTTL;
+    private final long cacheLoaderEntryTTL;
 
     /**
      * Flag to block competing threads if computation is ongoing.
      *  False is helpful for loaders returning no value. As long as a thread pass through, there is no need for competing threads to wait.
      *  True is helpful for loaders returning a value.
      */
-    private boolean blockCompetingThreads;
+    private final boolean blockCompetingThreads;
 
     /**
      * Maximum number of retry.
      */
-    private int nbRetryMax;
+    private final int nbRetryMax;
 
     /**
      * Retry instance.
      */
-    private Retry retry;
+    private final Retry retry;
 
     /**
      * Timer instance.
      */
-    private Timer timer = new Timer();
+    private final Timer timer;
 
     public CacheStampedeBlocker(String cacheName, int nbBuckets, boolean blockCompetingThreads) {
         this(cacheName, nbBuckets, blockCompetingThreads, MAX_RETRY_NUMBER, DEFAULT_CACHE_LOADER_ENTRY_TTL_MS);
@@ -127,7 +127,8 @@ public class CacheStampedeBlocker<K, V> {
         RetryRegistry registry = RetryRegistry.of(config);
         retry = registry.retry("cacheStampedeBlocker");
         this.cacheLoaderEntryTTL = cacheLoaderEntryTTL;
-        timer.schedule(
+        this.timer = new Timer(cacheName);
+        this.timer.schedule(
                 new TimerTask() {
                     @Override
                     public void run() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -364,12 +364,15 @@ ossindex.retry.backoff.max.duration=600000
 # Optional
 #This flag activate the cache stampede blocker for the repository meta analyzer allowing to handle high concurrency workloads when there
 #is a high ratio of duplicate components which can cause unnecessary external calls and index violation on PUBLIC.REPOSITORY_META_COMPONENT_COMPOUND_IDX during cache population.
-# The default value is false as enabling the cache stampede blocker can create useless locking if the portfolio does not have a high ratio of duplicate components.
-repo.meta.analyzer.cacheStampedeBlocker.enabled=false
+# The default value is true.
+repo.meta.analyzer.cacheStampedeBlocker.enabled=true
 
 # Optional
 #The cache stampede blocker use a striped (partitioned) lock to distribute locks across keys.
 #This parameter defines the number of bucket used by the striped lock. The lock used for a given key is derived from the key hashcode and number of buckets.
+#This value should be set according to your portfolio profile (i.e. number of projects and proportion of duplicates).
+#Too few buckets and an unbalanced portfolio (i.e. high number of purl going to the same partition) can lead to forced serialization
+#Too much buckets can lead to unnecessary memory usage. Note that the memory footprint of Striped Lock is 32 * (nbOfBuckets * 1) Bytes.
 # The default value is 1000.
 repo.meta.analyzer.cacheStampedeBlocker.lock.buckets=1000
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -361,3 +361,20 @@ ossindex.retry.backoff.multiplier=2
 # The default value is 10 minutes.
 ossindex.retry.backoff.max.duration=600000
 
+# Optional
+#This flag activate the cache stampede blocker for the repository meta analyzer allowing to handle high concurrency workloads when there
+#is a high ratio of duplicate components which can cause unnecessary external calls and index violation on PUBLIC.REPOSITORY_META_COMPONENT_COMPOUND_IDX during cache population.
+# The default value is false as enabling the cache stampede blocker can create useless locking if the portfolio does not have a high ratio of duplicate components.
+repo.meta.analyzer.cacheStampedeBlocker.enabled=false
+
+# Optional
+#The cache stampede blocker use a striped (partitioned) lock to distribute locks across keys.
+#This parameter defines the number of bucket used by the striped lock. The lock used for a given key is derived from the key hashcode and number of buckets.
+# The default value is 1000.
+repo.meta.analyzer.cacheStampedeBlocker.lock.buckets=1000
+
+# Optional
+#Defines the maximum number of attempts used by Resilience4J for exponential backoff retry regarding repo meta analyzer cache loading per key.
+# The default value is 10.
+repo.meta.analyzer.cacheStampedeBlocker.max.attempts=10
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -373,7 +373,8 @@ repo.meta.analyzer.cacheStampedeBlocker.enabled=true
 #This value should be set according to your portfolio profile (i.e. number of projects and proportion of duplicates).
 #Too few buckets and an unbalanced portfolio (i.e. high number of purl going to the same partition) can lead to forced serialization
 #Too much buckets can lead to unnecessary memory usage. Note that the memory footprint of Striped Lock is 32 * (nbOfBuckets * 1) Bytes.
-# The default value is 1000.
+#A value between 1_000 (~32 KB) and 1_000_000 (~32 MB) seems reasonable.
+# The default value is 1000 (~32KB).
 repo.meta.analyzer.cacheStampedeBlocker.lock.buckets=1000
 
 # Optional

--- a/src/test/java/org/dependencytrack/event/RepositoryMetaEventTest.java
+++ b/src/test/java/org/dependencytrack/event/RepositoryMetaEventTest.java
@@ -22,18 +22,25 @@ import org.dependencytrack.model.Component;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
 public class RepositoryMetaEventTest {
 
     @Test
     public void testDefaultConstructor() {
         RepositoryMetaEvent event = new RepositoryMetaEvent();
-        Assert.assertNull(event.getComponent());
+        Assert.assertEquals(Optional.empty(), event.getComponents());
     }
 
     @Test
     public void testComponentConstructor() {
+        List<Component> components = new LinkedList<>();
         Component component = new Component();
-        RepositoryMetaEvent event = new RepositoryMetaEvent(component);
-        Assert.assertEquals(component, event.getComponent());
+        components.add(component);
+        RepositoryMetaEvent event = new RepositoryMetaEvent(components);
+        Assert.assertEquals(components, event.getComponents().get());
     }
 }

--- a/src/test/java/org/dependencytrack/util/CacheStampedeBlockerTest.java
+++ b/src/test/java/org/dependencytrack/util/CacheStampedeBlockerTest.java
@@ -1,0 +1,75 @@
+package org.dependencytrack.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class CacheStampedeBlockerTest {
+
+    @Test
+    public void highConcurrencyScenarioWithSuccessfulCallable() throws ExecutionException, InterruptedException {
+        // Arrange
+        ExecutorService service = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 2);
+        CacheStampedeBlocker<String, Integer> cacheStampedeBlocker = new CacheStampedeBlocker<>("testCache", 10, true);
+        Map<String, Integer> cache = new HashMap<>();
+        for (int i = 0; i < 10; i++) {
+            // Populating a "cache" with initial value
+            cache.put("key-"+(i%10), 0);
+        }
+        List<Future<Optional<Integer>>> results = new ArrayList<>();
+
+        // Act
+        // 100 threads competing to update the cache for 10 distinct keys (10 threads / key). Only one should be able to increment the value.
+        for (int i = 0; i < 10_000; i++) {
+            final String key = "key-"+(i%10);
+            results.add(service.submit(() -> cacheStampedeBlocker.readThroughOrPopulateCache(key, () -> {
+                Thread.sleep(300);
+                cache.put(key,cache.get(key).intValue()+1);
+                return cache.get(key);
+            })));
+        }
+
+        // Assert
+        for (int i = 0; i < 10_000; i++) {
+            Optional<Integer> result = results.get(i).get();
+            Assert.assertTrue(result.isPresent());
+            Assert.assertEquals("Iteration "+i+" failed", Integer.valueOf(1), result.get());
+        }
+    }
+
+    @Test
+    public void highConcurrencyScenarioWithErroneousCallable() throws ExecutionException, InterruptedException {
+        // Arrange
+        ExecutorService service = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 2);
+        CacheStampedeBlocker<String, Integer> cacheStampedeBlocker = new CacheStampedeBlocker<>("testCache", 10, true);
+        Map<String, Integer> cache = new HashMap<>();
+        for (int i = 0; i < 10; i++) {
+            cache.put("key-"+(i%10), 0);
+        }
+        List<Future<Optional<Integer>>> results = new ArrayList<>();
+
+        // Act
+        for (int i = 0; i < 100; i++) {
+            final String key = "key-"+(i%10);
+            results.add(service.submit(() -> cacheStampedeBlocker.readThroughOrPopulateCache(key, () -> {
+                Thread.sleep(300);
+                throw new RuntimeException("test");
+            })));
+        }
+
+        // Assert
+        for (int i = 0; i < 100; i++) {
+            Optional<Integer> result = results.get(i).get();
+            Assert.assertTrue(result.isEmpty());
+        }
+    }
+}


### PR DESCRIPTION
Leverage the `COMPONENTANALYSISCACHE` table already used by vulnerability analyzers (See #1943)

## Done so far

- If a `RepositoryMetaComponent` entry exists for the current component and has been created in the last `scanner.analysis.cache.validity.period` (check performed using the `LAST_CHECK` column), the analysis is skipped
- For every repository, if there is an entry for the current `purl` in the  `COMPONENTANALYSISCACHE` table younger than `scanner.analysis.cache.validity.period`, the meta model built from the external call result is reused
-  For every repository, if there is an entry for the current `purl` in the  `COMPONENTANALYSISCACHE` table older than `scanner.analysis.cache.validity.period` or no entry, an external call is made and the `COMPONENTANALYSISCACHE` table is updated
- Even though caching is implemented, I resumed some modifications initiated in (#1772) : A single `RepositoryMetaEvent` with a list of components is created upon BOM upload
- Component Analysis Cache was fired 10s after startup and cleared all of the cache ignoring TTL : Cache clearing now takes into account TTL defined by `SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD`. There will be a conflict with #2123 regarding database update
- Implement a [Cache Stampede](https://en.wikipedia.org/wiki/Cache_stampede) solution to handle high concurrency use cases using [Guava Striped Lock](https://guava.dev/releases/19.0/api/docs/com/google/common/util/concurrent/Striped.html)

### Cache stampede

The idea is to provide an opt-in solution for high concurrency workloads using a sharded lock to avoid high friction.
If a Thread is loading the value for a given key and another thread jumps in, the second thread either return immediately (if the return value is not needed) or wait for the first thread to finish and provide the result of the computation. 
Following implementation goals were followed :

- Make it generic as possible to make it reusable for other use cases
- Make it configurable so that it can be adjusted to different use cases
- Disabled by default as it would not be beneficial for portfolio without a high ratio of duplicates. Enabling it would be a sin of commission not a sin of omission
- Make it observable : Counters for load/wait situation are exposed

## Metrics 

### Test context

Personal workstation : 8 CPU - 16 GB
Database : H2
Portfolio : 50 duplicates projects with 1174 components  and 702 duplicates each
SBOM are updated at once

**Improvements on CPU is not noticeable but the time taken but the `RepoMetaAnalyzerTask` is drastically reduced**

### Before

![metrics_monitoring](https://user-images.githubusercontent.com/6144741/201687295-839e663b-d6d6-435c-8dde-cf15cc21a3c2.png)
![timer](https://user-images.githubusercontent.com/6144741/201687299-278e872d-30b1-4461-b71e-0bd3c11937e3.png)

### After

![timer](https://user-images.githubusercontent.com/6144741/201687753-564672b6-fbea-446f-b3e1-5b3caf5229d5.png)
![metrics_monitoring](https://user-images.githubusercontent.com/6144741/201687756-944600d4-35ed-4d98-937f-aad98e3dd2b6.png)

Signed-off-by: Alioune SY <sy_alioune@yahoo.fr>