### PR TITLE
Fix: Detect and avoid infinite recursion during second upload of SBOM with nested duplicate

### DIFF
--- a/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
@@ -23,6 +23,7 @@ import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Dependency;
 import org.cyclonedx.model.Hash;
@@ -96,7 +97,8 @@ public class ModelConverter {
 
     @SuppressWarnings("deprecation")
     public static Component convert(final QueryManager qm, final org.cyclonedx.model.Component cycloneDxComponent, final Project project) {
-        Component component = qm.matchSingleIdentity(project, new ComponentIdentity(cycloneDxComponent));
+        ComponentIdentity parentIdentity = new ComponentIdentity(cycloneDxComponent);
+        Component component = qm.matchSingleIdentity(project, parentIdentity);
         if (component == null) {
             component = new Component();
             component.setProject(project);
@@ -187,7 +189,8 @@ public class ModelConverter {
             final Collection<Component> components = new ArrayList<>();
             for (int i = 0; i < cycloneDxComponent.getComponents().size(); i++) {
                 final org.cyclonedx.model.Component cycloneDxChildComponent = cycloneDxComponent.getComponents().get(i);
-                if (cycloneDxChildComponent != null) {
+                ComponentIdentity childIdentity = new ComponentIdentity(cycloneDxChildComponent);
+                if (cycloneDxChildComponent != null && !EqualsBuilder.reflectionEquals(parentIdentity, childIdentity)) {
                     components.add(convert(qm, cycloneDxChildComponent, project));
                 }
             }

--- a/src/test/resources/bom-2.json
+++ b/src/test/resources/bom-2.json
@@ -1,0 +1,35 @@
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2023-01-01T11:01:51Z",
+        "tools": [
+            {
+                "vendor": "changeme",
+                "name": "changeme",
+                "version": "0.62.3"
+            }
+        ]
+    },
+    "components": [
+        {
+            "bom-ref": "pkg:pypi/pillow@9.3.0",
+            "type": "library",
+            "name": "Pillow",
+            "version": "9.3.0",
+            "cpe": "cpe:2.3:a:alex_clark_\\(pil_fork_author\\):python-Pillow:9.3.0:*:*:*:*:*:*:*",
+            "purl": "pkg:pypi/Pillow@9.3.0",
+            "components": [
+                {
+                    "bom-ref": "pkg:pypi/pillow@9.3.0?package-id=212c649613e17901",
+                    "type": "library",
+                    "name": "Pillow",
+                    "version": "9.3.0",
+                    "cpe": "cpe:2.3:a:alex_clark_\\(pil_fork_author\\):python-Pillow:9.3.0:*:*:*:*:*:*:*",
+                    "purl": "pkg:pypi/Pillow@9.3.0"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Description

When a SBOM contains component with nested duplicate (componentA contains itself as a children), the second SBOM upload causes an infinite recursion.

### Addressed Issue

See #1905 for details

### Additional Details

N/A

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~[ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~[ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~[ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
