### PR TITLE
Feature: Handle repository meta analyzers errors gracefully

### DIFF
--- a/src/main/java/org/dependencytrack/exception/MetaAnalyzerException.java
+++ b/src/main/java/org/dependencytrack/exception/MetaAnalyzerException.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.exception;
+
+public class MetaAnalyzerException extends RuntimeException {
+
+    public MetaAnalyzerException(final String message) {
+        super(message);
+    }
+
+    public MetaAnalyzerException(final Throwable cause) {
+        super(cause);
+    }
+
+    public MetaAnalyzerException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/org/dependencytrack/tasks/repositories/CargoMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/CargoMetaAnalyzer.java
@@ -20,6 +20,7 @@ package org.dependencytrack.tasks.repositories;
 
 import alpine.common.logging.Logger;
 import com.github.packageurl.PackageURL;
+import org.dependencytrack.exception.MetaAnalyzerException;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.apache.http.HttpEntity;
@@ -101,6 +102,8 @@ public class CargoMetaAnalyzer extends AbstractMetaAnalyzer {
                 }
             } catch (IOException ex) {
                 handleRequestException(LOGGER, ex);
+            } catch (Exception ex) {
+                throw new MetaAnalyzerException(ex);
             }
         }
         return meta;

--- a/src/main/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzer.java
@@ -20,6 +20,7 @@ package org.dependencytrack.tasks.repositories;
 
 import alpine.common.logging.Logger;
 import com.github.packageurl.PackageURL;
+import org.dependencytrack.exception.MetaAnalyzerException;
 import org.json.JSONObject;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -132,8 +133,9 @@ public class ComposerMetaAnalyzer extends AbstractMetaAnalyzer {
             });
         } catch (IOException ex) {
             handleRequestException(LOGGER, ex);
+        } catch (Exception ex) {
+            throw new MetaAnalyzerException(ex);
         }
-
 
         return meta;
     }

--- a/src/main/java/org/dependencytrack/tasks/repositories/GemMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/GemMetaAnalyzer.java
@@ -23,6 +23,7 @@ import com.github.packageurl.PackageURL;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.util.EntityUtils;
+import org.dependencytrack.exception.MetaAnalyzerException;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
 import org.json.JSONObject;
@@ -79,6 +80,8 @@ public class GemMetaAnalyzer extends AbstractMetaAnalyzer {
                 }
             }catch (IOException ex){
                 handleRequestException(LOGGER, ex);
+            }catch (Exception ex) {
+                throw new MetaAnalyzerException(ex);
             }
 
         }

--- a/src/main/java/org/dependencytrack/tasks/repositories/GoModulesMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/GoModulesMetaAnalyzer.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.util.EntityUtils;
+import org.dependencytrack.exception.MetaAnalyzerException;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
 import org.json.JSONObject;
@@ -92,6 +93,8 @@ public class GoModulesMetaAnalyzer extends AbstractMetaAnalyzer {
             }
         } catch (IOException | ParseException e) {
             handleRequestException(LOGGER, e);
+        } catch (Exception ex) {
+            throw new MetaAnalyzerException(ex);
         }
 
         return meta;

--- a/src/main/java/org/dependencytrack/tasks/repositories/HexMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/HexMetaAnalyzer.java
@@ -23,6 +23,7 @@ import com.github.packageurl.PackageURL;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.util.EntityUtils;
+import org.dependencytrack.exception.MetaAnalyzerException;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
 import org.json.JSONArray;
@@ -107,6 +108,8 @@ public class HexMetaAnalyzer extends AbstractMetaAnalyzer {
                 }
             } catch (IOException e) {
                 handleRequestException(LOGGER, e);
+            } catch (Exception ex) {
+                throw new MetaAnalyzerException(ex);
             }
         }
         return meta;

--- a/src/main/java/org/dependencytrack/tasks/repositories/IMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/IMetaAnalyzer.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.tasks.repositories;
 
 import com.github.packageurl.PackageURL;
+import org.dependencytrack.exception.MetaAnalyzerException;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
 
