### PR TITLE
repo meta analyzer: lower log level, do not swallow exception details

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/repositories/RepositoryMetaAnalyzerTask.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/RepositoryMetaAnalyzerTask.java
@@ -128,7 +128,7 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
                 try {
                     cacheLoader.call();
                 } catch (Exception e) {
-                    LOGGER.error("Error while fetching component meta model for component(id="+component.getId()+"; purl="+component.getPurl()+") : "+e.getMessage());
+                    LOGGER.warn("Error while fetching component meta model for component(id="+component.getId()+"; purl="+component.getPurl()+") : "+e.getMessage(), e);
                 }
             }
         }


### PR DESCRIPTION
### Description
Common/harmless errors should be logged on a reasonable log level, for example `WARN`

### Addressed Issue
Currently common errors like no response are logged as `ERROR`

### Additional Details
Also th eexception details were not logged, making it time consuming to deduce the exact cause of the exception.

### Checklist
- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
~~- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective~~
~~- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended~~
~~- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic]~~(https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
~~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~~
