### PR TITLE
Show version status information on dependency graph nodes

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -583,13 +583,20 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             transientComponent.setUuid(entry.getValue().getUuid());
             transientComponent.setName(entry.getValue().getName());
             transientComponent.setVersion(entry.getValue().getVersion());
+            transientComponent.setPurl(entry.getValue().getPurl());
             transientComponent.setPurlCoordinates(entry.getValue().getPurlCoordinates());
             transientComponent.setDependencyGraph(entry.getValue().getDependencyGraph());
             transientComponent.setExpandDependencyGraph(entry.getValue().isExpandDependencyGraph());
-            final RepositoryType type = RepositoryType.resolve(transientComponent.getPurl());
-            if (RepositoryType.UNSUPPORTED != type) {
-                final RepositoryMetaComponent repoMetaComponent = getRepositoryMetaComponent(type, transientComponent.getPurl().getNamespace(), transientComponent.getPurl().getName());
-                transientComponent.setRepositoryMeta(repoMetaComponent);
+            if (transientComponent.getPurl() != null) {
+                final RepositoryType type = RepositoryType.resolve(transientComponent.getPurl());
+                if (RepositoryType.UNSUPPORTED != type) {
+                    final RepositoryMetaComponent repoMetaComponent = getRepositoryMetaComponent(type, transientComponent.getPurl().getNamespace(), transientComponent.getPurl().getName());
+                    if (repoMetaComponent != null) {
+                        RepositoryMetaComponent transientRepoMetaComponent = new RepositoryMetaComponent();
+                        transientRepoMetaComponent.setLatestVersion(repoMetaComponent.getLatestVersion());
+                        transientComponent.setRepositoryMeta(transientRepoMetaComponent);
+                    }
+                }
             }
             dependencyGraph.put(entry.getKey(), transientComponent);
         }

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -586,6 +586,11 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             transientComponent.setPurlCoordinates(entry.getValue().getPurlCoordinates());
             transientComponent.setDependencyGraph(entry.getValue().getDependencyGraph());
             transientComponent.setExpandDependencyGraph(entry.getValue().isExpandDependencyGraph());
+            final RepositoryType type = RepositoryType.resolve(transientComponent.getPurl());
+            if (RepositoryType.UNSUPPORTED != type) {
+                final RepositoryMetaComponent repoMetaComponent = getRepositoryMetaComponent(type, transientComponent.getPurl().getNamespace(), transientComponent.getPurl().getName());
+                transientComponent.setRepositoryMeta(repoMetaComponent);
+            }
             dependencyGraph.put(entry.getKey(), transientComponent);
         }
         return dependencyGraph;

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -40,6 +40,8 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentIdentity;
 import org.dependencytrack.model.License;
 import org.dependencytrack.model.Project;
+import org.dependencytrack.model.RepositoryType;
+import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.InternalComponentIdentificationUtil;
 
