### PR TITLE
Issue-2473 : fix OSV ecosystem to be unique

### DIFF
--- a/src/main/java/org/dependencytrack/model/VulnerabilityAlias.java
+++ b/src/main/java/org/dependencytrack/model/VulnerabilityAlias.java
@@ -200,6 +200,7 @@ public class VulnerabilityAlias implements Serializable {
             case NVD -> getCveId();
             case OSSINDEX -> getSonatypeId();
             case OSV -> getOsvId();
+            case SNYK -> getSnykId();
             case VULNDB -> getVulnDbId();
             default -> null;
         };

--- a/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
@@ -112,13 +112,13 @@ abstract class AbstractConfigPropertyResource extends AlpineResource {
                     return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("An error occurred while encrypting property value. Check log for details.").build();
                 }
             }
-        } else if(ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getGroupName().equals(json.getGroupName())) {
+        } else if(ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getPropertyName().equals(json.getPropertyName())) {
             String propertyValue = json.getPropertyValue();
             if (propertyValue != null && !propertyValue.isBlank()) {
-                Set<String> ecosystems = Arrays.stream(json.getPropertyValue().split(";")).map(String::trim).collect(Collectors.toSet());
+                Set<String> ecosystems = Arrays.stream(propertyValue.split(";")).map(String::trim).collect(Collectors.toSet());
                 property.setPropertyValue(String.join(";", ecosystems));
             } else {
-                property.setPropertyValue(json.getPropertyValue());
+                property.setPropertyValue(propertyValue);
             }
         } else {
             property.setPropertyValue(json.getPropertyValue());

--- a/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
@@ -31,6 +31,9 @@ import javax.ws.rs.core.Response;
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 abstract class AbstractConfigPropertyResource extends AlpineResource {
 
@@ -108,6 +111,14 @@ abstract class AbstractConfigPropertyResource extends AlpineResource {
                     LOGGER.error("An error occurred while encrypting config property value", e);
                     return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("An error occurred while encrypting property value. Check log for details.").build();
                 }
+            }
+        } else if(ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getGroupName().equals(json.getGroupName())) {
+            String propertyValue = json.getPropertyValue();
+            if (propertyValue != null && !propertyValue.isBlank()) {
+                Set<String> ecosystems = Arrays.stream(json.getPropertyValue().split(";")).map(String::trim).collect(Collectors.toSet());
+                property.setPropertyValue(String.join(";", ecosystems));
+            } else {
+                property.setPropertyValue(json.getPropertyValue());
             }
         } else {
             property.setPropertyValue(json.getPropertyValue());

--- a/src/main/java/org/dependencytrack/resources/v1/OsvEcosytemResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/OsvEcosytemResource.java
@@ -34,6 +34,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Path("/v1/integration/osv/ecosystem")
 @Api(value = "ecosystem", authorizations = @Authorization(value = "X-Api-Key"))
@@ -53,6 +54,27 @@ public class OsvEcosytemResource extends AlpineResource {
     public Response getAllEcosystems() {
         OsvDownloadTask osvDownloadTask = new OsvDownloadTask();
         final List<String> ecosystems = osvDownloadTask.getEcosystems();
+        return Response.ok(ecosystems).build();
+    }
+
+    @GET
+    @Path("/inactive")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Returns a list of available inactive ecosystems in OSV to be selected by user",
+            response = String.class,
+            responseContainer = "List"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Unauthorized")
+    })
+    @PermissionRequired(Permissions.Constants.SYSTEM_CONFIGURATION)
+    public Response getInactiveEcosystems() {
+        OsvDownloadTask osvDownloadTask = new OsvDownloadTask();
+        var selectedEcosystems = osvDownloadTask.getEnabledEcosystems();
+        final List<String> ecosystems = osvDownloadTask.getEcosystems().stream()
+                .filter(element -> !selectedEcosystems.contains(element))
+                .collect(Collectors.toList());
         return Response.ok(ecosystems).build();
     }
 }

--- a/src/main/java/org/dependencytrack/resources/v1/OsvEcosytemResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/OsvEcosytemResource.java
@@ -34,7 +34,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Path("/v1/integration/osv/ecosystem")
 @Api(value = "ecosystem", authorizations = @Authorization(value = "X-Api-Key"))
@@ -43,7 +42,7 @@ public class OsvEcosytemResource extends AlpineResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
-            value = "Returns a list of all not-yet-selected ecosystems in OSV",
+            value = "Returns a list of all ecosystems in OSV",
             response = String.class,
             responseContainer = "List"
     )
@@ -53,10 +52,7 @@ public class OsvEcosytemResource extends AlpineResource {
     @PermissionRequired(Permissions.Constants.SYSTEM_CONFIGURATION)
     public Response getAllEcosystems() {
         OsvDownloadTask osvDownloadTask = new OsvDownloadTask();
-        var selectedEcosystems = osvDownloadTask.getEnabledEcosystems();
-        final List<String> ecosystems = osvDownloadTask.getEcosystems().stream()
-                .filter(element -> !selectedEcosystems.contains(element))
-                .collect(Collectors.toList());
+        final List<String> ecosystems = osvDownloadTask.getEcosystems();
         return Response.ok(ecosystems).build();
     }
 }

