### PR TITLE
Improved handling of hierarchical dependencies

### DIFF
--- a/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
@@ -58,7 +58,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ModelConverter {
 


### PR DESCRIPTION
### Description

Modified the behaviour of ModelConverter to handle nested child components when processing dependencies. This prevents dependency information being lost, for example after a hierarchical merge using `cyclondx-cli`.

### Addressed Issue

Closes #2411 

### Additional Details

As requested I did add the ability to recurse in `ModelConverter.getComponentFromBomRef`, but ditched using that ability for a `HashMap` keyed on `bom-ref`.
I have tested this when deployed to check that it works. Below is the result of a hierachical merge between CycloneDX and Docker (Snyk) SBoMs:
![bom_foobar_new](https://user-images.githubusercontent.com/38717523/215806564-7d890789-57b0-49f6-b888-f27cb9412473.png)
I decided to not pass `flattenedComponents` to do other changes that would have affected external logic as I did not want to create more problems. The changes are focused the second part of `generateDependencies` where the transitives are processed.

Unfortunately I was uable to create any unit tests as I could not get them to run locally.

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