@@ -115,13 +117,22 @@ public class ComponentResource extends AlpineResource {
     @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
     public Response getComponentByUuid(
             @ApiParam(value = "The UUID of the component to retrieve", required = true)
-            @PathParam("uuid") String uuid) {
+            @PathParam("uuid") String uuid,
+            @ApiParam(value = "Optionally includes third-party metadata about the component from external repositories", required = false)
+            @QueryParam("includeRepositoryMetaData") boolean includeRepositoryMetaData) {
         try (QueryManager qm = new QueryManager()) {
             final Component component = qm.getObjectByUuid(Component.class, uuid);
             if (component != null) {
                 final Project project = component.getProject();
                 if (qm.hasAccess(super.getPrincipal(), project)) {
                     final Component detachedComponent = qm.detach(Component.class, component.getId()); // TODO: Force project to be loaded. It should be anyway, but JDO seems to be having issues here.
+                    if (includeRepositoryMetaData) {
+                        final RepositoryType type = RepositoryType.resolve(detachedComponent.getPurl());
+                        if (RepositoryType.UNSUPPORTED != type) {
+                            final RepositoryMetaComponent repoMetaComponent = qm.getRepositoryMetaComponent(type, detachedComponent.getPurl().getNamespace(), detachedComponent.getPurl().getName());
+                            detachedComponent.setRepositoryMeta(repoMetaComponent);
+                        }
+                    }
                     return Response.ok(detachedComponent).build();
                 } else {
                     return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified component is forbidden").build();

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -126,7 +126,7 @@ public class ComponentResource extends AlpineResource {
                 final Project project = component.getProject();
                 if (qm.hasAccess(super.getPrincipal(), project)) {
                     final Component detachedComponent = qm.detach(Component.class, component.getId()); // TODO: Force project to be loaded. It should be anyway, but JDO seems to be having issues here.
-                    if (includeRepositoryMetaData) {
+                    if (includeRepositoryMetaData && detachedComponent.getPurl() != null) {
                         final RepositoryType type = RepositoryType.resolve(detachedComponent.getPurl());
                         if (RepositoryType.UNSUPPORTED != type) {
                             final RepositoryMetaComponent repoMetaComponent = qm.getRepositoryMetaComponent(type, detachedComponent.getPurl().getNamespace(), detachedComponent.getPurl().getName());

--- a/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
@@ -515,6 +515,70 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
+    public void getDependencyGraphForComponentTestWithRepositoryMetaData() {
+        Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
+
+        Component component1 = new Component();
+        component1.setProject(project);
+        component1.setName("Component1");
+        component1.setVersion("1.0.0");
+        component1.setPurl("pkg:maven/org.acme/component1");
+        RepositoryMetaComponent meta1 = new RepositoryMetaComponent();
+        Date lastCheck = new Date();
+        meta1.setLastCheck(lastCheck);
+        meta1.setNamespace("org.acme");
+        meta1.setName("component1");
+        meta1.setLatestVersion("2.0.0");
+        meta1.setRepositoryType(RepositoryType.MAVEN);
+        qm.persist(meta1);
+        component1 = qm.createComponent(component1, false);
+
+        Component component1_1 = new Component();
+        component1_1.setProject(project);
+        component1_1.setName("Component1_1");
+        component1_1.setVersion("2.0.0");
+        component1_1.setPurl("pkg:maven/org.acme/component1_1");
+        RepositoryMetaComponent meta1_1 = new RepositoryMetaComponent();
+        meta1_1.setLastCheck(lastCheck);
+        meta1_1.setNamespace("org.acme");
+        meta1_1.setName("component1_1");
+        meta1_1.setLatestVersion("3.0.0");
+        meta1_1.setRepositoryType(RepositoryType.MAVEN);
+        qm.persist(meta1_1);
+        component1_1 = qm.createComponent(component1_1, false);
+
+        Component component1_1_1 = new Component();
+        component1_1_1.setProject(project);
+        component1_1_1.setName("Component1_1_1");
+        component1_1_1.setVersion("3.0.0");
+        component1_1_1.setPurl("pkg:maven/org.acme/component1_1_1");
+        RepositoryMetaComponent meta1_1_1 = new RepositoryMetaComponent();
+        meta1_1_1.setLastCheck(lastCheck);
+        meta1_1_1.setNamespace("org.acme");
+        meta1_1_1.setName("component1_1_1");
+        meta1_1_1.setLatestVersion("4.0.0");
+        meta1_1_1.setRepositoryType(RepositoryType.MAVEN);
+        qm.persist(meta1_1_1);
+        component1_1_1 = qm.createComponent(component1_1_1, false);
+
+        project.setDirectDependencies("[{\"uuid\":\"" + component1.getUuid() + "\"}]");
+        component1.setDirectDependencies("[{\"uuid\":\"" + component1_1.getUuid() + "\"}]");
+        component1_1.setDirectDependencies("[{\"uuid\":\"" + component1_1_1.getUuid() + "\"}]");
+
+        Response response = target(V1_COMPONENT + "/project/" + project.getUuid() + "/dependencyGraph/" + component1_1_1.getUuid())
+                .request().header(X_API_KEY, apiKey).get();
+        JsonObject json = parseJsonObject(response);
+        Assert.assertEquals(200, response.getStatus(), 0);
+
+        Assert.assertTrue(json.get(component1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
+        Assert.assertEquals("2.0.0", json.get(component1.getUuid().toString()).asJsonObject().get("repositoryMeta").asJsonObject().getString("latestVersion"));
+        Assert.assertTrue(json.get(component1_1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
+        Assert.assertEquals("3.0.0", json.get(component1_1.getUuid().toString()).asJsonObject().get("repositoryMeta").asJsonObject().getString("latestVersion"));
+        Assert.assertFalse(json.get(component1_1_1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
+        Assert.assertEquals("4.0.0", json.get(component1_1_1.getUuid().toString()).asJsonObject().get("repositoryMeta").asJsonObject().getString("latestVersion"));
+    }
+
+    @Test
     public void getDependencyGraphForComponentInvalidProjectUuidTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         Component component = new Component();


### PR DESCRIPTION
### Description

The information about the version status of a component is currently not displayed in the dependency graph, forcing users to switch to a different project tab, if they want to know about the version status.

This PR enhances the dependency graph to optionally display the version status information of a component on its corresponding node.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

Frontend: [#358](https://github.com/DependencyTrack/frontend/issues/358)

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

[Frontend PR](https://github.com/DependencyTrack/frontend/pull/359)

**Note:** For the sake of better readability, the version status icon will only be shown for outdated components.

![image](https://user-images.githubusercontent.com/113189967/207022827-32d33561-3ae6-4aa6-9395-0e0acf3d5ae6.png)

![image](https://user-images.githubusercontent.com/113189967/207022754-4a329d88-4401-4de6-bf7c-740829444d06.png)

![image](https://user-images.githubusercontent.com/113189967/207023206-0845d932-b76c-43a7-badc-686f1ccaf1b0.png)

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
~- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
~- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
