### PR TITLE
Correctly fix the handling of operator 'AND' in policies

### DIFF
--- a/src/main/java/org/dependencytrack/policy/PolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/PolicyEngine.java
@@ -96,7 +96,7 @@ public class PolicyEngine {
                     final List<PolicyConditionViolation> policyConditionViolationsFromEvaluator = evaluator.evaluate(policy, component);
                     if (!policyConditionViolationsFromEvaluator.isEmpty()) {
                         policyConditionViolations.addAll(policyConditionViolationsFromEvaluator);
-                        policyConditionsViolated += policyConditionViolationsFromEvaluator.stream()
+                        policyConditionsViolated += (int) policyConditionViolationsFromEvaluator.stream()
                                 .map(pcv -> pcv.getPolicyCondition()).sorted(policyConditionComparator).distinct().count();
                     }
                 }

--- a/src/main/java/org/dependencytrack/policy/PolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/PolicyEngine.java
@@ -29,7 +29,6 @@ import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.NotificationUtil;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 
@@ -46,14 +45,6 @@ public class PolicyEngine {
     private static final Logger LOGGER = Logger.getLogger(PolicyEngine.class);
 
     private final List<PolicyEvaluator> evaluators = new ArrayList<>();
-
-    private final Comparator<PolicyCondition> policyConditionComparator = new Comparator<PolicyCondition>() {
-
-        @Override
-        public int compare(PolicyCondition pc1, PolicyCondition pc2) {
-            return Long.valueOf(pc1.getId()).compareTo(Long.valueOf(pc2.getId()));
-        }
-    };
 
     public PolicyEngine() {
         evaluators.add(new SeverityPolicyEvaluator());
@@ -97,7 +88,10 @@ public class PolicyEngine {
                     if (!policyConditionViolationsFromEvaluator.isEmpty()) {
                         policyConditionViolations.addAll(policyConditionViolationsFromEvaluator);
                         policyConditionsViolated += (int) policyConditionViolationsFromEvaluator.stream()
-                                .map(pcv -> pcv.getPolicyCondition()).sorted(policyConditionComparator).distinct().count();
+                                .map(pcv -> pcv.getPolicyCondition().getId())
+                                .sorted()
+                                .distinct()
+                                .count();
                     }
                 }
                 if (Policy.Operator.ANY == policy.getOperator()) {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->
This change correctly fixes the handling of the 'AND'-operator in policies, even if the policy consists of multiple conditions of the same type.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
#1924
#2455

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->
Seeing how the first fix did not take in consideration that multiple conditions of the same type were handled in a single evaluator, it only actually counted the number of evaluators that found violations.
This implementation actually checks how many conditions per evaluator where violated and compares those with the number of actual conditions defined for a policy.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [X] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [X] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
