### PR TITLE
Issue 1932: Empty response on /api/v1/analysis endpoint

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
@@ -104,7 +104,7 @@ public class AnalysisResource extends AlpineResource {
             }
             final Analysis analysis = qm.getAnalysis(component, vulnerability);
             if (analysis == null) {
-                return Response.noContent().build();
+                return Response.status(Response.Status.NOT_FOUND).entity("No analysis exists.").build();
             }
             return Response.ok(analysis).build();
         }

--- a/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
@@ -102,8 +102,10 @@ public class AnalysisResource extends AlpineResource {
             if (vulnerability == null) {
                 return Response.status(Response.Status.NOT_FOUND).entity("The vulnerability could not be found.").build();
             }
-
             final Analysis analysis = qm.getAnalysis(component, vulnerability);
+            if (analysis == null) {
+                return Response.noContent().build();
+            }
             return Response.ok(analysis).build();
         }
     }

--- a/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
@@ -176,9 +176,9 @@ public class AnalysisResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
         assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
-        assertThat(getPlainTextBody(response)).isEmpty();
+        assertThat(getPlainTextBody(response)).isEqualTo("No analysis exists.");
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
@@ -205,8 +205,8 @@ public class AnalysisResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
-        assertThat(getPlainTextBody(response)).isEmpty();
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+        assertThat(getPlainTextBody(response)).isEqualTo("No analysis exists.");
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
@@ -182,6 +182,34 @@ public class AnalysisResourceTest extends ResourceTest {
     }
 
     @Test
+    public void noAnalysisExists() {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("Acme Component");
+        component.setVersion("2.0");
+        component = qm.createComponent(component, false);
+
+        var vulnerability = new Vulnerability();
+        vulnerability.setVulnId("INT-002");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.HIGH);
+        vulnerability.setComponents(List.of(component));
+        vulnerability = qm.createVulnerability(vulnerability, false);
+
+        final Response response = target(V1_ANALYSIS)
+                .queryParam("component", component.getUuid())
+                .queryParam("vulnerability", vulnerability.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+        assertThat(getPlainTextBody(response)).isEmpty();
+    }
+
+    @Test
     public void retrieveAnalysisWithProjectNotFoundTest() {
         initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
 

--- a/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
@@ -193,7 +193,7 @@ public class AnalysisResourceTest extends ResourceTest {
         component = qm.createComponent(component, false);
 
         var vulnerability = new Vulnerability();
-        vulnerability.setVulnId("INT-002");
+        vulnerability.setVulnId("INT-003");
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
         vulnerability.setComponents(List.of(component));


### PR DESCRIPTION
Sign-off-by kekkegenkai: kekkegenkai@gmail.com

### Description
The current implementation of the /api/v1/analysis endpoint returns the Statuscode 200 without any content in case no analysis is running/exists.
In this PR I changed this behavior. If no analysis is running the application returns a 404.

### Addressed Issue

#1932 

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
