### PR TITLE
Fix: Restoring lucene index build during startup & allow rebuild through UI

### DIFF
--- a/src/main/java/org/dependencytrack/event/IndexEvent.java
+++ b/src/main/java/org/dependencytrack/event/IndexEvent.java
@@ -18,7 +18,7 @@
  */
 package org.dependencytrack.event;
 
-import alpine.event.framework.Event;
+import alpine.event.framework.AbstractChainableEvent;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Cpe;
 import org.dependencytrack.model.License;
@@ -33,14 +33,15 @@ import org.dependencytrack.model.VulnerableSoftware;
  * @author Steve Springett
  * @since 3.0.0
  */
-public class IndexEvent implements Event {
+public class IndexEvent extends AbstractChainableEvent {
 
     public enum Action {
         CREATE,
         UPDATE,
         DELETE,
         COMMIT,
-        REINDEX
+        REINDEX,
+        CHECK
     }
 
     private final Action action;

--- a/src/main/java/org/dependencytrack/event/IndexEvent.java
+++ b/src/main/java/org/dependencytrack/event/IndexEvent.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.event;
 
 import alpine.event.framework.AbstractChainableEvent;
+import alpine.event.framework.SingletonCapableEvent;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Cpe;
 import org.dependencytrack.model.License;
@@ -26,6 +27,7 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ServiceComponent;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerableSoftware;
+import org.dependencytrack.search.IndexManager;
 
 /**
  * Defines various Lucene index events.
@@ -33,7 +35,7 @@ import org.dependencytrack.model.VulnerableSoftware;
  * @author Steve Springett
  * @since 3.0.0
  */
-public class IndexEvent extends AbstractChainableEvent {
+public class IndexEvent extends SingletonCapableEvent {
 
     public enum Action {
         CREATE,
@@ -48,43 +50,46 @@ public class IndexEvent extends AbstractChainableEvent {
     private Object indexableObject;
     private Class indexableClass;
 
-
     public IndexEvent(final Action action, final Project project) {
-        this.action = action;
+        this(action, Project.class);
         this.indexableObject = project;
     }
 
     public IndexEvent(final Action action, final Component component) {
-        this.action = action;
+        this(action, Component.class);
         this.indexableObject = component;
     }
 
     public IndexEvent(final Action action, final ServiceComponent service) {
-        this.action = action;
+        this(action, ServiceComponent.class);
         this.indexableObject = service;
     }
 
     public IndexEvent(final Action action, final Vulnerability vulnerability) {
-        this.action = action;
+        this(action, Vulnerability.class);
         this.indexableObject = vulnerability;
     }
 
     public IndexEvent(final Action action, final License license) {
-        this.action = action;
+        this(action, License.class);
         this.indexableObject = license;
     }
 
     public IndexEvent(final Action action, final Cpe cpe) {
-        this.action = action;
+        this(action, Cpe.class);
         this.indexableObject = cpe;
     }
 
     public IndexEvent(final Action action, final VulnerableSoftware vs) {
-        this.action = action;
+        this(action, VulnerableSoftware.class);
         this.indexableObject = vs;
     }
 
     public IndexEvent(final Action action, final Class clazz) {
+        if(action == Action.REINDEX) {
+            this.setSingleton(true);
+            this.setChainIdentifier(IndexManager.IndexType.getUuid(clazz));
+        }
         this.action = action;
         this.indexableClass = clazz;
     }

--- a/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
+++ b/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
@@ -90,7 +90,10 @@ public enum ConfigPropertyConstants {
     TASK_SCHEDULER_PORTFOLIO_VULNERABILITY_ANALYSIS_CADENCE("task-scheduler", "portfolio.vulnerability.analysis.cadence", "24", PropertyType.INTEGER, "Launch cadence (in hours) for portfolio vulnerability analysis"),
     TASK_SCHEDULER_REPOSITORY_METADATA_FETCH_CADENCE("task-scheduler", "repository.metadata.fetch.cadence", "24", PropertyType.INTEGER, "Metadada fetch cadence (in hours) for package repositories"),
     TASK_SCHEDULER_INTERNAL_COMPONENT_IDENTIFICATION_CADENCE("task-scheduler", "internal.components.identification.cadence", "6", PropertyType.INTEGER, "Internal component identification cadence (in hours)"),
-    TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_CADENCE("task-scheduler", "component.analysis.cache.clear.cadence", "24", PropertyType.INTEGER, "Cleanup cadence (in hours) for component analysis cache");
+    TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_CADENCE("task-scheduler", "component.analysis.cache.clear.cadence", "24", PropertyType.INTEGER, "Cleanup cadence (in hours) for component analysis cache"),
+    INDEXES_CONSISTENCY_CHECK_ENABLED("indexes", "consistency.check.enabled", "true", PropertyType.BOOLEAN, "Flag to enable lucene indexes periodic consistency check"),
+    INDEXES_CONSISTENCY_CHECK_CADENCE("indexes", "consistency.check.cadence", "4320", PropertyType.INTEGER, "Lucene indexes consistency check cadence (in minutes)"),
+    INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD("indexes", "consistency.check.delta.threshold", "20", PropertyType.INTEGER, "Threshold used to trigger an index rebuild when comparing database table and corresponding lucene index (in percentage). It must be an integer between 1 and 100");
 
     private String groupName;
     private String propertyName;

--- a/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
+++ b/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
@@ -91,9 +91,9 @@ public enum ConfigPropertyConstants {
     TASK_SCHEDULER_REPOSITORY_METADATA_FETCH_CADENCE("task-scheduler", "repository.metadata.fetch.cadence", "24", PropertyType.INTEGER, "Metadada fetch cadence (in hours) for package repositories"),
     TASK_SCHEDULER_INTERNAL_COMPONENT_IDENTIFICATION_CADENCE("task-scheduler", "internal.components.identification.cadence", "6", PropertyType.INTEGER, "Internal component identification cadence (in hours)"),
     TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_CADENCE("task-scheduler", "component.analysis.cache.clear.cadence", "24", PropertyType.INTEGER, "Cleanup cadence (in hours) for component analysis cache"),
-    INDEXES_CONSISTENCY_CHECK_ENABLED("indexes", "consistency.check.enabled", "true", PropertyType.BOOLEAN, "Flag to enable lucene indexes periodic consistency check"),
-    INDEXES_CONSISTENCY_CHECK_CADENCE("indexes", "consistency.check.cadence", "4320", PropertyType.INTEGER, "Lucene indexes consistency check cadence (in minutes)"),
-    INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD("indexes", "consistency.check.delta.threshold", "20", PropertyType.INTEGER, "Threshold used to trigger an index rebuild when comparing database table and corresponding lucene index (in percentage). It must be an integer between 1 and 100");
+    SEARCH_INDEXES_CONSISTENCY_CHECK_ENABLED("search-indexes", "consistency.check.enabled", "true", PropertyType.BOOLEAN, "Flag to enable lucene indexes periodic consistency check"),
+    SEARCH_INDEXES_CONSISTENCY_CHECK_CADENCE("search-indexes", "consistency.check.cadence", "4320", PropertyType.INTEGER, "Lucene indexes consistency check cadence (in minutes)"),
+    SEARCH_INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD("search-indexes", "consistency.check.delta.threshold", "20", PropertyType.INTEGER, "Threshold used to trigger an index rebuild when comparing database table and corresponding lucene index (in percentage). It must be an integer between 1 and 100");
 
     private String groupName;
     private String propertyName;

--- a/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
+++ b/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
@@ -66,27 +66,6 @@ public class DefaultObjectGenerator implements ServletContextListener {
             return;
         }
 
-        if (!IndexManager.exists(IndexManager.IndexType.LICENSE)) {
-            LOGGER.info("Dispatching event to reindex licenses");
-            Event.dispatch(new IndexEvent(IndexEvent.Action.REINDEX, License.class));
-        }
-        if (!IndexManager.exists(IndexManager.IndexType.PROJECT)) {
-            LOGGER.info("Dispatching event to reindex projects");
-            Event.dispatch(new IndexEvent(IndexEvent.Action.REINDEX, Project.class));
-        }
-        if (!IndexManager.exists(IndexManager.IndexType.COMPONENT)) {
-            LOGGER.info("Dispatching event to reindex components");
-            Event.dispatch(new IndexEvent(IndexEvent.Action.REINDEX, Component.class));
-        }
-        if (!IndexManager.exists(IndexManager.IndexType.VULNERABILITY)) {
-            LOGGER.info("Dispatching event to reindex vulnerabilities");
-            Event.dispatch(new IndexEvent(IndexEvent.Action.REINDEX, Vulnerability.class));
-        }
-        if (!IndexManager.exists(IndexManager.IndexType.VULNERABLESOFTWARE)) {
-            LOGGER.info("Dispatching event to reindex vulnerablesoftware");
-            Event.dispatch(new IndexEvent(IndexEvent.Action.REINDEX, VulnerableSoftware.class));
-        }
-
         loadDefaultPermissions();
         loadDefaultPersonas();
         loadDefaultLicenses();

--- a/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
@@ -63,7 +63,7 @@ abstract class AbstractConfigPropertyResource extends AlpineResource {
                 if(ConfigPropertyConstants.TASK_SCHEDULER_LDAP_SYNC_CADENCE.getGroupName().equals(json.getGroupName()) && propertyValue <= 0) {
                     return Response.status(Response.Status.BAD_REQUEST).entity("A Task scheduler cadence ("+json.getPropertyName()+") cannot be inferior to one hour.A value of "+propertyValue+" was provided.").build();
                 }
-                if(ConfigPropertyConstants.INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getPropertyName().equals(json.getPropertyName()) && (propertyValue < 1 || propertyValue > 100)) {
+                if(ConfigPropertyConstants.SEARCH_INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getPropertyName().equals(json.getPropertyName()) && (propertyValue < 1 || propertyValue > 100)) {
                     return Response.status(Response.Status.BAD_REQUEST).entity("Lucene index delta threshold ("+json.getPropertyName()+") cannot be inferior to 1 or superior to 100.A value of "+propertyValue+" was provided.").build();
                 }
                 property.setPropertyValue(String.valueOf(propertyValue));

--- a/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
@@ -63,6 +63,9 @@ abstract class AbstractConfigPropertyResource extends AlpineResource {
                 if(ConfigPropertyConstants.TASK_SCHEDULER_LDAP_SYNC_CADENCE.getGroupName().equals(json.getGroupName()) && propertyValue <= 0) {
                     return Response.status(Response.Status.BAD_REQUEST).entity("A Task scheduler cadence ("+json.getPropertyName()+") cannot be inferior to one hour.A value of "+propertyValue+" was provided.").build();
                 }
+                if(ConfigPropertyConstants.INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getPropertyName().equals(json.getPropertyName()) && (propertyValue < 1 || propertyValue > 100)) {
+                    return Response.status(Response.Status.BAD_REQUEST).entity("Lucene index delta threshold ("+json.getPropertyName()+") cannot be inferior to 1 or superior to 100.A value of "+propertyValue+" was provided.").build();
+                }
                 property.setPropertyValue(String.valueOf(propertyValue));
             } catch (NumberFormatException e) {
                 return Response.status(Response.Status.BAD_REQUEST).entity("The property expected an integer and an integer was not sent.").build();

--- a/src/main/java/org/dependencytrack/resources/v1/SearchResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/SearchResource.java
@@ -32,11 +32,14 @@ import org.dependencytrack.search.SearchManager;
 import org.dependencytrack.search.SearchResult;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * JAX-RS resources for processing search requests.
@@ -175,6 +178,30 @@ public class SearchResource extends AlpineResource {
             final SearchManager searchManager = new SearchManager();
             final SearchResult searchResult = searchManager.searchVulnerableSoftwareIndex(query, 1000);
             return Response.ok(searchResult).build();
+        }
+    }
+
+    @Path("/reindex")
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Rebuild lucene indexes for search operations"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 400, message = "No valid index type was provided")
+    })
+    @PermissionRequired(Permissions.Constants.SYSTEM_CONFIGURATION)
+    public Response reindex(@QueryParam("type") List<String> type) {
+        if (type == null || type.isEmpty()) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("No valid index type was provided").build();
+        }
+        try {
+            final SearchManager searchManager = new SearchManager();
+            String chainIdentifier = searchManager.reindex(type);
+            return Response.ok(Collections.singletonMap("token", chainIdentifier)).build();
+        } catch (IllegalArgumentException exception) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(exception.getMessage()).build();
         }
     }
 }

--- a/src/main/java/org/dependencytrack/resources/v1/SearchResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/SearchResource.java
@@ -40,6 +40,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * JAX-RS resources for processing search requests.
@@ -192,7 +193,7 @@ public class SearchResource extends AlpineResource {
             @ApiResponse(code = 400, message = "No valid index type was provided")
     })
     @PermissionRequired(Permissions.Constants.SYSTEM_CONFIGURATION)
-    public Response reindex(@QueryParam("type") List<String> type) {
+    public Response reindex(@QueryParam("type") Set<String> type) {
         if (type == null || type.isEmpty()) {
             return Response.status(Response.Status.BAD_REQUEST).entity("No valid index type was provided").build();
         }

--- a/src/main/java/org/dependencytrack/search/ComponentIndexer.java
+++ b/src/main/java/org/dependencytrack/search/ComponentIndexer.java
@@ -23,6 +23,7 @@ import alpine.notification.Notification;
 import alpine.notification.NotificationLevel;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.Term;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
@@ -77,6 +78,8 @@ public final class ComponentIndexer extends IndexManager implements ObjectIndexe
 
         try {
             getIndexWriter().addDocument(doc);
+        } catch (CorruptIndexException e) {
+            handleCorruptIndexException(e);
         } catch (IOException e) {
             LOGGER.error("An error occurred while adding component to index", e);
             Notification.dispatch(new Notification()
@@ -97,6 +100,8 @@ public final class ComponentIndexer extends IndexManager implements ObjectIndexe
     public void remove(final Component component) {
         try {
             getIndexWriter().deleteDocuments(new Term(IndexConstants.COMPONENT_UUID, component.getUuid().toString()));
+        } catch (CorruptIndexException e) {
+            handleCorruptIndexException(e);
         } catch (IOException e) {
             LOGGER.error("An error occurred while removing a component from the index", e);
             Notification.dispatch(new Notification()

--- a/src/main/java/org/dependencytrack/search/CpeIndexer.java
+++ b/src/main/java/org/dependencytrack/search/CpeIndexer.java
@@ -24,6 +24,7 @@ import alpine.notification.NotificationLevel;
 import alpine.persistence.PaginatedResult;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.Term;
 import org.dependencytrack.model.Cpe;
 import org.dependencytrack.notification.NotificationConstants;
@@ -77,6 +78,8 @@ public final class CpeIndexer extends IndexManager implements ObjectIndexer<Cpe>
 
         try {
             getIndexWriter().addDocument(doc);
+        } catch (CorruptIndexException e) {
+            handleCorruptIndexException(e);
         } catch (IOException e) {
             LOGGER.error("An error occurred while adding a CPE to the index", e);
             Notification.dispatch(new Notification()
@@ -97,6 +100,8 @@ public final class CpeIndexer extends IndexManager implements ObjectIndexer<Cpe>
     public void remove(final Cpe cpe) {
         try {
             getIndexWriter().deleteDocuments(new Term(IndexConstants.CPE_UUID, cpe.getUuid().toString()));
+        } catch (CorruptIndexException e) {
+            handleCorruptIndexException(e);
         } catch (IOException e) {
             LOGGER.error("An error occurred while removing a CPE from the index", e);
             Notification.dispatch(new Notification()

--- a/src/main/java/org/dependencytrack/search/FuzzyVulnerableSoftwareSearchManager.java
+++ b/src/main/java/org/dependencytrack/search/FuzzyVulnerableSoftwareSearchManager.java
@@ -1,6 +1,7 @@
 package org.dependencytrack.search;
 
 import alpine.common.logging.Logger;
+import alpine.event.framework.Event;
 import alpine.notification.Notification;
 import alpine.notification.NotificationLevel;
 import com.google.common.collect.Sets;
@@ -13,6 +14,7 @@ import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
+import org.dependencytrack.event.IndexEvent;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.notification.NotificationConstants;
@@ -171,6 +173,8 @@ public class FuzzyVulnerableSoftwareSearchManager {
                     .content("Corrupted Lucene index detected. Check log for details. " + e.getMessage())
                     .level(NotificationLevel.ERROR)
             );
+            LOGGER.info("Trying to rebuild the corrupted index "+indexManager.getIndexType().name());
+            Event.dispatch(new IndexEvent(IndexEvent.Action.REINDEX, indexManager.getIndexType().getClazz()));
         } catch (IOException e) {
             LOGGER.error("An I/O Exception occurred while searching Lucene index", e);
             Notification.dispatch(new Notification()

--- a/src/main/java/org/dependencytrack/search/IndexConstants.java
+++ b/src/main/java/org/dependencytrack/search/IndexConstants.java
@@ -80,7 +80,7 @@ public final class IndexConstants {
     static final String CPE_PRODUCT = "product";
     static final String CPE_VERSION = "version";
     static final String[] CPE_SEARCH_FIELDS = {
-            CPE_22, CPE_23, CPE_VENDOR, CPE_PRODUCT, CPE_VERSION
+            CPE_UUID, CPE_22, CPE_23, CPE_VENDOR, CPE_PRODUCT, CPE_VERSION
     };
 
     static final String VULNERABLESOFTWARE_UUID = "uuid";
@@ -90,7 +90,7 @@ public final class IndexConstants {
     static final String VULNERABLESOFTWARE_PRODUCT = "product";
     static final String VULNERABLESOFTWARE_VERSION = "version";
     static final String[] VULNERABLESOFTWARE_SEARCH_FIELDS = {
-            VULNERABLESOFTWARE_CPE_22, VULNERABLESOFTWARE_CPE_23, VULNERABLESOFTWARE_VENDOR,
+            VULNERABILITY_UUID, VULNERABLESOFTWARE_CPE_22, VULNERABLESOFTWARE_CPE_23, VULNERABLESOFTWARE_VENDOR,
             VULNERABLESOFTWARE_PRODUCT, VULNERABLESOFTWARE_VERSION
     };
 

--- a/src/main/java/org/dependencytrack/search/IndexManager.java
+++ b/src/main/java/org/dependencytrack/search/IndexManager.java
@@ -20,6 +20,8 @@ package org.dependencytrack.search;
 
 import alpine.Config;
 import alpine.common.logging.Logger;
+import alpine.event.framework.Event;
+import alpine.model.ConfigProperty;
 import alpine.notification.Notification;
 import alpine.notification.NotificationLevel;
 import org.apache.commons.collections4.CollectionUtils;
@@ -31,6 +33,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.CheckIndex;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
@@ -43,15 +46,29 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.SimpleFSDirectory;
+import org.apache.lucene.store.FSDirectory;
+import org.dependencytrack.event.IndexEvent;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Cpe;
+import org.dependencytrack.model.License;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.ServiceComponent;
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.notification.NotificationConstants;
 import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationScope;
+import org.dependencytrack.persistence.QueryManager;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+
+import static org.dependencytrack.model.ConfigPropertyConstants.INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD;
 
 /**
  * The IndexManager is an abstract class that provides wrappers and convenience methods
@@ -81,13 +98,31 @@ public abstract class IndexManager implements AutoCloseable {
      * @since 3.0.0
      */
     public enum IndexType {
-        PROJECT,
-        COMPONENT,
-        SERVICECOMPONENT,
-        VULNERABILITY,
-        LICENSE,
-        CPE,
-        VULNERABLESOFTWARE,
+        PROJECT(Project.class),
+        COMPONENT(Component.class),
+        SERVICECOMPONENT(ServiceComponent.class),
+        VULNERABILITY(Vulnerability.class),
+        LICENSE(License.class),
+        CPE(Cpe.class),
+        VULNERABLESOFTWARE(VulnerableSoftware.class);
+
+        final private Class<?> clazz;
+
+        IndexType(Class<?> clazz) {
+            this.clazz = clazz;
+        }
+
+        public Class<?> getClazz() {
+            return clazz;
+        }
+
+        public static Optional<IndexType> getIndexType(String type) {
+            try {
+                return Optional.of(valueOf(type));
+            } catch (Exception e) {
+                return Optional.empty();
+            }
+        }
     }
 
     /**
@@ -105,7 +140,7 @@ public abstract class IndexManager implements AutoCloseable {
      * @return the index type
      * @since 3.0.0
      */
-    protected IndexType getIndexType() {
+    public IndexType getIndexType() {
         return indexType;
     }
 
@@ -129,7 +164,7 @@ public abstract class IndexManager implements AutoCloseable {
                 );
             }
         }
-        return new SimpleFSDirectory(indexDir.toPath());
+        return FSDirectory.open(indexDir.toPath());
     }
 
     /**
@@ -157,14 +192,7 @@ public abstract class IndexManager implements AutoCloseable {
         return iwriter;
     }
 
-    /**
-     * Returns an {@link IndexSearcher} by opening the index directory first, if necessary.
-     *
-     * @return an {@link IndexSearcher}
-     * @throws IOException when the index directory cannot be opened
-     * @since 3.0.0
-     */
-    protected synchronized IndexSearcher getIndexSearcher() throws IOException {
+    private void ensureDirectoryReaderOpen() throws IOException {
         if (searchReader == null) {
             searchReader = DirectoryReader.open(getDirectory());
         } else {
@@ -173,6 +201,17 @@ public abstract class IndexManager implements AutoCloseable {
                 searchReader = changedReader;
             }
         }
+    }
+
+    /**
+     * Returns an {@link IndexSearcher} by opening the index directory first, if necessary.
+     *
+     * @return an {@link IndexSearcher}
+     * @throws IOException when the index directory cannot be opened
+     * @since 3.0.0
+     */
+    protected synchronized IndexSearcher getIndexSearcher() throws IOException {
+        ensureDirectoryReaderOpen();
         return new IndexSearcher(searchReader);
     }
 
@@ -196,6 +235,8 @@ public abstract class IndexManager implements AutoCloseable {
     public void commit() {
         try {
             getIndexWriter().commit();
+        } catch (CorruptIndexException e) {
+            handleCorruptIndexException(e);
         } catch (IOException e) {
             LOGGER.error("Error committing index", e);
             Notification.dispatch(new Notification()
@@ -206,6 +247,19 @@ public abstract class IndexManager implements AutoCloseable {
                     .level(NotificationLevel.ERROR)
             );
         }
+    }
+
+    protected void handleCorruptIndexException(CorruptIndexException e) {
+        LOGGER.error("Corrupted Lucene index detected", e);
+        Notification.dispatch(new Notification()
+                .scope(NotificationScope.SYSTEM)
+                .group(NotificationGroup.INDEXING_SERVICE)
+                .title(NotificationConstants.Title.CORE_INDEXING_SERVICES + "(" + indexType.name().toLowerCase() + ")")
+                .content("Corrupted Lucene index detected. Check log for details. " + e.getMessage())
+                .level(NotificationLevel.ERROR)
+        );
+        LOGGER.info("Trying to rebuild the corrupted index " + indexType.name());
+        Event.dispatch(new IndexEvent(IndexEvent.Action.REINDEX, indexType.getClazz()));
     }
 
     /**
@@ -278,14 +332,7 @@ public abstract class IndexManager implements AutoCloseable {
                 list.add(getIndexSearcher().doc(hit.doc));
             }
         } catch (CorruptIndexException e) {
-            LOGGER.error("Corrupted Lucene index detected", e);
-            Notification.dispatch(new Notification()
-                    .scope(NotificationScope.SYSTEM)
-                    .group(NotificationGroup.INDEXING_SERVICE)
-                    .title(NotificationConstants.Title.CORE_INDEXING_SERVICES)
-                    .content("Corrupted Lucene index detected. Check log for details. " + e.getMessage())
-                    .level(NotificationLevel.ERROR)
-            );
+            handleCorruptIndexException(e);
         } catch (IOException e) {
             LOGGER.error("An I/O exception occurred while searching Lucene index", e);
             Notification.dispatch(new Notification()
@@ -319,7 +366,17 @@ public abstract class IndexManager implements AutoCloseable {
      * @since 3.4.0
      */
     public void reindex() {
-        delete(indexType);
+        try {
+            LOGGER.info("Deleting " + indexType.name().toLowerCase() + " index");
+            // Cleaner way of purging the index
+            // Essentially a call to deleteAll() is equivalent to creating a new IndexWriter with IndexWriterConfig.OpenMode.CREATE
+            // It will abort all pending work, trash everything in memory and ensure proper locking on the IndexWriter object
+            getIndexWriter().deleteAll();
+            getIndexWriter().commit();
+        } catch (IOException e) {
+            LOGGER.error("An error occurred deleting cleanly the " + indexType.name().toLowerCase() + " index. Forcing delete", e);
+            delete(indexType);
+        }
     }
 
     /**
@@ -339,10 +396,106 @@ public abstract class IndexManager implements AutoCloseable {
     }
 
     /**
-     * Returns if the index directory exists or not.
-     * @since 3.4.0
+     * Ensure that all lucene indexes are healthy.
      */
-    public static boolean exists(final IndexType indexType) {
-        return getIndexDirectory(indexType).exists();
+    public static void ensureIndexesExists() {
+        Arrays.stream(IndexManager.IndexType.values()).forEach(indexType -> {
+            if (!isIndexHealthy(indexType)) {
+                LOGGER.info("(Re)Building index "+indexType.name().toLowerCase());
+                LOGGER.debug("Dispatching event to reindex "+indexType.name().toLowerCase());
+                Event.dispatch(new IndexEvent(IndexEvent.Action.REINDEX, indexType.getClazz()));
+            }
+        });
+    }
+
+    /**
+     * Check that the index exists and is not corrupted
+     */
+    private static boolean isIndexHealthy(final IndexType indexType) {
+        LOGGER.info("Checking the health of index "+indexType.name());
+        File indexDirectoryFile = getIndexDirectory(indexType);
+        LOGGER.debug("Checking FS directory "+indexDirectoryFile.toPath());
+        if(!indexDirectoryFile.exists()) {
+            LOGGER.warn("The index "+indexType.name()+" does not exist");
+            return false;
+        }
+        LOGGER.debug("Checking lucene index health");
+        Directory luceneIndexDirectory = null;
+        CheckIndex checkIndex = null;
+        try {
+            File writeLock = Path.of(indexDirectoryFile.getAbsolutePath(), IndexWriter.WRITE_LOCK_NAME).toFile();
+            if (writeLock.exists()) {
+                LOGGER.debug("Stale lock file detected. Deleting it");
+                writeLock.delete();
+            }
+            luceneIndexDirectory = FSDirectory.open(indexDirectoryFile.toPath());
+            checkIndex = new CheckIndex(luceneIndexDirectory);
+            checkIndex.setFailFast(true);
+            checkIndex.setInfoStream(System.out);
+            CheckIndex.Status status = checkIndex.checkIndex();
+            if(status.clean) {
+                LOGGER.info("The index "+indexType.name()+" is healthy");
+            } else {
+                LOGGER.error("The index " + indexType.name().toLowerCase() + " seems to be corrupted");
+            }
+            return status.clean;
+        } catch (IOException | CheckIndex.CheckIndexException e) {
+            LOGGER.error("The index " + indexType.name().toLowerCase() + " seems to be corrupted", e);
+            return false;
+        } finally {
+            try {
+                if (luceneIndexDirectory != null) {
+                    luceneIndexDirectory.close();
+                }
+                if (checkIndex != null) {
+                    checkIndex.close();
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * Check that the index exists, is not corrupted and is consistent with the database.
+     */
+    public static void checkIndexesConsistency() {
+        Arrays.stream(IndexType.values()).forEach(indexType -> {
+            try (QueryManager qm = new QueryManager()) {
+                LOGGER.info("Checking the index " + indexType.name().toLowerCase());
+                if (!isIndexHealthy(indexType)) {
+                    LOGGER.info("(Re)Building index "+indexType.name().toLowerCase());
+                    LOGGER.debug("Dispatching event to reindex "+indexType.name().toLowerCase());
+                    Event.dispatch(new IndexEvent(IndexEvent.Action.REINDEX, indexType.getClazz()));
+                }
+                final ConfigProperty deltaThresholdProperty = qm.getConfigProperty(
+                        INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getGroupName(), INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getPropertyName());
+                double deltaThreshold = Double.parseDouble(deltaThresholdProperty.getPropertyValue());
+                double databaseEntityCount = qm.getCount(indexType.getClazz());
+                LOGGER.info("Database entity count for type "+indexType.name()+" : "+databaseEntityCount);
+                IndexManager indexManager = IndexManagerFactory.getIndexManager(indexType.getClazz());
+                indexManager.ensureDirectoryReaderOpen();
+                double indexDocumentCount = indexManager.searchReader.numDocs();
+                LOGGER.info("Index document count for type "+indexType.name()+" : "+indexDocumentCount);
+                double max = Math.max(Math.max(databaseEntityCount, indexDocumentCount),1);
+                double delta = 100 * (Math.abs(databaseEntityCount-indexDocumentCount) / max);
+                delta = Math.max(Math.round(delta), 1);
+                LOGGER.info("Delta ratio for type "+indexType.name()+" : "+delta+"%");
+                if(delta > deltaThreshold) {
+                    LOGGER.info("Delta ratio is above the threshold of "+deltaThresholdProperty.getPropertyValue()+"%");
+                    LOGGER.debug("Dispatching event to reindex "+indexType.name().toLowerCase());
+                    Event.dispatch(new IndexEvent(IndexEvent.Action.REINDEX, indexType.getClazz()));
+                }
+            } catch (IOException e) {
+                LOGGER.error("An I/O exception occurred while trying to read Lucene index", e);
+                Notification.dispatch(new Notification()
+                        .scope(NotificationScope.SYSTEM)
+                        .group(NotificationGroup.INDEXING_SERVICE)
+                        .title(NotificationConstants.Title.CORE_INDEXING_SERVICES)
+                        .content("An I/O exception occurred while searching Lucene index. Check log for details. " + e.getMessage())
+                        .level(NotificationLevel.ERROR)
+                );
+            }
+        });
     }
 }

--- a/src/main/java/org/dependencytrack/search/IndexManagerFactory.java
+++ b/src/main/java/org/dependencytrack/search/IndexManagerFactory.java
@@ -69,4 +69,23 @@ public class IndexManagerFactory {
         throw new IllegalArgumentException("Unsupported indexer requested");
     }
 
+    public static IndexManager getIndexManager(final Class<?> clazz) {
+        if (Project.class == clazz) {
+            return ProjectIndexer.getInstance();
+        } else if (Component.class == clazz) {
+            return ComponentIndexer.getInstance();
+        } else if (ServiceComponent.class == clazz) {
+            return ServiceComponentIndexer.getInstance();
+        } else if (Vulnerability.class == clazz) {
+            return VulnerabilityIndexer.getInstance();
+        } else if (License.class == clazz) {
+            return LicenseIndexer.getInstance();
+        } else if (Cpe.class == clazz) {
+            return CpeIndexer.getInstance();
+        } else if (VulnerableSoftware.class == clazz) {
+            return VulnerableSoftwareIndexer.getInstance();
+        }
+        throw new IllegalArgumentException("Unsupported indexer requested");
+    }
+
 }

--- a/src/main/java/org/dependencytrack/search/IndexSubsystemInitializer.java
+++ b/src/main/java/org/dependencytrack/search/IndexSubsystemInitializer.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.search;
+
+import alpine.common.logging.Logger;
+import org.dependencytrack.RequirementsVerifier;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+/**
+ * Build lucene indexes if needed.
+ *
+ * @author Steve Springett
+ * @since 3.0.0
+ */
+public class IndexSubsystemInitializer implements ServletContextListener {
+
+    private static final Logger LOGGER = Logger.getLogger(IndexSubsystemInitializer.class);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void contextInitialized(final ServletContextEvent event) {
+        LOGGER.info("Building lucene indexes if required");
+
+        if (RequirementsVerifier.failedValidation()) {
+            return;
+        }
+
+        IndexManager.ensureIndexesExists();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void contextDestroyed(final ServletContextEvent event) {
+        // Nothing to be done
+    }
+}

--- a/src/main/java/org/dependencytrack/search/LicenseIndexer.java
+++ b/src/main/java/org/dependencytrack/search/LicenseIndexer.java
@@ -24,6 +24,7 @@ import alpine.notification.NotificationLevel;
 import alpine.persistence.PaginatedResult;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.Term;
 import org.dependencytrack.model.License;
 import org.dependencytrack.notification.NotificationConstants;
@@ -74,6 +75,8 @@ public final class LicenseIndexer extends IndexManager implements ObjectIndexer<
 
         try {
             getIndexWriter().addDocument(doc);
+        } catch (CorruptIndexException e) {
+            handleCorruptIndexException(e);
         } catch (IOException e) {
             LOGGER.error("An error occurred while adding a license to the index", e);
             Notification.dispatch(new Notification()
@@ -94,6 +97,8 @@ public final class LicenseIndexer extends IndexManager implements ObjectIndexer<
     public void remove(final License license) {
         try {
             getIndexWriter().deleteDocuments(new Term(IndexConstants.LICENSE_UUID, license.getUuid().toString()));
+        } catch (CorruptIndexException e) {
+            handleCorruptIndexException(e);
         } catch (IOException e) {
             LOGGER.error("An error occurred while removing a license from the index", e);
             Notification.dispatch(new Notification()

--- a/src/main/java/org/dependencytrack/search/ProjectIndexer.java
+++ b/src/main/java/org/dependencytrack/search/ProjectIndexer.java
@@ -24,6 +24,7 @@ import alpine.notification.NotificationLevel;
 import alpine.persistence.PaginatedResult;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.Term;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.notification.NotificationConstants;
@@ -87,6 +88,8 @@ public final class ProjectIndexer extends IndexManager implements ObjectIndexer<
 
         try {
             getIndexWriter().addDocument(doc);
+        } catch (CorruptIndexException e) {
+            handleCorruptIndexException(e);
         } catch (IOException e) {
             LOGGER.error("An error occurred while adding a project to the index", e);
             Notification.dispatch(new Notification()
@@ -107,6 +110,8 @@ public final class ProjectIndexer extends IndexManager implements ObjectIndexer<
     public void remove(final Project project) {
         try {
             getIndexWriter().deleteDocuments(new Term(IndexConstants.PROJECT_UUID, project.getUuid().toString()));
+        } catch (CorruptIndexException e) {
+            handleCorruptIndexException(e);
         } catch (IOException e) {
             LOGGER.error("An error occurred while removing a project from the index", e);
             Notification.dispatch(new Notification()

--- a/src/main/java/org/dependencytrack/search/SearchManager.java
+++ b/src/main/java/org/dependencytrack/search/SearchManager.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -162,7 +163,7 @@ public class SearchManager {
         return searchIndex(VulnerableSoftwareIndexer.getInstance(), queryString, limit);
     }
 
-    public String reindex(List<String> type) {
+    public String reindex(Set<String> type) {
         List<IndexManager.IndexType> indexTypes = type.stream().flatMap(t -> IndexManager.IndexType.getIndexType(t).stream()).toList();
         if(indexTypes.isEmpty()) {
             throw new IllegalArgumentException("No valid index type was provided");

--- a/src/main/java/org/dependencytrack/search/SearchManager.java
+++ b/src/main/java/org/dependencytrack/search/SearchManager.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.search;
 
 import alpine.common.logging.Logger;
+import alpine.event.framework.Event;
 import alpine.notification.Notification;
 import alpine.notification.NotificationLevel;
 import org.apache.commons.lang3.StringUtils;
@@ -29,6 +30,7 @@ import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
+import org.dependencytrack.event.IndexEvent;
 import org.dependencytrack.notification.NotificationConstants;
 import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationScope;
@@ -119,6 +121,8 @@ public class SearchManager {
                     .content("Corrupted Lucene index detected. Check log for details. " + e.getMessage())
                     .level(NotificationLevel.ERROR)
             );
+            LOGGER.info("Trying to rebuild the corrupted index "+indexManager.getIndexType().name());
+            Event.dispatch(new IndexEvent(IndexEvent.Action.REINDEX, indexManager.getIndexType().getClazz()));
         } catch (IOException e) {
             LOGGER.error("An I/O Exception occurred while searching Lucene index", e);
             Notification.dispatch(new Notification()
@@ -157,6 +161,27 @@ public class SearchManager {
     public SearchResult searchVulnerableSoftwareIndex(final String queryString, final int limit) {
         return searchIndex(VulnerableSoftwareIndexer.getInstance(), queryString, limit);
     }
+
+    public String reindex(List<String> type) {
+        List<IndexManager.IndexType> indexTypes = type.stream().flatMap(t -> IndexManager.IndexType.getIndexType(t).stream()).toList();
+        if(indexTypes.isEmpty()) {
+            throw new IllegalArgumentException("No valid index type was provided");
+        }
+        IndexEvent firstReindexEvent = new IndexEvent(IndexEvent.Action.REINDEX, indexTypes.get(0).getClazz());
+        String uuid = firstReindexEvent.getChainIdentifier().toString();
+        IndexEvent currentReindexEvent = firstReindexEvent;
+        for(IndexManager.IndexType indexType : indexTypes) {
+            if(indexType != indexTypes.get(0)) {
+                IndexEvent reindexEvent = new IndexEvent(IndexEvent.Action.REINDEX, indexType.getClazz());
+                currentReindexEvent.onSuccess(reindexEvent);
+                currentReindexEvent.onFailure(reindexEvent);
+                currentReindexEvent = reindexEvent;
+            }
+        }
+        Event.dispatch(firstReindexEvent);
+        return uuid;
+    }
+
     /**
      * Escapes special characters used in Lucene query syntax.
      * + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /

--- a/src/main/java/org/dependencytrack/search/ServiceComponentIndexer.java
+++ b/src/main/java/org/dependencytrack/search/ServiceComponentIndexer.java
@@ -24,6 +24,7 @@ import alpine.notification.NotificationLevel;
 import alpine.persistence.PaginatedResult;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.Term;
 import org.dependencytrack.model.ServiceComponent;
 import org.dependencytrack.notification.NotificationConstants;
@@ -77,6 +78,8 @@ public final class ServiceComponentIndexer extends IndexManager implements Objec
 
         try {
             getIndexWriter().addDocument(doc);
+        } catch (CorruptIndexException e) {
+            handleCorruptIndexException(e);
         } catch (IOException e) {
             LOGGER.error("An error occurred while adding service to index", e);
             Notification.dispatch(new Notification()
@@ -97,6 +100,8 @@ public final class ServiceComponentIndexer extends IndexManager implements Objec
     public void remove(final ServiceComponent service) {
         try {
             getIndexWriter().deleteDocuments(new Term(IndexConstants.SERVICECOMPONENT_UUID, service.getUuid().toString()));
+        } catch (CorruptIndexException e) {
+            handleCorruptIndexException(e);
         } catch (IOException e) {
             LOGGER.error("An error occurred while removing a service from the index", e);
             Notification.dispatch(new Notification()

--- a/src/main/java/org/dependencytrack/search/VulnerabilityIndexer.java
+++ b/src/main/java/org/dependencytrack/search/VulnerabilityIndexer.java
@@ -24,6 +24,7 @@ import alpine.notification.NotificationLevel;
 import alpine.persistence.PaginatedResult;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.Term;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.notification.NotificationConstants;
@@ -75,6 +76,8 @@ public final class VulnerabilityIndexer extends IndexManager implements ObjectIn
 
         try {
             getIndexWriter().addDocument(doc);
+        } catch (CorruptIndexException e) {
+            handleCorruptIndexException(e);
         } catch (IOException e) {
             LOGGER.error("An error occurred while adding a vulnerability to the index", e);
             Notification.dispatch(new Notification()
@@ -95,6 +98,8 @@ public final class VulnerabilityIndexer extends IndexManager implements ObjectIn
     public void remove(final Vulnerability vulnerability) {
         try {
             getIndexWriter().deleteDocuments(new Term(IndexConstants.VULNERABILITY_UUID, vulnerability.getUuid().toString()));
+        } catch (CorruptIndexException e) {
+            handleCorruptIndexException(e);
         } catch (IOException e) {
             LOGGER.error("An error occurred while removing a vulnerability from the index", e);
             Notification.dispatch(new Notification()

--- a/src/main/java/org/dependencytrack/search/VulnerableSoftwareIndexer.java
+++ b/src/main/java/org/dependencytrack/search/VulnerableSoftwareIndexer.java
@@ -24,6 +24,7 @@ import alpine.notification.NotificationLevel;
 import alpine.persistence.PaginatedResult;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.Term;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.notification.NotificationConstants;
@@ -78,6 +79,8 @@ public final class VulnerableSoftwareIndexer extends IndexManager implements Obj
 
         try {
             getIndexWriter().addDocument(doc);
+        } catch (CorruptIndexException e) {
+            handleCorruptIndexException(e);
         } catch (IOException e) {
             LOGGER.error("An error occurred while adding a VulnerableSoftware to the index", e);
             Notification.dispatch(new Notification()
@@ -98,6 +101,8 @@ public final class VulnerableSoftwareIndexer extends IndexManager implements Obj
     public void remove(final VulnerableSoftware vs) {
         try {
             getIndexWriter().deleteDocuments(new Term(IndexConstants.VULNERABLESOFTWARE_UUID, vs.getUuid().toString()));
+        } catch (CorruptIndexException e) {
+            handleCorruptIndexException(e);
         } catch (IOException e) {
             LOGGER.error("An error occurred while removing a VulnerableSoftware from the index", e);
             Notification.dispatch(new Notification()

--- a/src/main/java/org/dependencytrack/tasks/IndexTask.java
+++ b/src/main/java/org/dependencytrack/tasks/IndexTask.java
@@ -66,7 +66,7 @@ public class IndexTask implements Subscriber {
             } else if (IndexEvent.Action.REINDEX == event.getAction()) {
                 Timer timer = Timer.builder("lucene_index_rebuild")
                         .description("Lucene index rebuild")
-                        .tags("type", ((IndexManager) indexManager).getIndexType().name().toLowerCase())
+                        .tags("type", event.getIndexableClass().getName().toLowerCase())
                         .register(Metrics.getRegistry());
                 Timer.Sample recording = Timer.start();
                 indexManager.reindex();

--- a/src/main/java/org/dependencytrack/tasks/IndexTask.java
+++ b/src/main/java/org/dependencytrack/tasks/IndexTask.java
@@ -19,9 +19,12 @@
 package org.dependencytrack.tasks;
 
 import alpine.common.logging.Logger;
+import alpine.common.metrics.Metrics;
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
+import io.micrometer.core.instrument.Timer;
 import org.dependencytrack.event.IndexEvent;
+import org.dependencytrack.search.IndexManager;
 import org.dependencytrack.search.IndexManagerFactory;
 import org.dependencytrack.search.ObjectIndexer;
 
@@ -43,6 +46,12 @@ public class IndexTask implements Subscriber {
 
         if (e instanceof IndexEvent) {
             final IndexEvent event = (IndexEvent) e;
+
+            if (IndexEvent.Action.CHECK == event.getAction()) {
+                IndexManager.checkIndexesConsistency();
+                return;
+            }
+
             final ObjectIndexer indexManager = IndexManagerFactory.getIndexManager(event);
 
             if (IndexEvent.Action.CREATE == event.getAction()) {
@@ -55,7 +64,13 @@ public class IndexTask implements Subscriber {
             } else if (IndexEvent.Action.COMMIT == event.getAction()) {
                 indexManager.commit();
             } else if (IndexEvent.Action.REINDEX == event.getAction()) {
+                Timer timer = Timer.builder("lucene_index_rebuild")
+                        .description("Lucene index rebuild")
+                        .tags("type", ((IndexManager) indexManager).getIndexType().name().toLowerCase())
+                        .register(Metrics.getRegistry());
+                Timer.Sample recording = Timer.start();
                 indexManager.reindex();
+                recording.stop(timer);
             }
         }
     }

--- a/src/main/java/org/dependencytrack/tasks/TaskScheduler.java
+++ b/src/main/java/org/dependencytrack/tasks/TaskScheduler.java
@@ -28,6 +28,7 @@ import org.dependencytrack.event.ClearComponentAnalysisCacheEvent;
 import org.dependencytrack.event.DefectDojoUploadEventAbstract;
 import org.dependencytrack.event.FortifySscUploadEventAbstract;
 import org.dependencytrack.event.GitHubAdvisoryMirrorEvent;
+import org.dependencytrack.event.IndexEvent;
 import org.dependencytrack.event.InternalComponentIdentificationEvent;
 import org.dependencytrack.event.KennaSecurityUploadEventAbstract;
 import org.dependencytrack.event.NistMirrorEvent;
@@ -44,6 +45,8 @@ import static org.dependencytrack.model.ConfigPropertyConstants.DEFECTDOJO_ENABL
 import static org.dependencytrack.model.ConfigPropertyConstants.DEFECTDOJO_SYNC_CADENCE;
 import static org.dependencytrack.model.ConfigPropertyConstants.FORTIFY_SSC_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.FORTIFY_SSC_SYNC_CADENCE;
+import static org.dependencytrack.model.ConfigPropertyConstants.INDEXES_CONSISTENCY_CHECK_CADENCE;
+import static org.dependencytrack.model.ConfigPropertyConstants.INDEXES_CONSISTENCY_CHECK_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.KENNA_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.KENNA_SYNC_CADENCE;
 import static org.dependencytrack.model.ConfigPropertyConstants.TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_CADENCE;
@@ -112,6 +115,7 @@ public final class TaskScheduler extends AlpineTaskScheduler {
         scheduleConfigurableTask(300000, FORTIFY_SSC_ENABLED, FORTIFY_SSC_SYNC_CADENCE, new FortifySscUploadEventAbstract());
         scheduleConfigurableTask(300000, DEFECTDOJO_ENABLED, DEFECTDOJO_SYNC_CADENCE, new DefectDojoUploadEventAbstract());
         scheduleConfigurableTask(300000, KENNA_ENABLED, KENNA_SYNC_CADENCE, new KennaSecurityUploadEventAbstract());
+        scheduleConfigurableTask(10800000, INDEXES_CONSISTENCY_CHECK_ENABLED, INDEXES_CONSISTENCY_CHECK_CADENCE, new IndexEvent(IndexEvent.Action.CHECK, Object.class));
     }
 
     /**

--- a/src/main/java/org/dependencytrack/tasks/TaskScheduler.java
+++ b/src/main/java/org/dependencytrack/tasks/TaskScheduler.java
@@ -45,8 +45,8 @@ import static org.dependencytrack.model.ConfigPropertyConstants.DEFECTDOJO_ENABL
 import static org.dependencytrack.model.ConfigPropertyConstants.DEFECTDOJO_SYNC_CADENCE;
 import static org.dependencytrack.model.ConfigPropertyConstants.FORTIFY_SSC_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.FORTIFY_SSC_SYNC_CADENCE;
-import static org.dependencytrack.model.ConfigPropertyConstants.INDEXES_CONSISTENCY_CHECK_CADENCE;
-import static org.dependencytrack.model.ConfigPropertyConstants.INDEXES_CONSISTENCY_CHECK_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.SEARCH_INDEXES_CONSISTENCY_CHECK_CADENCE;
+import static org.dependencytrack.model.ConfigPropertyConstants.SEARCH_INDEXES_CONSISTENCY_CHECK_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.KENNA_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.KENNA_SYNC_CADENCE;
 import static org.dependencytrack.model.ConfigPropertyConstants.TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_CADENCE;
@@ -115,7 +115,7 @@ public final class TaskScheduler extends AlpineTaskScheduler {
         scheduleConfigurableTask(300000, FORTIFY_SSC_ENABLED, FORTIFY_SSC_SYNC_CADENCE, new FortifySscUploadEventAbstract());
         scheduleConfigurableTask(300000, DEFECTDOJO_ENABLED, DEFECTDOJO_SYNC_CADENCE, new DefectDojoUploadEventAbstract());
         scheduleConfigurableTask(300000, KENNA_ENABLED, KENNA_SYNC_CADENCE, new KennaSecurityUploadEventAbstract());
-        scheduleConfigurableTask(10800000, INDEXES_CONSISTENCY_CHECK_ENABLED, INDEXES_CONSISTENCY_CHECK_CADENCE, new IndexEvent(IndexEvent.Action.CHECK, Object.class));
+        scheduleConfigurableTask(10800000, SEARCH_INDEXES_CONSISTENCY_CHECK_ENABLED, SEARCH_INDEXES_CONSISTENCY_CHECK_CADENCE, new IndexEvent(IndexEvent.Action.CHECK, Object.class));
     }
 
     /**

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -47,6 +47,9 @@
     <listener>
         <listener-class>org.dependencytrack.notification.NotificationSubsystemInitializer</listener-class>
     </listener>
+    <listener>
+        <listener-class>org.dependencytrack.search.IndexSubsystemInitializer</listener-class>
+    </listener>
 
     <filter>
         <filter-name>WhitelistUrlFilter</filter-name>

--- a/src/test/java/org/dependencytrack/event/IndexEventTest.java
+++ b/src/test/java/org/dependencytrack/event/IndexEventTest.java
@@ -19,9 +19,11 @@
 package org.dependencytrack.event;
 
 import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Cpe;
 import org.dependencytrack.model.License;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.VulnerableSoftware;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -33,7 +35,7 @@ public class IndexEventTest {
         IndexEvent event = new IndexEvent(IndexEvent.Action.CREATE, project);
         Assert.assertEquals(IndexEvent.Action.CREATE, event.getAction());
         Assert.assertEquals(project, event.getObject());
-        Assert.assertNull(event.getIndexableClass());
+        Assert.assertEquals(Project.class,event.getIndexableClass());
     }
 
     @Test
@@ -42,7 +44,7 @@ public class IndexEventTest {
         IndexEvent event = new IndexEvent(IndexEvent.Action.UPDATE, component);
         Assert.assertEquals(IndexEvent.Action.UPDATE, event.getAction());
         Assert.assertEquals(component, event.getObject());
-        Assert.assertNull(event.getIndexableClass());
+        Assert.assertEquals(Component.class,event.getIndexableClass());
     }
 
     @Test
@@ -51,7 +53,7 @@ public class IndexEventTest {
         IndexEvent event = new IndexEvent(IndexEvent.Action.DELETE, vulnerability);
         Assert.assertEquals(IndexEvent.Action.DELETE, event.getAction());
         Assert.assertEquals(vulnerability, event.getObject());
-        Assert.assertNull(event.getIndexableClass());
+        Assert.assertEquals(Vulnerability.class, event.getIndexableClass());
     }
 
     @Test
@@ -60,7 +62,25 @@ public class IndexEventTest {
         IndexEvent event = new IndexEvent(IndexEvent.Action.COMMIT, license);
         Assert.assertEquals(IndexEvent.Action.COMMIT, event.getAction());
         Assert.assertEquals(license, event.getObject());
-        Assert.assertNull(event.getIndexableClass());
+        Assert.assertEquals(License.class, event.getIndexableClass());
+    }
+
+    @Test
+    public void testCpeEvent() {
+        Cpe cpe = new Cpe();
+        IndexEvent event = new IndexEvent(IndexEvent.Action.COMMIT, cpe);
+        Assert.assertEquals(IndexEvent.Action.COMMIT, event.getAction());
+        Assert.assertEquals(cpe, event.getObject());
+        Assert.assertEquals(Cpe.class, event.getIndexableClass());
+    }
+
+    @Test
+    public void testVulnerableSoftwareEvent() {
+        VulnerableSoftware vulnerableSoftware = new VulnerableSoftware();
+        IndexEvent event = new IndexEvent(IndexEvent.Action.COMMIT, vulnerableSoftware);
+        Assert.assertEquals(IndexEvent.Action.COMMIT, event.getAction());
+        Assert.assertEquals(vulnerableSoftware, event.getObject());
+        Assert.assertEquals(VulnerableSoftware.class, event.getIndexableClass());
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/event/IndexEventTest.java
+++ b/src/test/java/org/dependencytrack/event/IndexEventTest.java
@@ -74,11 +74,12 @@ public class IndexEventTest {
 
     @Test
     public void testActions() {
-        Assert.assertEquals(5, IndexEvent.Action.values().length);
+        Assert.assertEquals(6, IndexEvent.Action.values().length);
         Assert.assertEquals("CREATE", IndexEvent.Action.CREATE.name());
         Assert.assertEquals("UPDATE", IndexEvent.Action.UPDATE.name());
         Assert.assertEquals("DELETE", IndexEvent.Action.DELETE.name());
         Assert.assertEquals("COMMIT", IndexEvent.Action.COMMIT.name());
         Assert.assertEquals("REINDEX", IndexEvent.Action.REINDEX.name());
+        Assert.assertEquals("CHECK", IndexEvent.Action.CHECK.name());
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
@@ -147,7 +147,7 @@ public class ConfigPropertyResourceTest extends ResourceTest {
 
     @Test
     public void updateBadIndexConsistencyThresholdConfigPropertyTest() {
-        ConfigProperty property = qm.createConfigProperty(ConfigPropertyConstants.INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getGroupName(), ConfigPropertyConstants.INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getPropertyName(), "24", IConfigProperty.PropertyType.INTEGER, ConfigPropertyConstants.INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getDescription());
+        ConfigProperty property = qm.createConfigProperty(ConfigPropertyConstants.SEARCH_INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getGroupName(), ConfigPropertyConstants.SEARCH_INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getPropertyName(), "24", IConfigProperty.PropertyType.INTEGER, ConfigPropertyConstants.SEARCH_INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getDescription());
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("-1");
         Response response = target(V1_CONFIG_PROPERTY).request()

--- a/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
@@ -146,6 +146,19 @@ public class ConfigPropertyResourceTest extends ResourceTest {
     }
 
     @Test
+    public void updateBadIndexConsistencyThresholdConfigPropertyTest() {
+        ConfigProperty property = qm.createConfigProperty(ConfigPropertyConstants.INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getGroupName(), ConfigPropertyConstants.INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getPropertyName(), "24", IConfigProperty.PropertyType.INTEGER, ConfigPropertyConstants.INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getDescription());
+        ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
+        request.setPropertyValue("-1");
+        Response response = target(V1_CONFIG_PROPERTY).request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.entity(request, MediaType.APPLICATION_JSON));
+        Assert.assertEquals(400, response.getStatus(), 0);
+        String body = getPlainTextBody(response);
+        Assert.assertEquals("Lucene index delta threshold ("+request.getPropertyName()+") cannot be inferior to 1 or superior to 100.A value of -1 was provided.", body);
+    }
+
+    @Test
     public void updateConfigPropertyUrlTest() {
         ConfigProperty property = qm.createConfigProperty("my.group", "my.url", "http://localhost", IConfigProperty.PropertyType.URL, "A url");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());

--- a/src/test/java/org/dependencytrack/search/CpeIndexerTest.java
+++ b/src/test/java/org/dependencytrack/search/CpeIndexerTest.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.search;
+
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.Cpe;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.UUID;
+
+public class CpeIndexerTest extends PersistenceCapableTest {
+
+    @Test
+    public void getSearchFieldsTest() {
+        String[] fields = CpeIndexer.getInstance().getSearchFields();
+        Assert.assertEquals(6, fields.length);
+        Assert.assertEquals("uuid", fields[0]);
+        Assert.assertEquals("cpe22", fields[1]);
+        Assert.assertEquals("cpe23", fields[2]);
+        Assert.assertEquals("vendor", fields[3]);
+        Assert.assertEquals("product", fields[4]);
+        Assert.assertEquals("version", fields[5]);
+    }
+
+    @Test
+    public void getIndexTypeTest() {
+        Assert.assertEquals(IndexManager.IndexType.CPE, CpeIndexer.getInstance().getIndexType());
+    }
+
+    @Test
+    public void addTest() {
+        Cpe cpe = new Cpe();
+        cpe.setUuid(UUID.randomUUID());
+        cpe.setCpe22("cpe22");
+        cpe.setCpe23("cpe23");
+        cpe.setVendor("vendor");
+        cpe.setProduct("product");
+        cpe.setVersion("version");
+        CpeIndexer.getInstance().add(cpe);
+        CpeIndexer.getInstance().commit();
+        SearchManager searchManager = new SearchManager();
+        SearchResult result = searchManager.searchIndex(CpeIndexer.getInstance(), cpe.getCpe23(), 10);
+        Assert.assertEquals(1, result.getResults().size());
+        Assert.assertEquals(1, result.getResults().get(CpeIndexer.getInstance().getIndexType().name().toLowerCase()).size());
+    }
+
+    @Test
+    public void removeTest() {
+        Cpe cpe = new Cpe();
+        cpe.setUuid(UUID.randomUUID());
+        cpe.setCpe22("cpe22");
+        cpe.setCpe23("cpe23");
+        cpe.setVendor("vendor");
+        cpe.setProduct("product");
+        cpe.setVersion("version");
+        CpeIndexer.getInstance().add(cpe);
+        CpeIndexer.getInstance().commit();
+        SearchManager searchManager = new SearchManager();
+        CpeIndexer.getInstance().remove(cpe);
+        CpeIndexer.getInstance().commit();
+        SearchResult result = searchManager.searchIndex(CpeIndexer.getInstance(), cpe.getUuid().toString(), 10);
+        Assert.assertEquals(1, result.getResults().size());
+        Assert.assertEquals(0, result.getResults().get(CpeIndexer.getInstance().getIndexType().name().toLowerCase()).size());
+    }
+
+    @Test
+    public void reindexTest() {
+        CpeIndexer.getInstance().reindex();
+    }
+}

--- a/src/test/java/org/dependencytrack/search/VulnerableSoftwareIndexerTest.java
+++ b/src/test/java/org/dependencytrack/search/VulnerableSoftwareIndexerTest.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.search;
+
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.Cpe;
+import org.dependencytrack.model.VulnerableSoftware;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.UUID;
+
+public class VulnerableSoftwareIndexerTest extends PersistenceCapableTest {
+
+    @Test
+    public void getSearchFieldsTest() {
+        String[] fields = VulnerableSoftwareIndexer.getInstance().getSearchFields();
+        Assert.assertEquals(6, fields.length);
+        Assert.assertEquals("uuid", fields[0]);
+        Assert.assertEquals("cpe22", fields[1]);
+        Assert.assertEquals("cpe23", fields[2]);
+        Assert.assertEquals("vendor", fields[3]);
+        Assert.assertEquals("product", fields[4]);
+        Assert.assertEquals("version", fields[5]);
+    }
+
+    @Test
+    public void getIndexTypeTest() {
+        Assert.assertEquals(IndexManager.IndexType.VULNERABLESOFTWARE, VulnerableSoftwareIndexer.getInstance().getIndexType());
+    }
+
+    @Test
+    public void addTest() {
+        VulnerableSoftware vulnerableSoftware = new VulnerableSoftware();
+        vulnerableSoftware.setUuid(UUID.randomUUID());
+        vulnerableSoftware.setCpe22("cpe22");
+        vulnerableSoftware.setCpe23("cpe23");
+        vulnerableSoftware.setVendor("vendor");
+        vulnerableSoftware.setProduct("product");
+        vulnerableSoftware.setVersion("version");
+        VulnerableSoftwareIndexer.getInstance().add(vulnerableSoftware);
+        VulnerableSoftwareIndexer.getInstance().commit();
+        SearchManager searchManager = new SearchManager();
+        SearchResult result = searchManager.searchIndex(VulnerableSoftwareIndexer.getInstance(), vulnerableSoftware.getCpe23(), 10);
+        Assert.assertEquals(1, result.getResults().size());
+        Assert.assertEquals(1, result.getResults().get(VulnerableSoftwareIndexer.getInstance().getIndexType().name().toLowerCase()).size());
+    }
+
+    @Test
+    public void removeTest() {
+        VulnerableSoftware vulnerableSoftware = new VulnerableSoftware();
+        vulnerableSoftware.setUuid(UUID.randomUUID());
+        vulnerableSoftware.setCpe22("cpe22");
+        vulnerableSoftware.setCpe23("cpe23");
+        vulnerableSoftware.setVendor("vendor");
+        vulnerableSoftware.setProduct("product");
+        vulnerableSoftware.setVersion("version");
+        VulnerableSoftwareIndexer.getInstance().add(vulnerableSoftware);
+        VulnerableSoftwareIndexer.getInstance().commit();
+        SearchManager searchManager = new SearchManager();
+        VulnerableSoftwareIndexer.getInstance().remove(vulnerableSoftware);
+        VulnerableSoftwareIndexer.getInstance().commit();
+        SearchResult result = searchManager.searchIndex(VulnerableSoftwareIndexer.getInstance(), vulnerableSoftware.getUuid().toString(), 10);
+        Assert.assertEquals(1, result.getResults().size());
+        Assert.assertEquals(0, result.getResults().get(VulnerableSoftwareIndexer.getInstance().getIndexType().name().toLowerCase()).size());
+    }
+
+    @Test
+    public void reindexTest() {
+        VulnerableSoftwareIndexer.getInstance().reindex();
+    }
+}


### PR DESCRIPTION
### Description

Fix : Restoring lucene index build during startup by having a dedicated listener

The following features/fixes are introduced as part of this PR

1. Index healthcheck at startup using a servlet listener. Healthcheck consist of index directory existence check and corruption check using lucene API. Any failure trigger rebuild of corresponding index
2. A new configurable background task to perform health and consistency check. Healthcheck is the same one performed during startup. Concistency check consist of computing a delta ratio between DB and Lucene and comparing it to a configurable threshold. Any failure trigger rebuild of corresponding index
3. Any Lucene `CorruptIndexException` will trigger a rebuild of the corresponding index
4. A REST API (and corresponding GUI admin screen) is provided to manually rebuild the index if need be

https://github.com/DependencyTrack/dependency-track/issues/2235 is created to reduce as much as possible delta between DB and lucene that feature 2 above mitigate.

### Addressed Issue

#2104 

### Additional Details

Related frontend PR https://github.com/DependencyTrack/frontend/pull/338

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
~~- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~~
~~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~~
