### PR TITLE
Bom Upload: don't choke on removed project

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -74,6 +74,7 @@ public class BomUploadProcessingTask implements Subscriber {
                 
                 if (project == null) {
                     LOGGER.warn("Ignoring BOM Upload event for no longer existing project " + event.getProjectUuid());
+                    return;
                 }
                 
                 final List<Component> components;

--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -71,6 +71,11 @@ public class BomUploadProcessingTask implements Subscriber {
             final QueryManager qm = new QueryManager();
             try {
                 final Project project = qm.getObjectByUuid(Project.class, event.getProjectUuid());
+                
+                if (project == null) {
+                    LOGGER.warn("Ignoring BOM Upload event for no longer existing project " + event.getProjectUuid());
+                }
+                
                 final List<Component> components;
                 final List<Component> newComponents = new ArrayList<>();
                 final List<Component> flattenedComponents = new ArrayList<>();


### PR DESCRIPTION
Signed-off-by: Valentijn Scholten <valentijnscholten@gmail.com>

### Description
Handle deleted projects gracefully during `BomUploadEvent` (fixes #2458)

### Addressed Issue
Handle deleted projects gracefully during `BomUploadEvent` (fixes #2458)

### Additional Details
Should be rare, but still nice to not get ERRORs in your logs.

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
