### PR TITLE
Fix policy violation search

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/PolicyQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/PolicyQueryManager.java
@@ -268,16 +268,19 @@ final class PolicyQueryManager extends QueryManager implements IQueryManager {
      */
     @SuppressWarnings("unchecked")
     public PaginatedResult getPolicyViolations(final Project project, boolean includeSuppressed) {
+        PaginatedResult result;
+        final String projectFilter = includeSuppressed ? "project.id == :pid" : "project.id == :pid && (analysis.suppressed == false || analysis.suppressed == null)";
         final Query<PolicyViolation> query = pm.newQuery(PolicyViolation.class);
-        if (includeSuppressed) {
-            query.setFilter("project.id == :pid");
-        } else {
-            query.setFilter("project.id == :pid && (analysis.suppressed == false || analysis.suppressed == null)");
-        }
         if (orderBy == null) {
             query.setOrdering("timestamp desc, component.name, component.version");
         }
-        final PaginatedResult result = execute(query, project.getId());
+        if (filter != null) {
+            query.setFilter(projectFilter + " && (policyCondition.policy.name.toLowerCase().matches(:filter) || component.name.toLowerCase().matches(:filter))");
+            final String filterString = ".*" + filter.toLowerCase() + ".*";
+            result = execute(query, project.getId(), filterString);
+        } else {
+            result = execute(query, project.getId());
+        }
         for (final PolicyViolation violation: result.getList(PolicyViolation.class)) {
             violation.getPolicyCondition().getPolicy(); // force policy to ne included since its not the default
             violation.getComponent().getResolvedLicense(); // force resolved license to ne included since its not the default

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyViolationResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyViolationResourceTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.ws.rs.core.Response;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.UUID;
 
@@ -112,40 +113,70 @@ public class PolicyViolationResourceTest extends ResourceTest {
 
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
-        var component = new Component();
-        component.setProject(project);
-        component.setName("Acme Component");
-        component.setVersion("1.0");
-        component = qm.createComponent(component, false);
+        var component0 = new Component();
+        component0.setProject(project);
+        component0.setName("Acme Component 0");
+        component0.setVersion("1.0");
+        component0 = qm.createComponent(component0, false);
 
-        final Policy policy = qm.createPolicy("Blacklisted Version", Policy.Operator.ALL, Policy.ViolationState.FAIL);
-        final PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.VERSION, PolicyCondition.Operator.NUMERIC_EQUAL, "1.0");
+        var component1 = new Component();
+        component1.setProject(project);
+        component1.setName("Acme Component 1");
+        component1.setVersion("1.0");
+        component1 = qm.createComponent(component1, false);
 
-        var violation = new PolicyViolation();
-        violation.setType(PolicyViolation.Type.OPERATIONAL);
-        violation.setComponent(component);
-        violation.setPolicyCondition(condition);
-        violation.setTimestamp(new Date());
-        violation = qm.persist(violation);
+        final Policy policy0 = qm.createPolicy("Blacklisted Version 0", Policy.Operator.ALL, Policy.ViolationState.FAIL);
+        final PolicyCondition condition0 = qm.createPolicyCondition(policy0, PolicyCondition.Subject.VERSION, PolicyCondition.Operator.NUMERIC_EQUAL, "1.0");
+
+        final Policy policy1 = qm.createPolicy("Blacklisted Version 1", Policy.Operator.ALL, Policy.ViolationState.FAIL);
+        final PolicyCondition condition1 = qm.createPolicyCondition(policy1, PolicyCondition.Subject.VERSION, PolicyCondition.Operator.NUMERIC_EQUAL, "1.0");
+
+        ArrayList<PolicyViolation> filteredPolicyViolations = new ArrayList<>();
+        for (int i=0; i<10; i++) {
+            final boolean componentFilter = (i == 3);
+            final boolean conditionFilter = (i == 7);
+
+            var violation = new PolicyViolation();
+            violation.setType(PolicyViolation.Type.OPERATIONAL);
+            violation.setComponent(componentFilter ? component0 : component1);
+            violation.setPolicyCondition(conditionFilter ? condition0 : condition1);
+            violation.setTimestamp(new Date());
+            violation = qm.persist(violation);
+
+            if (conditionFilter || componentFilter) {
+                filteredPolicyViolations.add(violation);
+            }
+        }
 
         final Response response = target(V1_POLICY_VIOLATION)
+                .queryParam("searchText", "0")
                 .path("/project/" + project.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
-        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("2");
 
         final JsonArray jsonArray = parseJsonArray(response);
-        assertThat(jsonArray).hasSize(1);
+        assertThat(jsonArray).hasSize(2);
 
-        final JsonObject jsonObject = jsonArray.getJsonObject(0);
-        assertThat(jsonObject.getString("uuid")).isEqualTo(violation.getUuid().toString());
-        assertThat(jsonObject.getString("type")).isEqualTo(PolicyViolation.Type.OPERATIONAL.name());
-        assertThat(jsonObject.getJsonObject("policyCondition")).isNotNull();
-        assertThat(jsonObject.getJsonObject("policyCondition").getJsonObject("policy")).isNotNull();
-        assertThat(jsonObject.getJsonObject("policyCondition").getJsonObject("policy").getString("name")).isEqualTo("Blacklisted Version");
-        assertThat(jsonObject.getJsonObject("policyCondition").getJsonObject("policy").getString("violationState")).isEqualTo("FAIL");
+        final JsonObject jsonObject0 = jsonArray.getJsonObject(0);
+        assertThat(jsonObject0.getString("uuid")).isEqualTo(filteredPolicyViolations.get(1).getUuid().toString());
+        assertThat(jsonObject0.getString("type")).isEqualTo(PolicyViolation.Type.OPERATIONAL.name());
+        assertThat(jsonObject0.getJsonObject("policyCondition")).isNotNull();
+        assertThat(jsonObject0.getJsonObject("policyCondition").getJsonObject("policy")).isNotNull();
+        assertThat(jsonObject0.getJsonObject("policyCondition").getJsonObject("policy").getString("violationState")).isEqualTo("FAIL");
+        assertThat(jsonObject0.getJsonObject("policyCondition").getJsonObject("policy").getString("name")).isEqualTo("Blacklisted Version 0");
+        assertThat(jsonObject0.getJsonObject("component").getString("name")).isEqualTo("Acme Component 1");
+
+        final JsonObject jsonObject1 = jsonArray.getJsonObject(1);
+        assertThat(jsonObject1.getString("uuid")).isEqualTo(filteredPolicyViolations.get(0).getUuid().toString());
+        assertThat(jsonObject1.getString("type")).isEqualTo(PolicyViolation.Type.OPERATIONAL.name());
+        assertThat(jsonObject1.getJsonObject("policyCondition")).isNotNull();
+        assertThat(jsonObject1.getJsonObject("policyCondition").getJsonObject("policy")).isNotNull();
+        assertThat(jsonObject1.getJsonObject("policyCondition").getJsonObject("policy").getString("violationState")).isEqualTo("FAIL");
+        assertThat(jsonObject1.getJsonObject("policyCondition").getJsonObject("policy").getString("name")).isEqualTo("Blacklisted Version 1");
+        assertThat(jsonObject1.getJsonObject("component").getString("name")).isEqualTo("Acme Component 0");
     }
 
     @Test


### PR DESCRIPTION
### Description

This PR fixes a defect where policy violations listed for a project are not searchable. The fix adds missing filtering logic based on policy name or any specific component name.

### Addressed Issue

Fixes #2622

### Additional Details

N/A

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic]~(https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
