### PR TITLE
Fix potential `Invalid state. Transaction has already started` in `RepositoryMetaAnalyzerTask`

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1315,6 +1315,23 @@ public class QueryManager extends AlpineQueryManager {
         }
     }
 
+    /**
+     * Convenience method to ensure that any active transaction is rolled back.
+     * <p>
+     * Calling this method may sometimes be necessary due to {@link AlpineQueryManager#persist(Object)}
+     * no performing a rollback in case committing the transaction fails. This can impact other persistence
+     * operations performed in the same session (e.g. {@code NucleusTransactionException: Invalid state. Transaction has already started}).
+     *
+     * @see <a href="https://github.com/DependencyTrack/dependency-track/issues/2677">Issue 2677</a>
+     * @since 4.8.0
+     */
+    public void ensureNoActiveTransaction() {
+        final Transaction trx = pm.currentTransaction();
+        if (trx != null && trx.isActive()) {
+            trx.rollback();
+        }
+    }
+
     public void recursivelyDeleteTeam(Team team) {
         pm.setProperty("datanucleus.query.sql.allowAll", true);
         final Transaction trx = pm.currentTransaction();

--- a/src/main/java/org/dependencytrack/tasks/repositories/RepositoryMetaAnalyzerTask.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/RepositoryMetaAnalyzerTask.java
@@ -72,11 +72,9 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
     /**
      * {@inheritDoc}
      */
-    @SuppressWarnings("unchecked")
     public void inform(final Event e) {
-        if (e instanceof RepositoryMetaEvent) {
+        if (e instanceof final RepositoryMetaEvent event) {
             LOGGER.debug("Analyzing component repository metadata");
-            final RepositoryMetaEvent event = (RepositoryMetaEvent)e;
             // TODO - Remove when https://github.com/DependencyTrack/dependency-track/issues/2110 is implemented
             Timer timer = Timer.builder("repository_meta_analyzer_task")
                     .description("Repository meta analyzer task timer")
@@ -89,6 +87,7 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
                     // Refreshing the object by querying for it again is preventative
                     LOGGER.info("Performing component repository metadata analysis against " + components.size() + " components");
                     for (final Component component: components) {
+                        qm.ensureNoActiveTransaction(); // Workaround for https://github.com/DependencyTrack/dependency-track/issues/2677
                         analyze(qm, qm.getObjectById(Component.class, component.getId()));
                     }
                     LOGGER.info("Completed component repository metadata analysis against " + components.size() + " components");
@@ -101,6 +100,7 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
                         final List<Component> components = qm.getAllComponents(project);
                         LOGGER.debug("Performing component repository metadata analysis against " + components.size() + " components in project: " + project.getUuid());
                         for (final Component component: components) {
+                            qm.ensureNoActiveTransaction(); // Workaround for https://github.com/DependencyTrack/dependency-track/issues/2677
                             analyze(qm, component);
                         }
                         LOGGER.debug("Completed component repository metadata analysis against " + components.size() + " components in project: " + project.getUuid());


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

The task works in such a way that a single `QueryManager` (and thus DN `ExecutionContext` and associated transaction) is shared across analyses of multiple components. Failure to analyze one component does not abort the overall analysis for all components.

Due to missing transaction rollbacks, the `RepositoryMetaAnalyzerTask` could end up in a situation where the `QueryManager`s active transaction failed to commit for one component, such that persisting of results for all following components would fail with `NucleusTransactionException: Invalid state. Transaction has already started`.

This fix is a mere workaround for the missing rollback of the `persist` method. https://github.com/DependencyTrack/dependency-track/issues/2677 has been raised to address this for the entire application.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #2677.

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