--- a/src/main/java/org/dependencytrack/resources/v1/OsvEcosytemResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/OsvEcosytemResource.java
@@ -34,6 +34,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Path("/v1/integration/osv/ecosystem")
 @Api(value = "ecosystem", authorizations = @Authorization(value = "X-Api-Key"))
@@ -42,7 +43,7 @@ public class OsvEcosytemResource extends AlpineResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
-            value = "Returns a list of all ecosystems in OSV",
+            value = "Returns a list of all not-yet-selected ecosystems in OSV",
             response = String.class,
             responseContainer = "List"
     )
@@ -52,7 +53,10 @@ public class OsvEcosytemResource extends AlpineResource {
     @PermissionRequired(Permissions.Constants.SYSTEM_CONFIGURATION)
     public Response getAllEcosystems() {
         OsvDownloadTask osvDownloadTask = new OsvDownloadTask();
-        final List<String> ecosystems = osvDownloadTask.getEcosystems();
+        var selectedEcosystems = osvDownloadTask.getEnabledEcosystems();
+        final List<String> ecosystems = osvDownloadTask.getEcosystems().stream()
+                .filter(element -> !selectedEcosystems.contains(element))
+                .collect(Collectors.toList());
         return Response.ok(ecosystems).build();
     }
 }

--- a/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
+++ b/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
@@ -56,9 +56,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Scanner;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -72,11 +75,11 @@ public class OsvDownloadTask implements LoggableSubscriber {
 
     private static final Logger LOGGER = Logger.getLogger(OsvDownloadTask.class);
     private String ecosystemConfig;
-    private List<String> ecosystems;
+    private Set<String> ecosystems;
     private String osvBaseUrl;
 
     public List<String> getEnabledEcosystems() {
-        return this.ecosystems;
+        return this.ecosystems.stream().toList();
     }
 
     public OsvDownloadTask() {
@@ -85,7 +88,9 @@ public class OsvDownloadTask implements LoggableSubscriber {
             if (enabled != null) {
                 this.ecosystemConfig = enabled.getPropertyValue();
                 if (this.ecosystemConfig != null) {
-                    ecosystems = Arrays.stream(this.ecosystemConfig.split(";")).map(String::trim).toList();
+                    ecosystems = Arrays.stream(this.ecosystemConfig.split(";")).map(String::trim).collect(Collectors.toSet());
+                } else {
+                    ecosystems = new HashSet<>();
                 }
                 this.osvBaseUrl = qm.getConfigProperty(VULNERABILITY_SOURCE_GOOGLE_OSV_BASE_URL.getGroupName(), VULNERABILITY_SOURCE_GOOGLE_OSV_BASE_URL.getPropertyName()).getPropertyValue();
                 if (this.osvBaseUrl != null && !this.osvBaseUrl.endsWith("/")) {

--- a/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
+++ b/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
@@ -59,6 +59,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.Scanner;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -72,7 +74,7 @@ public class OsvDownloadTask implements LoggableSubscriber {
 
     private static final Logger LOGGER = Logger.getLogger(OsvDownloadTask.class);
     private String ecosystemConfig;
-    private List<String> ecosystems;
+    private Set<String> ecosystems;
     private String osvBaseUrl;
 
     public List<String> getEnabledEcosystems() {
@@ -85,7 +87,7 @@ public class OsvDownloadTask implements LoggableSubscriber {
             if (enabled != null) {
                 this.ecosystemConfig = enabled.getPropertyValue();
                 if (this.ecosystemConfig != null) {
-                    ecosystems = Arrays.stream(this.ecosystemConfig.split(";")).map(String::trim).toList();
+                    ecosystems = Arrays.stream(this.ecosystemConfig.split(";")).map(String::trim).collect(Collectors.toSet());
                 }
                 this.osvBaseUrl = qm.getConfigProperty(VULNERABILITY_SOURCE_GOOGLE_OSV_BASE_URL.getGroupName(), VULNERABILITY_SOURCE_GOOGLE_OSV_BASE_URL.getPropertyName()).getPropertyValue();
                 if (this.osvBaseUrl != null && !this.osvBaseUrl.endsWith("/")) {

--- a/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
+++ b/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
@@ -56,12 +56,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Scanner;
-import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -75,7 +72,7 @@ public class OsvDownloadTask implements LoggableSubscriber {
 
     private static final Logger LOGGER = Logger.getLogger(OsvDownloadTask.class);
     private String ecosystemConfig;
-    private Set<String> ecosystems;
+    private List<String> ecosystems;
     private String osvBaseUrl;
 
     public List<String> getEnabledEcosystems() {
@@ -88,9 +85,7 @@ public class OsvDownloadTask implements LoggableSubscriber {
             if (enabled != null) {
                 this.ecosystemConfig = enabled.getPropertyValue();
                 if (this.ecosystemConfig != null) {
-                    ecosystems = Arrays.stream(this.ecosystemConfig.split(";")).map(String::trim).collect(Collectors.toSet());
-                } else {
-                    ecosystems = new HashSet<>();
+                    ecosystems = Arrays.stream(this.ecosystemConfig.split(";")).map(String::trim).toList();
                 }
                 this.osvBaseUrl = qm.getConfigProperty(VULNERABILITY_SOURCE_GOOGLE_OSV_BASE_URL.getGroupName(), VULNERABILITY_SOURCE_GOOGLE_OSV_BASE_URL.getPropertyName()).getPropertyValue();
                 if (this.osvBaseUrl != null && !this.osvBaseUrl.endsWith("/")) {

--- a/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
@@ -239,4 +239,19 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         String body = json.getString(3);
         Assert.assertEquals("A Task scheduler cadence ("+prop4.getPropertyName()+") cannot be inferior to one hour.A value of -2 was provided.", body);
     }
+
+    @Test
+    public void updateConfigPropertyOsvEcosystemTest() {
+        ConfigProperty property = qm.createConfigProperty("my.group", ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getGroupName(), "maven;npm;maven", IConfigProperty.PropertyType.STRING, "List of ecosystems");
+        ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
+        request.setPropertyValue("maven;npm;maven");
+        Response response = target(V1_CONFIG_PROPERTY).request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.entity(request, MediaType.APPLICATION_JSON));
+        Assert.assertEquals(200, response.getStatus(), 0);
+        JsonObject json = parseJsonObject(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals(ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getGroupName(), json.getString("propertyName"));
+        Assert.assertEquals("maven;npm", json.getString("propertyValue"));
+    }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
@@ -242,7 +242,7 @@ public class ConfigPropertyResourceTest extends ResourceTest {
 
     @Test
     public void updateConfigPropertyOsvEcosystemTest() {
-        ConfigProperty property = qm.createConfigProperty("my.group", ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getGroupName(), "maven;npm;maven", IConfigProperty.PropertyType.STRING, "List of ecosystems");
+        ConfigProperty property = qm.createConfigProperty("my.group", ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getPropertyName(), "maven;npm;maven", IConfigProperty.PropertyType.STRING, "List of ecosystems");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("maven;npm;maven");
         Response response = target(V1_CONFIG_PROPERTY).request()
@@ -251,7 +251,7 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         Assert.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals(ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getGroupName(), json.getString("propertyName"));
+        Assert.assertEquals(ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getPropertyName(), json.getString("propertyName"));
         Assert.assertEquals("maven;npm", json.getString("propertyValue"));
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/OsvEcosystemResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/OsvEcosystemResourceTest.java
@@ -52,7 +52,7 @@ public class OsvEcosystemResourceTest extends ResourceTest {
         super.before();
         qm.createConfigProperty(VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getGroupName(),
                 VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getPropertyName(),
-                "Maven;DWF",
+                "Maven;npm;Maven",
                 IConfigProperty.PropertyType.STRING,
                 "List of ecosystems");
         qm.createConfigProperty(VULNERABILITY_SOURCE_GOOGLE_OSV_BASE_URL.getGroupName(),
@@ -63,7 +63,7 @@ public class OsvEcosystemResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getAllEcosystemsTest() {
+    public void getEcosystemsTest() {
         Response response = target(V1_OSV_ECOSYSTEM).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -72,5 +72,14 @@ public class OsvEcosystemResourceTest extends ResourceTest {
         JsonArray json = parseJsonArray(response);
         Assert.assertNotNull(json);
         Assert.assertFalse(json.isEmpty());
+        var total = json.size();
+
+        response = target(V1_OSV_ECOSYSTEM + "/inactive").request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        json = parseJsonArray(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals(total-2, json.size());
     }
 }

--- a/src/test/java/org/dependencytrack/tasks/OsvDownloadTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/OsvDownloadTaskTest.java
@@ -55,7 +55,7 @@ public class OsvDownloadTaskTest extends PersistenceCapableTest {
     public void setUp() {
         qm.createConfigProperty(VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getGroupName(),
                 VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getPropertyName(),
-                "Maven;DWF",
+                "Maven;DWF;Maven",
                 IConfigProperty.PropertyType.STRING,
                 "List of ecosystems");
         qm.createConfigProperty(VULNERABILITY_SOURCE_GOOGLE_OSV_BASE_URL.getGroupName(),


### PR DESCRIPTION
Signed-off-by: sahibamittal <sahiba.mittal@citi.com>

### Description

While selecting ecosystems for OSV mirroring, same ecosystem can be selected multiple times. This may cause duplicate downloading of one ecosystem (large files) from OSV client, which may result in repeated processing of already processed vulnerabilities.
Issue: https://github.com/DependencyTrack/dependency-track/issues/2473

### Addressed Issue

1. Fix the selection of ecosystems to be unique list. Handle the list of ecosystems to be unique in backend.
2. Add a missing check in switch block for SNYK in VulnerabilityAlias.java (not related to this issue).

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
