### PR TITLE
Add support for component age policy conditions

### DIFF
--- a/src/main/java/org/dependencytrack/model/PolicyCondition.java
+++ b/src/main/java/org/dependencytrack/model/PolicyCondition.java
@@ -63,7 +63,7 @@ public class PolicyCondition implements Serializable {
     }
 
     public enum Subject {
-        //AGE,
+        AGE,
         //ANALYZER,
         //BOM,
         COORDINATES,

--- a/src/main/java/org/dependencytrack/policy/ComponentAgePolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/ComponentAgePolicyEvaluator.java
@@ -1,0 +1,122 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.policy;
+
+import alpine.common.logging.Logger;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Policy;
+import org.dependencytrack.model.PolicyCondition;
+import org.dependencytrack.model.RepositoryMetaComponent;
+import org.dependencytrack.model.RepositoryType;
+import org.dependencytrack.persistence.QueryManager;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Evaluates a {@link Component}'s published date against a {@link Policy}.
+ * <p>
+ * Age values can be provided in ISO-8601 period format, see {@link Period#parse(CharSequence)}.
+ *
+ * @since 4.8.0
+ */
+public class ComponentAgePolicyEvaluator extends AbstractPolicyEvaluator {
+
+    private static final Logger LOGGER = Logger.getLogger(ComponentAgePolicyEvaluator.class);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PolicyCondition.Subject supportedSubject() {
+        return PolicyCondition.Subject.AGE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<PolicyConditionViolation> evaluate(final Policy policy, final Component component) {
+        final var violations = new ArrayList<PolicyConditionViolation>();
+        if (component.getPurl() == null) {
+            return violations;
+        }
+
+        final RepositoryType repoType = RepositoryType.resolve(component.getPurl());
+        if (RepositoryType.UNSUPPORTED == repoType) {
+            return violations;
+        }
+
+        final RepositoryMetaComponent metaComponent;
+        try (final var qm = new QueryManager()) {
+            metaComponent = qm.getRepositoryMetaComponent(repoType,
+                    component.getPurl().getNamespace(), component.getPurl().getName());
+            qm.getPersistenceManager().detachCopy(metaComponent);
+        }
+        if (metaComponent == null || metaComponent.getPublished() == null) {
+            return violations;
+        }
+
+        for (final PolicyCondition condition : super.extractSupportedConditions(policy)) {
+            if (evaluate(condition, metaComponent.getPublished())) {
+                violations.add(new PolicyConditionViolation(condition, component));
+            }
+        }
+
+        return violations;
+    }
+
+    private boolean evaluate(final PolicyCondition condition, final Date published) {
+        final Period agePeriod;
+        try {
+            agePeriod = Period.parse(condition.getValue());
+        } catch (DateTimeParseException e) {
+            LOGGER.error("Invalid age duration format", e);
+            return false;
+        }
+
+        if (agePeriod.isZero() || agePeriod.isNegative()) {
+            LOGGER.warn("Age durations must not be zero or negative");
+            return false;
+        }
+
+        final LocalDate publishedDate = LocalDate.ofInstant(published.toInstant(), ZoneId.systemDefault());
+        final LocalDate ageDate = publishedDate.plus(agePeriod);
+        final LocalDate today = LocalDate.now();
+
+        return switch (condition.getOperator()) {
+            case NUMERIC_GREATER_THAN -> ageDate.isBefore(today);
+            case NUMERIC_GREATER_THAN_OR_EQUAL -> ageDate.isEqual(today) || ageDate.isBefore(today);
+            case NUMERIC_EQUAL -> ageDate.isEqual(today);
+            case NUMERIC_NOT_EQUAL -> !ageDate.isEqual(today);
+            case NUMERIC_LESSER_THAN_OR_EQUAL -> ageDate.isEqual(today) || ageDate.isAfter(today);
+            case NUMERIC_LESS_THAN -> ageDate.isAfter(LocalDate.now());
+            default -> {
+                LOGGER.warn("Operator %s is not supported for component age conditions".formatted(condition.getOperator()));
+                yield false;
+            }
+        };
+    }
+
+}

--- a/src/main/java/org/dependencytrack/policy/PolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/PolicyEngine.java
@@ -55,6 +55,7 @@ public class PolicyEngine {
         evaluators.add(new CpePolicyEvaluator());
         evaluators.add(new SwidTagIdPolicyEvaluator());
         evaluators.add(new VersionPolicyEvaluator());
+        evaluators.add(new ComponentAgePolicyEvaluator());
         evaluators.add(new ComponentHashPolicyEvaluator());
         evaluators.add(new CwePolicyEvaluator());
     }
@@ -127,6 +128,7 @@ public class PolicyEngine {
             case CWE:
             case SEVERITY:
                 return PolicyViolation.Type.SECURITY;
+            case AGE:
             case COORDINATES:
             case PACKAGE_URL:
             case CPE:

--- a/src/test/java/org/dependencytrack/policy/ComponentAgePolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/ComponentAgePolicyEvaluatorTest.java
@@ -1,0 +1,124 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.policy;
+
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Policy;
+import org.dependencytrack.model.PolicyCondition.Operator;
+import org.dependencytrack.model.PolicyCondition.Subject;
+import org.dependencytrack.model.RepositoryMetaComponent;
+import org.dependencytrack.model.RepositoryType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class ComponentAgePolicyEvaluatorTest extends PersistenceCapableTest {
+
+    @Parameterized.Parameters(name = "[{index}] publishedDate={0} operator={1} ageValue={2} shouldViolate={3}")
+    public static Collection<?> testParameters() {
+        return Arrays.asList(new Object[][]{
+                // Component is older by one day.
+                {Instant.now().minus(Duration.ofDays(667)), Operator.NUMERIC_GREATER_THAN, "P666D", true},
+                {Instant.now().minus(Duration.ofDays(667)), Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "P666D", true},
+                {Instant.now().minus(Duration.ofDays(667)), Operator.NUMERIC_EQUAL, "P666D", false},
+                {Instant.now().minus(Duration.ofDays(667)), Operator.NUMERIC_NOT_EQUAL, "P666D", true},
+                {Instant.now().minus(Duration.ofDays(667)), Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "P666D", false},
+                {Instant.now().minus(Duration.ofDays(667)), Operator.NUMERIC_LESS_THAN, "P666D", false},
+                // Component is newer by one day.
+                {Instant.now().minus(Duration.ofDays(665)), Operator.NUMERIC_GREATER_THAN, "P666D", false},
+                {Instant.now().minus(Duration.ofDays(665)), Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "P666D", false},
+                {Instant.now().minus(Duration.ofDays(665)), Operator.NUMERIC_EQUAL, "P666D", false},
+                {Instant.now().minus(Duration.ofDays(665)), Operator.NUMERIC_NOT_EQUAL, "P666D", true},
+                {Instant.now().minus(Duration.ofDays(665)), Operator.NUMERIC_LESS_THAN, "P666D", true},
+                // Component is exactly as old.
+                {Instant.now().minus(Duration.ofDays(666)), Operator.NUMERIC_GREATER_THAN, "P666D", false},
+                {Instant.now().minus(Duration.ofDays(666)), Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "P666D", true},
+                {Instant.now().minus(Duration.ofDays(666)), Operator.NUMERIC_EQUAL, "P666D", true},
+                {Instant.now().minus(Duration.ofDays(666)), Operator.NUMERIC_NOT_EQUAL, "P666D", false},
+                {Instant.now().minus(Duration.ofDays(666)), Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "P666D", true},
+                {Instant.now().minus(Duration.ofDays(666)), Operator.NUMERIC_LESS_THAN, "P666D", false},
+                // Unsupported operator.
+                {Instant.now().minus(Duration.ofDays(666)), Operator.MATCHES, "P666D", false},
+                // Negative age period.
+                {Instant.now().minus(Duration.ofDays(666)), Operator.NUMERIC_EQUAL, "P-666D", false},
+                // Invalid age period format.
+                {Instant.now().minus(Duration.ofDays(666)), Operator.NUMERIC_EQUAL, "foobar", false},
+                // No known publish date.
+                {null, Operator.NUMERIC_EQUAL, "P666D", false},
+        });
+    }
+
+    private final Instant publishedDate;
+    private final Operator operator;
+    private final String ageValue;
+    private final boolean shouldViolate;
+
+    public ComponentAgePolicyEvaluatorTest(final Instant publishedDate, final Operator operator,
+                                           final String ageValue, final boolean shouldViolate) {
+        this.publishedDate = publishedDate;
+        this.operator = operator;
+        this.ageValue = ageValue;
+        this.shouldViolate = shouldViolate;
+    }
+
+    @Test
+    public void evaluateTest() {
+        final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
+        final var condition = qm.createPolicyCondition(policy, Subject.AGE, operator, ageValue);
+
+        final var metaComponent = new RepositoryMetaComponent();
+        metaComponent.setRepositoryType(RepositoryType.MAVEN);
+        metaComponent.setNamespace("foo");
+        metaComponent.setName("bar");
+        metaComponent.setLatestVersion("6.6.6");
+        if (publishedDate != null) {
+            metaComponent.setPublished(Date.from(publishedDate));
+        }
+        metaComponent.setLastCheck(new Date());
+        qm.persist(metaComponent);
+
+        final var component = new Component();
+        component.setPurl("pkg:maven/foo/bar@1.2.3");
+
+        final var evaluator = new ComponentAgePolicyEvaluator();
+        evaluator.setQueryManager(qm);
+
+        final List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        if (shouldViolate) {
+            assertThat(violations).hasSize(1);
+            final PolicyConditionViolation violation = violations.get(0);
+            assertThat(violation.getComponent()).isEqualTo(component);
+            assertThat(violation.getPolicyCondition()).isEqualTo(condition);
+        } else {
+            assertThat(violations).isEmpty();
+        }
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This PR implements a policy condition for component age.

The age can be provided in [ISO-8601 period format](https://en.wikipedia.org/wiki/ISO_8601#Durations), e.g.:

* `P1Y`: 1 year
* `P2Y3M`: 2 years, 3 months
* `P7D`: 7 days

Lowest allowed time unit is days. Specifying hours, minutes, or seconds is not allowed.
This limitation is enforced by Java's [`Period`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Period.html) class, which is used behind the scenes.

The frontend will show a tooltip to let users know about the format.

<img width="1267" alt="image" src="https://user-images.githubusercontent.com/5693141/215279293-7c97ca67-4347-4eda-9ebc-b9716ce68035.png">

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #772

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

We have to rely on external package repositories to provide the publish date of components. 

Not all repositories support this. In particular, for Rubygems and NPM components we currently do not get the publish date.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
