### PR TITLE
Reduce heap usage during NVD mirroring

### DIFF
--- a/src/main/java/org/dependencytrack/parser/nvd/NvdParser.java
+++ b/src/main/java/org/dependencytrack/parser/nvd/NvdParser.java
@@ -20,7 +20,14 @@ package org.dependencytrack.parser.nvd;
 
 import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.StringUtils;
+import org.datanucleus.PropertyNames;
 import org.dependencytrack.event.IndexEvent;
 import org.dependencytrack.model.Cpe;
 import org.dependencytrack.model.Cwe;
@@ -33,19 +40,17 @@ import us.springett.parsers.cpe.exceptions.CpeEncodingException;
 import us.springett.parsers.cpe.exceptions.CpeParsingException;
 import us.springett.parsers.cpe.values.Part;
 
-import javax.json.Json;
-import javax.json.JsonArray;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
-import javax.json.JsonString;
 import java.io.File;
 import java.io.InputStream;
+import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.sql.Date;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Parser and processor of NVD data feeds.
@@ -62,6 +67,11 @@ public final class NvdParser {
         NONE
     }
 
+    // TODO: Use global ObjectMapper instance once
+    // https://github.com/DependencyTrack/dependency-track/pull/2520
+    // is merged.
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     public void parse(final File file) {
         if (!file.getName().endsWith(".json")) {
             return;
@@ -70,137 +80,154 @@ public final class NvdParser {
         LOGGER.info("Parsing " + file.getName());
 
         try (InputStream in = Files.newInputStream(file.toPath());
-             final JsonReader reader = Json.createReader(in)) {
+             final JsonParser parser = objectMapper.createParser(in)) {
 
-            final JsonObject root = reader.readObject();
-            final JsonArray cveItems = root.getJsonArray("CVE_Items");
-
-            cveItems.forEach((c) -> {
-                final JsonObject cveItem = (JsonObject) c;
-                try (QueryManager qm = new QueryManager().withL2CacheDisabled()) {
-                    final Vulnerability vulnerability = new Vulnerability();
-                    vulnerability.setSource(Vulnerability.Source.NVD);
-
-                    // CVE ID
-                    final JsonObject cve = cveItem.getJsonObject("cve");
-                    final JsonObject meta0 = cve.getJsonObject("CVE_data_meta");
-                    final JsonString meta1 = meta0.getJsonString("ID");
-                    vulnerability.setVulnId(meta1.getString());
-
-                    // CVE Published and Modified dates
-                    final String publishedDateString = cveItem.getString("publishedDate");
-                    final String lastModifiedDateString = cveItem.getString("lastModifiedDate");
-                    try {
-                        if (StringUtils.isNotBlank(publishedDateString)) {
-                            vulnerability.setPublished(Date.from(OffsetDateTime.parse(publishedDateString).toInstant()));
+            JsonToken current = parser.nextToken();
+            while (parser.nextToken() != JsonToken.END_OBJECT) {
+                final String fieldName = parser.getCurrentName();
+                current = parser.nextToken();
+                if ("CVE_Items".equals(fieldName)) {
+                    if (current == JsonToken.START_ARRAY) {
+                        while (parser.nextToken() != JsonToken.END_ARRAY) {
+                            final ObjectNode cveItem = parser.readValueAsTree();
+                            parseCveItem(cveItem);
                         }
-                        if (StringUtils.isNotBlank(lastModifiedDateString)) {
-                            vulnerability.setUpdated(Date.from(OffsetDateTime.parse(lastModifiedDateString).toInstant()));
-                        }
-                    } catch (DateTimeParseException | NullPointerException | IllegalArgumentException e) {
-                        LOGGER.error("Unable to parse dates from NVD data feed", e);
+                    } else {
+                        parser.skipChildren();
                     }
-
-                    // CVE Description
-                    final JsonObject descO = cve.getJsonObject("description");
-                    final JsonArray desc1 = descO.getJsonArray("description_data");
-                    final StringBuilder descriptionBuilder = new StringBuilder();
-                    for (int j = 0; j < desc1.size(); j++) {
-                        final JsonObject desc2 = desc1.getJsonObject(j);
-                        if ("en".equals(desc2.getString("lang"))) {
-                            descriptionBuilder.append(desc2.getString("value"));
-                            if (j < desc1.size() - 1) {
-                                descriptionBuilder.append("\n\n");
-                            }
-                        }
-                    }
-                    vulnerability.setDescription(descriptionBuilder.toString());
-
-                    // CVE Impact
-                    parseCveImpact(cveItem, vulnerability);
-
-                    // CWE
-                    final JsonObject prob0 = cve.getJsonObject("problemtype");
-                    final JsonArray prob1 = prob0.getJsonArray("problemtype_data");
-                    for (int j = 0; j < prob1.size(); j++) {
-                        final JsonObject prob2 = prob1.getJsonObject(j);
-                        final JsonArray prob3 = prob2.getJsonArray("description");
-                        for (int k = 0; k < prob3.size(); k++) {
-                            final JsonObject prob4 = prob3.getJsonObject(k);
-                            if ("en".equals(prob4.getString("lang"))) {
-                                final String cweString = prob4.getString("value");
-                                if (cweString != null && cweString.startsWith("CWE-")) {
-                                    final Cwe cwe = CweResolver.getInstance().resolve(qm, cweString);
-                                    if (cwe != null) {
-                                        vulnerability.addCwe(cwe);
-                                    } else {
-                                        LOGGER.warn("CWE " + cweString + " now found in Dependency-Track database. This could signify an issue with the NVD or with Dependency-Track not having advanced knowledge of this specific CWE identifier.");
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    // References
-                    final JsonObject ref0 = cve.getJsonObject("references");
-                    final JsonArray ref1 = ref0.getJsonArray("reference_data");
-                    final StringBuilder sb = new StringBuilder();
-                    for (int l = 0; l < ref1.size(); l++) {
-                        final JsonObject ref2 = ref1.getJsonObject(l);
-                        for (final String s : ref2.keySet()) {
-                            if ("url".equals(s)) {
-                                // Convert reference to Markdown format
-                                final String url = ref2.getString("url");
-                                sb.append("* [").append(url).append("](").append(url).append(")\n");
-                            }
-                        }
-                    }
-                    final String references = sb.toString();
-                    if (references.length() > 0) {
-                        vulnerability.setReferences(references.substring(0, references.lastIndexOf("\n")));
-                    }
-
-                    // Update the vulnerability
-                    LOGGER.debug("Synchronizing: " + vulnerability.getVulnId());
-                    final Vulnerability synchronizeVulnerability = qm.synchronizeVulnerability(vulnerability, false);
-                    final List<VulnerableSoftware> vsListOld = qm.detach(qm.getVulnerableSoftwareByVulnId(synchronizeVulnerability.getSource(), synchronizeVulnerability.getVulnId()));
-
-                    // CPE
-                    List<VulnerableSoftware> vsList = new ArrayList<>();
-                    final JsonObject configurations = cveItem.getJsonObject("configurations");
-                    final JsonArray nodes = configurations.getJsonArray("nodes");
-                    for (int j = 0; j < nodes.size(); j++) {
-                        final JsonObject node = nodes.getJsonObject(j);
-                        final List<VulnerableSoftware> vulnerableSoftwareInNode = new ArrayList<>();
-                        final Operator nodeOperator = Operator.valueOf(node.getString("operator", Operator.NONE.name()));
-                        if (node.containsKey("children")) {
-                            // https://github.com/DependencyTrack/dependency-track/issues/1033
-                            final JsonArray children = node.getJsonArray("children");
-                            if (children.size() > 0) {
-                                for (int l = 0; l < children.size(); l++) {
-                                    final JsonObject child = children.getJsonObject(l);
-                                    vulnerableSoftwareInNode.addAll(parseCpes(qm, child));
-                                }
-                            } else {
-                                vulnerableSoftwareInNode.addAll(parseCpes(qm, node));
-                            }
-                        } else {
-                            vulnerableSoftwareInNode.addAll(parseCpes(qm, node));
-                        }
-                        vsList.addAll(reconcile(vulnerableSoftwareInNode, nodeOperator));
-                    }
-                    qm.persist(vsList);
-                    qm.updateAffectedVersionAttributions(synchronizeVulnerability, vsList, Vulnerability.Source.NVD);
-                    vsList = qm.reconcileVulnerableSoftware(synchronizeVulnerability, vsListOld, vsList, Vulnerability.Source.NVD);
-                    synchronizeVulnerability.setVulnerableSoftware(vsList);
-                    qm.persist(synchronizeVulnerability);
+                } else {
+                    parser.skipChildren();
                 }
-            });
+            }
         } catch (Exception e) {
             LOGGER.error("An error occurred while parsing NVD JSON data", e);
         }
         Event.dispatch(new IndexEvent(IndexEvent.Action.COMMIT, Vulnerability.class));
         Event.dispatch(new IndexEvent(IndexEvent.Action.COMMIT, Cpe.class));
+    }
+
+    private void parseCveItem(final ObjectNode cveItem) {
+        try (QueryManager qm = new QueryManager().withL2CacheDisabled()) {
+            qm.getPersistenceManager().setProperty(PropertyNames.PROPERTY_PERSISTENCE_BY_REACHABILITY_AT_COMMIT, "false");
+
+            final Vulnerability vulnerability = new Vulnerability();
+            vulnerability.setSource(Vulnerability.Source.NVD);
+
+            // CVE ID
+            final var cve = (ObjectNode) cveItem.get("cve");
+            final var meta0 = (ObjectNode) cve.get("CVE_data_meta");
+            vulnerability.setVulnId(meta0.get("ID").asText());
+
+            // CVE Published and Modified dates
+            final String publishedDateString = cveItem.get("publishedDate").asText();
+            final String lastModifiedDateString = cveItem.get("lastModifiedDate").asText();
+            try {
+                if (StringUtils.isNotBlank(publishedDateString)) {
+                    vulnerability.setPublished(Date.from(OffsetDateTime.parse(publishedDateString).toInstant()));
+                }
+                if (StringUtils.isNotBlank(lastModifiedDateString)) {
+                    vulnerability.setUpdated(Date.from(OffsetDateTime.parse(lastModifiedDateString).toInstant()));
+                }
+            } catch (DateTimeParseException | NullPointerException | IllegalArgumentException e) {
+                LOGGER.error("Unable to parse dates from NVD data feed", e);
+            }
+
+            // CVE Description
+            final var descO = (ObjectNode) cve.get("description");
+            final var desc1 = (ArrayNode) descO.get("description_data");
+            final StringBuilder descriptionBuilder = new StringBuilder();
+            for (int j = 0; j < desc1.size(); j++) {
+                final var desc2 = (ObjectNode) desc1.get(j);
+                if ("en".equals(desc2.get("lang").asText())) {
+                    descriptionBuilder.append(desc2.get("value").asText());
+                    if (j < desc1.size() - 1) {
+                        descriptionBuilder.append("\n\n");
+                    }
+                }
+            }
+            vulnerability.setDescription(descriptionBuilder.toString());
+
+            // CVE Impact
+            parseCveImpact(cveItem, vulnerability);
+
+            // CWE
+            final var prob0 = (ObjectNode) cve.get("problemtype");
+            final var prob1 = (ArrayNode) prob0.get("problemtype_data");
+            for (int j = 0; j < prob1.size(); j++) {
+                final var prob2 = (ObjectNode) prob1.get(j);
+                final var prob3 = (ArrayNode) prob2.get("description");
+                for (int k = 0; k < prob3.size(); k++) {
+                    final var prob4 = (ObjectNode) prob3.get(k);
+                    if ("en".equals(prob4.get("lang").asText())) {
+                        final String cweString = prob4.get("value").asText();
+                        if (cweString != null && cweString.startsWith("CWE-")) {
+                            final Cwe cwe = CweResolver.getInstance().resolve(qm, cweString);
+                            if (cwe != null) {
+                                vulnerability.addCwe(cwe);
+                            } else {
+                                LOGGER.warn("CWE " + cweString + " now found in Dependency-Track database. This could signify an issue with the NVD or with Dependency-Track not having advanced knowledge of this specific CWE identifier.");
+                            }
+                        }
+                    }
+                }
+            }
+
+            // References
+            final var ref0 = (ObjectNode) cve.get("references");
+            final var ref1 = (ArrayNode) ref0.get("reference_data");
+            final StringBuilder sb = new StringBuilder();
+            for (int l = 0; l < ref1.size(); l++) {
+                final var ref2 = (ObjectNode) ref1.get(l);
+                final Iterator<String> fieldNameIter = ref2.fieldNames();
+                while (fieldNameIter.hasNext()) {
+                    final String s = fieldNameIter.next();
+                    if ("url".equals(s)) {
+                        // Convert reference to Markdown format
+                        final String url = ref2.get("url").asText();
+                        sb.append("* [").append(url).append("](").append(url).append(")\n");
+                    }
+                }
+            }
+            final String references = sb.toString();
+            if (references.length() > 0) {
+                vulnerability.setReferences(references.substring(0, references.lastIndexOf("\n")));
+            }
+
+            // Update the vulnerability
+            LOGGER.debug("Synchronizing: " + vulnerability.getVulnId());
+            final Vulnerability synchronizeVulnerability = qm.synchronizeVulnerability(vulnerability, false);
+            final List<VulnerableSoftware> vsListOld = qm.detach(qm.getVulnerableSoftwareByVulnId(synchronizeVulnerability.getSource(), synchronizeVulnerability.getVulnId()));
+
+            // CPE
+            List<VulnerableSoftware> vsList = new ArrayList<>();
+            final var configurations = (ObjectNode) cveItem.get("configurations");
+            final var nodes = (ArrayNode) configurations.get("nodes");
+            for (int j = 0; j < nodes.size(); j++) {
+                final var node = (ObjectNode) nodes.get(j);
+                final List<VulnerableSoftware> vulnerableSoftwareInNode = new ArrayList<>();
+                final Operator nodeOperator = Operator.valueOf(node.get("operator").asText(Operator.NONE.name()));
+                if (node.has("children")) {
+                    // https://github.com/DependencyTrack/dependency-track/issues/1033
+                    final var children = (ArrayNode) node.get("children");
+                    if (children.size() > 0) {
+                        for (int l = 0; l < children.size(); l++) {
+                            final var child = (ObjectNode) children.get(l);
+                            vulnerableSoftwareInNode.addAll(parseCpes(qm, child));
+                        }
+                    } else {
+                        vulnerableSoftwareInNode.addAll(parseCpes(qm, node));
+                    }
+                } else {
+                    vulnerableSoftwareInNode.addAll(parseCpes(qm, node));
+                }
+                vsList.addAll(reconcile(vulnerableSoftwareInNode, nodeOperator));
+            }
+            qm.persist(vsList);
+            qm.updateAffectedVersionAttributions(synchronizeVulnerability, vsList, Vulnerability.Source.NVD);
+            vsList = qm.reconcileVulnerableSoftware(synchronizeVulnerability, vsListOld, vsList, Vulnerability.Source.NVD);
+            synchronizeVulnerability.setVulnerableSoftware(vsList);
+            qm.persist(synchronizeVulnerability);
+        }
     }
 
     /**
@@ -236,40 +263,40 @@ public final class NvdParser {
         return vulnerableSoftwareList;
     }
 
-    private void parseCveImpact(final JsonObject cveItem, final Vulnerability vuln) {
-        final JsonObject imp0 = cveItem.getJsonObject("impact");
-        final JsonObject imp1 = imp0.getJsonObject("baseMetricV2");
+    private void parseCveImpact(final ObjectNode cveItem, final Vulnerability vuln) {
+        final var imp0 = (ObjectNode) cveItem.get("impact");
+        final var imp1 = (ObjectNode) imp0.get("baseMetricV2");
         if (imp1 != null) {
-            final JsonObject imp2 = imp1.getJsonObject("cvssV2");
+            final var imp2 = (ObjectNode) imp1.get("cvssV2");
             if (imp2 != null) {
-                final Cvss cvss = Cvss.fromVector(imp2.getJsonString("vectorString").getString());
+                final Cvss cvss = Cvss.fromVector(imp2.get("vectorString").asText());
                 vuln.setCvssV2Vector(cvss.getVector()); // normalize the vector but use the scores from the feed
-                vuln.setCvssV2BaseScore(imp2.getJsonNumber("baseScore").bigDecimalValue());
+                vuln.setCvssV2BaseScore(BigDecimal.valueOf(imp2.get("baseScore").asDouble()));
             }
-            vuln.setCvssV2ExploitabilitySubScore(imp1.getJsonNumber("exploitabilityScore").bigDecimalValue());
-            vuln.setCvssV2ImpactSubScore(imp1.getJsonNumber("impactScore").bigDecimalValue());
+            vuln.setCvssV2ExploitabilitySubScore(BigDecimal.valueOf(imp1.get("exploitabilityScore").asDouble()));
+            vuln.setCvssV2ImpactSubScore(BigDecimal.valueOf(imp1.get("impactScore").asDouble()));
         }
 
-        final JsonObject imp3 = imp0.getJsonObject("baseMetricV3");
+        final var imp3 = (ObjectNode) imp0.get("baseMetricV3");
         if (imp3 != null) {
-            final JsonObject imp4 = imp3.getJsonObject("cvssV3");
+            final var imp4 = (ObjectNode) imp3.get("cvssV3");
             if (imp4 != null) {
-                final Cvss cvss = Cvss.fromVector(imp4.getJsonString("vectorString").getString());
+                final Cvss cvss = Cvss.fromVector(imp4.get("vectorString").asText());
                 vuln.setCvssV3Vector(cvss.getVector()); // normalize the vector but use the scores from the feed
-                vuln.setCvssV3BaseScore(imp4.getJsonNumber("baseScore").bigDecimalValue());
+                vuln.setCvssV3BaseScore(BigDecimal.valueOf(imp4.get("baseScore").asDouble()));
             }
-            vuln.setCvssV3ExploitabilitySubScore(imp3.getJsonNumber("exploitabilityScore").bigDecimalValue());
-            vuln.setCvssV3ImpactSubScore(imp3.getJsonNumber("impactScore").bigDecimalValue());
+            vuln.setCvssV3ExploitabilitySubScore(BigDecimal.valueOf(imp3.get("exploitabilityScore").asDouble()));
+            vuln.setCvssV3ImpactSubScore(BigDecimal.valueOf(imp3.get("impactScore").asDouble()));
         }
     }
 
-    private List<VulnerableSoftware> parseCpes(final QueryManager qm, final JsonObject node) {
+    private List<VulnerableSoftware> parseCpes(final QueryManager qm, final ObjectNode node) {
         final List<VulnerableSoftware> vsList = new ArrayList<>();
-        if (node.containsKey("cpe_match")) {
-            final JsonArray cpeMatches = node.getJsonArray("cpe_match");
+        if (node.has("cpe_match")) {
+            final var cpeMatches = (ArrayNode) node.get("cpe_match");
             for (int k = 0; k < cpeMatches.size(); k++) {
-                final JsonObject cpeMatch = cpeMatches.getJsonObject(k);
-                if (cpeMatch.getBoolean("vulnerable", true)) { // only parse the CPEs marked as vulnerable
+                final var cpeMatch = (ObjectNode) cpeMatches.get(k);
+                if (cpeMatch.get("vulnerable").asBoolean(true)) { // only parse the CPEs marked as vulnerable
                     final VulnerableSoftware vs = generateVulnerableSoftware(qm, cpeMatch);
                     if (vs != null) {
                         vsList.add(vs);
@@ -280,12 +307,12 @@ public final class NvdParser {
         return vsList;
     }
 
-    private VulnerableSoftware generateVulnerableSoftware(final QueryManager qm, final JsonObject cpeMatch) {
-        final String cpe23Uri = cpeMatch.getString("cpe23Uri");
-        final String versionEndExcluding = cpeMatch.getString("versionEndExcluding", null);
-        final String versionEndIncluding = cpeMatch.getString("versionEndIncluding", null);
-        final String versionStartExcluding = cpeMatch.getString("versionStartExcluding", null);
-        final String versionStartIncluding = cpeMatch.getString("versionStartIncluding", null);
+    private VulnerableSoftware generateVulnerableSoftware(final QueryManager qm, final ObjectNode cpeMatch) {
+        final String cpe23Uri = cpeMatch.get("cpe23Uri").asText();
+        final String versionEndExcluding = Optional.ofNullable(cpeMatch.get("versionEndExcluding")).map(JsonNode::asText).orElse(null);
+        final String versionEndIncluding = Optional.ofNullable(cpeMatch.get("versionEndIncluding")).map(JsonNode::asText).orElse(null);
+        final String versionStartExcluding = Optional.ofNullable(cpeMatch.get("versionStartExcluding")).map(JsonNode::asText).orElse(null);
+        final String versionStartIncluding = Optional.ofNullable(cpeMatch.get("versionStartIncluding")).map(JsonNode::asText).orElse(null);
         VulnerableSoftware vs = qm.getVulnerableSoftwareByCpe23(cpe23Uri, versionEndExcluding,
                 versionEndIncluding, versionStartExcluding, versionStartIncluding);
         if (vs != null) {
@@ -293,7 +320,7 @@ public final class NvdParser {
         }
         try {
             vs = ModelConverter.convertCpe23UriToVulnerableSoftware(cpe23Uri);
-            vs.setVulnerable(cpeMatch.getBoolean("vulnerable", true));
+            vs.setVulnerable(cpeMatch.get("vulnerable").asBoolean(true));
             vs.setVersionEndExcluding(versionEndExcluding);
             vs.setVersionEndIncluding(versionEndIncluding);
             vs.setVersionStartExcluding(versionStartExcluding);

--- a/src/main/java/org/dependencytrack/persistence/VulnerableSoftwareQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerableSoftwareQueryManager.java
@@ -132,6 +132,12 @@ final class VulnerableSoftwareQueryManager extends QueryManager implements IQuer
         var filter = "cpe23 == :cpe23";
         final var parameters = new HashMap<String, Object>();
         parameters.put("cpe23", Objects.requireNonNull(cpe23));
+
+        // When building the query filter, ensure that null values are
+        // not passed as parameters, as this would bypass the query compilation
+        // cache. This method is called very frequently during NVD mirroring,
+        // we should avoid the overhead of repeated re-compilation if possible.
+        // See also: https://github.com/DependencyTrack/dependency-track/issues/2540
         if (versionEndExcluding != null) {
             filter += " && versionEndExcluding == :vee";
             parameters.put("vee", versionEndExcluding);

--- a/src/main/java/org/dependencytrack/persistence/VulnerableSoftwareQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerableSoftwareQueryManager.java
@@ -32,7 +32,9 @@ import org.h2.util.StringUtils;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 
 final class VulnerableSoftwareQueryManager extends QueryManager implements IQueryManager {
 
@@ -127,9 +129,37 @@ final class VulnerableSoftwareQueryManager extends QueryManager implements IQuer
                                                            String versionEndExcluding, String versionEndIncluding,
                                                            String versionStartExcluding, String versionStartIncluding) {
         final Query<VulnerableSoftware> query = pm.newQuery(VulnerableSoftware.class);
-        query.setFilter("cpe23 == :cpe23 && versionEndExcluding == :versionEndExcluding && versionEndIncluding == :versionEndIncluding && versionStartExcluding == :versionStartExcluding && versionStartIncluding == :versionStartIncluding");
+        var filter = "cpe23 == :cpe23";
+        final var parameters = new HashMap<String, Object>();
+        parameters.put("cpe23", Objects.requireNonNull(cpe23));
+        if (versionEndExcluding != null) {
+            filter += " && versionEndExcluding == :vee";
+            parameters.put("vee", versionEndExcluding);
+        } else {
+            filter += " && versionEndExcluding == null";
+        }
+        if (versionEndIncluding != null) {
+            filter += " && versionEndIncluding == :vei";
+            parameters.put("vei", versionEndIncluding);
+        } else {
+            filter += " && versionEndIncluding == null";
+        }
+        if (versionStartExcluding != null) {
+            filter += " && versionStartExcluding == :vse";
+            parameters.put("vse", versionStartExcluding);
+        } else {
+            filter += " && versionStartExcluding == null";
+        }
+        if (versionStartIncluding != null) {
+            filter += " && versionStartIncluding == :vsi";
+            parameters.put("vsi", versionStartIncluding);
+        } else {
+            filter += " && versionStartIncluding == null";
+        }
+        query.setFilter(filter);
+        query.setNamedParameters(parameters);
         query.setRange(0, 1);
-        return singleResult(query.executeWithArray(cpe23, versionEndExcluding, versionEndIncluding, versionStartExcluding, versionStartIncluding));
+        return query.executeUnique();
     }
 
     /**


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This PR makes further improvements to the resource efficiency of the NVD mirroring task.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #2524 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

I was able to identify multiple memory hogs and causes of excessive allocations.

* The DataNucleus query compilation cache was bypassed for fetch methods that were called *very* frequently (see #2540)
* Some HTTP response and file streams were kept open for the entire duration of their respective processing, preventing related objects to be GC'd
* NVD feed files were previously parsed using [JSON-P](https://javaee.github.io/jsonp/). Uncompressed feed files can be ~100mb in size. Loading and parsing them into memory at once caused a lot of objects to be created that, for some reason, couldn't be GC'd in a timely manner. Switching to [Jackson Streaming](https://www.baeldung.com/jackson-streaming-api) had a *huge* impact.

In previous PRs, we already fixed:

* `IndexEvent`s piling up in the hundreds of thousands while NVD mirroring was running (see #2526)
* `Vulnerability` and `VulnerableSoftware` objects swamping the DataNucleus L2 cache (see #2525)

Below are some comparisons of how the mirroring behaves in different versions. All tests were run on an M1 Pro, with parallel GC (`-XX:+UseParallelGC`).

#### Comparisons (H2)

The following graphs show resource usage of DT v4.7.1 using H2 as database. Note how heap usage keeps increasing, and even reaches **5GB** on multiple occasions. Also note the spikes in CPU usage, which are caused / accompanied by a rather high GC activity.

<img width="1253" alt="h2_v4 7 1" src="https://user-images.githubusercontent.com/5693141/223539697-1c19d501-6d9d-4475-a0e4-3f2e3f42363c.png">

The following graphs show the same scenario for the current `master`. Note how heap usage does not increase steadily, and stays lower overall, barely reaching 3.5GB. Both CPU usage and GC activity show less prominent spikes.

<img width="1253" alt="h2_master" src="https://user-images.githubusercontent.com/5693141/223540322-1b6cfdb2-e610-49a5-9294-10494aca3ca4.png">

Finally, with this PR, heap usage is reduced in even more, staying around ~1.5GB most of the time, but still increasing to 3GB towards the end. GC can work much more efficiently, which is evident by heap usage dropping below the 500mb mark between spikes. CPU and GC activity again shows even fewer spikes than before.

<img width="1253" alt="h2_pr" src="https://user-images.githubusercontent.com/5693141/223541440-b619ed09-cc5e-423e-8e49-40501260893f.png">

#### Comparisons (PostgreSQL)

By inspecting heap dumps of the above test scenarios, looking for more ways to improve, I noticed that the majority of objects, especially non-GCable objects sticking around in the "Old" generation, were caused by H2. Even though we use H2 in *embedded* (not in-memory) mode, it still causes excessive heap utilization.

So I repeated the experiments with an external database, in this case PostgreSQL.

The following, again, shows v4.7.1. Still, incredibly high heap usage that keeps climbing up.

<img width="1253" alt="postgres_v4 7 1" src="https://user-images.githubusercontent.com/5693141/223543318-d62717e4-93ef-4928-906c-17576cce79b1.png">

As previously seen with H2, things change significantly with the current `master`.

<img width="1253" alt="postgres_master" src="https://user-images.githubusercontent.com/5693141/223545602-656b6566-8815-460c-a910-d7b81895c3ed.png">

But it gets *absolutely wild* with this PR. Heap usage is *way* down, we spend most of the time *below* **250MB**. And yes, I compared database dumps. The mirrored data is identical to what we get with the current `master` 🤪

<img width="1253" alt="postgres_pr" src="https://user-images.githubusercontent.com/5693141/223549642-89b53726-b686-4b01-835f-fbe158aeeff1.png">


### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
