### PR TITLE
Fix NPE for email alerts without explicit destination

### DIFF
--- a/src/test/java/org/dependencytrack/notification/publisher/SendMailPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/SendMailPublisherTest.java
@@ -17,7 +17,6 @@ public class SendMailPublisherTest {
     return Json.createObjectBuilder().add("destination", destination).build();
   }
 
-
   @Test
   public void testSingleDestination() {
     JsonObject config = configWithDestination("john@doe.com");
@@ -32,6 +31,10 @@ public class SendMailPublisherTest {
                              SendMailPublisher.parseDestination(config));
   }
 
+  @Test
+  public void testNullDestination() {
+    Assert.assertArrayEquals(null, SendMailPublisher.parseDestination(Json.createObjectBuilder().build()));
+  }
 
   @Test
   public void testEmptyDestinations() {
@@ -291,6 +294,37 @@ public class SendMailPublisherTest {
     teams.add(team);
 
     Assert.assertArrayEquals(new String[] {"john@doe.com", "steve@jobs.org", "managedUser@Test.com", "ldapUser@Test.com"}, SendMailPublisher.parseDestination(config, teams));
+  }
+
+  @Test
+  public void testNullConfigDestinationAndTeamsDestination() {
+    JsonObject config = Json.createObjectBuilder().build();
+    ManagedUser managedUser = new ManagedUser();
+    managedUser.setUsername("ManagedUserTest");
+    managedUser.setEmail("managedUser@Test.com");
+    List<ManagedUser> managedUsers = new ArrayList<>();
+    managedUsers.add(managedUser);
+
+    LdapUser ldapUser = new LdapUser();
+    ldapUser.setUsername("ldapUserTest");
+    ldapUser.setEmail("ldapUser@Test.com");
+    List<LdapUser> ldapUsers = new ArrayList<>();
+    ldapUsers.add(ldapUser);
+
+    OidcUser oidcUser = new OidcUser();
+    oidcUser.setUsername("oidcUserTest");
+    oidcUser.setEmail("john@doe.com");
+    List<OidcUser> oidcUsers = new ArrayList<>();
+    oidcUsers.add(oidcUser);
+
+    List<Team> teams = new ArrayList<>();
+    Team team = new Team();
+    team.setManagedUsers(managedUsers);
+    team.setLdapUsers(ldapUsers);
+    team.setOidcUsers(oidcUsers);
+    teams.add(team);
+
+    Assert.assertArrayEquals(new String[] {"managedUser@Test.com", "ldapUser@Test.com", "john@doe.com"}, SendMailPublisher.parseDestination(config, teams));
   }
 
   @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

When an email alert is configured without populating the *Destination* field, but by assigning teams to it, sending of alerts would fail with a `NullPointerException`.

The cause was the code expecting the *Destination* to never be not set. This PR fixes the issue by adding additional `null` checks.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #2698

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
