### PR TITLE
Policy Evaluator: add null check to versionMatches

### DIFF
--- a/src/main/java/org/dependencytrack/policy/CoordinatesPolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/CoordinatesPolicyEvaluator.java
@@ -85,6 +85,9 @@ public class CoordinatesPolicyEvaluator extends AbstractPolicyEvaluator {
     }
 
     private boolean versionMatches(final PolicyCondition.Operator conditionOperator, final String conditionValue, final String part) {
+        if (conditionValue == null && part == null) {
+            return true;
+        }
         final Matcher versionOperatorMatcher = VERSION_OPERATOR_PATTERN.matcher(conditionValue);
         if (!versionOperatorMatcher.find()) {
             // No operator provided, use default matching algorithm


### PR DESCRIPTION
### Description
Fixes #2135 (at least the original opening exception in there)


### Addressed Issue
Fixes a possible nullpointer during policy evaluation.

### Additional Details
The other `matches` method in this class seems to default to `true` for when the condition or part is empty, so I added that check for `versionMatches` as well. Not sure if this is the best/final/ultimate solution. But I am not actually using policies, just wanted to get rid of this NullPointer that can interfere with processing / policy evaluations. Maybe some checks should be added to not allow policies with empty fields? Or it should be made more clear what empty fields mean and handle them better.

There's another exception mentioned in #2135 around license policy evaluation, but I don't know what should be the result if the license group is empty (true or false).

### Checklist

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
