### PR TITLE
Checking policies violated instead of violations to fix ALL-policy

### DIFF
--- a/src/main/java/org/dependencytrack/policy/PolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/PolicyEngine.java
@@ -80,19 +80,19 @@ public class PolicyEngine {
                     || isPolicyAssignedToProjectTag(policy, component.getProject())) {
                 LOGGER.debug("Evaluating component (" + component.getUuid() +") against policy (" + policy.getUuid() + ")");
                 final List<PolicyConditionViolation> policyConditionViolations = new ArrayList<>();
-                int policiesViolated = 0;
+                int policyConditionsViolated = 0;
                 for (final PolicyEvaluator evaluator : evaluators) {
                     evaluator.setQueryManager(qm);
                     if (policyConditionViolations.addAll(evaluator.evaluate(policy, component))) {
-                        policiesViolated++;
+                        policyConditionsViolated++;
                     }
                 }
                 if (Policy.Operator.ANY == policy.getOperator()) {
-                    if (policiesViolated > 0) {
+                    if (policyConditionsViolated > 0) {
                         policyViolations.addAll(createPolicyViolations(qm, policyConditionViolations));
                     }
                 } else if (Policy.Operator.ALL == policy.getOperator()) {
-                    if (policiesViolated == policy.getPolicyConditions().size()) {
+                    if (policyConditionsViolated == policy.getPolicyConditions().size()) {
                         policyViolations.addAll(createPolicyViolations(qm, policyConditionViolations));
                     }
                 }

--- a/src/main/java/org/dependencytrack/policy/PolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/PolicyEngine.java
@@ -66,7 +66,7 @@ public class PolicyEngine {
             final List<Policy> policies = qm.getAllPolicies();
             for (final Component c: components) {
                 final Component component = qm.getObjectById(Component.class, c.getId());
-                violations = this.evaluate(qm, policies, component);
+                violations.addAll(this.evaluate(qm, policies, component));
             }
         }
         LOGGER.info("Policy analysis complete");
@@ -80,16 +80,19 @@ public class PolicyEngine {
                     || isPolicyAssignedToProjectTag(policy, component.getProject())) {
                 LOGGER.debug("Evaluating component (" + component.getUuid() +") against policy (" + policy.getUuid() + ")");
                 final List<PolicyConditionViolation> policyConditionViolations = new ArrayList<>();
+                int policiesViolated = 0;
                 for (final PolicyEvaluator evaluator : evaluators) {
                     evaluator.setQueryManager(qm);
-                    policyConditionViolations.addAll(evaluator.evaluate(policy, component));
+                    if (policyConditionViolations.addAll(evaluator.evaluate(policy, component))) {
+                        policiesViolated++;
+                    }
                 }
                 if (Policy.Operator.ANY == policy.getOperator()) {
-                    if (policyConditionViolations.size() > 0) {
+                    if (policiesViolated > 0) {
                         policyViolations.addAll(createPolicyViolations(qm, policyConditionViolations));
                     }
                 } else if (Policy.Operator.ALL == policy.getOperator()) {
-                    if (policyConditionViolations.size() == policy.getPolicyConditions().size()) {
+                    if (policiesViolated == policy.getPolicyConditions().size()) {
                         policyViolations.addAll(createPolicyViolations(qm, policyConditionViolations));
                     }
                 }

--- a/src/test/java/org/dependencytrack/policy/PolicyEngineTest.java
+++ b/src/test/java/org/dependencytrack/policy/PolicyEngineTest.java
@@ -179,5 +179,14 @@ public class PolicyEngineTest extends PersistenceCapableTest {
         PolicyEngine policyEngine = new PolicyEngine();
         List<PolicyViolation> violations = policyEngine.evaluate(components);
         Assert.assertEquals(3, violations.size());
+        PolicyViolation policyViolation = violations.get(0);
+        Assert.assertEquals("Log4J", policyViolation.getComponent().getName());
+        Assert.assertEquals(PolicyCondition.Subject.SEVERITY, policyViolation.getPolicyCondition().getSubject());
+        policyViolation = violations.get(1);
+        Assert.assertEquals("Log4J", policyViolation.getComponent().getName());
+        Assert.assertEquals(PolicyCondition.Subject.SEVERITY, policyViolation.getPolicyCondition().getSubject());
+        policyViolation = violations.get(2);
+        Assert.assertEquals("Log4J", policyViolation.getComponent().getName());
+        Assert.assertEquals(PolicyCondition.Subject.PACKAGE_URL, policyViolation.getPolicyCondition().getSubject());
     }
 }


### PR DESCRIPTION
### Description

Checking the actual number of policies violated instead of the number of violations found, since this can be different and it broke policy that are configured for ALL conditions to (not) match.

### Addressed Issue

Fixes #1924

### Additional Details

Using the return-value of 'List.addAll' to check if any violations were added by the evaluator to add 1 to the counter. Changed the check on 'ANY' to also use this counter for a little performance-gain.

Also found a bug in the method `evaluate(List)`, which until now only returned the **last** list of violations instead of all -- found this because my new test wasn't failing on the old code although it should have.

### Checklist

- [X] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [X] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
