### PR TITLE
Fix NPE in `DefectDojoClient` when `scan_type` of a test is `null`

### DIFF
--- a/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoClient.java
+++ b/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoClient.java
@@ -117,8 +117,10 @@ public class DefectDojoClient {
                                 stringResponse = EntityUtils.toString(response1.getEntity());
                             }
                             dojoObj = new JSONObject(stringResponse);
-                            dojoArray = dojoObj.getJSONArray("results");
-                            dojoTests.addAll(jsonToList(dojoArray));
+                            dojoArray = dojoObj.optJSONArray("results");
+                            if (dojoArray != null) {
+                                dojoTests.addAll(jsonToList(dojoArray));
+                            }
                         }
                         LOGGER.debug("Successfully retrieved the test list ");
                         return dojoTests;
@@ -136,12 +138,11 @@ public class DefectDojoClient {
 
     // Given the engagement id and scan type, search for existing test id
     public String getDojoTestId(final String engagementID, final ArrayList<String> dojoTests) {
-        for (int i = 0; i < dojoTests.size(); i++) {
-            String s = dojoTests.get(i);
-            JSONObject dojoTest = new JSONObject(s);
-            if (dojoTest.get("engagement").toString().equals(engagementID) &&
-                    dojoTest.get("scan_type").toString().equals("Dependency Track Finding Packaging Format (FPF) Export")) {
-                return dojoTest.get("id").toString();
+        for (final String dojoTestJson : dojoTests) {
+            JSONObject dojoTest = new JSONObject(dojoTestJson);
+            if (dojoTest.optString("engagement").equals(engagementID) &&
+                    dojoTest.optString("scan_type").equals("Dependency Track Finding Packaging Format (FPF) Export")) {
+                return dojoTest.optString("id");
             }
         }
         return "";

--- a/src/test/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploaderTest.java
+++ b/src/test/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploaderTest.java
@@ -272,7 +272,7 @@ public class DefectDojoUploaderTest extends PersistenceCapableTest {
                         .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
                         .withBody("""
                                 {
-                                  "count": 2,
+                                  "count": 3,
                                   "next": "%s/api/v2/tests/?engagement=666&limit=100&offset=100",
                                   "previous": null,
                                   "results": [
@@ -302,6 +302,32 @@ public class DefectDojoUploaderTest extends PersistenceCapableTest {
                                       "api_scan_configuration": null,
                                       "notes": [],
                                       "files": []
+                                    },
+                                    {
+                                      "id": 2,
+                                      "tags": [],
+                                      "test_type_name": "API Test",
+                                      "finding_groups": [],
+                                      "title": null,
+                                      "description": null,
+                                      "target_start": "2023-04-29T00:00:00Z",
+                                      "target_end": "2023-04-29T21:36:22.798765Z",
+                                      "estimated_time": null,
+                                      "actual_time": null,
+                                      "percent_complete": 100,
+                                      "updated": "2023-04-29T21:36:22.858597Z",
+                                      "created": "2023-04-29T21:36:22.802993Z",
+                                      "version": "",
+                                      "build_id": "",
+                                      "commit_hash": "",
+                                      "branch_tag": "",
+                                      "engagement": 666,
+                                      "lead": 1,
+                                      "test_type": 1,
+                                      "environment": 7,
+                                      "api_scan_configuration": null,
+                                      "notes": [],
+                                      "files": []
                                     }
                                   ],
                                   "prefetch": {}
@@ -317,12 +343,12 @@ public class DefectDojoUploaderTest extends PersistenceCapableTest {
                         .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
                         .withBody("""
                                 {
-                                   "count": 2,
+                                   "count": 3,
                                    "next": null,
                                    "previous": "%s/api/v2/tests/?engagement=666&limit=100",
                                    "results": [
                                      {
-                                       "id": 2,
+                                       "id": 3,
                                        "tags": [],
                                        "test_type_name": "Dependency Track Finding Packaging Format (FPF) Export",
                                        "finding_groups": [],
@@ -395,7 +421,7 @@ public class DefectDojoUploaderTest extends PersistenceCapableTest {
                         .withBody(equalTo("666")))
                 .withAnyRequestBodyPart(aMultipart()
                         .withName("test")
-                        .withBody(equalTo("2")))
+                        .withBody(equalTo("3")))
                 .withAnyRequestBodyPart(aMultipart()
                         .withName("scan_type")
                         .withBody(equalTo("Dependency Track Finding Packaging Format (FPF) Export")))


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This PR fixes NPEs in the DefectDojo integration, which occurred when the `scan_type` field in DD responses was `null` or not set at all.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #2628

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
