### PR TITLE
Separate policy evaluation into its own task

### DIFF
--- a/src/main/java/org/dependencytrack/event/EventSubsystemInitializer.java
+++ b/src/main/java/org/dependencytrack/event/EventSubsystemInitializer.java
@@ -38,6 +38,7 @@ import org.dependencytrack.tasks.KennaSecurityUploadTask;
 import org.dependencytrack.tasks.NewVulnerableDependencyAnalysisTask;
 import org.dependencytrack.tasks.NistMirrorTask;
 import org.dependencytrack.tasks.OsvDownloadTask;
+import org.dependencytrack.tasks.PolicyEvaluationTask;
 import org.dependencytrack.tasks.TaskScheduler;
 import org.dependencytrack.tasks.VexUploadProcessingTask;
 import org.dependencytrack.tasks.VulnDbSyncTask;
@@ -51,7 +52,6 @@ import org.dependencytrack.tasks.scanners.InternalAnalysisTask;
 import org.dependencytrack.tasks.scanners.OssIndexAnalysisTask;
 import org.dependencytrack.tasks.scanners.SnykAnalysisTask;
 import org.dependencytrack.tasks.scanners.VulnDbAnalysisTask;
-
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
@@ -94,6 +94,7 @@ public class EventSubsystemInitializer implements ServletContextListener {
         EVENT_SERVICE.subscribe(PortfolioVulnerabilityAnalysisEvent.class, VulnerabilityAnalysisTask.class);
         EVENT_SERVICE.subscribe(SnykAnalysisEvent.class, SnykAnalysisTask.class);
         EVENT_SERVICE.subscribe(RepositoryMetaEvent.class, RepositoryMetaAnalyzerTask.class);
+        EVENT_SERVICE.subscribe(PolicyEvaluationEvent.class, PolicyEvaluationTask.class);
         EVENT_SERVICE.subscribe(ComponentMetricsUpdateEvent.class, ComponentMetricsUpdateTask.class);
         EVENT_SERVICE.subscribe(ProjectMetricsUpdateEvent.class, ProjectMetricsUpdateTask.class);
         EVENT_SERVICE.subscribe(PortfolioMetricsUpdateEvent.class, PortfolioMetricsUpdateTask.class);
@@ -110,6 +111,7 @@ public class EventSubsystemInitializer implements ServletContextListener {
         EVENT_SERVICE_ST.subscribe(IndexEvent.class, IndexTask.class);
         EVENT_SERVICE.subscribe(NistMirrorEvent.class, NistMirrorTask.class);
         EVENT_SERVICE.subscribe(EpssMirrorEvent.class, EpssMirrorTask.class);
+
 
         TaskScheduler.getInstance();
     }
@@ -133,6 +135,7 @@ public class EventSubsystemInitializer implements ServletContextListener {
         EVENT_SERVICE.unsubscribe(VulnDbAnalysisTask.class);
         EVENT_SERVICE.unsubscribe(VulnerabilityAnalysisTask.class);
         EVENT_SERVICE.unsubscribe(RepositoryMetaAnalyzerTask.class);
+        EVENT_SERVICE.unsubscribe(PolicyEvaluationTask.class);
         EVENT_SERVICE.unsubscribe(ComponentMetricsUpdateTask.class);
         EVENT_SERVICE.unsubscribe(ProjectMetricsUpdateTask.class);
         EVENT_SERVICE.unsubscribe(PortfolioMetricsUpdateTask.class);

--- a/src/main/java/org/dependencytrack/event/PolicyEvaluationEvent.java
+++ b/src/main/java/org/dependencytrack/event/PolicyEvaluationEvent.java
@@ -18,19 +18,15 @@
  */
 package org.dependencytrack.event;
 
-import java.util.ArrayList;
-import java.util.List;
+import alpine.event.framework.AbstractChainableEvent;
+import alpine.event.framework.Event;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
-import alpine.event.framework.AbstractChainableEvent;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * Defines a general purpose event to analyze components for vulnerabilities.
- * Additional logic in the event handler performs analysis on what specific
- * type of analysis should take place.
- *
- * @author Steve Springett
- * @since 3.0.0
+ * Defines an {@link Event} used to trigger policy evaluation.
  */
 public class PolicyEvaluationEvent extends AbstractChainableEvent {
 

--- a/src/main/java/org/dependencytrack/event/PolicyEvaluationEvent.java
+++ b/src/main/java/org/dependencytrack/event/PolicyEvaluationEvent.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.event;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Project;
+import alpine.event.framework.AbstractChainableEvent;
+
+/**
+ * Defines a general purpose event to analyze components for vulnerabilities.
+ * Additional logic in the event handler performs analysis on what specific
+ * type of analysis should take place.
+ *
+ * @author Steve Springett
+ * @since 3.0.0
+ */
+public class PolicyEvaluationEvent extends AbstractChainableEvent {
+
+    private List<Component> components = new ArrayList<>();
+    private Project project;
+
+    /**
+     * Default constructed used to signal that a portfolio analysis
+     * should be performed on all components.
+     */
+    public PolicyEvaluationEvent() {
+
+    }
+
+    /**
+     * Creates an event to analyze the specified components.
+     * @param components the components to analyze
+     */
+    public PolicyEvaluationEvent(final List<Component> components) {
+        this.components = components;
+    }
+
+    /**
+     * Creates an event to analyze the specified component.
+     * @param component the component to analyze
+     */
+    public PolicyEvaluationEvent(final Component component) {
+        this.components.add(component);
+    }
+
+    /**
+     * Returns the list of components to analyze.
+     * @return the list of components to analyze
+     */
+    public List<Component> getComponents() {
+        return this.components;
+    }
+
+    /**
+     * Fluent method that sets the project these components are
+     * optionally a part of and returns this instance.
+     */
+    public PolicyEvaluationEvent project(final Project project) {
+        this.project = project;
+        return this;
+    }
+
+    /**
+     * Returns the project these components are optionally a part of.
+     */
+    public Project getProject() {
+        return project;
+    }
+
+}

--- a/src/main/java/org/dependencytrack/event/RepositoryMetaEvent.java
+++ b/src/main/java/org/dependencytrack/event/RepositoryMetaEvent.java
@@ -18,14 +18,13 @@
  */
 package org.dependencytrack.event;
 
-import alpine.event.framework.Event;
+import alpine.event.framework.AbstractChainableEvent;
 import org.dependencytrack.model.Component;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-public class RepositoryMetaEvent implements Event {
+public class RepositoryMetaEvent extends AbstractChainableEvent {
 
     private Optional<List<Component>> components = Optional.empty();
 

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -517,6 +517,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         project.setCpe(transientProject.getCpe());
         project.setPurl(transientProject.getPurl());
         project.setSwidTagId(transientProject.getSwidTagId());
+        project.setExternalReferences(transientProject.getExternalReferences());
 
         if (Boolean.TRUE.equals(project.isActive()) && !Boolean.TRUE.equals(transientProject.isActive()) && hasActiveChild(project)){
             throw new IllegalArgumentException("Project cannot be set to inactive if active children are present.");

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -18,20 +18,19 @@
  */
 package org.dependencytrack.resources.v1;
 
-import java.util.List;
-import java.util.Map;
-import javax.validation.Validator;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import alpine.event.framework.Event;
+import alpine.persistence.PaginatedResult;
+import alpine.server.auth.PermissionRequired;
+import alpine.server.resources.AlpineResource;
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.ResponseHeader;
 import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.event.InternalComponentIdentificationEvent;
@@ -46,19 +45,20 @@ import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.InternalComponentIdentificationUtil;
-import com.github.packageurl.MalformedPackageURLException;
-import com.github.packageurl.PackageURL;
-import alpine.event.framework.Event;
-import alpine.persistence.PaginatedResult;
-import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
-import io.swagger.annotations.Authorization;
-import io.swagger.annotations.ResponseHeader;
+import javax.validation.Validator;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
 
 /**
  * JAX-RS resources for processing components.

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -18,36 +18,8 @@
  */
 package org.dependencytrack.resources.v1;
 
-import alpine.event.framework.Event;
-import alpine.persistence.PaginatedResult;
-import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
-import com.github.packageurl.MalformedPackageURLException;
-import com.github.packageurl.PackageURL;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
-import io.swagger.annotations.Authorization;
-import io.swagger.annotations.ResponseHeader;
-import org.apache.commons.lang3.StringUtils;
-import org.dependencytrack.auth.Permissions;
-import org.dependencytrack.event.InternalComponentIdentificationEvent;
-import org.dependencytrack.event.RepositoryMetaEvent;
-import org.dependencytrack.event.VulnerabilityAnalysisEvent;
-import org.dependencytrack.model.Component;
-import org.dependencytrack.model.ComponentIdentity;
-import org.dependencytrack.model.License;
-import org.dependencytrack.model.Project;
-import org.dependencytrack.model.RepositoryType;
-import org.dependencytrack.model.RepositoryMetaComponent;
-import org.dependencytrack.persistence.QueryManager;
-import org.dependencytrack.util.InternalComponentIdentificationUtil;
-
 import java.util.List;
 import java.util.Map;
-
 import javax.validation.Validator;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -60,6 +32,33 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.StringUtils;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.event.InternalComponentIdentificationEvent;
+import org.dependencytrack.event.PolicyEvaluationEvent;
+import org.dependencytrack.event.RepositoryMetaEvent;
+import org.dependencytrack.event.VulnerabilityAnalysisEvent;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.ComponentIdentity;
+import org.dependencytrack.model.License;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.RepositoryMetaComponent;
+import org.dependencytrack.model.RepositoryType;
+import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.util.InternalComponentIdentificationUtil;
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import alpine.event.framework.Event;
+import alpine.persistence.PaginatedResult;
+import alpine.server.auth.PermissionRequired;
+import alpine.server.resources.AlpineResource;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.ResponseHeader;
 
 /**
  * JAX-RS resources for processing components.
@@ -310,8 +309,13 @@ public class ComponentResource extends AlpineResource {
             component.setNotes(StringUtils.trimToNull(jsonComponent.getNotes()));
 
             component = qm.createComponent(component, true);
-            Event.dispatch(new VulnerabilityAnalysisEvent(component));
-            Event.dispatch(new RepositoryMetaEvent(List.of(component)));
+            Event.dispatch(
+                new VulnerabilityAnalysisEvent(component)
+                // Wait for RepositoryMetaEvent after VulnerabilityAnalysisEvent,
+                // as both might be needed in policy evaluation
+                .onSuccess(new RepositoryMetaEvent(List.of(component)))
+                .onSuccess(new PolicyEvaluationEvent(component))
+            );
             return Response.status(Response.Status.CREATED).entity(component).build();
         }
     }
@@ -394,8 +398,13 @@ public class ComponentResource extends AlpineResource {
                 component.setNotes(StringUtils.trimToNull(jsonComponent.getNotes()));
 
                 component = qm.updateComponent(component, true);
-                Event.dispatch(new VulnerabilityAnalysisEvent(component));
-                Event.dispatch(new RepositoryMetaEvent(List.of(component)));
+                Event.dispatch(
+                    new VulnerabilityAnalysisEvent(component)
+                    // Wait for RepositoryMetaEvent after VulnerabilityAnalysisEvent,
+// as both might be needed in policy evaluation
+                    .onSuccess(new RepositoryMetaEvent(List.of(component)))
+                    .onSuccess(new PolicyEvaluationEvent(component))
+                );
                 return Response.ok(component).build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the component could not be found.").build();

--- a/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
@@ -18,28 +18,6 @@
  */
 package org.dependencytrack.resources.v1;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import org.dependencytrack.auth.Permissions;
-import org.dependencytrack.event.PolicyEvaluationEvent;
-import org.dependencytrack.event.RepositoryMetaEvent;
-import org.dependencytrack.event.VulnerabilityAnalysisEvent;
-import org.dependencytrack.integrations.FindingPackagingFormat;
-import org.dependencytrack.model.Component;
-import org.dependencytrack.model.Finding;
-import org.dependencytrack.model.Project;
-import org.dependencytrack.model.Vulnerability;
-import org.dependencytrack.persistence.QueryManager;
 import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
 import alpine.server.auth.PermissionRequired;
@@ -51,6 +29,28 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.ResponseHeader;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.event.PolicyEvaluationEvent;
+import org.dependencytrack.event.RepositoryMetaEvent;
+import org.dependencytrack.event.VulnerabilityAnalysisEvent;
+import org.dependencytrack.integrations.FindingPackagingFormat;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Finding;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.persistence.QueryManager;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * JAX-RS resources for processing findings.

--- a/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
@@ -18,6 +18,28 @@
  */
 package org.dependencytrack.resources.v1;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.event.PolicyEvaluationEvent;
+import org.dependencytrack.event.RepositoryMetaEvent;
+import org.dependencytrack.event.VulnerabilityAnalysisEvent;
+import org.dependencytrack.integrations.FindingPackagingFormat;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Finding;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.persistence.QueryManager;
 import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
 import alpine.server.auth.PermissionRequired;
@@ -29,27 +51,6 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.ResponseHeader;
-import org.dependencytrack.auth.Permissions;
-import org.dependencytrack.event.VulnerabilityAnalysisEvent;
-import org.dependencytrack.integrations.FindingPackagingFormat;
-import org.dependencytrack.model.Component;
-import org.dependencytrack.model.Finding;
-import org.dependencytrack.model.Project;
-import org.dependencytrack.model.Vulnerability;
-import org.dependencytrack.persistence.QueryManager;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * JAX-RS resources for processing findings.
@@ -160,6 +161,10 @@ public class FindingResource extends AlpineResource {
                   final List<Component> detachedComponents = qm.detach(qm.getAllComponents(project));
                   final Project detachedProject = qm.detach(Project.class, project.getId());
                   final VulnerabilityAnalysisEvent vae = new VulnerabilityAnalysisEvent(detachedComponents).project(detachedProject);
+                  // Wait for RepositoryMetaEvent after VulnerabilityAnalysisEvent,
+                  // as both might be needed in policy evaluation
+                  vae.onSuccess(new RepositoryMetaEvent(detachedComponents));
+                  vae.onSuccess(new PolicyEvaluationEvent(detachedComponents).project(detachedProject));
                   Event.dispatch(vae);
 
                   return Response.ok(Collections.singletonMap("token", vae.getChainIdentifier())).build();

--- a/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -41,6 +41,7 @@ import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.v1.vo.CloneProjectRequest;
 
 import java.security.Principal;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -326,7 +327,7 @@ public class ProjectResource extends AlpineResource {
             }
         }
     }
-    
+
     @PATCH
     @Path("/{uuid}")
     @Consumes(MediaType.APPLICATION_JSON)
@@ -393,9 +394,13 @@ public class ProjectResource extends AlpineResource {
                     modified |= project.getParent() == null || !parent.getUuid().equals(project.getParent().getUuid());
                     project.setParent(parent);
                 }
-                if (jsonProject.getTags() != null && (!Collections.isEmpty(jsonProject.getTags()) || !Collections.isEmpty(project.getTags()))) {
+                if (isCollectionModified(jsonProject.getTags(), project.getTags())) {
                     modified = true;
                     project.setTags(jsonProject.getTags());
+                }
+                if (isCollectionModified(jsonProject.getExternalReferences(), project.getExternalReferences())) {
+                   modified = true;
+                   project.setExternalReferences(jsonProject.getExternalReferences());
                 }
                 if (modified) {
                     try {
@@ -413,6 +418,13 @@ public class ProjectResource extends AlpineResource {
                 return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the project could not be found.").build();
             }
         }
+    }
+
+    /**
+     * returns `true` if the given [updated] collection should be considered an update of the [original] collection.
+     */
+    private static <T> boolean isCollectionModified(Collection<T> updated, Collection<T> original) {
+       return updated != null && (!Collections.isEmpty(updated) || !Collections.isEmpty(original));
     }
 
     /**

--- a/src/main/java/org/dependencytrack/tasks/PolicyEvaluationTask.java
+++ b/src/main/java/org/dependencytrack/tasks/PolicyEvaluationTask.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.tasks;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.dependencytrack.event.PolicyEvaluationEvent;
+import org.dependencytrack.event.ProjectMetricsUpdateEvent;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.policy.PolicyEngine;
+import alpine.common.logging.Logger;
+import alpine.event.framework.Event;
+import alpine.event.framework.Subscriber;
+
+public class PolicyEvaluationTask implements Subscriber {
+
+    private static final Logger LOGGER = Logger.getLogger(PolicyEvaluationTask.class);
+
+    /**
+     * {@inheritDoc}
+     */
+    public void inform(final Event e) {
+        if (e instanceof PolicyEvaluationEvent) {
+            final PolicyEvaluationEvent event = (PolicyEvaluationEvent) e;
+            LOGGER.info("Starting policy evaluation");
+            if (event.getComponents() != null && !event.getComponents().isEmpty()) {
+                performPolicyEvaluation(event.getProject(), event.getComponents());
+            } else if (event.getProject() != null) {
+                performPolicyEvaluation(event.getProject(), new ArrayList<>());
+            }
+            LOGGER.info("Policy evaluation complete");
+        }
+    }
+
+    private void performPolicyEvaluation(Project project, List<Component> components) {
+        // Evaluate the components against applicable policies via the PolicyEngine.
+        final PolicyEngine pe = new PolicyEngine();
+        pe.evaluate(components);
+        if (project != null) {
+            Event.dispatch(new ProjectMetricsUpdateEvent(project.getUuid()));
+        }
+    }
+
+}

--- a/src/main/java/org/dependencytrack/tasks/PolicyEvaluationTask.java
+++ b/src/main/java/org/dependencytrack/tasks/PolicyEvaluationTask.java
@@ -18,16 +18,16 @@
  */
 package org.dependencytrack.tasks;
 
-import java.util.ArrayList;
-import java.util.List;
+import alpine.common.logging.Logger;
+import alpine.event.framework.Event;
+import alpine.event.framework.Subscriber;
 import org.dependencytrack.event.PolicyEvaluationEvent;
 import org.dependencytrack.event.ProjectMetricsUpdateEvent;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.policy.PolicyEngine;
-import alpine.common.logging.Logger;
-import alpine.event.framework.Event;
-import alpine.event.framework.Subscriber;
+import java.util.ArrayList;
+import java.util.List;
 
 public class PolicyEvaluationTask implements Subscriber {
 
@@ -36,16 +36,16 @@ public class PolicyEvaluationTask implements Subscriber {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void inform(final Event e) {
-        if (e instanceof PolicyEvaluationEvent) {
-            final PolicyEvaluationEvent event = (PolicyEvaluationEvent) e;
-            LOGGER.info("Starting policy evaluation");
-            if (event.getComponents() != null && !event.getComponents().isEmpty()) {
-                performPolicyEvaluation(event.getProject(), event.getComponents());
-            } else if (event.getProject() != null) {
-                performPolicyEvaluation(event.getProject(), new ArrayList<>());
+        if (e instanceof PolicyEvaluationEvent event) {
+            if (event.getProject() != null) {
+                if (event.getComponents() != null && !event.getComponents().isEmpty()) {
+                    performPolicyEvaluation(event.getProject(), event.getComponents());
+                } else {
+                    performPolicyEvaluation(event.getProject(), new ArrayList<>());
+                }
             }
-            LOGGER.info("Policy evaluation complete");
         }
     }
 

--- a/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
@@ -64,7 +64,7 @@ public class VulnerabilityAnalysisTask implements Subscriber {
     public void inform(final Event e) {
         if (e instanceof VulnerabilityAnalysisEvent) {
             final VulnerabilityAnalysisEvent event = (VulnerabilityAnalysisEvent) e;
-
+            LOGGER.info("Analyzing vulnerabilities");
             if (event.getComponents() != null && event.getComponents().size() > 0) {
                 final List<Component> components = new ArrayList<>();
                 try (final QueryManager qm = new QueryManager()) {
@@ -76,10 +76,8 @@ public class VulnerabilityAnalysisTask implements Subscriber {
                     }
                     analyzeComponents(qm, components, e);
                 }
-                performPolicyEvaluation(event.getProject(), components);
-            } else if (event.getProject() != null) {
-                performPolicyEvaluation(event.getProject(), new ArrayList<>());
             }
+            LOGGER.info("Vulnerability analysis complete");
         } else if (e instanceof PortfolioVulnerabilityAnalysisEvent) {
             final PortfolioVulnerabilityAnalysisEvent event = (PortfolioVulnerabilityAnalysisEvent) e;
             LOGGER.info("Analyzing portfolio");

--- a/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
@@ -41,7 +41,6 @@ import org.dependencytrack.tasks.scanners.OssIndexAnalysisTask;
 import org.dependencytrack.tasks.scanners.ScanTask;
 import org.dependencytrack.tasks.scanners.SnykAnalysisTask;
 import org.dependencytrack.tasks.scanners.VulnDbAnalysisTask;
-
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -61,10 +60,9 @@ public class VulnerabilityAnalysisTask implements Subscriber {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void inform(final Event e) {
-        if (e instanceof VulnerabilityAnalysisEvent) {
-            final VulnerabilityAnalysisEvent event = (VulnerabilityAnalysisEvent) e;
-            LOGGER.info("Analyzing vulnerabilities");
+        if (e instanceof VulnerabilityAnalysisEvent event) {
             if (event.getComponents() != null && event.getComponents().size() > 0) {
                 final List<Component> components = new ArrayList<>();
                 try (final QueryManager qm = new QueryManager()) {
@@ -77,9 +75,7 @@ public class VulnerabilityAnalysisTask implements Subscriber {
                     analyzeComponents(qm, components, e);
                 }
             }
-            LOGGER.info("Vulnerability analysis complete");
-        } else if (e instanceof PortfolioVulnerabilityAnalysisEvent) {
-            final PortfolioVulnerabilityAnalysisEvent event = (PortfolioVulnerabilityAnalysisEvent) e;
+        } else if (e instanceof PortfolioVulnerabilityAnalysisEvent event) {
             LOGGER.info("Analyzing portfolio");
             try (final QueryManager qm = new QueryManager()) {
                 final List<UUID> projectUuids = qm.getAllProjects(true)

--- a/src/main/java/org/dependencytrack/tasks/scanners/VulnDbAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/VulnDbAnalysisTask.java
@@ -36,7 +36,6 @@ import org.dependencytrack.parser.vulndb.VulnDbClient;
 import org.dependencytrack.parser.vulndb.model.Results;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.NotificationUtil;
-
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -58,6 +57,7 @@ public class VulnDbAnalysisTask extends BaseComponentAnalyzerTask implements Sub
 
     private String apiBaseUrl;
 
+    @Override
     public AnalyzerIdentity getAnalyzerIdentity() {
         return AnalyzerIdentity.VULNDB_ANALYZER;
     }
@@ -73,6 +73,7 @@ public class VulnDbAnalysisTask extends BaseComponentAnalyzerTask implements Sub
     /**
      * {@inheritDoc}
      */
+    @Override
     public void inform(final Event e) {
         if (e instanceof VulnDbAnalysisEvent) {
             if (!super.isEnabled(ConfigPropertyConstants.SCANNER_VULNDB_ENABLED)) {
@@ -110,11 +111,11 @@ public class VulnDbAnalysisTask extends BaseComponentAnalyzerTask implements Sub
             }
             final var event = (VulnDbAnalysisEvent) e;
             vulnerabilityAnalysisLevel = event.getVulnerabilityAnalysisLevel();
-            LOGGER.info("Starting VulnDB analysis task");
+            LOGGER.debug("Starting VulnDB analysis task");
             if (!event.getComponents().isEmpty()) {
                 analyze(event.getComponents());
             }
-            LOGGER.info("VulnDB analysis complete");
+            LOGGER.debug("VulnDB analysis complete");
         }
     }
 
@@ -124,6 +125,7 @@ public class VulnDbAnalysisTask extends BaseComponentAnalyzerTask implements Sub
      * @param component the Component to analyze
      * @return true if VulnDbAnalysisTask should analyze, false if not
      */
+    @Override
     public boolean isCapable(final Component component) {
         return component.getCpe() != null;
     }
@@ -133,6 +135,7 @@ public class VulnDbAnalysisTask extends BaseComponentAnalyzerTask implements Sub
      *
      * @param components a list of Components
      */
+    @Override
     public void analyze(final List<Component> components) {
         final var api = new VulnDbClient(this.apiConsumerKey, this.apiConsumerSecret, this.apiBaseUrl);
         for (final Component component : components) {

--- a/src/test/java/org/dependencytrack/event/PolicyEvaluationEventTest.java
+++ b/src/test/java/org/dependencytrack/event/PolicyEvaluationEventTest.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.event;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Project;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PolicyEvaluationEventTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        PolicyEvaluationEvent event = new PolicyEvaluationEvent();
+        Assert.assertNull(event.getProject());
+        Assert.assertEquals(0, event.getComponents().size());
+    }
+
+    @Test
+    public void testComponentConstructor() {
+        Component component = new Component();
+        PolicyEvaluationEvent event = new PolicyEvaluationEvent(component);
+        Assert.assertEquals(1, event.getComponents().size());
+    }
+
+    @Test
+    public void testComponentsConstructor() {
+        Component component = new Component();
+        List<Component> components = new ArrayList<>();
+        components.add(component);
+        PolicyEvaluationEvent event = new PolicyEvaluationEvent(components);
+        Assert.assertEquals(1, event.getComponents().size());
+    }
+
+    @Test
+    public void testProjectCriteria() {
+        Project project = new Project();
+        PolicyEvaluationEvent event = new PolicyEvaluationEvent().project(project);
+        Assert.assertEquals(project, event.getProject());
+        Assert.assertEquals(0, event.getComponents().size());
+    }
+}

--- a/src/test/java/org/dependencytrack/event/RepositoryMetaEventTest.java
+++ b/src/test/java/org/dependencytrack/event/RepositoryMetaEventTest.java
@@ -21,8 +21,6 @@ package org.dependencytrack.event;
 import org.dependencytrack.model.Component;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;


### PR DESCRIPTION
### Description

Separate policy evaluation into its own task

### Addressed Issue

closes #2423 

### Additional Details

I've chained the VulnerabilityAnalysisEvent and the RepositoryMetaEvent as both are needed for example when evaluating an VersionDistancePolicyEvaluator (#2528 )

N.B. no new tests added. I assume it's covered in excisting tests as there is no logical change? Will check on this...

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
