### PR TITLE
New VersionDistance policy to check and report outdated components

### DIFF
--- a/src/main/java/org/dependencytrack/exception/PolicyException.java
+++ b/src/main/java/org/dependencytrack/exception/PolicyException.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.exception;
+
+public class PolicyException extends RuntimeException {
+
+    public PolicyException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/dependencytrack/model/PolicyCondition.java
+++ b/src/main/java/org/dependencytrack/model/PolicyCondition.java
@@ -22,7 +22,6 @@ import alpine.common.validation.RegexSequence;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.PersistenceCapable;
@@ -77,7 +76,8 @@ public class PolicyCondition implements Serializable {
         VERSION,
         COMPONENT_HASH,
         CWE,
-        VULNERABILITY_ID
+        VULNERABILITY_ID,
+        VERSION_DISTANCE
     }
 
     @PrimaryKey

--- a/src/main/java/org/dependencytrack/policy/ComponentAgePolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/ComponentAgePolicyEvaluator.java
@@ -25,7 +25,6 @@ import org.dependencytrack.model.PolicyCondition;
 import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.persistence.QueryManager;
-
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.ZoneId;
@@ -111,7 +110,7 @@ public class ComponentAgePolicyEvaluator extends AbstractPolicyEvaluator {
             case NUMERIC_EQUAL -> ageDate.isEqual(today);
             case NUMERIC_NOT_EQUAL -> !ageDate.isEqual(today);
             case NUMERIC_LESSER_THAN_OR_EQUAL -> ageDate.isEqual(today) || ageDate.isAfter(today);
-            case NUMERIC_LESS_THAN -> ageDate.isAfter(LocalDate.now());
+            case NUMERIC_LESS_THAN -> ageDate.isAfter(today);
             default -> {
                 LOGGER.warn("Operator %s is not supported for component age conditions".formatted(condition.getOperator()));
                 yield false;

--- a/src/main/java/org/dependencytrack/policy/PolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/PolicyEngine.java
@@ -27,7 +27,6 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Tag;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.NotificationUtil;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -59,6 +58,7 @@ public class PolicyEngine {
         evaluators.add(new ComponentHashPolicyEvaluator());
         evaluators.add(new CwePolicyEvaluator());
         evaluators.add(new VulnerabilityIdPolicyEvaluator());
+        evaluators.add(new VersionDistancePolicyEvaluator());
     }
 
     public List<PolicyViolation> evaluate(final List<Component> components) {
@@ -140,7 +140,7 @@ public class PolicyEngine {
         }
         return switch (subject) {
             case CWE, SEVERITY, VULNERABILITY_ID -> PolicyViolation.Type.SECURITY;
-            case AGE, COORDINATES, PACKAGE_URL, CPE, SWID_TAGID, COMPONENT_HASH, VERSION ->
+            case AGE, COORDINATES, PACKAGE_URL, CPE, SWID_TAGID, COMPONENT_HASH, VERSION, VERSION_DISTANCE ->
                     PolicyViolation.Type.OPERATIONAL;
             case LICENSE, LICENSE_GROUP -> PolicyViolation.Type.LICENSE;
         };

--- a/src/main/java/org/dependencytrack/policy/VersionDistancePolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/VersionDistancePolicyEvaluator.java
@@ -1,0 +1,163 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.policy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Policy;
+import org.dependencytrack.model.PolicyCondition;
+import org.dependencytrack.model.PolicyCondition.Operator;
+import org.dependencytrack.model.RepositoryMetaComponent;
+import org.dependencytrack.model.RepositoryType;
+import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.util.VersionDistance;
+import org.json.JSONObject;
+
+import alpine.common.logging.Logger;
+
+/**
+ * Evaluates the {@link VersionDistance} between a {@link Component}'s current and it's latest
+ * version against a {@link Policy}. This makes it possible to add a policy for checking outdated
+ * components. The policy "greater than 0:1.?.?" for example means, a difference of only one
+ * between the curren version's major number and the latest version's major number is allowed.
+ *
+ * VersionDistances can be combined in a policy. For example "greater than 1:1.?.?" means a
+ * difference of only one epoch number or one major number is allowed. Or "greater than 1.1.?"
+ * means a difference of only one majr number or one minor number is allowed
+ *
+ * @since 4.9.0
+ */
+public class VersionDistancePolicyEvaluator extends AbstractPolicyEvaluator {
+
+    private static final Logger LOGGER = Logger.getLogger(VersionDistancePolicyEvaluator.class);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PolicyCondition.Subject supportedSubject() {
+        return PolicyCondition.Subject.VERSION_DISTANCE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<PolicyConditionViolation> evaluate(final Policy policy, final Component component) {
+        final var violations = new ArrayList<PolicyConditionViolation>();
+        if (component.getPurl() == null) {
+            return violations;
+        }
+
+        final RepositoryType repoType = RepositoryType.resolve(component.getPurl());
+        if (RepositoryType.UNSUPPORTED == repoType) {
+            return violations;
+        }
+
+        final RepositoryMetaComponent metaComponent;
+        try (final var qm = new QueryManager()) {
+            metaComponent = qm.getRepositoryMetaComponent(repoType,
+                    component.getPurl().getNamespace(), component.getPurl().getName());
+            qm.getPersistenceManager().detachCopy(metaComponent);
+        }
+        if (metaComponent == null || metaComponent.getLatestVersion() == null) {
+            return violations;
+        }
+
+        final var versionDistance = VersionDistance.getVersionDistance(component.getVersion(),metaComponent.getLatestVersion());
+
+        for (final PolicyCondition condition : super.extractSupportedConditions(policy)) {
+            if (isDirectDependency(component) && evaluate(condition, versionDistance)) {
+                violations.add(new PolicyConditionViolation(condition, component));
+            }
+        }
+
+        return violations;
+    }
+
+    /**
+     * Evaluate VersionDistance conditions for a given versionDistance. A condition
+     *
+     * @param condition operator and value containing combined {@link VersionDistance} values
+     * @param versionDistance the {@link VersionDistance} to evalue
+     * @return true if the condition is true for the components versionDistance, false otherwise
+     */
+    private boolean evaluate(final PolicyCondition condition, final VersionDistance versionDistance) {
+        final var operator = condition.getOperator();
+        final var value = condition.getValue();
+
+        if (!StringUtils.isEmpty(value)) {
+            final var json = new JSONObject(value);
+            final var epoch = json.optString("epoch", "0");
+            final var major = json.optString("major", "?");
+            final var minor = json.optString("minor", "?");
+            final var patch = json.optString("patch", "?");
+
+            final List<VersionDistance> versionDistanceList;
+            try {
+                versionDistanceList = VersionDistance.parse(epoch+":"+major+"."+minor+"."+patch);
+            } catch (IllegalArgumentException e) {
+                LOGGER.error("Invalid version distance format", e);
+                return false;
+            }
+            if (versionDistanceList.isEmpty()) {
+                versionDistanceList.add(new VersionDistance(0,0,0));
+            }
+            return versionDistanceList.stream().reduce(
+                false,
+                (latest, current) -> latest || matches(operator, current, versionDistance),
+                Boolean::logicalOr
+            );
+        }
+        return false;
+
+
+
+    }
+
+    private boolean matches(final Operator operator, final VersionDistance policyDistance, final VersionDistance versionDistance) {
+        return switch (operator) {
+            case NUMERIC_GREATER_THAN -> versionDistance.compareTo(policyDistance) > 0;
+            case NUMERIC_GREATER_THAN_OR_EQUAL -> versionDistance.compareTo(policyDistance) >= 0;
+            case NUMERIC_EQUAL -> versionDistance.compareTo(policyDistance) == 0;
+            case NUMERIC_NOT_EQUAL -> versionDistance.compareTo(policyDistance) != 0;
+            case NUMERIC_LESSER_THAN_OR_EQUAL -> versionDistance.compareTo(policyDistance) <= 0;
+            case NUMERIC_LESS_THAN -> versionDistance.compareTo(policyDistance) < 0;
+            default -> {
+                LOGGER.warn("Operator %s is not supported for component age conditions".formatted(operator));
+                yield false;
+            }
+        };
+    }
+
+    /**
+     * Test if the components project direct dependencies contain a givven component
+     * If so, the component is a direct dependency of the project
+     *
+     * @param component component to test
+     * @return If the components project direct dependencies contain the component
+     */
+    private boolean isDirectDependency(Component component) {
+        return component.getProject().getDirectDependencies().contains("\"uuid\":\"" + component.getUuid().toString() + "\"");
+    }
+
+}

--- a/src/main/java/org/dependencytrack/util/VersionDistance.java
+++ b/src/main/java/org/dependencytrack/util/VersionDistance.java
@@ -1,0 +1,354 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.util;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A version distance consists of four parts for each of the difference in epoch,
+ * major, minor or patch numbers between two versions.
+ *
+ * Each part is computed by calculating the difference of each number found in the
+ * two versions. Since only the most significant part found is of any interest, only the
+ * first difference found will be set, all others will be zero. This makes it easy to
+ * compare two versions. For example the distence between 1.0.2 and 2.0.0 equals 1.0.0,
+ * meaning the major number differs by one.
+ *
+ * Epoch is also support, so the distance will look like <epoch>:<major>.<minor>.<patch>:
+ * <ul>
+ *   <li>1:0.0.0/li>
+ *   <li>0:1.0.0/li>
+ *   <li>1:0.0.0/li>
+ *   <li>0:0.3.0/li>
+ *   <li>0:0.0.1/li>
+ * </ul>
+ * N.B. Optional build numbers, as fourtth number, are neglected
+ *
+ * VersionDistances can be compared to each other, but makes no sense to do math with
+ * them: the difference between 1.6.0 and 1.2.3 is 0.4.0, but the sum of 1.6.0 and
+ * 0.4.0 is not equal to 1.6.3.
+ *
+ * VersionDistances are absolute, negative distances are not allowed.
+ *
+ * @since 4.9.0
+ */
+public class VersionDistance implements Comparable<VersionDistance>,  Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String GROUP_EPOCH = "epoch";
+    private static final String GROUP_MAJOR = "major";
+    private static final String GROUP_MINOR = "minor";
+    private static final String GROUP_PATCH = "patch";
+
+    private static final Pattern DISTANCE_PATTERN = Pattern.compile(
+        // Optional epoch part: numbers before the first : sign.
+        "^(?:(?<"+GROUP_EPOCH+">\\d+):)?" +
+        "(?<"+GROUP_MAJOR+">\\?|\\d+)"+
+        "(?:\\.(?<"+GROUP_MINOR+">\\?|\\d+))?"+
+        "(?:\\.(?<"+GROUP_PATCH+">\\?|\\d+))?"+
+        "$"
+    );
+
+    // Semver-like version:any numbers parts without characters appended, with optial leading v.
+    // Optionally appended with label and/or build metadata
+    protected static final Pattern VERSION_PATTERN = Pattern.compile(
+        "^(?:(?<"+GROUP_EPOCH+">.*):)?" + // Optional epoch part: number before the first : sign. Match any characters here so we can fail on incorrect values
+        "v?(?<"+GROUP_MAJOR+">\\d+[a-z]*)?(?:\\.(?<"+GROUP_MINOR+">\\d+[a-z]*))?(?:\\.(?<"+GROUP_PATCH+">\\d+[a-z]*))?" + // version part, at least major version (numeric), optinali minor (numeric) or patch (numeric) version. Ignore the rest
+        ".*$", // build numbers, labels and build metadata
+        Pattern.CASE_INSENSITIVE
+    );
+
+    private int epoch;
+    private int major;
+    private int minor;
+    private int patch;
+
+    /**
+     * Default all parts are set to 0
+     */
+    public VersionDistance() {
+        this.epoch = 0;
+        this.major = 0;
+        this.minor = 0;
+        this.patch = 0;
+    }
+
+    private void validate() throws IllegalArgumentException {
+        if ((epoch != 0) && ((major >= 0) || (minor >= 0) || (patch >= 0))) {
+            throw new IllegalArgumentException("Only the most significant number can be greater than 0, more significant parts cannot be ?");
+        }
+        if ((major != 0) && ((minor >= 0) || (patch >= 0))) {
+            throw new IllegalArgumentException("Only the most significant number can be greater than 0, more significant parts cannot be ?");
+        }
+        if ((minor != 0) && (patch >= 0)) {
+            throw new IllegalArgumentException("Only the most significant number can be greater than 0, more significant parts cannot be ?");
+        }
+    }
+
+    public VersionDistance(int major, int minor, int patch) throws IllegalArgumentException {
+        this (0, major, minor, patch);
+    }
+
+    public VersionDistance(int epoch, int major, int minor, int patch) throws IllegalArgumentException {
+        this.epoch = epoch;
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+        validate ();
+    }
+
+    public VersionDistance(String distance) throws NumberFormatException, IllegalArgumentException {
+        epoch = 0;
+        major = 0;
+        minor = 0;
+        patch = 0;
+        if (!StringUtils.isEmpty(distance)) {
+            final var distanceMatcher = DISTANCE_PATTERN.matcher(distance);
+            if (distanceMatcher.matches()) {
+                epoch = parseVersion(distanceMatcher.group(GROUP_EPOCH));
+                if (epoch == -1) {
+                    epoch = 0;
+                }
+                major = parseVersion(distanceMatcher.group(GROUP_MAJOR));
+                minor = parseVersion(distanceMatcher.group(GROUP_MINOR));
+                if ((major != 0) && (distanceMatcher.group(GROUP_MINOR) == null)) {
+                    minor = -1;
+                }
+                patch = parseVersion(distanceMatcher.group(GROUP_PATCH));
+                if ((minor != 0) && (distanceMatcher.group(GROUP_PATCH) == null)) {
+                    patch = -1;
+                }
+                validate();
+            } else {
+                throw new NumberFormatException("Invallid version distance: " + distance);
+            }
+        }
+    }
+
+    private static int parseVersion(String version) throws NumberFormatException {
+        if (StringUtils.isEmpty(version)) {
+            return 0;
+        }
+        if ("?".equals(version)) {
+            return -1;
+        }
+        return Integer.parseInt(version);
+    }
+
+    /**
+     * Parse a string of combined {@link VersionDistance}s and return tham as a {@link VersionDistance} {@link List}
+     * @param combinedDistances combined version distance string, e.g 1:1.?.? -> (1:?.?.?, 0:1.?.?)
+     * @return List of separate {@link VersionDistance}s
+     * @throws NumberFormatException in case a version distance cannot be parsed
+     */
+    public static List<VersionDistance> parse(String combinedDistances) throws NumberFormatException {
+        final List<VersionDistance> result = new ArrayList<VersionDistance>();
+        final var distanceMatcher = DISTANCE_PATTERN.matcher(combinedDistances);
+        if (distanceMatcher.matches()) {
+            final var epoch = parseVersion(distanceMatcher.group(GROUP_EPOCH));
+            if (epoch > 0) {
+                result.add(new VersionDistance(epoch, -1, -1, -1));
+            }
+            final var major = parseVersion(distanceMatcher.group(GROUP_MAJOR));
+            if (major > 0) {
+                result.add(new VersionDistance(0, major, -1, -1));
+            }
+            final var minor = parseVersion(distanceMatcher.group(GROUP_MINOR));
+            if (minor > 0) {
+                result.add(new VersionDistance(0, 0, minor, -1));
+            }
+            final var patch = parseVersion(distanceMatcher.group(GROUP_PATCH));
+            if (patch > 0) {
+                result.add(new VersionDistance(0, 0, 0, patch));
+            }
+        } else {
+            throw new NumberFormatException("Invallid version distance: " + combinedDistances);
+        }
+        return result;
+    }
+
+    public void setEpoch(int epoch) {
+        this.epoch = epoch;
+    }
+
+    public int getEpoch() {
+        return epoch;
+    }
+
+    public void setMajor(int major) {
+        this.major = major;
+    }
+
+    public int getMajor() {
+        return major;
+    }
+
+    public void setMinor(int minor) {
+        this.minor = minor;
+    }
+
+    public int getMinor() {
+        return minor;
+    }
+
+    public void setPatch(int patch) {
+        this.patch = patch;
+    }
+
+    public int getPatch() {
+        return patch;
+    }
+
+    private int compareEpoch(VersionDistance other) {
+        return epoch - other.getEpoch();
+    }
+
+    private int compareMajor(VersionDistance other) {
+        return major - other.getMajor();
+    }
+
+    private int compareMinor(VersionDistance other) {
+        return minor - other.getMinor();
+    }
+
+    private int comparePatch(VersionDistance other) {
+        return patch - other.getPatch();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        // self check
+        if (this == o) {
+            return true;
+        }
+        // null check
+        if (o == null) {
+            return false;
+        }
+        // type check and cast
+        if (getClass() != o.getClass()) {
+            return false;
+        }
+        VersionDistance versionDistance = (VersionDistance) o;
+        // field comparison
+        return versionDistance.getEpoch() == epoch && versionDistance.getMajor() == major && versionDistance.getMinor() == minor && versionDistance.getPatch() == patch;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 11 + epoch;
+        result *= 17 + major;
+        result *= 23 + minor;
+        result *= 31 + patch;
+        return result;
+    }
+
+    @Override
+    public int compareTo(VersionDistance other) {
+        final var epochDistance = compareEpoch(other);
+        final var majorDistance = compareMajor(other);
+        final var minorDistance = compareMinor(other);
+        final var patchDistance = comparePatch(other);
+        if (epochDistance != 0) {
+            return epochDistance;
+        }
+        if (majorDistance != 0) {
+            return majorDistance;
+        }
+        if (minorDistance != 0) {
+            return minorDistance;
+        }
+        if (patchDistance != 0) {
+            return patchDistance;
+        }
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        return epoch + ":" + (major < 0 ? "?" : major) + "." + (minor < 0 ? "?" : minor) + "." + (patch < 0 ? "?" : patch);
+    }
+
+    /**
+     * Calculates the distance between two versions by calculating the absolute
+     * difference in the epoch numbers, major version numbers, the minor version
+     * numbers or the patch version numbers. When a number is not foud in the
+     * version string, 0 is assumed.
+     *
+     * Only the first (most significant) difference number will be set, all
+     * others will be 0. So the distance will look like <epoch>:<major>.<minor>.<patch>:
+     * 1:?.?.?
+     * 0:1.?.?
+     * 1:?.?.?
+     * 0:0.3.?
+     * 0:0.0.1
+     *
+     * @param version1 the first version
+     * @param version2 the second version
+     *
+     * @return VersionDistance distance between version1 and version2
+     */
+    public static VersionDistance getVersionDistance(String version1, String version2) {
+        if (version1 == null) {
+            version1 = "";
+        }
+        if (version2 == null) {
+            version2 = "";
+        }
+        final var v1matcher = VERSION_PATTERN.matcher(version1);
+        final var v2matcher = VERSION_PATTERN.matcher(version2);
+        if (v1matcher.matches() && v2matcher.matches()) {
+            // version1
+            final var epoch1 = VersionDistance.parseVersion(v1matcher.group(GROUP_EPOCH));
+            final var major1 = VersionDistance.parseVersion(v1matcher.group(GROUP_MAJOR));
+            final var minor1 = VersionDistance.parseVersion(v1matcher.group(GROUP_MINOR));
+            final var patch1 = VersionDistance.parseVersion(v1matcher.group(GROUP_PATCH));
+            // version2
+            final var epoch2 = VersionDistance.parseVersion(v2matcher.group(GROUP_EPOCH));
+            final var major2 = VersionDistance.parseVersion(v2matcher.group(GROUP_MAJOR));
+            final var minor2 = VersionDistance.parseVersion(v2matcher.group(GROUP_MINOR));
+            final var patch2 = VersionDistance.parseVersion(v2matcher.group(GROUP_PATCH));
+
+            final var epochDistance = Math.abs(epoch2 - epoch1);
+            final var majorDistance = Math.abs(major2 - major1);
+            final var minorDistance = Math.abs(minor2 - minor1);
+            final var patchDistance = Math.abs(patch2 - patch1);
+            if (epochDistance != 0) {
+                return new VersionDistance(epochDistance, -1, -1, -1);
+            }
+            if (majorDistance != 0) {
+                return new VersionDistance(0, majorDistance, -1, -1);
+            }
+            if (minorDistance != 0) {
+                return new VersionDistance(0, 0, minorDistance, -1);
+            }
+            if (patchDistance != 0) {
+                return new VersionDistance(0, 0, 0, patchDistance);
+            }
+            return new VersionDistance(0, 0, 0, 0);
+        }
+        throw new NumberFormatException("Incompatible versions: " + version1 + ", " + version2);
+    }
+
+}

--- a/src/test/java/org/dependencytrack/policy/VersionDistancePolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/VersionDistancePolicyEvaluatorTest.java
@@ -1,0 +1,165 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Policy;
+import org.dependencytrack.model.PolicyCondition.Operator;
+import org.dependencytrack.model.PolicyCondition.Subject;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.RepositoryMetaComponent;
+import org.dependencytrack.model.RepositoryType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class VersionDistancePolicyEvaluatorTest extends PersistenceCapableTest {
+
+    @Parameterized.Parameters(name = "[{index}] version={0} latestVersion={1} operator={2} distance={3} shouldViolate={4}")
+    public static Collection<?> testParameters() {
+        return Arrays.asList(new Object[][]{
+            {"1.0.0", "1.0.0", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
+            {"1.0.0", "1.0.0", Operator.NUMERIC_GREATER_THAN, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
+            // Latest version is 1 minor newer than current version
+            {"1.2.3", "1.3.1", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", true},
+            {"1.2.3", "1.3.1", Operator.NUMERIC_GREATER_THAN, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", false},
+            {"1.2.3", "1.3.1", Operator.NUMERIC_EQUAL, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", true},
+            {"1.2.3", "1.3.1", Operator.NUMERIC_NOT_EQUAL, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", false},
+            {"1.2.3", "1.3.1", Operator.NUMERIC_LESS_THAN, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", false},
+            {"1.2.3", "1.3.1", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", true},
+            // Latest version is 1 major newer than current version
+            {"1.2.3", "2.1.1", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
+            {"1.2.3", "2.1.1", Operator.NUMERIC_GREATER_THAN, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
+            {"1.2.3", "2.1.1", Operator.NUMERIC_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
+            {"1.2.3", "2.1.1", Operator.NUMERIC_NOT_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
+            {"1.2.3", "2.1.1", Operator.NUMERIC_LESS_THAN, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
+            {"1.2.3", "2.1.1", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
+            // Latest version is 2 major newer than current version
+            {"1.2.3", "3.0.1", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", true},
+            {"1.2.3", "3.0.1", Operator.NUMERIC_GREATER_THAN, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", false},
+            {"1.2.3", "3.0.1", Operator.NUMERIC_EQUAL, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", true},
+            {"1.2.3", "3.0.1", Operator.NUMERIC_NOT_EQUAL, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", false},
+            {"1.2.3", "3.0.1", Operator.NUMERIC_LESS_THAN, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", false},
+            {"1.2.3", "3.0.1", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", true},
+            // Component is latest version.
+            {"1.2.3", "1.2.3", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", true},
+            {"1.2.3", "1.2.3", Operator.NUMERIC_GREATER_THAN, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", false},
+            {"1.2.3", "1.2.3", Operator.NUMERIC_EQUAL, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", true},
+            {"1.2.3", "1.2.3", Operator.NUMERIC_NOT_EQUAL, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", false},
+            {"1.2.3", "1.2.3", Operator.NUMERIC_LESS_THAN, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", false},
+            {"1.2.3", "1.2.3", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", true},
+            // Negative distanse.
+            {"2.3.4", "1.2.3", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
+            {"2.3.4", "1.2.3", Operator.NUMERIC_GREATER_THAN, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
+            {"2.3.4", "1.2.3", Operator.NUMERIC_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
+            {"2.3.4", "1.2.3", Operator.NUMERIC_NOT_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
+            {"2.3.4", "1.2.3", Operator.NUMERIC_LESS_THAN, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
+            {"2.3.4", "1.2.3", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
+            // Combined policies.
+            {"2.0.0", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
+            {"1:1.0.0", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
+            {"1:2.0.0", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
+            {"1.0.0", "1.0.0", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
+            {"1.0.0", "1.0.0", Operator.NUMERIC_LESS_THAN, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
+            {"1.0.0", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
+            {"1.0.0", "1.0.0", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
+            {"1.0.0", "1.0.0", Operator.NUMERIC_GREATER_THAN, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
+            {"2:2.0.0", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
+            {"3.2.2", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"0\", \"major\": \"1\", \"minor\": \"1\", \"patch\": \"1\" }", false},
+            {"1.2.2", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"0\", \"major\": \"0\", \"minor\": \"1\", \"patch\": \"1\" }", false},
+            {"0.2.2", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"0\", \"major\": \"0\", \"minor\": \"1\", \"patch\": \"1\" }", false},
+            // Unsupported operator.
+            {"1.2.3", "2.1.1", Operator.MATCHES, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
+            // Invalid distanse format.
+            {"1.2.3", "2.1.1", Operator.NUMERIC_EQUAL, "{ \"major\": \"1a\" }", false},
+            // No known latestVersion.
+            {"1.2.3", null, Operator.NUMERIC_EQUAL, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", false},
+        });
+    }
+
+    private final String version;
+    private final String latestVersion;
+    private final Operator operator;
+    private final String versionDistance;
+    private final boolean shouldViolate;
+
+    public VersionDistancePolicyEvaluatorTest(final String version, String latestVersion,
+            Operator operator, String versionDistance, boolean shouldViolate) {
+        this.version = version;
+        this.latestVersion = latestVersion;
+        this.operator = operator;
+        this.versionDistance = versionDistance;
+        this.shouldViolate = shouldViolate;
+    }
+
+    @Test
+    public void evaluateTest() {
+        final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
+        final var condition = qm.createPolicyCondition(policy, Subject.VERSION_DISTANCE, operator, versionDistance);
+
+        final var project = new Project();
+        project.setName("name");
+        project.setActive(true);
+
+        final var metaComponent = new RepositoryMetaComponent();
+        metaComponent.setRepositoryType(RepositoryType.MAVEN);
+        metaComponent.setNamespace("foo");
+        metaComponent.setName("bar");
+        metaComponent.setLatestVersion("6.6.6");
+        if (latestVersion != null) {
+            metaComponent.setLatestVersion(latestVersion);
+        }
+        metaComponent.setLastCheck(new Date());
+        qm.persist(metaComponent);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setGroup("foo");
+        component.setName("bar");
+        component.setPurl("pkg:maven/foo/bar@" + version);
+        component.setVersion(version);
+        qm.persist(component);
+
+        project.setDirectDependencies("[{\"uuid\":\""+component.getUuid()+"\"}]");
+        qm.persist(project);
+
+        final var evaluator = new VersionDistancePolicyEvaluator();
+        evaluator.setQueryManager(qm);
+
+        final List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        if (shouldViolate) {
+            assertThat(violations).hasSize(1);
+            final PolicyConditionViolation violation = violations.get(0);
+            assertThat(violation.getComponent()).isEqualTo(component);
+            assertThat(violation.getPolicyCondition()).isEqualTo(condition);
+        } else {
+            assertThat(violations).isEmpty();
+        }
+    }
+
+}

--- a/src/test/java/org/dependencytrack/util/VersionDistanceTest.java
+++ b/src/test/java/org/dependencytrack/util/VersionDistanceTest.java
@@ -1,0 +1,115 @@
+package org.dependencytrack.util;
+
+import java.util.Arrays;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class VersionDistanceTest {
+
+    @Test
+    public void testVersionDistance() {
+        Assert.assertEquals("0:1.?.?", new VersionDistance("1").toString());
+        Assert.assertEquals("1:?.?.?", new VersionDistance("1:?").toString());
+        Assert.assertEquals("0:0.0.0", new VersionDistance().toString());
+        Assert.assertEquals("0:0.0.0", new VersionDistance(null).toString());
+        Assert.assertEquals("0:0.0.0", new VersionDistance(0,0,0).toString());
+        Assert.assertEquals("0:1.?.?", new VersionDistance(1, -1,-1).toString());
+        Assert.assertEquals("0:0.2.?", new VersionDistance(0, 2, -1).toString());
+        Assert.assertEquals("0:0.2.?", new VersionDistance("0:0.2").toString());
+        Assert.assertEquals("0:2.?.?", new VersionDistance("2").toString());
+
+        Assert.assertThrows(NumberFormatException.class, () -> new VersionDistance("ax").toString());
+        Assert.assertThrows(NumberFormatException.class, () -> new VersionDistance("1a").toString());
+        Assert.assertThrows(NumberFormatException.class, () -> new VersionDistance("1.2.3.4").toString());
+        Assert.assertThrows(NumberFormatException.class, () -> new VersionDistance("1a.2b.3c").toString());
+        Assert.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("1.0.0").toString());
+        Assert.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("1.1.0").toString());
+        Assert.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("?:1.0.0").toString());
+        Assert.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("0:?.0.0").toString());
+        Assert.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("?:1.0.0").toString());
+        Assert.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("0:?.1.0").toString());
+    }
+
+    @Test
+    public void testCompareTo() {
+        Assert.assertEquals(0, new VersionDistance(null).compareTo(new VersionDistance("0")));
+        Assert.assertTrue(new VersionDistance("2.?.?").compareTo(new VersionDistance("1.?.?")) > 0);
+
+        Assert.assertEquals(0, new VersionDistance().compareTo(new VersionDistance()));
+        Assert.assertEquals(0, new VersionDistance("0.0").compareTo(new VersionDistance("0")));
+        Assert.assertEquals(0, new VersionDistance("1.?.?").compareTo(new VersionDistance("1.?.?")));
+
+        Assert.assertTrue(new VersionDistance("1").compareTo(new VersionDistance()) > 0);
+        Assert.assertTrue(new VersionDistance("1").compareTo(new VersionDistance(null)) > 0);
+        Assert.assertTrue(new VersionDistance("1.?").compareTo(new VersionDistance("0")) > 0);
+        Assert.assertTrue(new VersionDistance("1.?.?").compareTo(new VersionDistance("0.0")) > 0);
+        Assert.assertTrue(new VersionDistance("1.?.?").compareTo(new VersionDistance("0.0.0")) > 0);
+        Assert.assertTrue(new VersionDistance("2.?.?").compareTo(new VersionDistance("1.?.?")) > 0);
+        Assert.assertTrue(new VersionDistance("1.?.?").compareTo(new VersionDistance("0.1.?")) > 0);
+        Assert.assertTrue(new VersionDistance("0.1.?").compareTo(new VersionDistance("0.0.1")) > 0);
+
+        Assert.assertTrue(new VersionDistance().compareTo(new VersionDistance("1")) < 0);
+        Assert.assertTrue(new VersionDistance(null).compareTo(new VersionDistance("1")) < 0);
+        Assert.assertTrue(new VersionDistance("0").compareTo(new VersionDistance("1.?")) < 0);
+        Assert.assertTrue(new VersionDistance("0.0").compareTo(new VersionDistance("0.0.1")) < 0);
+        Assert.assertTrue(new VersionDistance("0.1.?").compareTo(new VersionDistance("1.?.?")) < 0);
+        Assert.assertTrue(new VersionDistance("1.?.?").compareTo(new VersionDistance("2.?.?")) < 0);
+        Assert.assertTrue(new VersionDistance("1.?.?").compareTo(new VersionDistance("2.?.?")) < 0);
+        Assert.assertTrue(new VersionDistance("0.1.?").compareTo(new VersionDistance("0.2.?")) < 0);
+        Assert.assertTrue(new VersionDistance("0.0.1").compareTo(new VersionDistance("0.0.2")) < 0);
+
+        Assert.assertTrue(VersionDistance.getVersionDistance("1.0.0", "0.1.0").compareTo(new VersionDistance("1.?.?")) == 0);
+        Assert.assertTrue(VersionDistance.getVersionDistance("1.1.0", "1.0.0").compareTo(new VersionDistance("0.1.?")) == 0);
+        Assert.assertTrue(VersionDistance.getVersionDistance("1.0.0", "1.1.0").compareTo(new VersionDistance("0.1.?")) == 0);
+        Assert.assertTrue(VersionDistance.getVersionDistance("1.2.3", "2.1.0").compareTo(new VersionDistance("1.?.?")) == 0);
+        Assert.assertTrue(VersionDistance.getVersionDistance("2.2.2", "2.4.4").compareTo(new VersionDistance("0.1.?")) > 0);
+        Assert.assertTrue(VersionDistance.getVersionDistance("1.1.1", "1.1.3").compareTo(new VersionDistance("0.0.1")) > 0);
+    }
+
+    @Test
+    public void testEquals() {
+        Assert.assertEquals(new VersionDistance("0.0"), new VersionDistance(""));
+        Assert.assertEquals(new VersionDistance("0:0"), new VersionDistance(null));
+        Assert.assertEquals(new VersionDistance("4:?.?.?"), new VersionDistance("4:?"));
+        Assert.assertEquals(new VersionDistance("1.?.?"), new VersionDistance("1"));
+        Assert.assertEquals(new VersionDistance("0:1.?.?"), new VersionDistance("1.?"));
+    }
+
+    @Test
+    public void testGetVersionDistance() {
+        Assert.assertEquals(new VersionDistance("0.0.0"), VersionDistance.getVersionDistance("", null));
+        Assert.assertEquals(new VersionDistance("0.0.0"), VersionDistance.getVersionDistance(null, ""));
+        Assert.assertEquals(new VersionDistance("1.?.?"), VersionDistance.getVersionDistance("2", "1.0"));
+        Assert.assertEquals(new VersionDistance("0.1.?"), VersionDistance.getVersionDistance("1", "1.1.0"));
+        Assert.assertEquals(new VersionDistance("0.0.1"), VersionDistance.getVersionDistance("1", "1.0.1"));
+        Assert.assertEquals(new VersionDistance("2.?.?"), VersionDistance.getVersionDistance("1.2", "3.4.0"));
+        Assert.assertEquals(new VersionDistance("0:2.?"), VersionDistance.getVersionDistance("1.f", "3.4.0"));
+        Assert.assertEquals(new VersionDistance("2.?.?"), VersionDistance.getVersionDistance("1.", "3.4.0"));
+        Assert.assertEquals(new VersionDistance("2.?.?"), VersionDistance.getVersionDistance("1.2.3", "3.4.0"));
+        Assert.assertEquals(new VersionDistance("3.?.?"), VersionDistance.getVersionDistance("0.1.2", "3.4.0"));
+        Assert.assertEquals(new VersionDistance("0.2.?"), VersionDistance.getVersionDistance("3.2.2", "3.4.0"));
+        Assert.assertEquals(new VersionDistance("0.0.1"), VersionDistance.getVersionDistance("0.0.1", "0.0.2"));
+        Assert.assertEquals(new VersionDistance("2.?.?"), VersionDistance.getVersionDistance("3.4.0", "1.2.3"));
+        Assert.assertEquals(new VersionDistance("3.?.?"), VersionDistance.getVersionDistance("3.4.0", "0.1.2"));
+        Assert.assertEquals(new VersionDistance("0.2.?"), VersionDistance.getVersionDistance("3.4.0", "3.2.2"));
+        Assert.assertEquals(new VersionDistance("0.0.1"), VersionDistance.getVersionDistance("0.0.2", "0.0.1"));
+        // optional build numbers are ignored:
+        Assert.assertEquals(new VersionDistance("0.0.0"), VersionDistance.getVersionDistance("0.0.0.1", "0.0.0.5"));
+
+        Assert.assertThrows(NumberFormatException.class, () -> VersionDistance.getVersionDistance("a:", "1"));
+        Assert.assertThrows(NumberFormatException.class, () -> VersionDistance.getVersionDistance("1a.2.3", "1"));
+        Assert.assertThrows(NumberFormatException.class, () -> VersionDistance.getVersionDistance("1.2a.3", "1"));
+        Assert.assertThrows(NumberFormatException.class, () -> VersionDistance.getVersionDistance("1.2.3a", "1"));
+    }
+
+    @Test
+    public void testParse() {
+        Assert.assertEquals(Arrays.asList(new VersionDistance(0,1,-1)), VersionDistance.parse("0.1.?"));
+        Assert.assertEquals(Arrays.asList(new VersionDistance(1,-1,-1), new VersionDistance(0,1,-1)), VersionDistance.parse("1.1.?"));
+        Assert.assertEquals(Arrays.asList(new VersionDistance(1, -1,-1,-1), new VersionDistance(1,-1, -1), new VersionDistance(0,1,-1)), VersionDistance.parse("1:1.1.?"));
+        Assert.assertEquals(Arrays.asList(), VersionDistance.parse("0:?.?.?"));
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> VersionDistance.parse("1.2.3a.1"));
+    }
+
+}


### PR DESCRIPTION
### Description

Dependenct Track now supports a Component Age policy and a Component Version policy, but both are unsuitable to detect outdated components. For this the distance between the current component version and it's latest version needs to be analysed.

The VersionDistancePolicyEvaluator evaluates the VersionDistance between a Component's current and it's latest version. The policy "greater than 0:1.?.?" for example, means  a difference of only one between the curren version's major number and the latest version's major number is allowed.

Combining VersionDistances is also supported: "greater than 1:1.?.?". This way multiple parts (epoch or major) number can be considered in one go, combining them with a Boolean OR. Not sure yet if this will be supported in the UI...

### Addressed Issue

closes #2528, addresses #208, #257

### Additional Details

Together with the Age Policy and the Version Policy this would enable advanced policies like "no outdated versions (one major difference), but only if the minor version is at least exactly 1 and when it is older than 21 days. (3.0.0 is to early, but 3.1.0 is considered safe, when it's older than three weeks without a patch release)"

Accompanying PR for the frontend https://github.com/DependencyTrack/frontend/pull/432/

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [x] This PR introduces new or alters existing behavior, ~and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