@@ -65,6 +66,7 @@ public interface IMetaAnalyzer {
      * The component to analyze.
      * @param component the component to analyze
      * @return a MetaModel object
+     * @throws MetaAnalyzerException in case of any issue during metadata generation
      * @since 3.1.0
      */
     MetaModel analyze(Component component);

--- a/src/main/java/org/dependencytrack/tasks/repositories/MavenMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/MavenMetaAnalyzer.java
@@ -23,6 +23,7 @@ import com.github.packageurl.PackageURL;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.dependencytrack.exception.MetaAnalyzerException;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.util.DateUtil;
@@ -105,6 +106,8 @@ public class MavenMetaAnalyzer extends AbstractMetaAnalyzer {
                 }
             } catch (IOException | ParserConfigurationException | SAXException | XPathExpressionException e) {
                 handleRequestException(LOGGER, e);
+            } catch (Exception ex) {
+                throw new MetaAnalyzerException(ex);
             }
 
         }

--- a/src/main/java/org/dependencytrack/tasks/repositories/NpmMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/NpmMetaAnalyzer.java
@@ -23,6 +23,7 @@ import com.github.packageurl.PackageURL;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.util.EntityUtils;
+import org.dependencytrack.exception.MetaAnalyzerException;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
 import org.json.JSONObject;
@@ -89,6 +90,8 @@ public class NpmMetaAnalyzer extends AbstractMetaAnalyzer {
                 }
             } catch (IOException e) {
                 handleRequestException(LOGGER, e);
+            } catch (Exception ex) {
+                throw new MetaAnalyzerException(ex);
             }
         }
         return meta;

--- a/src/main/java/org/dependencytrack/tasks/repositories/NugetMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/NugetMetaAnalyzer.java
@@ -24,6 +24,7 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.util.EntityUtils;
 import org.apache.maven.artifact.versioning.ComparableVersion;
+import org.dependencytrack.exception.MetaAnalyzerException;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
 import org.json.JSONArray;
@@ -119,6 +120,8 @@ public class NugetMetaAnalyzer extends AbstractMetaAnalyzer {
             }
         } catch (IOException e) {
             handleRequestException(LOGGER, e);
+        } catch (Exception ex) {
+            throw new MetaAnalyzerException(ex);
         }
         return false;
     }
@@ -160,6 +163,8 @@ public class NugetMetaAnalyzer extends AbstractMetaAnalyzer {
             }
         } catch (IOException e) {
             handleRequestException(LOGGER, e);
+        } catch (Exception ex) {
+            throw new MetaAnalyzerException(ex);
         }
         return false;
     }

--- a/src/main/java/org/dependencytrack/tasks/repositories/PypiMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/PypiMetaAnalyzer.java
@@ -23,6 +23,7 @@ import com.github.packageurl.PackageURL;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.util.EntityUtils;
+import org.dependencytrack.exception.MetaAnalyzerException;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
 import org.json.JSONArray;
@@ -102,6 +103,8 @@ public class PypiMetaAnalyzer extends AbstractMetaAnalyzer {
                 }
             } catch (IOException e) {
                 handleRequestException(LOGGER, e);
+            } catch (Exception ex) {
+                throw new MetaAnalyzerException(ex);
             }
         }
         return meta;

--- a/src/main/java/org/dependencytrack/tasks/repositories/RepositoryMetaAnalyzerTask.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/RepositoryMetaAnalyzerTask.java
@@ -29,7 +29,6 @@ import io.micrometer.core.instrument.Timer;
 import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.common.ConfigKey;
 import org.dependencytrack.event.RepositoryMetaEvent;
-import org.dependencytrack.exception.MetaAnalyzerException;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentAnalysisCache;
 import org.dependencytrack.model.ConfigPropertyConstants;
@@ -44,7 +43,6 @@ import org.dependencytrack.util.PurlUtil;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
@@ -67,9 +65,7 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
                 "repositoryMetaCache",
                 Config.getInstance().getPropertyAsInt(ConfigKey.REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_LOCK_BUCKETS),
                 false,
