### PR TITLE
logging: reduce periodic details to debug level

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/GitHubAdvisoryMirrorTask.java
+++ b/src/main/java/org/dependencytrack/tasks/GitHubAdvisoryMirrorTask.java
@@ -169,7 +169,7 @@ public class GitHubAdvisoryMirrorTask implements LoggableSubscriber {
      * @param advisories the results to synchronize
      */
     void updateDatasource(final List<GitHubSecurityAdvisory> advisories) {
-        LOGGER.info("Updating datasource with GitHub advisories");
+        LOGGER.debug("Updating datasource with GitHub advisories");
         try (QueryManager qm = new QueryManager()) {
             for (final GitHubSecurityAdvisory advisory: advisories) {
                 LOGGER.debug("Synchronizing GitHub advisory: " + advisory.getGhsaId());

--- a/src/main/java/org/dependencytrack/tasks/metrics/ProjectMetricsUpdateTask.java
+++ b/src/main/java/org/dependencytrack/tasks/metrics/ProjectMetricsUpdateTask.java
@@ -57,7 +57,7 @@ public class ProjectMetricsUpdateTask implements Subscriber {
     }
 
     private void updateMetrics(final UUID uuid) throws Exception {
-        LOGGER.info("Executing metrics update for project " + uuid);
+        LOGGER.debug("Executing metrics update for project " + uuid);
         final var counters = new Counters();
 
         try (final QueryManager qm = new QueryManager()) {
@@ -146,7 +146,7 @@ public class ProjectMetricsUpdateTask implements Subscriber {
             }
         }
 
-        LOGGER.info("Completed metrics update for project " + uuid + " in " +
+        LOGGER.debug("Completed metrics update for project " + uuid + " in " +
                 DurationFormatUtils.formatDuration(new Date().getTime() - counters.measuredAt.getTime(), "mm:ss:SS"));
     }
 

--- a/src/main/java/org/dependencytrack/tasks/repositories/RepositoryMetaAnalyzerTask.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/RepositoryMetaAnalyzerTask.java
@@ -94,15 +94,16 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
                     LOGGER.info("Completed component repository metadata analysis against " + components.size() + " components");
                 }
             } else {
+                LOGGER.info("Analyzing portfolio component repository metadata");
                 try (final QueryManager qm = new QueryManager()) {
                     final List<Project> projects = qm.getAllProjects(true);
                     for (final Project project: projects) {
                         final List<Component> components = qm.getAllComponents(project);
-                        LOGGER.info("Performing component repository metadata analysis against " + components.size() + " components in project: " + project.getUuid());
+                        LOGGER.debug("Performing component repository metadata analysis against " + components.size() + " components in project: " + project.getUuid());
                         for (final Component component: components) {
                             analyze(qm, component);
                         }
-                        LOGGER.info("Completed component repository metadata analysis against " + components.size() + " components in project: " + project.getUuid());
+                        LOGGER.debug("Completed component repository metadata analysis against " + components.size() + " components in project: " + project.getUuid());
                     }
                 }
                 LOGGER.info("Portfolio component repository metadata analysis complete");


### PR DESCRIPTION
After enabling cloudwatch logging for my DT logs, I noticed the volume was a little more than expected.
Turns out 90% of the logging is coming from periodic tasks like updating metrics and syncing advisories. 
I suggest to reduce some of these loglines to DEBUG level instead of INFO level. 
Especially for the metrics updates I don't think it's necessary to log on INFO level 2 lines for each project every hour.

![image](https://user-images.githubusercontent.com/4426050/209314492-6fa7ac62-5e86-4bdc-adb8-5476c5d863ec.png)
