### PR TITLE
Execute `NistMirrorTask` and `EpssMirrorTask` on multi-threaded event service

### DIFF
--- a/src/main/java/org/dependencytrack/event/EpssMirrorEvent.java
+++ b/src/main/java/org/dependencytrack/event/EpssMirrorEvent.java
@@ -18,7 +18,9 @@
  */
 package org.dependencytrack.event;
 
-import alpine.event.framework.Event;
+import alpine.event.framework.SingletonCapableEvent;
+
+import java.util.UUID;
 
 /**
  * Defines an event used to start a mirror of EPSS.
@@ -26,6 +28,13 @@ import alpine.event.framework.Event;
  * @author Steve Springett
  * @since 4.5.0
  */
-public class EpssMirrorEvent implements Event {
+public class EpssMirrorEvent extends SingletonCapableEvent {
+
+    private static final UUID CHAIN_IDENTIFIER = UUID.fromString("63aa687a-17f0-4e2d-abd3-e2016b3c4f0a");
+
+    public EpssMirrorEvent() {
+        setChainIdentifier(CHAIN_IDENTIFIER);
+        setSingleton(true);
+    }
 
 }

--- a/src/main/java/org/dependencytrack/event/EventSubsystemInitializer.java
+++ b/src/main/java/org/dependencytrack/event/EventSubsystemInitializer.java
@@ -108,8 +108,8 @@ public class EventSubsystemInitializer implements ServletContextListener {
         EVENT_SERVICE.subscribe(NewVulnerableDependencyAnalysisEvent.class, NewVulnerableDependencyAnalysisTask.class);
 
         EVENT_SERVICE_ST.subscribe(IndexEvent.class, IndexTask.class);
-        EVENT_SERVICE_ST.subscribe(NistMirrorEvent.class, NistMirrorTask.class);
-        EVENT_SERVICE_ST.subscribe(EpssMirrorEvent.class, EpssMirrorTask.class);
+        EVENT_SERVICE.subscribe(NistMirrorEvent.class, NistMirrorTask.class);
+        EVENT_SERVICE.subscribe(EpssMirrorEvent.class, EpssMirrorTask.class);
 
         TaskScheduler.getInstance();
     }
@@ -148,8 +148,8 @@ public class EventSubsystemInitializer implements ServletContextListener {
         EVENT_SERVICE.shutdown();
 
         EVENT_SERVICE_ST.unsubscribe(IndexTask.class);
-        EVENT_SERVICE_ST.unsubscribe(NistMirrorTask.class);
-        EVENT_SERVICE_ST.unsubscribe(EpssMirrorTask.class);
+        EVENT_SERVICE.unsubscribe(NistMirrorTask.class);
+        EVENT_SERVICE.unsubscribe(EpssMirrorTask.class);
         EVENT_SERVICE_ST.shutdown();
     }
 }

--- a/src/main/java/org/dependencytrack/event/NistMirrorEvent.java
+++ b/src/main/java/org/dependencytrack/event/NistMirrorEvent.java
@@ -18,7 +18,9 @@
  */
 package org.dependencytrack.event;
 
-import alpine.event.framework.Event;
+import alpine.event.framework.SingletonCapableEvent;
+
+import java.util.UUID;
 
 /**
  * Defines an event used to start a mirror of the NVD.
@@ -26,6 +28,13 @@ import alpine.event.framework.Event;
  * @author Steve Springett
  * @since 3.0.0
  */
-public class NistMirrorEvent implements Event {
+public class NistMirrorEvent extends SingletonCapableEvent {
+
+    private static final UUID CHAIN_IDENTIFIER = UUID.fromString("077fa5fe-2f7a-457f-a0f1-9e9a0e578ede");
+
+    public NistMirrorEvent() {
+        setChainIdentifier(CHAIN_IDENTIFIER);
+        setSingleton(true);
+    }
 
 }


### PR DESCRIPTION
### Description

This PR slightly reduces the overall memory footprint of DT while NVD mirroring is taking place. 

It also enables search index updates while NVD and EPSS mirroring are running.

### Addressed Issue

N/A

### Additional Details

Because `IndexTask` also runs on `SingleThreadedEventService`, `IndexEvent`s queue up in the hundreds of thousands until the `NistMirrorTask` completes. As every `IndexEvent` may additionally contain objects of type `Project`, `Component`, `Vulnerability`, etc., keeping so many events in memory has a noticeable impact on heap utilization.

`IndexTask` *must* run on the single-threaded event service, as it's operations are spread across multiple events (create -> update -> commit), and they must be executed in sequence.

For NVD and EPSS mirroring however, they can be executed on the multi-threaded event service by making their respective events `SingletonCapableEvent`s.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [ ] ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
