### PR TITLE
Minor bugfix for PolicyEngine

### DIFF
--- a/src/main/java/org/dependencytrack/policy/PolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/PolicyEngine.java
@@ -66,9 +66,9 @@ public class PolicyEngine {
         List<PolicyViolation> violations = new ArrayList<>();
         try (final QueryManager qm = new QueryManager()) {
             final List<Policy> policies = qm.getAllPolicies();
-            for (final Component c: components) {
-                final Component component = qm.getObjectById(Component.class, c.getId());
-                violations.addAll(this.evaluate(qm, policies, component));
+            for (final Component component : components) {
+                final Component componentFromDb = qm.getObjectById(Component.class, component.getId());
+                violations.addAll(this.evaluate(qm, policies, componentFromDb));
             }
         }
         LOGGER.info("Policy analysis complete");
@@ -80,7 +80,7 @@ public class PolicyEngine {
         for (final Policy policy : policies) {
             if (policy.isGlobal() || isPolicyAssignedToProject(policy, component.getProject())
                     || isPolicyAssignedToProjectTag(policy, component.getProject())) {
-                LOGGER.debug("Evaluating component (" + component.getUuid() +") against policy (" + policy.getUuid() + ")");
+                LOGGER.debug("Evaluating component (" + component.getUuid() + ") against policy (" + policy.getUuid() + ")");
                 final List<PolicyConditionViolation> policyConditionViolations = new ArrayList<>();
                 int policyConditionsViolated = 0;
                 for (final PolicyEvaluator evaluator : evaluators) {
@@ -99,22 +99,20 @@ public class PolicyEngine {
                     if (policyConditionsViolated > 0) {
                         policyViolations.addAll(createPolicyViolations(qm, policyConditionViolations));
                     }
-                } else if (Policy.Operator.ALL == policy.getOperator()) {
-                    if (policyConditionsViolated == policy.getPolicyConditions().size()) {
-                        policyViolations.addAll(createPolicyViolations(qm, policyConditionViolations));
-                    }
+                } else if (Policy.Operator.ALL == policy.getOperator() && policyConditionsViolated == policy.getPolicyConditions().size()) {
+                    policyViolations.addAll(createPolicyViolations(qm, policyConditionViolations));
                 }
             }
         }
         qm.reconcilePolicyViolations(component, policyViolations);
-        for (final PolicyViolation pv: qm.getAllPolicyViolations(component)) {
+        for (final PolicyViolation pv : qm.getAllPolicyViolations(component)) {
             NotificationUtil.analyzeNotificationCriteria(qm, pv);
         }
         return policyViolations;
     }
 
     private boolean isPolicyAssignedToProject(Policy policy, Project project) {
-        if (policy.getProjects() == null || policy.getProjects().size() == 0) {
+        if (policy.getProjects() == null || policy.getProjects().isEmpty()) {
             return false;
         }
         return (policy.getProjects().stream().anyMatch(p -> p.getId() == project.getId()) || (Boolean.TRUE.equals(policy.isIncludeChildren()) && isPolicyAssignedToParentProject(policy, project)));
@@ -122,7 +120,7 @@ public class PolicyEngine {
 
     private List<PolicyViolation> createPolicyViolations(final QueryManager qm, final List<PolicyConditionViolation> pcvList) {
         final List<PolicyViolation> policyViolations = new ArrayList<>();
-        for (PolicyConditionViolation pcv: pcvList) {
+        for (PolicyConditionViolation pcv : pcvList) {
             final PolicyViolation pv = new PolicyViolation();
             pv.setComponent(pcv.getComponent());
             pv.setPolicyCondition(pcv.getPolicyCondition());
@@ -134,35 +132,29 @@ public class PolicyEngine {
     }
 
     private PolicyViolation.Type determineViolationType(final PolicyCondition.Subject subject) {
-        switch(subject) {
-            case CWE:
-            case SEVERITY:
-            case VULNERABILITY_ID:
-                return PolicyViolation.Type.SECURITY;
-            case AGE:
-            case COORDINATES:
-            case PACKAGE_URL:
-            case CPE:
-            case SWID_TAGID:
-            case COMPONENT_HASH:
-            case VERSION:
-                return PolicyViolation.Type.OPERATIONAL;
-            case LICENSE:
-            case LICENSE_GROUP:
-                return PolicyViolation.Type.LICENSE;
-        }
-        return null;
+        return switch (subject) {
+            case CWE, SEVERITY, VULNERABILITY_ID -> PolicyViolation.Type.SECURITY;
+            case AGE, COORDINATES, PACKAGE_URL, CPE, SWID_TAGID, COMPONENT_HASH, VERSION ->
+                    PolicyViolation.Type.OPERATIONAL;
+            case LICENSE, LICENSE_GROUP -> PolicyViolation.Type.LICENSE;
+        };
     }
 
+
     private boolean isPolicyAssignedToProjectTag(Policy policy, Project project) {
-        if (policy.getTags() == null || policy.getTags().size() == 0) {
+        if (policy.getTags() == null || policy.getTags().isEmpty()) {
             return false;
         }
-        for(Tag projectTag : project.getTags()){
-            return policy.getTags().stream().anyMatch(p -> p.getId() == projectTag.getId());
+        boolean flag = false;
+        for (Tag projectTag : project.getTags()) {
+            flag = policy.getTags().stream().anyMatch(policyTag -> policyTag.getId() == projectTag.getId());
+            if (flag) {
+                break;
+            }
         }
-        return false;
+        return flag;
     }
+
 
     private boolean isPolicyAssignedToParentProject(Policy policy, Project child) {
         if (child.getParent() == null) {
@@ -170,7 +162,7 @@ public class PolicyEngine {
         }
         if (policy.getProjects().stream().anyMatch(p -> p.getId() == child.getParent().getId())) {
             return true;
-        } 
+        }
         return isPolicyAssignedToParentProject(policy, child.getParent());
     }
 }

--- a/src/main/java/org/dependencytrack/policy/PolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/PolicyEngine.java
@@ -131,7 +131,10 @@ public class PolicyEngine {
         return policyViolations;
     }
 
-    private PolicyViolation.Type determineViolationType(final PolicyCondition.Subject subject) {
+    public PolicyViolation.Type determineViolationType(final PolicyCondition.Subject subject) {
+        if (subject == null) {
+            return null;
+        }
         return switch (subject) {
             case CWE, SEVERITY, VULNERABILITY_ID -> PolicyViolation.Type.SECURITY;
             case AGE, COORDINATES, PACKAGE_URL, CPE, SWID_TAGID, COMPONENT_HASH, VERSION ->

--- a/src/test/java/org/dependencytrack/policy/PolicyEngineTest.java
+++ b/src/test/java/org/dependencytrack/policy/PolicyEngineTest.java
@@ -32,6 +32,7 @@ import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -142,6 +143,13 @@ public class PolicyEngineTest extends PersistenceCapableTest {
         Assert.assertEquals(0, violations.size());
     }
 
+    @Test
+    public void determineViolationTypeTest(){
+        PolicyCondition policyCondition = new PolicyCondition();
+        policyCondition.setSubject(null);
+        PolicyEngine policyEngine = new PolicyEngine();
+        Assertions.assertNull(policyEngine.determineViolationType(policyCondition.getSubject()));
+    }
     @Test
     public void issue1924() {
         Policy policy = qm.createPolicy("Policy 1924", Policy.Operator.ALL, Policy.ViolationState.INFO);


### PR DESCRIPTION
added bugfix for isPolicyAssignedToProjectTag to scan through all project tags

### Description

Currently the isPolicyAssignedToProjectTag method in the policyEngine class takes the first project tag and compares it with all the policy tags and if there is a match it returns true.
Expected behaviour is that all the tags of a project would be compared with all the tags of a policy and if there is a match this method would return true. This PR provides this fix

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue
Fixes below issue:
Currently the isPolicyAssignedToProjectTag method in the policyEngine class takes the first project tag and compares it with all the policy tags and if there is a match it returns true.

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
