### PR TITLE
remove superfluous ComponentMetricsUpdate event dispatch

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTask.java
@@ -44,7 +44,6 @@ import org.apache.http.HttpHeaders;
 import org.dependencytrack.common.ConfigKey;
 import org.dependencytrack.common.ManagedHttpClientFactory;
 import org.dependencytrack.common.UnirestFactory;
-import org.dependencytrack.event.ComponentMetricsUpdateEvent;
 import org.dependencytrack.event.OssIndexAnalysisEvent;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ConfigPropertyConstants;

--- a/src/main/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTask.java
@@ -327,7 +327,6 @@ public class OssIndexAnalysisTask extends BaseComponentAnalyzerTask implements C
                                 addVulnerabilityToCache(component, vulnerability);
                             }
                         }
-                        Event.dispatch(new ComponentMetricsUpdateEvent(component.getUuid()));
                         updateAnalysisCacheStats(qm, Vulnerability.Source.OSSINDEX, API_BASE_URL, component.getPurl().toString(), component.getCacheResult());
                     }
                 }


### PR DESCRIPTION
### Description

Remove a superfluous dispatch of a `ComponentMetricsUpdateEvent` in `OSSindexAnalysisTask`.

### Addressed Issue

The `OSSindexAnalysisTask` is emitting a `ComponentMetricsUpdateEvent` for each component that was analyzed.
This seems to be superfluous because `OSSindexAnalysisTask` is only triggered from a `VulnerabilityAnalysisTask` and that already triggers a `ProjectMetricsUpdateEvent` when analysis is complete. The latter will also update all metrics for all components in that project.


### Additional Details

If my reasoning is correct, this PR will reduce the load on the event system. The `ComponentMetricsUpdateEvent` is the most frequently ocurring event, at least in my instance (7days):

![image](https://user-images.githubusercontent.com/4426050/217293400-a4225082-344c-4e0f-a59c-6bdf1991ed78.png)

It should go to zero as the `ProjectMetricsUpdateEvent` doesn't emit individual `ComponentMetricsUpdateEvent` instances, it performs the metrics update inline.

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
