### PR TITLE
Add support for filtering by project in component identity lookups

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -189,60 +189,64 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
      * @return a list of components
      */
     public PaginatedResult getComponents(ComponentIdentity identity) {
-        return getComponents(identity, false);
+        return getComponents(identity, null, false);
+    }
+
+    public PaginatedResult getComponents(ComponentIdentity identity, boolean includeMetrics) {
+        return getComponents(identity, null, includeMetrics);
     }
 
     /**
      * Returns Components by their identity.
      * @param identity the ComponentIdentity to query against
+     * @param project The {@link Project} the {@link Component}s shall belong to
      * @param includeMetrics whether or not to include component metrics or not
      * @return a list of components
      */
-    public PaginatedResult getComponents(ComponentIdentity identity, boolean includeMetrics) {
+    public PaginatedResult getComponents(ComponentIdentity identity, Project project, boolean includeMetrics) {
         if (identity == null) {
             return null;
         }
 
+        final var queryFilterElements = new ArrayList<String>();
+        final var queryParams = new HashMap<String, Object>();
+
+        if (project != null) {
+            queryFilterElements.add(" project == :project ");
+            queryParams.put("project", project);
+        }
+
         final PaginatedResult result;
         if (identity.getGroup() != null || identity.getName() != null || identity.getVersion() != null) {
-
-            var params = new HashMap<String, Object>();
-            var queryFilterElements = new ArrayList<String>();
-
             if (identity.getGroup() != null) {
                 queryFilterElements.add(" group.toLowerCase().matches(:group) ");
-                params.put("group", ".*" + identity.getGroup().toLowerCase() + ".*");
+                queryParams.put("group", ".*" + identity.getGroup().toLowerCase() + ".*");
             }
             if (identity.getName() != null) {
                 queryFilterElements.add(" name.toLowerCase().matches(:name) ");
-                params.put("name", ".*" + identity.getName().toLowerCase() + ".*");
+                queryParams.put("name", ".*" + identity.getName().toLowerCase() + ".*");
             }
             if (identity.getVersion() != null) {
                 queryFilterElements.add(" version.toLowerCase().matches(:version) ");
-                params.put("version", ".*" + identity.getVersion().toLowerCase() + ".*");
+                queryParams.put("version", ".*" + identity.getVersion().toLowerCase() + ".*");
             }
 
-            var queryFilter = "(" + String.join(" && ", queryFilterElements) + ")";
-            result = loadComponents(queryFilter, params);
-
+            result = loadComponents("(" + String.join(" && ", queryFilterElements) + ")", queryParams);
         } else if (identity.getPurl() != null) {
-            var queryFilter = "(purl.toLowerCase().matches(:purl))";
-            var filterString = ".*" + identity.getPurl().canonicalize().toLowerCase() + ".*";
-            var params = Map.<String, Object>of("purl", filterString);
-            result = loadComponents(queryFilter, params);
+            queryFilterElements.add("purl.toLowerCase().matches(:purl)");
+            queryParams.put("purl", ".*" + identity.getPurl().canonicalize().toLowerCase() + ".*");
 
+            result = loadComponents("(" + String.join(" && ", queryFilterElements) + ")", queryParams);
         } else if (identity.getCpe() != null) {
-            var queryFilter = "(cpe.toLowerCase().matches(:cpe))";
-            var filterString = ".*" + identity.getCpe().toLowerCase() + ".*";
-            var params = Map.<String, Object>of("cpe", filterString);
-            result = loadComponents(queryFilter, params);
+            queryFilterElements.add("cpe.toLowerCase().matches(:cpe)");
+            queryParams.put("cpe", ".*" + identity.getCpe().toLowerCase() + ".*");
 
+            result = loadComponents("(" + String.join(" && ", queryFilterElements) + ")", queryParams);
         } else if (identity.getSwidTagId() != null) {
-            var queryFilter = "(swidTagId.toLowerCase().matches(:swidTagId))";
-            var filterString = ".*" + identity.getSwidTagId().toLowerCase() + ".*";
-            var params = Map.<String, Object>of("swidTagId", filterString);
-            result = loadComponents(queryFilter, params);
+            queryFilterElements.add("swidTagId.toLowerCase().matches(:swidTagId)");
+            queryParams.put("swidTagId", ".*" + identity.getSwidTagId().toLowerCase() + ".*");
 
+            result = loadComponents("(" + String.join(" && ", queryFilterElements) + ")", queryParams);
         } else {
             result = new PaginatedResult();
         }

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -475,6 +475,10 @@ public class QueryManager extends AlpineQueryManager {
         return getComponentQueryManager().getComponents(identity, includeMetrics);
     }
 
+    public PaginatedResult getComponents(ComponentIdentity identity, Project project, boolean includeMetrics) {
+        return getComponentQueryManager().getComponents(identity, project, includeMetrics);
+    }
+
     public Component createComponent(Component component, boolean commitIndex) {
         return getComponentQueryManager().createComponent(component, commitIndex);
     }

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -153,8 +153,20 @@ public class ComponentResource extends AlpineResource {
                                            @ApiParam(value = "The cpe of the component")
                                            @QueryParam("cpe") String cpe,
                                            @ApiParam(value = "The swidTagId of the component")
-                                           @QueryParam("swidTagId") String swidTagId) {
+                                           @QueryParam("swidTagId") String swidTagId,
+                                           @ApiParam(value = "The project the component belongs to")
+                                           @QueryParam("project") String projectUuid) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+            Project project = null;
+            if (projectUuid != null) {
+                project = qm.getObjectByUuid(Project.class, projectUuid);
+                if (project == null) {
+                    return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();
+                }
+                if (!qm.hasAccess(super.getPrincipal(), project)) {
+                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
+                }
+            }
             PackageURL packageURL = null;
             if (purl != null) {
                 try {
@@ -170,7 +182,7 @@ public class ComponentResource extends AlpineResource {
                     && identity.getPurl() == null && identity.getCpe() == null && identity.getSwidTagId() == null) {
                 return Response.ok().header(TOTAL_COUNT_HEADER, 0).build();
             } else {
-                final PaginatedResult result = qm.getComponents(identity, true);
+                final PaginatedResult result = qm.getComponents(identity, project, true);
                 return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
             }
         }


### PR DESCRIPTION
### Description

This PR adds a `project` query parameter to the `GET /api/v1/component/identity` endpoint. 

Filtering by project makes lookups more efficient on both sever- and client-side when only components of a certain projects are of interest.

### Addressed Issue

Closes #2228

### Additional Details

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
