### PR TITLE
Fixed vulndb result to have cacheResult and added apply analysis from cache

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/scanners/VulnDbAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/VulnDbAnalysisTask.java
@@ -116,7 +116,10 @@ public class VulnDbAnalysisTask extends BaseComponentAnalyzerTask implements Sub
     public void analyze(final List<Component> components) {
         final VulnDbApi api = new VulnDbApi(this.apiConsumerKey, this.apiConsumerSecret, UnirestFactory.getUnirestInstance());
         for (final Component component: components) {
-            if (!component.isInternal() && isCapable(component)
+            if(isCacheCurrent(Vulnerability.Source.VULNDB, TARGET_HOST, component.getCpe())){
+                applyAnalysisFromCache(Vulnerability.Source.VULNDB, TARGET_HOST, component.getCpe(),component, AnalyzerIdentity.VULNDB_ANALYZER, vulnerabilityAnalysisLevel);
+            }
+            else if (!component.isInternal() && isCapable(component)
                     && !isCacheCurrent(Vulnerability.Source.VULNDB, TARGET_HOST, component.getCpe())) {
                 int page = 1;
                 boolean more = true;
@@ -149,7 +152,7 @@ public class VulnDbAnalysisTask extends BaseComponentAnalyzerTask implements Sub
                 qm.addVulnerability(vulnerability, vulnerableComponent, this.getAnalyzerIdentity());
                 addVulnerabilityToCache(vulnerableComponent, vulnerability);
             }
-            updateAnalysisCacheStats(qm, Vulnerability.Source.VULNDB, TARGET_HOST, vulnerableComponent.getCpe(), component.getCacheResult());
+            updateAnalysisCacheStats(qm, Vulnerability.Source.VULNDB, TARGET_HOST, vulnerableComponent.getCpe(), vulnerableComponent.getCacheResult());
             return results.getPage() * PAGE_SIZE < results.getTotal();
         }
     }


### PR DESCRIPTION
Signed-off-by: mehab <meha.bhargava2@gmail.com>

### Description
In the current implementation of Vulndb analysis task there are two issues seen:
1.  The cacheResult is empty even though the cacheResult is being set for the component at an earlier step.
2.  Even though component analysis result is added to cache, the cache result, if current, is never applied ie applyAnalysisFromCache

Expected behavior:
1. The cacheResult should not be null once it is set for a component.
2. Analysis from cache should be applied when applicable.
<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue
Addresses below issues: 
1. Cache result for a component being analysed by Vulndb
2.  Applying analysis from cache for Vulndbanalysis task.
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x ] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [x ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
