### PR TITLE
Issue-2571 : map Snyk remedies to recommendation

### DIFF
--- a/src/main/java/org/dependencytrack/parser/snyk/SnykParser.java
+++ b/src/main/java/org/dependencytrack/parser/snyk/SnykParser.java
@@ -82,6 +82,16 @@ public class SnykParser {
                     } else {
                         vsList = parseVersionRanges(qm, purl, representation);
                     }
+
+                    JSONArray remedies = coordinates.getJSONObject(countCoordinates).optJSONArray("remedies");
+                    if (remedies != null) {
+                        var recommendation = "";
+                        for (int remedyCount = 0; remedyCount < remedies.length(); remedyCount++) {
+                            var remedy = remedies.getJSONObject(remedyCount).optString("description");
+                            recommendation += remedy + System.lineSeparator();
+                        }
+                        vulnerability.setRecommendation(recommendation);
+                    }
                 }
             }
             final List<VulnerableSoftware> vsListOld = qm.detach(qm.getVulnerableSoftwareByVulnId(vulnerability.getSource(), vulnerability.getVulnId()));

--- a/src/test/java/org/dependencytrack/tasks/scanners/SnykAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/SnykAnalysisTaskTest.java
@@ -302,6 +302,7 @@ public class SnykAnalysisTaskTest extends PersistenceCapableTest {
         assertThat(vulnerability.getSeverity()).isEqualTo(Severity.HIGH);
         assertThat(vulnerability.getCreated()).isInSameDayAs("2022-10-31");
         assertThat(vulnerability.getUpdated()).isInSameDayAs("2022-11-26");
+        assertThat(vulnerability.getRecommendation()).contains("Upgrade the package version to 5.0.4,6.0.4 to fix this vulnerability");
         assertThat(vulnerability.getAliases()).satisfiesExactly(
                 alias -> {
                     assertThat(alias.getSnykId()).isEqualTo("SNYK-JAVA-COMFASTERXMLWOODSTOX-3091135");


### PR DESCRIPTION
### Description

Remedies info in vulnerabilities reported by Snyk are not mapped currently. It is an additional and helpful info which can be used in DT. Map the remedies from Snyk (if available) to the recommendations in vulnerabilities in DT.

### Addressed Issue

https://github.com/DependencyTrack/dependency-track/issues/2571

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
