### PR TITLE
Fixing broken link in DEVELOPING.md

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -259,7 +259,7 @@ docker build --build-arg WAR_FILENAME=dependency-track-bundled.jar -t dependency
 ## Documentation
 
 The documentation is built using [Jekyll](https://jekyllrb.com/) and published to 
-[docs.dependencytrack.org](https://docs.dependecytrack.org). Sources are located in the [`docs`](./docs) directory.
+[docs.dependencytrack.org](https://docs.dependencytrack.org). Sources are located in the [`docs`](./docs) directory.
 
 There is a lot going on in `docs`, but most of the time you'll want to spend your time in these directories:
 


### PR DESCRIPTION
fixed minor typo in url linking to dt documentation

### Description

Found a broken link (docs.dependecytrack.org instead of docs.depende**n**cytrack.org) when checking out the DEVELOPING.md.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [ ] ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
