### PR TITLE
Fix: AffectedComponent mapping from VulnerableSoftware in case of purl with no namespace

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/vo/AffectedComponent.java
+++ b/src/main/java/org/dependencytrack/resources/v1/vo/AffectedComponent.java
@@ -76,7 +76,6 @@ public class AffectedComponent {
             identityType = IdentityType.PURL;
             identity = vs.getPurl();
         } else if (vs.getPurlType() != null
-                && vs.getPurlNamespace() != null
                 && vs.getPurlName() != null) {
             TreeMap<String, String> qualifiers = null;
             if (vs.getPurlQualifiers() != null) {

--- a/src/main/java/org/dependencytrack/tasks/GitHubAdvisoryMirrorTask.java
+++ b/src/main/java/org/dependencytrack/tasks/GitHubAdvisoryMirrorTask.java
@@ -300,6 +300,7 @@ public class GitHubAdvisoryMirrorTask implements LoggableSubscriber {
             vs.setPurlType(purl.getType());
             vs.setPurlNamespace(purl.getNamespace());
             vs.setPurlName(purl.getName());
+            vs.setPurl(purl.canonicalize());
             vs.setVersionStartIncluding(versionStartIncluding);
             vs.setVersionStartExcluding(versionStartExcluding);
             vs.setVersionEndIncluding(versionEndIncluding);

--- a/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
+++ b/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
@@ -303,6 +303,7 @@ public class OsvDownloadTask implements LoggableSubscriber {
         vs.setPurlType(purl.getType());
         vs.setPurlNamespace(purl.getNamespace());
         vs.setPurlName(purl.getName());
+        vs.setPurl(purl.canonicalize());
         vs.setVulnerable(true);
         vs.setVersion(affectedPackage.getVersion());
         vs.setVersionStartIncluding(versionStartIncluding);

--- a/src/test/java/org/dependencytrack/resources/v1/vo/AffectedComponentTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/vo/AffectedComponentTest.java
@@ -71,6 +71,20 @@ public class AffectedComponentTest {
         }
 
         @Test
+        public void shouldMapPurlToPurlIdentityEvenWhenNoNamespace() {
+            final var vs = new VulnerableSoftware();
+            vs.setPurlType(PackageURL.StandardTypes.GOLANG);
+            vs.setPurlName("bar");
+            vs.setPurlVersion("baz");
+            vs.setPurlQualifiers("{\"ping\":\"pong\"}");
+            vs.setPurlSubpath("1/2/3");
+
+            final var affectedComponent = new AffectedComponent(vs);
+            assertThat(affectedComponent.getIdentityType()).isEqualTo(AffectedComponent.IdentityType.PURL);
+            assertThat(affectedComponent.getIdentity()).isEqualTo("pkg:golang/bar@baz?ping=pong#1/2/3");
+        }
+
+        @Test
         public void shouldMapPurlFragmentsToPurlIdentity() {
             final var vs = new VulnerableSoftware();
             vs.setPurlType(PackageURL.StandardTypes.GOLANG);


### PR DESCRIPTION
### Addressed Issue

#2231

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective