### PR TITLE
Replace usages of `org.json` with Jackson

### DIFF
--- a/.checkstyle.xml
+++ b/.checkstyle.xml
@@ -10,7 +10,9 @@
     </module>
     <module name="TreeWalker">
         <module name="AvoidStarImport"/>
-        <module name="IllegalImport"/>
+        <module name="IllegalImport">
+            <property name="illegalPkgs" value="org.json"/>
+        </module>
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
     </module>

--- a/src/main/java/org/dependencytrack/common/Jackson.java
+++ b/src/main/java/org/dependencytrack/common/Jackson.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.common;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Helper class wrapping a Jackson {@link ObjectMapper} and providing various utility methods.
+ *
+ * @since 4.8.0
+ */
+public final class Jackson {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private Jackson() {
+    }
+
+    public static ObjectReader objectReader() {
+        return OBJECT_MAPPER.reader();
+    }
+
+    public static ObjectWriter objectWriter() {
+        return OBJECT_MAPPER.writer();
+    }
+
+    public static JsonNodeFactory nodeFactory() {
+        return OBJECT_MAPPER.getNodeFactory();
+    }
+
+    public static ArrayNode newArray() {
+        return nodeFactory().arrayNode();
+    }
+
+    public static ObjectNode newObject() {
+        return nodeFactory().objectNode();
+    }
+
+    public static JsonNode readString(final String string) throws IOException {
+        return readString(string, JsonNode.class);
+    }
+
+    public static <T> T readString(final String string, Class<T> clazz) throws IOException {
+        return objectReader().readValue(string, clazz);
+    }
+
+    public static JsonNode readHttpResponse(final CloseableHttpResponse response) throws IOException {
+        return readHttpResponse(response, JsonNode.class);
+    }
+
+    public static <T> T readHttpResponse(final CloseableHttpResponse response, final Class<T> clazz) throws IOException {
+        try (final InputStream entityInputStream = response.getEntity().getContent()) {
+            return objectReader().readValue(entityInputStream, clazz);
+        }
+    }
+
+    public static ArrayNode asArray(final JsonNode jsonNode, final String fieldName) {
+        final JsonNode arrayNode = jsonNode.get(fieldName);
+        if (!arrayNode.isArray()) {
+            return nodeFactory().arrayNode();
+        }
+
+        return (ArrayNode) arrayNode;
+    }
+
+}

--- a/src/main/java/org/dependencytrack/common/Jackson.java
+++ b/src/main/java/org/dependencytrack/common/Jackson.java
@@ -18,6 +18,8 @@
  */
 package org.dependencytrack.common;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -29,6 +31,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.text.SimpleDateFormat;
 
 /**
  * Helper class wrapping a Jackson {@link ObjectMapper} and providing various utility methods.
@@ -37,7 +40,13 @@ import java.io.InputStream;
  */
 public final class Jackson {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER;
+
+    static {
+        OBJECT_MAPPER = new ObjectMapper()
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .setDateFormat(new SimpleDateFormat("HH:mm:ss.SSSZ"));
+    }
 
     private Jackson() {
     }
@@ -87,6 +96,21 @@ public final class Jackson {
         }
 
         return (ArrayNode) arrayNode;
+    }
+
+    /**
+     * An alternative to {@link JsonNode#toString()} that makes use of the customized {@link ObjectMapper}.
+     *
+     * @param value The value to serialize
+     * @return The serialized valued
+     * @throws RuntimeException When serialization failed
+     */
+    public static <T extends JsonNode> String toString(final T value) {
+        try {
+            return objectWriter().writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/src/main/java/org/dependencytrack/integrations/FindingPackagingFormat.java
+++ b/src/main/java/org/dependencytrack/integrations/FindingPackagingFormat.java
@@ -20,11 +20,13 @@ package org.dependencytrack.integrations;
 
 import alpine.model.About;
 import alpine.model.ConfigProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.dependencytrack.common.Jackson;
 import org.dependencytrack.model.Finding;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.DateUtil;
-import org.json.JSONObject;
 
 import java.util.Date;
 import java.util.List;
@@ -34,7 +36,9 @@ import static org.dependencytrack.model.ConfigPropertyConstants.GENERAL_BASE_URL
 
 public class FindingPackagingFormat {
 
-    /** FPF is versioned. If the format changes, the version needs to be bumped. */
+    /**
+     * FPF is versioned. If the format changes, the version needs to be bumped.
+     */
     private static final String FPF_VERSION = "1.1";
     private static final String FIELD_APPLICATION = "application";
     private static final String FIELD_VERSION = "version";
@@ -49,17 +53,17 @@ public class FindingPackagingFormat {
     private static final String FIELD_PROJECT = "project";
     private static final String FIELD_FINDINGS = "findings";
 
-    private final JSONObject payload;
+    private final JsonNode payload;
 
     public FindingPackagingFormat(final UUID projectUuid, final List<Finding> findings) {
         payload = initialize(projectUuid, findings);
     }
 
-    public JSONObject getDocument() {
-        return payload;
+    public String getDocument() {
+        return Jackson.toString(payload);
     }
 
-    private JSONObject initialize(final UUID projectUuid, final List<Finding> findings) {
+    private JsonNode initialize(final UUID projectUuid, final List<Finding> findings) {
         try (QueryManager qm = new QueryManager()) {
             final Project project = qm.getObjectByUuid(Project.class, projectUuid);
             final About about = new About();
@@ -70,7 +74,7 @@ public class FindingPackagingFormat {
                 This is useful for file-based parsing systems that needs to be able to
                 identify what type of file it is, and what type of system generated it.
              */
-            final JSONObject meta = new JSONObject();
+            final ObjectNode meta = Jackson.newObject();
             meta.put(FIELD_APPLICATION, about.getApplication());
             meta.put(FIELD_VERSION, about.getVersion());
             meta.put(FIELD_TIMESTAMP, DateUtil.toISO8601(new Date()));
@@ -78,15 +82,14 @@ public class FindingPackagingFormat {
                 meta.put(FIELD_BASE_URL, baseUrl.getPropertyValue());
             }
 
-
             /*
                 Findings are specific to a given project. This information is useful for
                 systems outside of Dependency-Track so that they can perform mappings as
                 well as not have to perform additional queries back to Dependency-Track
                 to discover basic project information.
              */
-            final JSONObject projectJson = new JSONObject();
-            projectJson.put(FIELD_UUID, project.getUuid());
+            final ObjectNode projectJson = Jackson.newObject();
+            projectJson.put(FIELD_UUID, project.getUuid().toString());
             projectJson.put(FIELD_NAME, project.getName());
             if (project.getVersion() != null) {
                 projectJson.put(FIELD_VERSION, project.getVersion());
@@ -95,22 +98,21 @@ public class FindingPackagingFormat {
                 projectJson.put(FIELD_DESCRIPTION, project.getDescription());
             }
             if (project.getPurl() != null) {
-                projectJson.put(FIELD_PURL, project.getPurl());
+                projectJson.put(FIELD_PURL, project.getPurl().toString());
             }
             if (project.getCpe() != null) {
                 projectJson.put(FIELD_CPE, project.getCpe());
             }
 
-
             /*
                 Add the meta and project objects along with the findings array
                 to a root json object and return.
              */
-            final JSONObject root = new JSONObject();
+            final ObjectNode root = Jackson.newObject();
             root.put(FIELD_VERSION, FPF_VERSION);
-            root.put(FIELD_META, meta);
-            root.put(FIELD_PROJECT, projectJson);
-            root.put(FIELD_FINDINGS, findings);
+            root.set(FIELD_META, meta);
+            root.set(FIELD_PROJECT, projectJson);
+            root.putPOJO(FIELD_FINDINGS, findings);
             return root;
         }
     }

--- a/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploader.java
+++ b/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploader.java
@@ -26,7 +26,6 @@ import org.dependencytrack.integrations.ProjectFindingUploader;
 import org.dependencytrack.model.Finding;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectProperty;
-import org.json.JSONObject;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -78,8 +77,8 @@ public class DefectDojoUploader extends AbstractIntegrationPoint implements Proj
 
     @Override
     public InputStream process(final Project project, final List<Finding> findings) {
-        final JSONObject fpf = new FindingPackagingFormat(project.getUuid(), findings).getDocument();
-        return new ByteArrayInputStream(fpf.toString(2).getBytes());
+        final var fpf = new FindingPackagingFormat(project.getUuid(), findings);
+        return new ByteArrayInputStream(fpf.getDocument().getBytes());
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploader.java
+++ b/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploader.java
@@ -20,6 +20,7 @@ package org.dependencytrack.integrations.defectdojo;
 
 import alpine.common.logging.Logger;
 import alpine.model.ConfigProperty;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.dependencytrack.integrations.AbstractIntegrationPoint;
 import org.dependencytrack.integrations.FindingPackagingFormat;
 import org.dependencytrack.integrations.ProjectFindingUploader;
@@ -30,7 +31,6 @@ import org.dependencytrack.model.ProjectProperty;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.dependencytrack.model.ConfigPropertyConstants.DEFECTDOJO_API_KEY;
@@ -89,8 +89,8 @@ public class DefectDojoUploader extends AbstractIntegrationPoint implements Proj
         final ProjectProperty engagementId = qm.getProjectProperty(project, DEFECTDOJO_ENABLED.getGroupName(), ENGAGEMENTID_PROPERTY);
         try {
             final DefectDojoClient client = new DefectDojoClient(this, new URL(defectDojoUrl.getPropertyValue()));
-            final ArrayList testsIds = client.getDojoTestIds(apiKey.getPropertyValue(), engagementId.getPropertyValue());
-            final String testId = client.getDojoTestId(engagementId.getPropertyValue(), testsIds);
+            final ArrayNode tests = client.getDojoTestIds(apiKey.getPropertyValue(), engagementId.getPropertyValue());
+            final String testId = client.getDojoTestId(engagementId.getPropertyValue(), tests);
             if (isReimportConfigured(project) || Boolean.parseBoolean(globalReimportEnabled.getPropertyValue())) {
                 LOGGER.debug("Found existing test Id: " + testId);
                 if (testId.equals("")) {

--- a/src/main/java/org/dependencytrack/integrations/fortifyssc/FortifySscUploader.java
+++ b/src/main/java/org/dependencytrack/integrations/fortifyssc/FortifySscUploader.java
@@ -27,7 +27,6 @@ import org.dependencytrack.integrations.ProjectFindingUploader;
 import org.dependencytrack.model.Finding;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectProperty;
-import org.json.JSONObject;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -35,9 +34,8 @@ import java.net.URL;
 import java.util.List;
 
 import static org.dependencytrack.model.ConfigPropertyConstants.FORTIFY_SSC_ENABLED;
-
-import static org.dependencytrack.model.ConfigPropertyConstants.FORTIFY_SSC_URL;
 import static org.dependencytrack.model.ConfigPropertyConstants.FORTIFY_SSC_TOKEN;
+import static org.dependencytrack.model.ConfigPropertyConstants.FORTIFY_SSC_URL;
 
 public class FortifySscUploader extends AbstractIntegrationPoint implements ProjectFindingUploader {
 
@@ -68,8 +66,8 @@ public class FortifySscUploader extends AbstractIntegrationPoint implements Proj
 
     @Override
     public InputStream process(final Project project, final List<Finding> findings) {
-        final JSONObject fpf = new FindingPackagingFormat(project.getUuid(), findings).getDocument();
-        return new ByteArrayInputStream(fpf.toString(2).getBytes());
+        final var fpf = new FindingPackagingFormat(project.getUuid(), findings);
+        return new ByteArrayInputStream(fpf.getDocument().getBytes());
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
@@ -123,7 +123,7 @@ public class FindingResource extends AlpineResource {
                 if (qm.hasAccess(super.getPrincipal(), project)) {
                     final List<Finding> findings = qm.getFindings(project);
                     final FindingPackagingFormat fpf = new FindingPackagingFormat(UUID.fromString(uuid), findings);
-                    final Response.ResponseBuilder rb = Response.ok(fpf.getDocument().toString(), "application/json");
+                    final Response.ResponseBuilder rb = Response.ok(fpf.getDocument(), "application/json");
                     rb.header("Content-Disposition", "inline; filename=findings-" + uuid + ".fpf");
                     return rb.build();
                 } else {

--- a/src/test/java/org/dependencytrack/integrations/FindingPackagingFormatTest.java
+++ b/src/test/java/org/dependencytrack/integrations/FindingPackagingFormatTest.java
@@ -65,7 +65,7 @@ public class FindingPackagingFormatTest extends PersistenceCapableTest {
 
         final var fpf = new FindingPackagingFormat(project.getUuid(), qm.getFindings(project));
 
-        assertThatJson(fpf.getDocument().toString())
+        assertThatJson(fpf.getDocument())
                 .withMatcher("appVersion", equalTo(Config.getInstance().getApplicationVersion()))
                 .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
                 .withMatcher("componentUuidA", equalTo(componentA.getUuid().toString()))
@@ -103,11 +103,6 @@ public class FindingPackagingFormatTest extends PersistenceCapableTest {
                                 "source": "INTERNAL",
                                 "aliases": [
                                   {
-                                    "id": "${json-unit.any-number}",
-                                    "allBySource": {
-                                      "INTERNAL": "INTERNAL-001",
-                                      "NVD": "CVE-123"
-                                    },
                                     "cveId": "CVE-123",
                                     "internalId": "INTERNAL-001"
                                   }


### PR DESCRIPTION
### Description

In cases where we don't directly map JSON to and from POJOs, we currently predominantly use [`org.json:json`](https://github.com/stleary/JSON-java). 

That library once shipped with Unirest, but Unirest switched to another serialization library, and we have moved away from Unirest recently, too.

This PR replaces usages of `org.json` with Jackson.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #1113

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Another option would've been to use [JSON-P](https://javaee.github.io/jsonp/), but the spec and its implementations lack capabilities of object mapping. That is, it's not possible to `put` a POJO into a JSON object using the JSON-P API. Jackson supports this.

Tests for various existing JSON transformations (e.g. the FPF) will be added along the way, to ensure that this change does not introduce regressions.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
