### PR TITLE
Change dependency to component to show info again

### DIFF
--- a/src/main/resources/templates/notification/publisher/msteams.peb
+++ b/src/main/resources/templates/notification/publisher/msteams.peb
@@ -31,11 +31,11 @@
       "facts": [
         {
           "name": "Project",
-          "value": "{{ subject.dependency.project.toString | escape(strategy="json") }}"
+          "value": "{{ subject.component.project.toString | escape(strategy="json") }}"
         },
         {
           "name": "Component",
-          "value": "{{ subject.dependency.component.toString | escape(strategy="json") }}"
+          "value": "{{ subject.component.toString | escape(strategy="json") }}"
         }
       ],
       {% elseif notification.group == "PROJECT_AUDIT_CHANGE" %}


### PR DESCRIPTION
### Description

The MSTeams notification shows blank entries:
![image](https://user-images.githubusercontent.com/33425497/229555560-7ef14c4c-a618-4d1f-88a7-1ebd2f439c79.png)
This PR replaces the "dependency" key with "component" just like the Slack integration does it.
### Addressed Issue

#2638

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->
Manually tested
### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
