### PR TITLE
Support AuthN and AuthZ disabled

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
@@ -23,7 +23,6 @@ import alpine.common.util.BooleanUtil;
 import alpine.common.util.UuidUtil;
 import alpine.model.IConfigProperty;
 import alpine.security.crypto.DataEncryption;
-import alpine.server.resources.AlpineResource;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.persistence.QueryManager;
 
@@ -32,7 +31,7 @@ import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-abstract class AbstractConfigPropertyResource extends AlpineResource {
+abstract class AbstractConfigPropertyResource extends ExtendedAlpineResource {
 
     private final Logger LOGGER = Logger.getLogger(this.getClass()); // Use the classes that extend this, not this class itself
     static final String ENCRYPTED_PLACEHOLDER = "HiddenDecryptedPropertyPlaceholder";

--- a/src/main/java/org/dependencytrack/resources/v1/AccessControlResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AccessControlResource.java
@@ -23,7 +23,6 @@ import alpine.model.ConfigProperty;
 import alpine.model.Team;
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -57,7 +56,7 @@ import java.util.List;
  */
 @Path("/v1/acl")
 @Api(value = "acl", authorizations = @Authorization(value = "X-Api-Key"))
-public class AccessControlResource extends AlpineResource {
+public class AccessControlResource extends ExtendedAlpineResource {
 
     private static final Logger LOGGER = Logger.getLogger(AccessControlResource.class);
 

--- a/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
@@ -25,7 +25,6 @@ import alpine.model.ManagedUser;
 import alpine.model.OidcUser;
 import alpine.model.UserPrincipal;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -62,7 +61,7 @@ import javax.ws.rs.core.Response;
  */
 @Path("/v1/analysis")
 @Api(value = "analysis", authorizations = @Authorization(value = "X-Api-Key"))
-public class AnalysisResource extends AlpineResource {
+public class AnalysisResource extends ExtendedAlpineResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/dependencytrack/resources/v1/BadgeResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BadgeResource.java
@@ -21,7 +21,6 @@ package org.dependencytrack.resources.v1;
 import alpine.common.util.BooleanUtil;
 import alpine.model.ConfigProperty;
 import alpine.server.auth.AuthenticationNotRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -48,7 +47,7 @@ import static org.dependencytrack.model.ConfigPropertyConstants.GENERAL_BADGE_EN
  */
 @Path("/v1/badge")
 @Api(value = "badge")
-public class BadgeResource extends AlpineResource {
+public class BadgeResource extends ExtendedAlpineResource {
 
     private static final String SVG_MEDIA_TYPE = "image/svg+xml";
 

--- a/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -23,7 +23,6 @@ import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
 import alpine.model.ManagedUser;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -75,47 +74,9 @@ import java.util.UUID;
  */
 @Path("/v1/bom")
 @Api(value = "bom", authorizations = @Authorization(value = "X-Api-Key"))
-public class BomResource extends AlpineResource {
+public class BomResource extends ExtendedAlpineResource {
 
     private static final Logger LOGGER = Logger.getLogger(BomResource.class);
-
-    /**
-     * Returns the principal for who initiated the request.  If
-     * ALPINE_ENFORCE_AUTHENTICATION is disabled then the admin ManagedUser is
-     * returned.
-     * @return a Principal object
-     * @see alpine.model.ApiKey
-     * @see alpine.model.LdapUser
-     * @see alpine.model.ManagedUser
-     */
-    @Override
-    protected Principal getPrincipal() {
-        if (!Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.ENFORCE_AUTHENTICATION)) {
-            // Authentication is not enabled, try returning admin principal
-            try (QueryManager qm = new QueryManager()) {
-                final ManagedUser user = qm.getManagedUser("admin");
-                if (user != null) {
-                    return (Principal) user;
-                }
-            }
-        }
-        return super.getPrincipal();
-    }
-
-    /**
-     * Convenience method that returns true if the principal has the specified permission,
-     * or false if not.  If ALPINE_ENFORCE_AUTHENTICATION is disabled then the
-     * true will always be returned.
-     * @param permission the permission to check
-     * @return true if principal has permission assigned, false if not
-     */
-    @Override
-    protected boolean hasPermission(final String permission) {
-        if (!Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.ENFORCE_AUTHENTICATION)) {
-            return true;
-        }
-        return super.hasPermission(permission);
-    }
 
     @GET
     @Path("/cyclonedx/project/{uuid}")

--- a/src/main/java/org/dependencytrack/resources/v1/CalculatorResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/CalculatorResource.java
@@ -18,7 +18,6 @@
  */
 package org.dependencytrack.resources.v1;
 
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -43,7 +42,7 @@ import javax.ws.rs.core.Response;
  */
 @Path("/v1/calculator")
 @Api(value = "calculator", authorizations = @Authorization(value = "X-Api-Key"))
-public class CalculatorResource extends AlpineResource {
+public class CalculatorResource extends ExtendedAlpineResource {
 
     @GET
     @Path("/cvss")

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -21,7 +21,6 @@ package org.dependencytrack.resources.v1;
 import alpine.event.framework.Event;
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import io.swagger.annotations.Api;
@@ -64,7 +63,7 @@ import javax.ws.rs.core.Response;
  */
 @Path("/v1/component")
 @Api(value = "component", authorizations = @Authorization(value = "X-Api-Key"))
-public class ComponentResource extends AlpineResource {
+public class ComponentResource extends ExtendedAlpineResource {
 
     @GET
     @Path("/project/{uuid}")

--- a/src/main/java/org/dependencytrack/resources/v1/CweResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/CweResource.java
@@ -19,7 +19,6 @@
 package org.dependencytrack.resources.v1;
 
 import alpine.persistence.PaginatedResult;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -45,7 +44,7 @@ import javax.ws.rs.core.Response;
  */
 @Path("/v1/cwe")
 @Api(value = "cwe", authorizations = @Authorization(value = "X-Api-Key"))
-public class CweResource extends AlpineResource {
+public class CweResource extends ExtendedAlpineResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/dependencytrack/resources/v1/ExtendedAlpineResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ExtendedAlpineResource.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Sam Gleske. All Rights Reserved.
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1;
+
+import alpine.Config;
+import alpine.model.ManagedUser;
+import alpine.server.resources.AlpineResource;
+import java.security.Principal;
+import org.dependencytrack.persistence.QueryManager;
+
+/**
+ * An extension of AlpineResource that provides all of the same features but for
+ * Dependency-Track also enables disabled authentication and authorization from
+ * Alpine.  Anonymous is treated the same as admin user or Administrators team.
+ * @since 4.7.0
+ */
+public abstract class ExtendedAlpineResource extends AlpineResource {
+    /**
+     * Returns the principal for who initiated the request.  If
+     * ALPINE_ENFORCE_AUTHENTICATION is disabled then the admin ManagedUser is
+     * returned.
+     * @return a Principal object
+     * @see alpine.model.ApiKey
+     * @see alpine.model.LdapUser
+     * @see alpine.model.ManagedUser
+     */
+    @Override
+    protected Principal getPrincipal() {
+        if (Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.ENFORCE_AUTHENTICATION)) {
+            // Authentication is not enabled, try returning admin principal
+            try (QueryManager qm = new QueryManager()) {
+                final ManagedUser user = qm.getManagedUser("admin");
+                if (user != null) {
+                    return (Principal) user;
+                }
+            }
+        }
+        return super.getPrincipal();
+    }
+
+    /**
+     * Convenience method that returns true if the principal has the specified permission,
+     * or false if not.  If ALPINE_ENFORCE_AUTHENTICATION is disabled then the
+     * true will always be returned.
+     * @param permission the permission to check
+     * @return true if principal has permission assigned, false if not
+     */
+    @Override
+    protected boolean hasPermission(final String permission) {
+        if (!Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.ENFORCE_AUTHENTICATION)) {
+            return true;
+        }
+        return super.hasPermission(permission);
+    }
+}

--- a/src/main/java/org/dependencytrack/resources/v1/ExtendedAlpineResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ExtendedAlpineResource.java
@@ -43,7 +43,7 @@ public abstract class ExtendedAlpineResource extends AlpineResource {
      */
     @Override
     protected Principal getPrincipal() {
-        if (Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.ENFORCE_AUTHENTICATION)) {
+        if (!Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.ENFORCE_AUTHENTICATION)) {
             // Authentication is not enabled, try returning admin principal
             try (QueryManager qm = new QueryManager()) {
                 final ManagedUser user = qm.getManagedUser("admin");

--- a/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
@@ -21,7 +21,6 @@ package org.dependencytrack.resources.v1;
 import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -60,7 +59,7 @@ import java.util.stream.Collectors;
  */
 @Path("/v1/finding")
 @Api(value = "finding", authorizations = @Authorization(value = "X-Api-Key"))
-public class FindingResource extends AlpineResource {
+public class FindingResource extends ExtendedAlpineResource {
 
     private static final Logger LOGGER = Logger.getLogger(FindingResource.class);
 

--- a/src/main/java/org/dependencytrack/resources/v1/LdapResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/LdapResource.java
@@ -24,7 +24,6 @@ import alpine.model.Team;
 import alpine.server.auth.LdapConnectionWrapper;
 import alpine.server.auth.PermissionRequired;
 import alpine.server.cache.CacheManager;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -60,7 +59,7 @@ import java.util.stream.Collectors;
  */
 @Path("/v1/ldap")
 @Api(value = "ldap", authorizations = @Authorization(value = "X-Api-Key"))
-public class LdapResource extends AlpineResource {
+public class LdapResource extends ExtendedAlpineResource {
 
     private static final Logger LOGGER = Logger.getLogger(LdapResource.class);
 

--- a/src/main/java/org/dependencytrack/resources/v1/LicenseGroupResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/LicenseGroupResource.java
@@ -20,7 +20,6 @@ package org.dependencytrack.resources.v1;
 
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -55,7 +54,7 @@ import java.util.List;
  */
 @Path("/v1/licenseGroup")
 @Api(value = "licenseGroup", authorizations = @Authorization(value = "X-Api-Key"))
-public class LicenseGroupResource extends AlpineResource {
+public class LicenseGroupResource extends ExtendedAlpineResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/dependencytrack/resources/v1/LicenseResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/LicenseResource.java
@@ -20,7 +20,6 @@ package org.dependencytrack.resources.v1;
 
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -52,7 +51,7 @@ import alpine.common.logging.Logger;
  */
 @Path("/v1/license")
 @Api(value = "license", authorizations = @Authorization(value = "X-Api-Key"))
-public class LicenseResource extends AlpineResource {
+public class LicenseResource extends ExtendedAlpineResource {
 
     private static final Logger LOGGER = Logger.getLogger(LicenseResource.class);
 

--- a/src/main/java/org/dependencytrack/resources/v1/MetricsResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/MetricsResource.java
@@ -20,7 +20,6 @@ package org.dependencytrack.resources.v1;
 
 import alpine.event.framework.Event;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -58,7 +57,7 @@ import java.util.List;
  */
 @Path("/v1/metrics")
 @Api(value = "metrics", authorizations = @Authorization(value = "X-Api-Key"))
-public class MetricsResource extends AlpineResource {
+public class MetricsResource extends ExtendedAlpineResource {
 
     @GET
     @Path("/vulnerability")

--- a/src/main/java/org/dependencytrack/resources/v1/NotificationPublisherResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/NotificationPublisherResource.java
@@ -23,7 +23,6 @@ import alpine.model.ConfigProperty;
 import alpine.notification.Notification;
 import alpine.notification.NotificationLevel;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.*;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.ConfigPropertyConstants;
@@ -55,7 +54,7 @@ import java.util.List;
  */
 @Path("/v1/notification/publisher")
 @Api(authorizations = @Authorization(value = "X-Api-Key"))
-public class NotificationPublisherResource extends AlpineResource {
+public class NotificationPublisherResource extends ExtendedAlpineResource {
 
     private static final Logger LOGGER = Logger.getLogger(NotificationPublisherResource.class);
 

--- a/src/main/java/org/dependencytrack/resources/v1/NotificationRuleResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/NotificationRuleResource.java
@@ -22,7 +22,6 @@ import alpine.common.logging.Logger;
 import alpine.model.Team;
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -60,7 +59,7 @@ import java.util.List;
  */
 @Path("/v1/notification/rule")
 @Api(authorizations = @Authorization(value = "X-Api-Key"))
-public class NotificationRuleResource extends AlpineResource {
+public class NotificationRuleResource extends ExtendedAlpineResource {
 
     private static final Logger LOGGER = Logger.getLogger(NotificationRuleResource.class);
 

--- a/src/main/java/org/dependencytrack/resources/v1/OidcResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/OidcResource.java
@@ -6,7 +6,6 @@ import alpine.model.OidcGroup;
 import alpine.model.Team;
 import alpine.server.auth.AuthenticationNotRequired;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import alpine.server.util.OidcUtil;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -40,7 +39,7 @@ import java.util.stream.Collectors;
  */
 @Path("/v1/oidc")
 @Api(value = "oidc", authorizations = @Authorization(value = "X-Api-Key"))
-public class OidcResource extends AlpineResource {
+public class OidcResource extends ExtendedAlpineResource {
 
     private static final Logger LOGGER = Logger.getLogger(OidcResource.class);
 

--- a/src/main/java/org/dependencytrack/resources/v1/OsvEcosytemResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/OsvEcosytemResource.java
@@ -19,7 +19,6 @@
 package org.dependencytrack.resources.v1;
 
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -37,7 +36,7 @@ import java.util.List;
 
 @Path("/v1/integration/osv/ecosystem")
 @Api(value = "ecosystem", authorizations = @Authorization(value = "X-Api-Key"))
-public class OsvEcosytemResource extends AlpineResource {
+public class OsvEcosytemResource extends ExtendedAlpineResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/dependencytrack/resources/v1/PermissionResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/PermissionResource.java
@@ -23,7 +23,6 @@ import alpine.model.Permission;
 import alpine.model.Team;
 import alpine.model.UserPrincipal;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -53,7 +52,7 @@ import java.util.List;
  */
 @Path("/v1/permission")
 @Api(value = "permission", authorizations = @Authorization(value = "X-Api-Key"))
-public class PermissionResource extends AlpineResource {
+public class PermissionResource extends ExtendedAlpineResource {
 
     private static final Logger LOGGER = Logger.getLogger(PermissionResource.class);
 

--- a/src/main/java/org/dependencytrack/resources/v1/PolicyConditionResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/PolicyConditionResource.java
@@ -20,7 +20,6 @@
 package org.dependencytrack.resources.v1;
 
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -52,7 +51,7 @@ import javax.ws.rs.core.Response;
  */
 @Path("/v1/policy")
 @Api(value = "policyCondition", authorizations = @Authorization(value = "X-Api-Key"))
-public class PolicyConditionResource extends AlpineResource {
+public class PolicyConditionResource extends ExtendedAlpineResource {
 
     @PUT
     @Path("/{uuid}/condition")

--- a/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
@@ -20,7 +20,6 @@ package org.dependencytrack.resources.v1;
 
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -56,7 +55,7 @@ import java.util.List;
  */
 @Path("/v1/policy")
 @Api(value = "policy", authorizations = @Authorization(value = "X-Api-Key"))
-public class PolicyResource extends AlpineResource {
+public class PolicyResource extends ExtendedAlpineResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/dependencytrack/resources/v1/PolicyViolationResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/PolicyViolationResource.java
@@ -20,7 +20,6 @@ package org.dependencytrack.resources.v1;
 
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -53,7 +52,7 @@ import java.util.Collection;
  */
 @Path("/v1/violation")
 @Api(value = "violation", authorizations = @Authorization(value = "X-Api-Key"))
-public class PolicyViolationResource extends AlpineResource {
+public class PolicyViolationResource extends ExtendedAlpineResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -22,7 +22,6 @@ import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.jsonwebtoken.lang.Collections;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -67,7 +66,7 @@ import javax.ws.rs.core.Response;
  */
 @Path("/v1/project")
 @Api(value = "project", authorizations = @Authorization(value = "X-Api-Key"))
-public class ProjectResource extends AlpineResource {
+public class ProjectResource extends ExtendedAlpineResource {
 
     private static final Logger LOGGER = Logger.getLogger(ProjectResource.class);
 

--- a/src/main/java/org/dependencytrack/resources/v1/RepositoryResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/RepositoryResource.java
@@ -21,7 +21,6 @@ package org.dependencytrack.resources.v1;
 import alpine.persistence.PaginatedResult;
 import alpine.security.crypto.DataEncryption;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import io.swagger.annotations.Api;
@@ -59,7 +58,7 @@ import javax.ws.rs.core.Response;
  */
 @Path("/v1/repository")
 @Api(value = "repository", authorizations = @Authorization(value = "X-Api-Key"))
-public class RepositoryResource extends AlpineResource {
+public class RepositoryResource extends ExtendedAlpineResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/dependencytrack/resources/v1/SearchResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/SearchResource.java
@@ -19,7 +19,6 @@
 package org.dependencytrack.resources.v1;
 
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -46,7 +45,7 @@ import javax.ws.rs.core.Response;
  */
 @Path("/v1/search")
 @Api(value = "search", authorizations = @Authorization(value = "X-Api-Key"))
-public class SearchResource extends AlpineResource {
+public class SearchResource extends ExtendedAlpineResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/dependencytrack/resources/v1/ServiceResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ServiceResource.java
@@ -20,7 +20,6 @@ package org.dependencytrack.resources.v1;
 
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -54,7 +53,7 @@ import javax.ws.rs.core.Response;
  */
 @Path("/v1/service")
 @Api(value = "service", authorizations = @Authorization(value = "X-Api-Key"))
-public class ServiceResource extends AlpineResource {
+public class ServiceResource extends ExtendedAlpineResource {
 
     @GET
     @Path("/project/{uuid}")

--- a/src/main/java/org/dependencytrack/resources/v1/TagResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/TagResource.java
@@ -2,7 +2,6 @@ package org.dependencytrack.resources.v1;
 
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -23,7 +22,7 @@ import javax.ws.rs.core.Response;
 
 @Path("/v1/tag")
 @Api(value = "tag", authorizations = @Authorization(value = "X-Api-Key"))
-public class TagResource extends AlpineResource {
+public class TagResource extends ExtendedAlpineResource {
 
     @GET
     @Path("/{policyUuid}")

--- a/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
@@ -21,6 +21,7 @@ package org.dependencytrack.resources.v1;
 import alpine.Config;
 import alpine.common.logging.Logger;
 import alpine.model.ApiKey;
+import alpine.model.ManagedUser;
 import alpine.model.Team;
 import alpine.server.auth.PermissionRequired;
 import alpine.server.resources.AlpineResource;
@@ -293,6 +294,16 @@ public class TeamResource extends AlpineResource {
                     }
                 } else {
                     return Response.status(Response.Status.BAD_REQUEST).entity("Invalid API key supplied.").build();
+                }
+            }
+        }
+        // Authentication is not enabled, try to return Administrators team
+        try (QueryManager qm = new QueryManager()) {
+            final ManagedUser user = qm.getManagedUser("admin");
+            if (user != null) {
+                if(!user.getTeams().isEmpty()) {
+                    final Team team = user.getTeams().get(0);
+                    return Response.ok(team).build();
                 }
             }
         }

--- a/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
@@ -24,7 +24,6 @@ import alpine.model.ApiKey;
 import alpine.model.ManagedUser;
 import alpine.model.Team;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -58,7 +57,7 @@ import java.util.List;
  */
 @Path("/v1/team")
 @Api(value = "team", authorizations = @Authorization(value = "X-Api-Key"))
-public class TeamResource extends AlpineResource {
+public class TeamResource extends ExtendedAlpineResource {
 
     private static final Logger LOGGER = Logger.getLogger(TeamResource.class);
 

--- a/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
@@ -297,14 +297,10 @@ public class TeamResource extends ExtendedAlpineResource {
             }
         }
         // Authentication is not enabled, try to return Administrators team
-        try (QueryManager qm = new QueryManager()) {
-            final ManagedUser user = qm.getManagedUser("admin");
-            if (user != null) {
-                if(!user.getTeams().isEmpty()) {
-                    final Team team = user.getTeams().get(0);
-                    return Response.ok(team).build();
-                }
-            }
+        final ManagedUser user = (ManagedUser) getPrincipal();
+        if (user != null && !user.getTeams().isEmpty()) {
+            final Team team = user.getTeams().get(0);
+            return Response.ok(team).build();
         }
         // Authentication is not enabled, but we need to return a positive response without any principal data.
         return Response.ok().build();

--- a/src/main/java/org/dependencytrack/resources/v1/UserResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/UserResource.java
@@ -34,7 +34,6 @@ import alpine.server.auth.JsonWebToken;
 import alpine.server.auth.OidcAuthenticationService;
 import alpine.server.auth.PasswordService;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -70,47 +69,9 @@ import java.util.List;
  */
 @Path("/v1/user")
 @Api(value = "user", authorizations = @Authorization(value = "X-Api-Key"))
-public class UserResource extends AlpineResource {
+public class UserResource extends ExtendedAlpineResource {
 
     private static final Logger LOGGER = Logger.getLogger(UserResource.class);
-
-    /**
-     * Returns the principal for who initiated the request.  If
-     * ALPINE_ENFORCE_AUTHENTICATION is disabled then the admin ManagedUser is
-     * returned.
-     * @return a Principal object
-     * @see alpine.model.ApiKey
-     * @see alpine.model.LdapUser
-     * @see alpine.model.ManagedUser
-     */
-    @Override
-    protected Principal getPrincipal() {
-        if (Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.ENFORCE_AUTHENTICATION)) {
-            // Authentication is not enabled, try returning admin principal
-            try (QueryManager qm = new QueryManager()) {
-                final ManagedUser user = qm.getManagedUser("admin");
-                if (user != null) {
-                    return (Principal) user;
-                }
-            }
-        }
-        return super.getPrincipal();
-    }
-
-    /**
-     * Convenience method that returns true if the principal has the specified permission,
-     * or false if not.  If ALPINE_ENFORCE_AUTHENTICATION is disabled then the
-     * true will always be returned.
-     * @param permission the permission to check
-     * @return true if principal has permission assigned, false if not
-     */
-    @Override
-    protected boolean hasPermission(final String permission) {
-        if (!Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.ENFORCE_AUTHENTICATION)) {
-            return true;
-        }
-        return super.hasPermission(permission);
-    }
 
     @POST
     @Path("login")

--- a/src/main/java/org/dependencytrack/resources/v1/UserResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/UserResource.java
@@ -307,11 +307,9 @@ public class UserResource extends ExtendedAlpineResource {
             }
         }
         // Authentication is not enabled, try returning admin username
-        try (QueryManager qm = new QueryManager()) {
-            final ManagedUser user = qm.getManagedUser("admin");
-            if (user != null) {
-                return Response.ok(user).build();
-            }
+        final ManagedUser user = (ManagedUser) getPrincipal();
+        if (user != null) {
+            return Response.ok(user).build();
         }
         // Authentication is not enabled, but we need to return a positive response without any principal data.
         return Response.ok().build();

--- a/src/main/java/org/dependencytrack/resources/v1/VexResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/VexResource.java
@@ -21,7 +21,6 @@ package org.dependencytrack.resources.v1;
 import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -70,7 +69,7 @@ import java.util.List;
  */
 @Path("/v1/vex")
 @Api(value = "vex", authorizations = @Authorization(value = "X-Api-Key"))
-public class VexResource extends AlpineResource {
+public class VexResource extends ExtendedAlpineResource {
 
     private static final Logger LOGGER = Logger.getLogger(VexResource.class);
 

--- a/src/main/java/org/dependencytrack/resources/v1/ViolationAnalysisResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ViolationAnalysisResource.java
@@ -25,7 +25,6 @@ import alpine.model.ManagedUser;
 import alpine.model.OidcUser;
 import alpine.model.UserPrincipal;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -60,7 +59,7 @@ import javax.ws.rs.core.Response;
  */
 @Path("/v1/violation/analysis")
 @Api(value = "violationanalysis", authorizations = @Authorization(value = "X-Api-Key"))
-public class ViolationAnalysisResource extends AlpineResource {
+public class ViolationAnalysisResource extends ExtendedAlpineResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
@@ -20,7 +20,6 @@ package org.dependencytrack.resources.v1;
 
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -66,7 +65,7 @@ import java.util.List;
  */
 @Path("/v1/vulnerability")
 @Api(value = "vulnerability", authorizations = @Authorization(value = "X-Api-Key"))
-public class VulnerabilityResource extends AlpineResource {
+public class VulnerabilityResource extends ExtendedAlpineResource {
 
     @GET
     @Path("/component/{uuid}")


### PR DESCRIPTION
Description
-----------

I use DependencyTrack locally through VSCode Dev Containers.  Authentication and authorization setup is tedious every time I rebuild my development environment.

This adds support for uploading SBOM while authentication and authorization is disabled.

Addressed Issue
---------------

Is related to:

* Issue https://github.com/DependencyTrack/frontend/issues/333
* Pull Request https://github.com/DependencyTrack/frontend/pull/334
* relates to #653

Additional Details
------------------

In current master branch, starting apiserver, if I set the following environment:

```yaml
ALPINE_ENFORCE_AUTHENTICATION: 'false'
ALPINE_ENFORCE_AUTHORIZATION: 'false'
```

And I attempt to upload a BOM, then I get the following error.

```
The principal does not have permission to create project.
```

I'm new to this project so still working to figure out writing tests for it.  I have manually validated it works by building it and testing it in conjunction with the frontend pull request.

My development host is Ubuntu 20.04 Linux and I built the Docker image with the following commands.

```bash
docker run -it --rm -u "$(id -u):$(id -g)" -v "$PWD:$PWD" -w "$PWD" maven:3-eclipse-temurin-17-alpine /bin/bash -exc '
  mvn package -Dmaven.test.skip=true -P enhance -P embedded-jetty -Dlogback.configuration.file=src/main/docker/logback.xml
  mvn clean -P clean-exclude-wars
  '

docker build -t apiserver:snapshot -f src/main/docker/Dockerfile .
```

Checklist
---------

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly