### PR TITLE
Map Snyk publication time

### DIFF
--- a/src/main/java/org/dependencytrack/parser/snyk/SnykParser.java
+++ b/src/main/java/org/dependencytrack/parser/snyk/SnykParser.java
@@ -59,8 +59,14 @@ public class SnykParser {
         if (vulnAttributes != null && vulnAttributes.optString("type").equalsIgnoreCase("package_vulnerability")) {
             // get the references of the data record (vulnerability)
             final JSONObject slots = vulnAttributes.optJSONObject("slots");
-            if (slots != null && slots.optJSONArray("references") != null) {
-                vulnerability.setReferences(addReferences(slots));
+            if (slots != null) {
+                var publishedTime = jsonStringToTimestamp(slots.optString("publication_time"));
+                if (publishedTime != null) {
+                    vulnerability.setPublished(Date.from(publishedTime.toInstant()));
+                }
+                if (slots.optJSONArray("references") != null) {
+                    vulnerability.setReferences(addReferences(slots));
+                }
             }
             vulnerability.setTitle(vulnAttributes.optString("title", null));
             vulnerability.setDescription(vulnAttributes.optString("description", null));

--- a/src/test/java/org/dependencytrack/tasks/scanners/SnykAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/SnykAnalysisTaskTest.java
@@ -302,6 +302,7 @@ public class SnykAnalysisTaskTest extends PersistenceCapableTest {
         assertThat(vulnerability.getSeverity()).isEqualTo(Severity.HIGH);
         assertThat(vulnerability.getCreated()).isInSameDayAs("2022-10-31");
         assertThat(vulnerability.getUpdated()).isInSameDayAs("2022-11-26");
+        assertThat(vulnerability.getPublished()).isInSameDayAs("2022-10-31");
         assertThat(vulnerability.getRecommendation()).contains("Upgrade the package version to 5.0.4,6.0.4 to fix this vulnerability");
         assertThat(vulnerability.getAliases()).satisfiesExactly(
                 alias -> {


### PR DESCRIPTION
### Description

Mapping for publication time of vulnerability is missing while paring Snyk results. 
Added the missing mapping.

### Addressed Issue

NA

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
