### PR TITLE
Fix: Null subject on project audit change notification mails

### DIFF
--- a/src/main/java/org/dependencytrack/notification/NotificationRouter.java
+++ b/src/main/java/org/dependencytrack/notification/NotificationRouter.java
@@ -116,7 +116,7 @@ public class NotificationRouter implements Subscriber {
     }
 
     private boolean canRestrictNotificationToRuleProjects(Notification initialNotification, NotificationRule rule) {
-        return (initialNotification.getSubject() instanceof NewVulnerabilityIdentified || initialNotification.getSubject() instanceof AnalysisDecisionChange) &&
+        return initialNotification.getSubject() instanceof NewVulnerabilityIdentified &&
                 rule.getProjects() != null
                 && rule.getProjects().size() > 0;
     }


### PR DESCRIPTION
### Description

Subjects on project audit change notifications were null since 4.7.0
It's a missed code impact of #975 :

- `AnalysisDecisionChange` model was enhanced to be mapped to a [single project instead of a list of project](https://github.com/DependencyTrack/dependency-track/pull/2065/files#diff-10848e88053f05102e0b27a1b0741ff562ceadafcad5d8704ecfa4cfa40b45bf)
- The filter `canRestrictNotificationToRuleProjects` was no longer relevant for `AnalysisDecisionChange`

### Addressed Issue

#2420

### Additional Details

N/A

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
