### PR TITLE
Issue 2197: Allow to bypass starting requirements

### DIFF
--- a/docs/_docs/getting-started/deploy-docker.md
+++ b/docs/_docs/getting-started/deploy-docker.md
@@ -18,6 +18,8 @@ other than a modern version of Docker.
 | 4.5GB RAM   | 16GB RAM    |
 | 2 CPU cores | 4 CPU cores |
 
+> These requirements can be disabled by setting the 'system.requirement.check.enabled' property or the 'SYSTEM_REQUIREMENT_CHECK_ENABLED' environment variable to 'false'. 
+
 ### Container Requirements (Front End)
 
 | Minimum     | Recommended |
@@ -172,9 +174,11 @@ services:
     # - REPO_META_ANALYZER_CACHESTAMPEDEBLOCKER_LOCK_BUCKETS=1000
     # - REPO_META_ANALYZER_CACHESTAMPEDEBLOCKER_MAX_ATTEMPTS=10
     #
+    # Optional configuration for the system requirements
+    # - SYSTEM_REQUIREMENT_CHECK_ENABLED=true
     # Optional environmental variables to provide more JVM arguments to the API Server JVM, i.e. "-XX:ActiveProcessorCount=8"
     # - EXTRA_JAVA_OPTIONS=
-
+    
     deploy:
       resources:
         limits:

--- a/docs/_docs/getting-started/deploy-exewar.md
+++ b/docs/_docs/getting-started/deploy-exewar.md
@@ -35,6 +35,8 @@ Refer to [distributions](../distributions/) for details.
 If minimum requirements are not met, Dependency-Track will not start correctly. However, for systems with Java 17 
 already installed, this method of execution may provide the fastest deployment path.
 
+> These requirements can be disabled by setting the 'system.requirement.check.enabled' property or the 'SYSTEM_REQUIREMENT_CHECK_ENABLED' environment variable to 'false'.
+
 ### Startup
 
 ```bash

--- a/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -16,7 +16,8 @@ public enum ConfigKey implements Config.Key {
     OSSINDEX_RETRY_EXPONENTIAL_BACKOFF_MAX_DURATION("ossindex.retry.backoff.max.duration", Duration.ofMinutes(10).toMillis()),
     REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_ENABLED("repo.meta.analyzer.cacheStampedeBlocker.enabled", true),
     REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_LOCK_BUCKETS("repo.meta.analyzer.cacheStampedeBlocker.lock.buckets", 1000),
-    REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_MAX_ATTEMPTS("repo.meta.analyzer.cacheStampedeBlocker.max.attempts", 10);
+    REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_MAX_ATTEMPTS("repo.meta.analyzer.cacheStampedeBlocker.max.attempts", 10),
+    SYSTEM_REQUIREMENT_CHECK_ENABLED("system.requirement.check.enabled", true);
 
     private final String propertyName;
     private final Object defaultValue;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -318,6 +318,11 @@ alpine.oidc.team.synchronization=false
 alpine.oidc.teams.claim=groups
 
 # Optional
+# Define whether system requirement check is enable.
+# The default value is true.
+system.requirement.check.enabled=true
+
+# Optional
 # Defines the size of the thread pool used to perform requests to the Snyk API in parallel.
 # The thread pool will only be used when Snyk integration is enabled.
 # A high number may result in a quicker excession of API rate limits,


### PR DESCRIPTION
### Description

In this PR, I added a new environment variable called **system.requirement.check.enabled** that allow users to disable Dependency-Track requirements startup check.

### Addressed Issue

Fixes DependencyTrack/dependency-track#2197

### Checklist

- [ ] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
