### PR TITLE
DataNucleus: Add logging bridge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
         <lib.resilience4j.version>2.0.1</lib.resilience4j.version>
         <lib.woodstox.version>6.5.0</lib.woodstox.version>
         <lib.junit-params.version>1.1.1</lib.junit-params.version>
+        <lib.log4j-over-slf4j.version>2.0.6</lib.log4j-over-slf4j.version>
         <!-- JDBC Drivers -->
         <lib.jdbc-driver.mssql.version>11.2.3.jre17</lib.jdbc-driver.mssql.version>
         <!-- Leave at 8.0.29 until https://github.com/datanucleus/datanucleus-rdbms/issues/446 is resolved! -->
@@ -309,6 +310,12 @@
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-micrometer</artifactId>
             <version>${lib.resilience4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>${lib.log4j-over-slf4j.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->


### PR DESCRIPTION
### Description

Adds the `log4j-over-slf4j` logging bridge which is needed to see `DataNucleus` log output.

### Addressed Issue

Currently all DataNucleus logging is not logged. With the above dependency DataNucleus logs *can be* outputted.
In the default config no logs appear as the log level is WARN for the DataNucleus category by default.

This addition is usefule because:
- If there are WARN or ERROR log line outputted by DN, they will no longer be hidden from the log output;
- If a user wants to troubleshoot something around DN, they can now do that without having to build a custom container image;


### Additional Details

The `log4j-over-slf4j.jar` is about `25kb` in size.

For those who want to log DN, they can add something like this to their `logback.xml`:

    <logger name="DataNucleus" level="DEBUG" additivity="false">
        <appender-ref ref="STDOUT" />
        <appender-ref ref="FILE" />
    </logger>

or

    <logger name="DataNucleus.Datastore.Native" level="DEBUG" additivity="false">
        <appender-ref ref="STDOUT" />
        <appender-ref ref="FILE" />
    </logger>

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
