### PR TITLE
Issue 2255: create endpoint to fetch many components and services

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -34,6 +34,8 @@ import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
+import org.dependencytrack.resources.v1.vo.DependencyGraphResponse;
+
 import javax.jdo.FetchPlan;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
@@ -41,6 +43,7 @@ import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonValue;
 import java.io.StringReader;
+import java.util.UUID;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -632,6 +635,18 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             dependencyGraph.put(entry.getKey(), transientComponent);
         }
         return dependencyGraph;
+    }
+
+    /**
+     * Returns a list of all {@link DependencyGraphResponse} objects by {@link Component} UUID.
+     * @param uuids a list of {@link Component} UUIDs
+     * @return a list of {@link DependencyGraphResponse} objects
+     * @since 4.9.0
+     */
+    public List<DependencyGraphResponse> getDependencyGraphByUUID(final List<UUID> uuids) {
+        final Query<Component> query = this.getObjectsByUuidsQuery(Component.class, uuids);
+        query.setResult("uuid, name, version, purl, directDependencies, null");
+        return List.copyOf(query.executeResultList(DependencyGraphResponse.class));
     }
 
     private void getParentDependenciesOfComponent(Project project, Component parentNode, Map<String, Component> dependencyGraph, Component searchedComponent) {

--- a/src/main/java/org/dependencytrack/persistence/ServiceComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ServiceComponentQueryManager.java
@@ -25,12 +25,14 @@ import org.dependencytrack.event.IndexEvent;
 import org.dependencytrack.model.ComponentIdentity;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ServiceComponent;
+import org.dependencytrack.resources.v1.vo.DependencyGraphResponse;
 
 import javax.jdo.FetchPlan;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 final class ServiceComponentQueryManager extends QueryManager implements IQueryManager {
 
@@ -262,5 +264,17 @@ final class ServiceComponentQueryManager extends QueryManager implements IQueryM
         //deletePolicyViolations(service);
         delete(service);
         commitSearchIndex(commitIndex, ServiceComponent.class);
+    }
+
+    /**
+     * Returns a list of all {@link DependencyGraphResponse} objects by {@link ServiceComponent} UUID.
+     * @param uuids a list of {@link ServiceComponent} UUIDs
+     * @return a list of {@link DependencyGraphResponse} objects
+     * @since 4.9.0
+     */
+    public List<DependencyGraphResponse> getDependencyGraphByUUID(final List<UUID> uuids) {
+        final Query<ServiceComponent> query = this.getObjectsByUuidsQuery(ServiceComponent.class, uuids);
+        query.setResult("uuid, name, version, null, null, null");
+        return List.copyOf(query.executeResultList(DependencyGraphResponse.class));
     }
 }

--- a/src/main/java/org/dependencytrack/resources/v1/DependencyGraphResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/DependencyGraphResource.java
@@ -1,0 +1,234 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+package org.dependencytrack.resources.v1;
+
+import alpine.server.auth.PermissionRequired;
+import alpine.server.resources.AlpineResource;
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.RepositoryMetaComponent;
+import org.dependencytrack.model.RepositoryType;
+import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.persistence.RepositoryQueryManager;
+import org.dependencytrack.resources.v1.vo.DependencyGraphResponse;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonException;
+import javax.json.JsonReader;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * JAX-RS resources for processing requests related to DependencyGraph.
+ */
+@Path("/v1/dependencyGraph")
+@Api(value = "dependencyGraph", authorizations = @Authorization(value = "X-Api-Key"))
+public class DependencyGraphResource extends AlpineResource {
+
+    @GET
+    @Path("/project/{uuid}/directDependencies")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Returns a list of specific components and services from project UUID",
+            response = DependencyGraphResponse.class,
+            responseContainer = "List"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Access to a specified component is forbidden"),
+            @ApiResponse(code = 404, message = "Any component can be found"),
+    })
+    @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
+    public Response getComponentsAndServicesByProjectUuid(final @PathParam("uuid") String uuid) {
+        try (QueryManager qm = new QueryManager()) {
+            final Project project = qm.getObjectByUuid(Project.class, uuid);
+
+            if (project == null) {
+                return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();
+            }
+
+            if (!qm.hasAccess(super.getPrincipal(), project)) {
+                return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
+            }
+
+            final String directDependenciesJSON = project.getDirectDependencies();
+
+            if (directDependenciesJSON != null) {
+                final List<DependencyGraphResponse> response = getDependencyGraphFromDirectDependenciesJSON(qm, directDependenciesJSON);
+                return Response.ok(response).build();
+            } else {
+                return Response.ok(List.of()).build();
+            }
+        }
+    }
+
+    @GET
+    @Path("/component/{uuid}/directDependencies")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Returns a list of specific components and services from component UUID",
+            response = DependencyGraphResponse.class,
+            responseContainer = "List"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Access to a specified component is forbidden"),
+            @ApiResponse(code = 404, message = "Any component can be found"),
+    })
+    @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
+    public Response getComponentsAndServicesByComponentUuid(final @PathParam("uuid") String uuid) {
+        try (QueryManager qm = new QueryManager()) {
+            final Component component = qm.getObjectByUuid(Component.class, uuid);
+            if (component == null) {
+                return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();
+            }
+
+            if (!qm.hasAccess(super.getPrincipal(), component.getProject())) {
+                return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified component is forbidden").build();
+            }
+
+            final String directDependenciesJSON = component.getDirectDependencies();
+
+            if (directDependenciesJSON != null) {
+                final List<DependencyGraphResponse> response = getDependencyGraphFromDirectDependenciesJSON(qm, directDependenciesJSON);
+                return Response.ok(response).build();
+            } else {
+                return Response.ok(List.of()).build();
+            }
+        }
+    }
+
+
+    /**
+     * This method takes a {@link QueryManager} and a JSON string representing direct dependencies,
+     * and returns a list of {@link DependencyGraphResponse} objects.
+     *
+     * @param qm                     the {@link QueryManager} used to fetch dependencies
+     * @param directDependenciesJSON the JSON string representing direct dependencies
+     * @return a list of {@link DependencyGraphResponse} objects representing the dependency graph
+     * @since 4.9.0
+     */
+    private List<DependencyGraphResponse> getDependencyGraphFromDirectDependenciesJSON(final QueryManager qm, final String directDependenciesJSON) {
+        // Parse the JSON to collect the UUIDs
+        JsonArray directDependencies = null;
+
+        try (final JsonReader jsonReader = Json.createReader(new StringReader(directDependenciesJSON))) {
+            directDependencies = jsonReader.readArray();
+        } catch (JsonException e) {
+            return List.of();
+        }
+
+        final List<DependencyGraphResponse> response = new ArrayList<>(directDependencies.size());
+
+        // Collect all the UUIDs
+        final List<UUID> uuids = directDependencies.stream().map(directDependency -> directDependency.asJsonObject().getString("uuid")).map(UUID::fromString).toList();
+
+        // Fetch all child components
+        final List<DependencyGraphResponse> components = qm.getComponentDependencyGraphByUuids(uuids);
+
+        // Map the components to their respective repository types
+        final HashMap<DependencyGraphResponse, RepositoryQueryManager.RepositoryMetaComponentSearch> repoMetaComponentSearchListHashMap = new HashMap<>(components.size());
+
+        // Set of unique repository meta components
+        final HashSet<RepositoryQueryManager.RepositoryMetaComponentSearch> repoMetaComponentSearches = new HashSet<>(components.size());
+
+
+        PackageURL purl = null;
+        RepositoryType type = null;
+        RepositoryQueryManager.RepositoryMetaComponentSearch repositoryMetaComponentSearch = null;
+
+        // Fetch all the latest versions for the components
+        for (DependencyGraphResponse dependencyGraphResponse : components) {
+
+            // Only components that got a purl can be searched for latest version
+            if (dependencyGraphResponse.purl() != null) {
+                try {
+                    purl = new PackageURL(dependencyGraphResponse.purl());
+                } catch (MalformedPackageURLException e) {
+                    purl = null;
+                }
+
+                if (purl != null) {
+                    type = RepositoryType.resolve(purl);
+                    if (RepositoryType.UNSUPPORTED != type) {
+
+                        // Create a new repository meta component search
+                        repositoryMetaComponentSearch = new RepositoryQueryManager.RepositoryMetaComponentSearch(type, purl.getNamespace(), purl.getName());
+
+                        // Add the repository meta component search to the set
+                        repoMetaComponentSearches.add(repositoryMetaComponentSearch);
+                    }
+                }
+            }
+
+            // Keep the link between the component and the repository meta component search
+            repoMetaComponentSearchListHashMap.put(dependencyGraphResponse, repositoryMetaComponentSearch);
+        }
+
+        // Fetch the latest versions for the components
+        final List<RepositoryMetaComponent> repositoryMetaComponents = qm.getRepositoryMetaComponentsBatch(repoMetaComponentSearches.stream().toList());
+
+        // Create HashMap with the repository meta components and their latest version
+        final HashMap<RepositoryQueryManager.RepositoryMetaComponentSearch, String> repositoryMetaComponentsSet = new HashMap<>(repositoryMetaComponents.size());
+
+        for (RepositoryMetaComponent repositoryMetaComponent : repositoryMetaComponents) {
+            repositoryMetaComponentsSet.put(new RepositoryQueryManager.RepositoryMetaComponentSearch(repositoryMetaComponent.getRepositoryType(), repositoryMetaComponent.getNamespace(), repositoryMetaComponent.getName()), repositoryMetaComponent.getLatestVersion());
+        }
+
+        // Add the latest version to the components
+        for (Map.Entry<DependencyGraphResponse, RepositoryQueryManager.RepositoryMetaComponentSearch> dependencyGraphResponseEntry : repoMetaComponentSearchListHashMap.entrySet()) {
+            if (dependencyGraphResponseEntry.getValue() == null) {
+                response.add(dependencyGraphResponseEntry.getKey());
+            } else {
+                response.add(new DependencyGraphResponse(dependencyGraphResponseEntry.getKey(), repositoryMetaComponentsSet.get(dependencyGraphResponseEntry.getValue())));
+            }
+        }
+
+        // if the response size is not equal to the uuids size, then we have some services to add
+        if (uuids.size() != components.size()) {
+            response.addAll(qm.getServiceDependencyGraphByUuids(uuids));
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/org/dependencytrack/resources/v1/vo/DependencyGraphResponse.java
+++ b/src/main/java/org/dependencytrack/resources/v1/vo/DependencyGraphResponse.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+package org.dependencytrack.resources.v1.vo;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * Response-Object that represent light component or service for rendering DependencyGraph
+ *
+ * @author Nathan Mittelette <mittelette.nathan@gmail.com>
+ * @since 4.9.0
+ */
+public record DependencyGraphResponse(UUID uuid, String name, String version, String purl, String directDependencies, String latestVersion) implements Serializable {
+
+    public DependencyGraphResponse(DependencyGraphResponse source, String latestVersion) {
+        this(source.uuid(), source.name(), source.version(), source.purl(), source.directDependencies(), latestVersion);
+    }
+
+}

--- a/src/test/java/org/dependencytrack/ResourceTest.java
+++ b/src/test/java/org/dependencytrack/ResourceTest.java
@@ -51,6 +51,7 @@ public abstract class ResourceTest extends JerseyTest {
     protected final String V1_BOM = "/v1/bom";
     protected final String V1_CALCULATOR = "/v1/calculator";
     protected final String V1_COMPONENT = "/v1/component";
+    protected final String V1_DEPENDENCY_GRAPH = "/v1/dependencyGraph";
     protected final String V1_CONFIG_PROPERTY = "/v1/configProperty";
     protected final String V1_CWE = "/v1/cwe";
     protected final String V1_DEPENDENCY = "/v1/dependency";

--- a/src/test/java/org/dependencytrack/resources/v1/DependencyGraphResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/DependencyGraphResourceTest.java
@@ -1,0 +1,316 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+package org.dependencytrack.resources.v1;
+
+import alpine.server.filters.ApiFilter;
+import alpine.server.filters.AuthenticationFilter;
+import com.github.packageurl.PackageURL;
+import org.apache.http.HttpStatus;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.model.*;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.json.JSONArray;
+import org.junit.Test;
+
+import javax.json.JsonArray;
+import javax.ws.rs.core.Response;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DependencyGraphResourceTest extends ResourceTest {
+
+    @Override
+    protected DeploymentContext configureDeployment() {
+        return ServletDeploymentContext.forServlet(new ServletContainer(
+                        new ResourceConfig(DependencyGraphResource.class)
+                                .register(ApiFilter.class)
+                                .register(AuthenticationFilter.class)))
+                .build();
+    }
+
+
+    @Test
+    public void getComponentsAndServicesByComponentUuidTests() {
+        final int nbIteration = 100;
+        final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
+
+        final List<Component> components = new ArrayList<>(nbIteration);
+        final List<ServiceComponent> serviceComponents = new ArrayList<>(nbIteration);
+
+        for (int i = 0; i < nbIteration; i++) {
+            Component component = new Component();
+            component.setProject(project);
+            component.setName("Component Name");
+            component.setVersion(String.valueOf(i));
+            components.add(qm.createComponent(component, false));
+        }
+
+        for (int i = 0; i < nbIteration; i++) {
+            ServiceComponent service = new ServiceComponent();
+            service.setProject(project);
+            service.setName("Component Name");
+            service.setVersion(String.valueOf(i));
+            serviceComponents.add(qm.createServiceComponent(service, false));
+        }
+
+        final Component rootComponent = new Component();
+        rootComponent.setProject(project);
+        rootComponent.setName("Root Component Name");
+        rootComponent.setVersion("1.0.0");
+
+        final JSONArray jsonArray = new JSONArray();
+        for (Component component : components) {
+            jsonArray.put(new ComponentIdentity(component).toJSON());
+        }
+
+        for(ServiceComponent serviceComponent : serviceComponents) {
+            jsonArray.put(new ComponentIdentity(serviceComponent).toJSON());
+        }
+
+        rootComponent.setDirectDependencies(jsonArray.toString());
+
+        final UUID rootUuid = qm.createComponent(rootComponent, false).getUuid();
+
+        final Response response = target(V1_DEPENDENCY_GRAPH + "/component/" + rootUuid.toString() + "/directDependencies")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+
+        final JsonArray json = parseJsonArray(response);
+
+        assertThat(json.size()).isEqualTo(nbIteration * 2);
+    }
+
+    @Test
+    public void getComponentsAndServicesByComponentUuidWithRepositoryMetaTests() {
+        final int nbIteration = 100;
+        final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
+
+        final String purlTemplate = "pkg:maven/%s/%s@%s?type=jar";
+        final String nameTemplate = "fakePackage-%d";
+        final String namespaceTemplate = "com.fake.package%d";
+
+        final String latestVersion = "1.0.0";
+
+        final List<Component> components = new ArrayList<>(nbIteration);
+        final List<ServiceComponent> serviceComponents = new ArrayList<>(nbIteration);
+
+        String purl;
+        String name;
+        String namespace;
+        RepositoryMetaComponent repositoryMetaComponent;
+        for (int i = 0; i < nbIteration; i++) {
+            Component component = new Component();
+            component.setProject(project);
+            component.setName("Component Name");
+            component.setVersion(String.valueOf(i));
+            try {
+                name = String.format(nameTemplate, i);
+                namespace = String.format(namespaceTemplate, i);
+                purl = String.format(purlTemplate, namespace, name, latestVersion);
+
+                repositoryMetaComponent = new RepositoryMetaComponent();
+                repositoryMetaComponent.setRepositoryType(RepositoryType.MAVEN);
+                repositoryMetaComponent.setName(name);
+                repositoryMetaComponent.setNamespace(namespace);
+                repositoryMetaComponent.setPublished(new Date());
+                repositoryMetaComponent.setLastCheck(new Date());
+                repositoryMetaComponent.setLatestVersion(latestVersion);
+                qm.synchronizeRepositoryMetaComponent(repositoryMetaComponent);
+            } catch (Exception e) {
+                purl = null;
+                repositoryMetaComponent = null;
+            }
+            component.setPurl(purl);
+            components.add(qm.createComponent(component, false));
+        }
+
+        for (int i = 0; i < nbIteration; i++) {
+            ServiceComponent service = new ServiceComponent();
+            service.setProject(project);
+            service.setName("Component Name");
+            service.setVersion(String.valueOf(i));
+            serviceComponents.add(qm.createServiceComponent(service, false));
+        }
+
+        final Component rootComponent = new Component();
+        rootComponent.setProject(project);
+        rootComponent.setName("Root Component Name");
+        rootComponent.setVersion("1.0.0");
+
+        final JSONArray jsonArray = new JSONArray();
+        for (Component component : components) {
+            jsonArray.put(new ComponentIdentity(component).toJSON());
+        }
+
+        for(ServiceComponent serviceComponent : serviceComponents) {
+            jsonArray.put(new ComponentIdentity(serviceComponent).toJSON());
+        }
+
+        rootComponent.setDirectDependencies(jsonArray.toString());
+
+        final UUID rootUuid = qm.createComponent(rootComponent, false).getUuid();
+
+        final Response response = target(V1_DEPENDENCY_GRAPH + "/component/" + rootUuid.toString() + "/directDependencies")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+
+        final JsonArray json = parseJsonArray(response);
+
+        assertThat(json.size()).isEqualTo(nbIteration * 2);
+    }
+
+    @Test
+    public void getComponentsAndServicesByProjectUuidTests() {
+        final int nbIteration = 100;
+        final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
+
+        final List<Component> components = new ArrayList<>(nbIteration);
+        final List<ServiceComponent> serviceComponents = new ArrayList<>(nbIteration);
+
+        for (int i = 0; i < nbIteration; i++) {
+            Component component = new Component();
+            component.setProject(project);
+            component.setName("Component Name");
+            component.setVersion(String.valueOf(i));
+            components.add(qm.createComponent(component, false));
+        }
+
+        for (int i = 0; i < nbIteration; i++) {
+            ServiceComponent service = new ServiceComponent();
+            service.setProject(project);
+            service.setName("Component Name");
+            service.setVersion(String.valueOf(i));
+            serviceComponents.add(qm.createServiceComponent(service, false));
+        }
+
+        final JSONArray jsonArray = new JSONArray();
+        for (Component component : components) {
+            jsonArray.put(new ComponentIdentity(component).toJSON());
+        }
+
+        for(ServiceComponent serviceComponent : serviceComponents) {
+            jsonArray.put(new ComponentIdentity(serviceComponent).toJSON());
+        }
+
+        project.setDirectDependencies(jsonArray.toString());
+        qm.updateProject(project, false);
+
+        final Response response = target(V1_DEPENDENCY_GRAPH + "/project/" + project.getUuid().toString() + "/directDependencies")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+
+        final JsonArray json = parseJsonArray(response);
+
+        assertThat(json.size()).isEqualTo(nbIteration * 2);
+    }
+
+    @Test
+    public void getComponentsAndServicesByProjectUuidWithRepositoryMetaTests() {
+        final int nbIteration = 100;
+        final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
+
+        final String purlTemplate = "pkg:maven/%s/%s@%s?type=jar";
+        final String nameTemplate = "fakePackage-%d";
+        final String namespaceTemplate = "com.fake.package%d";
+
+        final String latestVersion = "1.0.0";
+
+        final List<Component> components = new ArrayList<>(nbIteration);
+        final List<ServiceComponent> serviceComponents = new ArrayList<>(nbIteration);
+
+        String purl;
+        String name;
+        String namespace;
+        RepositoryMetaComponent repositoryMetaComponent;
+        for (int i = 0; i < nbIteration; i++) {
+            Component component = new Component();
+            component.setProject(project);
+            component.setName("Component Name");
+            component.setVersion(String.valueOf(i));
+            try {
+                name = String.format(nameTemplate, i);
+                namespace = String.format(namespaceTemplate, i);
+                purl = String.format(purlTemplate, namespace, name, latestVersion);
+
+                repositoryMetaComponent = new RepositoryMetaComponent();
+                repositoryMetaComponent.setRepositoryType(RepositoryType.MAVEN);
+                repositoryMetaComponent.setName(name);
+                repositoryMetaComponent.setNamespace(namespace);
+                repositoryMetaComponent.setPublished(new Date());
+                repositoryMetaComponent.setLastCheck(new Date());
+                repositoryMetaComponent.setLatestVersion(latestVersion);
+                qm.synchronizeRepositoryMetaComponent(repositoryMetaComponent);
+            } catch (Exception e) {
+                purl = null;
+                repositoryMetaComponent = null;
+            }
+            component.setPurl(purl);
+            components.add(qm.createComponent(component, false));
+        }
+
+        for (int i = 0; i < nbIteration; i++) {
+            ServiceComponent service = new ServiceComponent();
+            service.setProject(project);
+            service.setName("Component Name");
+            service.setVersion(String.valueOf(i));
+            serviceComponents.add(qm.createServiceComponent(service, false));
+        }
+
+        final JSONArray jsonArray = new JSONArray();
+        for (Component component : components) {
+            jsonArray.put(new ComponentIdentity(component).toJSON());
+        }
+
+        for(ServiceComponent serviceComponent : serviceComponents) {
+            jsonArray.put(new ComponentIdentity(serviceComponent).toJSON());
+        }
+
+        project.setDirectDependencies(jsonArray.toString());
+        qm.updateProject(project, false);
+
+        final Response response = target(V1_DEPENDENCY_GRAPH + "/project/" + project.getUuid().toString() + "/directDependencies")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+
+        final JsonArray json = parseJsonArray(response);
+
+        assertThat(json.size()).isEqualTo(nbIteration * 2);
+    }
+}


### PR DESCRIPTION
### Description

In this PR I create two new endpoints `GET /api/v1/dependencyGraph/project/{uuid}/directDependencies` and 
`GET /api/v1/dependencyGraph/component/{uuid}/directDependencies`.

The purpose of this endpoint it's to avoid the frontend from doing multiple requests to the backend to fetch each node of the Dependency Graph. With this endpoint, you can get all directDependencies of a project or a component by providing his UUID.

### Addressed Issue

fixes https://github.com/DependencyTrack/dependency-track/issues/2255

### Additional Details

The frontend changes are available in this PR : https://github.com/DependencyTrack/frontend/pull/455

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
