### PR TITLE
Disable DataNucleus L2 cache for mirroring tasks

### DIFF
--- a/src/main/java/org/dependencytrack/model/Vulnerability.java
+++ b/src/main/java/org/dependencytrack/model/Vulnerability.java
@@ -33,6 +33,7 @@ import org.dependencytrack.resources.v1.serializers.CweSerializer;
 import org.dependencytrack.resources.v1.serializers.Iso8601DateSerializer;
 import org.dependencytrack.resources.v1.vo.AffectedComponent;
 import org.dependencytrack.util.VulnerabilityUtil;
+
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Convert;
 import javax.jdo.annotations.Extension;
@@ -54,6 +55,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -514,12 +516,10 @@ public class Vulnerability implements Serializable {
         if (cwes == null) {
             this.cwes = null;
         } else {
-            this.cwes = new ArrayList<>();
-            for (final Integer integer : cwes) {
-                if (integer != null) {
-                    this.cwes.add(integer);
-                }
-            }
+            final List<Integer> nonNullCwes = cwes.stream()
+                    .filter(Objects::nonNull)
+                    .toList();
+            this.cwes = new ArrayList<>(nonNullCwes);
         }
     }
 

--- a/src/main/java/org/dependencytrack/parser/epss/EpssParser.java
+++ b/src/main/java/org/dependencytrack/parser/epss/EpssParser.java
@@ -56,7 +56,7 @@ public final class EpssParser {
                     final String cveId = values.get(0);
                     final BigDecimal epssScore = new BigDecimal(values.get(1));
                     final BigDecimal percentile = new BigDecimal(values.get(2));
-                    try (final QueryManager qm = new QueryManager()) {
+                    try (final QueryManager qm = new QueryManager().withL2CacheDisabled()) {
                         final Vulnerability vuln = qm.getVulnerabilityByVulnId(Vulnerability.Source.NVD, cveId);
                         if (vuln != null) {
                             vuln.setEpssScore(epssScore);

--- a/src/main/java/org/dependencytrack/parser/nvd/NvdParser.java
+++ b/src/main/java/org/dependencytrack/parser/nvd/NvdParser.java
@@ -77,7 +77,7 @@ public final class NvdParser {
 
             cveItems.forEach((c) -> {
                 final JsonObject cveItem = (JsonObject) c;
-                try (QueryManager qm = new QueryManager()) {
+                try (QueryManager qm = new QueryManager().withL2CacheDisabled()) {
                     final Vulnerability vulnerability = new Vulnerability();
                     vulnerability.setSource(Vulnerability.Source.NVD);
 

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -29,6 +29,7 @@ import alpine.persistence.AlpineQueryManager;
 import alpine.persistence.PaginatedResult;
 import alpine.resources.AlpineRequest;
 import com.github.packageurl.PackageURL;
+import org.datanucleus.PropertyNames;
 import org.datanucleus.api.jdo.JDOQuery;
 import org.dependencytrack.event.IndexEvent;
 import org.dependencytrack.model.AffectedVersionAttribution;
@@ -312,6 +313,22 @@ public class QueryManager extends AlpineQueryManager {
             cacheQueryManager = (request == null) ? new CacheQueryManager(getPersistenceManager()) : new CacheQueryManager(getPersistenceManager(), request);
         }
         return cacheQueryManager;
+    }
+
+    /**
+     * Disables the second level cache for this {@link QueryManager} instance.
+     * <p>
+     * Disabling the L2 cache is useful in situations where large amounts of objects
+     * are created or updated in close succession, and it's unlikely that they'll be
+     * accessed again anytime soon. Keeping those objects in cache would unnecessarily
+     * blow up heap usage.
+     *
+     * @return This {@link QueryManager} instance
+     * @see <a href="https://www.datanucleus.org/products/accessplatform_6_0/jdo/persistence.html#cache_level2">L2 Cache docs</a>
+     */
+    public QueryManager withL2CacheDisabled() {
+        pm.setProperty(PropertyNames.PROPERTY_CACHE_L2_TYPE, "none");
+        return this;
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/org/dependencytrack/tasks/GitHubAdvisoryMirrorTask.java
+++ b/src/main/java/org/dependencytrack/tasks/GitHubAdvisoryMirrorTask.java
@@ -182,7 +182,7 @@ public class GitHubAdvisoryMirrorTask implements LoggableSubscriber {
      */
     void updateDatasource(final List<GitHubSecurityAdvisory> advisories) {
         LOGGER.debug("Updating datasource with GitHub advisories");
-        try (QueryManager qm = new QueryManager()) {
+        try (QueryManager qm = new QueryManager().withL2CacheDisabled()) {
             for (final GitHubSecurityAdvisory advisory : advisories) {
                 LOGGER.debug("Synchronizing GitHub advisory: " + advisory.getGhsaId());
                 final Vulnerability mappedVulnerability = mapAdvisoryToVulnerability(qm, advisory);

--- a/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
+++ b/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
@@ -154,7 +154,7 @@ public class OsvDownloadTask implements LoggableSubscriber {
 
     public void updateDatasource(final OsvAdvisory advisory) {
 
-        try (QueryManager qm = new QueryManager()) {
+        try (QueryManager qm = new QueryManager().withL2CacheDisabled()) {
 
             LOGGER.debug("Synchronizing Google OSV advisory: " + advisory.getId());
             final Vulnerability vulnerability = mapAdvisoryToVulnerability(qm, advisory);


### PR DESCRIPTION
### Description

This PR lowers the memory footprint of mirroring operations, by disabling the "Second Level" cache of the object relational mapper we use (DataNucleus). **The cache is only disabled for mirroring operations, other areas of DT are not impacted**.

Prior to this change, heap usage would kreep up to almost 5.5 GB while mirroring the NVD and EPSS. Even after a manual GC invocation at the end, ~2.8 GB would still remain in heap.

<img width="609" alt="nvd-mirror-vanilla_manual-gc" src="https://user-images.githubusercontent.com/5693141/221380585-3057eba7-2cfa-4350-8b41-0028b0f7a1fa.png">

After disabling L2 caching, overall heap usage stays lower (peaks at  ~4.2 GB), and a manual GC shows that pretty much the entire heap can be reclaimed.

<img width="609" alt="Screenshot 2023-02-25 at 22 31 58" src="https://user-images.githubusercontent.com/5693141/221380702-79143f01-ee42-4cd6-aa0c-d919f706d929.png">


### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

Objects that are persisted (created, updated) are put into DN's second level cache. Per default, the cache keeps soft references to objects.

https://www.datanucleus.org/products/accessplatform_6_0/jdo/persistence.html#cache_level2

While this kind of cache may be beneficial for BAU operations, it is totally overkill for our mirroring tasks. Over the course of mirroring the NVD for the first time alone, the cache will grow to over 2 million objects. The majority of those objects will never be accessed again, especially not soon enough for the cache to be of any use.

Soft references can potentially stay for a long time, and thus may inflate heap utilization.

There is a bug in DN that caused NPEs in `Vulnerability#setCwes` on newly created `Vulnerability` objects when L2 cache is disabled. The DN-internal method `dnGetcwes` would return `null`, despite the `cwes` field being initialized with `new ArrayList<>()` one line before. Not sure why this happens, but it can be prevented by setting the `cwes` field to a fully initialized list.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