-                Config.getInstance().getPropertyAsInt(ConfigKey.REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_MAX_ATTEMPTS),
-                Duration.ofMinutes(10).toMillis(),
-                MetaAnalyzerException.class
+                Config.getInstance().getPropertyAsInt(ConfigKey.REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_MAX_ATTEMPTS)
         );
     }
 

--- a/src/main/java/org/dependencytrack/tasks/repositories/RepositoryMetaAnalyzerTask.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/RepositoryMetaAnalyzerTask.java
@@ -29,6 +29,7 @@ import io.micrometer.core.instrument.Timer;
 import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.common.ConfigKey;
 import org.dependencytrack.event.RepositoryMetaEvent;
+import org.dependencytrack.exception.MetaAnalyzerException;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentAnalysisCache;
 import org.dependencytrack.model.ConfigPropertyConstants;
@@ -43,6 +44,7 @@ import org.dependencytrack.util.PurlUtil;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
@@ -65,7 +67,9 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
                 "repositoryMetaCache",
                 Config.getInstance().getPropertyAsInt(ConfigKey.REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_LOCK_BUCKETS),
                 false,
-                Config.getInstance().getPropertyAsInt(ConfigKey.REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_MAX_ATTEMPTS)
+                Config.getInstance().getPropertyAsInt(ConfigKey.REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_MAX_ATTEMPTS),
+                Duration.ofMinutes(10).toMillis(),
+                MetaAnalyzerException.class
         );
     }
 

--- a/src/main/java/org/dependencytrack/util/CacheStampedeBlocker.java
+++ b/src/main/java/org/dependencytrack/util/CacheStampedeBlocker.java
@@ -22,6 +22,7 @@ import alpine.common.logging.Logger;
 import alpine.common.metrics.Metrics;
 import com.google.common.util.concurrent.Striped;
 import io.github.resilience4j.core.IntervalFunction;
+import io.github.resilience4j.core.predicate.PredicateCreator;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.github.resilience4j.retry.RetryRegistry;
@@ -128,7 +129,7 @@ public class CacheStampedeBlocker<K, V> {
         this(cacheName, nbBuckets, blockCompetingThreads, nbRetryMax, DEFAULT_CACHE_LOADER_ENTRY_TTL_MS);
     }
 
