### PR TITLE
Validating purl-policies should now only return 1 violation

### DIFF
--- a/src/main/java/org/dependencytrack/policy/PackageURLPolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/PackageURLPolicyEvaluator.java
@@ -56,26 +56,12 @@ public class PackageURLPolicyEvaluator extends AbstractPolicyEvaluator {
         for (final PolicyCondition condition: super.extractSupportedConditions(policy)) {
             LOGGER.debug("Evaluating component (" + component.getUuid() + ") against policy condition (" + condition.getUuid() + ")");
             if (PolicyCondition.Operator.MATCHES == condition.getOperator()) {
-                if (component.getPurl() != null) {
-                    if (component.getPurl().canonicalize().contains(condition.getValue())) {
-                        violations.add(new PolicyConditionViolation(condition, component));
-                    }
-                }
-                if (component.getPurlCoordinates() != null) {
-                    if (component.getPurlCoordinates().canonicalize().contains(condition.getValue())) {
-                        violations.add(new PolicyConditionViolation(condition, component));
-                    }
+                if (component.getPurl().canonicalize().contains(condition.getValue())) {
+                    violations.add(new PolicyConditionViolation(condition, component));
                 }
             } else if (PolicyCondition.Operator.NO_MATCH == condition.getOperator()) {
-                if (component.getPurl() != null && component.getPurlCoordinates() != null) {
-                    if (!component.getPurl().canonicalize().contains(condition.getValue())
-                            && !component.getPurlCoordinates().canonicalize().contains(condition.getValue()) ) {
-                        violations.add(new PolicyConditionViolation(condition, component));
-                    }
-                } else if (component.getPurl() != null) {
-                    if (!component.getPurl().canonicalize().contains(condition.getValue())) {
-                        violations.add(new PolicyConditionViolation(condition, component));
-                    }
+                if (!component.getPurl().canonicalize().contains(condition.getValue())) {
+                    violations.add(new PolicyConditionViolation(condition, component));
                 }
             }
         }

--- a/src/test/java/org/dependencytrack/policy/PackageURLPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/PackageURLPolicyEvaluatorTest.java
@@ -77,4 +77,30 @@ public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
         Assert.assertEquals(0, violations.size());
     }
 
+    @Test
+    public void issue1925_matches() throws Exception {
+        Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.MATCHES, "pkg:generic/acme/example-component@1.0");
+        Component component = new Component();
+        component.setPurl(new PackageURL("pkg:generic/acme/example-component@1.0?type=jar"));
+        component.setPurlCoordinates(new PackageURL("pkg:generic/acme/example-component@1.0"));
+        PolicyEvaluator evaluator = new PackageURLPolicyEvaluator();
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        Assert.assertEquals(1, violations.size());
+        PolicyConditionViolation violation = violations.get(0);
+        Assert.assertEquals(component, violation.getComponent());
+        Assert.assertEquals(condition, violation.getPolicyCondition());
+    }
+
+    @Test
+    public void issue1925_no_match() throws Exception {
+        Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.NO_MATCH, "pkg:generic/acme/example-component@1.0");
+        Component component = new Component();
+        component.setPurl(new PackageURL("pkg:generic/acme/example-component@1.0?type=jar"));
+        component.setPurlCoordinates(new PackageURL("pkg:generic/acme/example-component@1.0"));
+        PolicyEvaluator evaluator = new PackageURLPolicyEvaluator();
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        Assert.assertEquals(0, violations.size());
+    }
 }


### PR DESCRIPTION
### Description

Validating purl-policies should now only return 1 violation.

### Addressed Issue

Fixes #1925
Fixes #2212

### Additional Details

Discussion of the solution can be found in #2330. Small change from the proposed solution there because of an already existing check for `null` on the `purl`.

### Checklist

- [X] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [X] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
