### PR TITLE
Fix: Exact match between CPE with NA (-) update part

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/scanners/AbstractVulnerableSoftwareAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/AbstractVulnerableSoftwareAnalysisTask.java
@@ -198,6 +198,10 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
      * <code>false</code>
      */
     private static boolean compareUpdate(VulnerableSoftware vs, String targetUpdate) {
+
+        if (targetUpdate != null && targetUpdate.equals(vs.getUpdate())) {
+            return true;
+        }
         if (LogicalValue.NA.getAbbreviation().equals(vs.getUpdate())) {
             return false;
         }


### PR DESCRIPTION
### Description

https://github.com/DependencyTrack/dependency-track/discussions/2188

### Addressed Issue

See https://github.com/DependencyTrack/dependency-track/pull/1929#issuecomment-1331223525

This PR fix a bug making `cpe:2.3:a:xiph:speex:1.2:-:*:*:*:*:*:*` not equal to `cpe:2.3:a:xiph:speex:1.2:-:*:*:*:*:*:*` when performing internal analysis. Special cases (`NA` and `ANY` on each part) are handled before making the simplest of comparison.

Right now, the relation 6 in the picture below from [NIST CPE matching spec](https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7696.pdf) is correctly handled for CPE's update part.

![cpe_comparison](https://user-images.githubusercontent.com/6144741/206663021-17ee4ee2-388e-4375-97e7-a769b24f016f.png)


### Additional Details

N/A

### Checklist
- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
~~- [] This PR implements an enhancement, and I have provided tests to verify that it works as intended~~
~~- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~~
~~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~~