-    public CacheStampedeBlocker(String cacheName, int nbBuckets, boolean blockCompetingThreads, int nbRetryMax, long cacheLoaderEntryTTL, Class<? extends Exception>... ignoredExceptions) {
+    public CacheStampedeBlocker(String cacheName, int nbBuckets, boolean blockCompetingThreads, int nbRetryMax, long cacheLoaderEntryTTL, Class<? extends Exception>... retryableExceptions) {
         LOGGER.debug("Striped Lock is configured with "+nbBuckets+" buckets");
         this.cacheName = cacheName;
         stripedLock = Striped.lazyWeakReadWriteLock(nbBuckets);
@@ -140,7 +141,7 @@ public class CacheStampedeBlocker<K, V> {
         RetryConfig config = RetryConfig.custom()
                 .maxAttempts(this.nbRetryMax)
                 .intervalFunction(intervalWithCustomExponentialBackoff)
-                .ignoreExceptions(ignoredExceptions)
+                .retryOnException(PredicateCreator.createExceptionsPredicate(retryableExceptions).orElse(throwable -> false))
                 .failAfterMaxAttempts(true)
                 .build();
         RetryRegistry registry = RetryRegistry.of(config);

--- a/src/test/java/org/dependencytrack/util/CacheStampedeBlockerTest.java
+++ b/src/test/java/org/dependencytrack/util/CacheStampedeBlockerTest.java
@@ -3,6 +3,7 @@ package org.dependencytrack.util;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,13 +13,15 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class CacheStampedeBlockerTest {
+
+    private ExecutorService service = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 2);
 
     @Test
     public void highConcurrencyScenarioWithSuccessfulCallable() throws ExecutionException, InterruptedException {
         // Arrange
-        ExecutorService service = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 2);
         CacheStampedeBlocker<String, Integer> cacheStampedeBlocker = new CacheStampedeBlocker<>("testCache", 10, true);
         Map<String, Integer> cache = new HashMap<>();
         for (int i = 0; i < 10; i++) {
@@ -49,7 +52,6 @@ public class CacheStampedeBlockerTest {
     @Test
     public void highConcurrencyScenarioWithErroneousCallable() throws ExecutionException, InterruptedException {
         // Arrange
-        ExecutorService service = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 2);
         CacheStampedeBlocker<String, Integer> cacheStampedeBlocker = new CacheStampedeBlocker<>("testCache", 10, true);
         Map<String, Integer> cache = new HashMap<>();
         for (int i = 0; i < 10; i++) {
@@ -71,5 +73,39 @@ public class CacheStampedeBlockerTest {
             Optional<Integer> result = results.get(i).get();
             Assert.assertTrue(result.isEmpty());
         }
+    }
+
+    @Test
+    public void retryScenarioWithNonIgnoredException() {
+        // Arrange
+        CacheStampedeBlocker<String, Integer> cacheStampedeBlocker = new CacheStampedeBlocker<>("testCache", 10, true, 3);
+
+        // Act
+        AtomicInteger counter = new AtomicInteger();
+        cacheStampedeBlocker.readThroughOrPopulateCache("key", () -> {
+            counter.incrementAndGet();
+            // Throwing ArithmeticException
+            return 2 / 0;
+        });
+
+        // Assert
+        Assert.assertEquals(3, counter.get());
+    }
+
+    @Test
+    public void retryScenarioWithIgnoredException() {
+        // Arrange
+        CacheStampedeBlocker<String, Integer> cacheStampedeBlocker = new CacheStampedeBlocker<>("testCache", 10, true, 3, Duration.ofMinutes(10).toMillis(), ArithmeticException.class);
+
+        // Act
+        AtomicInteger counter = new AtomicInteger();
+        cacheStampedeBlocker.readThroughOrPopulateCache("key", () -> {
+            counter.incrementAndGet();
+            // Throwing ArithmeticException
+            return 2 / 0;
+        });
+
+        // Assert
+        Assert.assertEquals(1, counter.get());
     }
 }

--- a/src/test/java/org/dependencytrack/util/CacheStampedeBlockerTest.java
+++ b/src/test/java/org/dependencytrack/util/CacheStampedeBlockerTest.java
@@ -76,7 +76,7 @@ public class CacheStampedeBlockerTest {
     }
 
     @Test
-    public void retryScenarioWithNonIgnoredException() {
+    public void retryScenarioWithNonRetryableException() {
         // Arrange
         CacheStampedeBlocker<String, Integer> cacheStampedeBlocker = new CacheStampedeBlocker<>("testCache", 10, true, 3);
 
@@ -89,11 +89,11 @@ public class CacheStampedeBlockerTest {
         });
 
         // Assert
-        Assert.assertEquals(3, counter.get());
+        Assert.assertEquals(1, counter.get());
     }
 
     @Test
-    public void retryScenarioWithIgnoredException() {
+    public void retryScenarioWithRetryableException() {
         // Arrange
         CacheStampedeBlocker<String, Integer> cacheStampedeBlocker = new CacheStampedeBlocker<>("testCache", 10, true, 3, Duration.ofMinutes(10).toMillis(), ArithmeticException.class);
 
@@ -106,6 +106,6 @@ public class CacheStampedeBlockerTest {
         });
 
         // Assert
-        Assert.assertEquals(1, counter.get());
+        Assert.assertEquals(3, counter.get());
     }
 }


### PR DESCRIPTION
### Description

Trivial exceptions around metadata analysis (component not found in unrelated repositories) were logged with error level and swallowed stacktraces. Moreover due to resilience4j configuration, this caused excessive retries slowing down the BOM upload process. This enhancement provides :

- Ability to provide `CacheStampedeBlocker` with a list of exceptions to ignore
- An unique and specific exception `MetaAnalyzerException` for repository metadata fetch unhandled issues
- `RepometadataAnalyzerTask` enhancement to instruct `CacheStampedeBlocker` to ignore `MetaAnalyzerException`
- Better exception logging with appropriate level and stack propagation


### Addressed Issue

See #2456 

### Additional Details

N/A

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
