### PR TITLE
Fix memory leak issue in policy evaluation

### DIFF
--- a/src/main/java/org/dependencytrack/policy/AbstractPolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/AbstractPolicyEvaluator.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractPolicyEvaluator implements PolicyEvaluator {
 
-    protected QueryManager qm = new QueryManager();
+    protected QueryManager qm;
 
     public void setQueryManager(final QueryManager qm) {
         this.qm = qm;

--- a/src/test/java/org/dependencytrack/policy/ComponentHashPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/ComponentHashPolicyEvaluatorTest.java
@@ -23,13 +23,20 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
 
 public class ComponentHashPolicyEvaluatorTest extends PersistenceCapableTest {
 
-    PolicyEvaluator evaluator = new ComponentHashPolicyEvaluator();
+    PolicyEvaluator evaluator;
+
+    @Before
+    public void initEvaluator() {
+        evaluator = new ComponentHashPolicyEvaluator();
+        evaluator.setQueryManager(qm);
+    }
 
     @Test
     public void hasMatch() {

--- a/src/test/java/org/dependencytrack/policy/CoordinatesPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/CoordinatesPolicyEvaluatorTest.java
@@ -23,11 +23,20 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
 
 public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
+
+    private PolicyEvaluator evaluator;
+
+    @Before
+    public void initEvaluator() {
+        evaluator = new CoordinatesPolicyEvaluator();
+        evaluator.setQueryManager(qm);
+    }
 
     @Test
     public void hasFullMatch() {
@@ -38,7 +47,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         component.setGroup("Acme");
         component.setName("Test Component");
         component.setVersion("1.0.0");
-        PolicyEvaluator evaluator = new CoordinatesPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
@@ -54,7 +62,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setName("Test Component");
         component.setVersion("1.0.0");
-        PolicyEvaluator evaluator = new CoordinatesPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
@@ -71,7 +78,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         component.setGroup("Anything here");
         component.setName("Test Component");
         component.setVersion("1.0.0");
-        PolicyEvaluator evaluator = new CoordinatesPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
@@ -88,7 +94,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         component.setGroup("Acme");
         component.setName("Test Component");
         component.setVersion("2.0.0");
-        PolicyEvaluator evaluator = new CoordinatesPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -102,7 +107,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         component.setGroup("Acme");
         component.setName("Test");
         component.setVersion("1.0.0");
-        PolicyEvaluator evaluator = new CoordinatesPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -116,7 +120,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         component.setGroup("Example");
         component.setName("Test Component");
         component.setVersion("1.0.0");
-        PolicyEvaluator evaluator = new CoordinatesPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -129,7 +132,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setName("Test Component");
         component.setVersion("1.0.0");
-        PolicyEvaluator evaluator = new CoordinatesPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -141,7 +143,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
         Component component = new Component();
         component.setName("Example Component");
-        PolicyEvaluator evaluator = new CoordinatesPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -153,7 +154,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.MATCHES, def);
         Component component = new Component();
         component.setName("Test Component");
-        PolicyEvaluator evaluator = new CoordinatesPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -165,7 +165,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.IS, def);
         Component component = new Component();
         component.setName("Test Component");
-        PolicyEvaluator evaluator = new CoordinatesPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -177,7 +176,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
 
         final var component = new Component();
-        final var evaluator = new CoordinatesPolicyEvaluator();
 
         Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
     }
@@ -190,7 +188,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
 
         final var component = new Component();
         component.setVersion("1.0.0");
-        final var evaluator = new CoordinatesPolicyEvaluator();
 
         Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
     }
@@ -202,7 +199,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
 
         final var component = new Component();
-        final var evaluator = new CoordinatesPolicyEvaluator();
 
         // Component version is lower
         component.setVersion("1.1.0");
@@ -224,7 +220,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
 
         final var component = new Component();
-        final var evaluator = new CoordinatesPolicyEvaluator();
 
         // Component version is lower
         component.setVersion("1.1.0");
@@ -246,7 +241,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
 
         final var component = new Component();
-        final var evaluator = new CoordinatesPolicyEvaluator();
 
         // Component version is lower
         component.setVersion("1.1.0");
@@ -268,7 +262,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
 
         final var component = new Component();
-        final var evaluator = new CoordinatesPolicyEvaluator();
 
         // Component version is lower
         component.setVersion("1.1.0");
@@ -290,7 +283,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
 
         final var component = new Component();
-        final var evaluator = new CoordinatesPolicyEvaluator();
 
         // Component version is lower
         component.setVersion("1.1.0");
@@ -312,7 +304,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
 
         final var component = new Component();
-        final var evaluator = new CoordinatesPolicyEvaluator();
 
         // Component version is lower
         component.setVersion("1.1.0");
@@ -334,7 +325,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
 
         final var component = new Component();
-        final var evaluator = new CoordinatesPolicyEvaluator();
 
         // Component version is lower
         component.setVersion("1.1.0");
@@ -356,7 +346,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
 
         final var component = new Component();
-        final var evaluator = new CoordinatesPolicyEvaluator();
 
         // Component version is lower
         component.setVersion("1.1.0");
@@ -378,7 +367,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
 
         final var component = new Component();
-        final var evaluator = new CoordinatesPolicyEvaluator();
 
         // Component version is lower
         component.setVersion("1.1.0");
@@ -400,7 +388,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
 
         final var component = new Component();
-        final var evaluator = new CoordinatesPolicyEvaluator();
 
         // Component version is lower
         component.setVersion("1.1.0");
@@ -422,7 +409,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
 
         final var component = new Component();
-        final var evaluator = new CoordinatesPolicyEvaluator();
 
         // Component version is lower
         component.setVersion("1.1.0");
@@ -444,7 +430,6 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
 
         final var component = new Component();
-        final var evaluator = new CoordinatesPolicyEvaluator();
 
         // Component version is lower
         component.setVersion("1.1.0");

--- a/src/test/java/org/dependencytrack/policy/CpePolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/CpePolicyEvaluatorTest.java
@@ -18,15 +18,25 @@
  */
 package org.dependencytrack.policy;
 
-import java.util.List;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
+
 public class CpePolicyEvaluatorTest extends PersistenceCapableTest {
+
+    private PolicyEvaluator evaluator;
+
+    @Before
+    public void initEvaluator() {
+        evaluator = new CpePolicyEvaluator();
+        evaluator.setQueryManager(qm);
+    }
 
     @Test
     public void hasMatch() {
@@ -34,7 +44,6 @@ public class CpePolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.CPE, PolicyCondition.Operator.MATCHES, "cpe:/a:acme:application:1.0.0");
         Component component = new Component();
         component.setCpe("cpe:/a:acme:application:1.0.0");
-        PolicyEvaluator evaluator = new CpePolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
@@ -48,7 +57,6 @@ public class CpePolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.CPE, PolicyCondition.Operator.NO_MATCH, ".+");
         Component component = new Component();
         component.setCpe(null);
-        PolicyEvaluator evaluator = new CpePolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
@@ -62,7 +70,6 @@ public class CpePolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.CPE, PolicyCondition.Operator.MATCHES, "cpe:/a:acme:application:1.0.0");
         Component component = new Component();
         component.setCpe("cpe:/a:acme:application:2.0.0");
-        PolicyEvaluator evaluator = new CpePolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -73,7 +80,6 @@ public class CpePolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, "cpe:/a:acme:application:1.0.0");
         Component component = new Component();
         component.setCpe("cpe:/a:acme:application:1.0.0");
-        PolicyEvaluator evaluator = new CpePolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -84,7 +90,6 @@ public class CpePolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.CPE, PolicyCondition.Operator.IS, "cpe:/a:acme:application:1.0.0");
         Component component = new Component();
         component.setCpe("cpe:/a:acme:application:1.0.0");
-        PolicyEvaluator evaluator = new CpePolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }

--- a/src/test/java/org/dependencytrack/policy/LicenseGroupPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/LicenseGroupPolicyEvaluatorTest.java
@@ -25,6 +25,7 @@ import org.dependencytrack.model.LicenseGroup;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -32,6 +33,14 @@ import java.util.List;
 import java.util.UUID;
 
 public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
+
+    private PolicyEvaluator evaluator;
+
+    @Before
+    public void initEvaluator() {
+        evaluator = new LicenseGroupPolicyEvaluator();
+        evaluator.setQueryManager(qm);
+    }
 
     @Test
     public void hasMatch() {
@@ -51,7 +60,6 @@ public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.detach(PolicyCondition.class, condition.getId());
         Component component = new Component();
         component.setResolvedLicense(license);
-        PolicyEvaluator evaluator = new LicenseGroupPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
     }
@@ -73,7 +81,6 @@ public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.detach(PolicyCondition.class, condition.getId());
         Component component = new Component();
         component.setResolvedLicense(license);
-        PolicyEvaluator evaluator = new LicenseGroupPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -90,7 +97,6 @@ public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setResolvedLicense(null);
 
-        PolicyEvaluator evaluator = new LicenseGroupPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
     }
@@ -111,7 +117,6 @@ public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.IS, lg.getUuid().toString());
         Component component = new Component();
         component.setResolvedLicense(license);
-        PolicyEvaluator evaluator = new LicenseGroupPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -132,7 +137,6 @@ public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.LICENSE_GROUP, PolicyCondition.Operator.MATCHES, lg.getUuid().toString());
         Component component = new Component();
         component.setResolvedLicense(license);
-        PolicyEvaluator evaluator = new LicenseGroupPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -150,7 +154,6 @@ public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.detach(PolicyCondition.class, condition.getId());
         Component component = new Component();
         component.setResolvedLicense(license);
-        PolicyEvaluator evaluator = new LicenseGroupPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }

--- a/src/test/java/org/dependencytrack/policy/LicensePolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/LicensePolicyEvaluatorTest.java
@@ -24,12 +24,21 @@ import org.dependencytrack.model.License;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
 import java.util.UUID;
 
 public class LicensePolicyEvaluatorTest extends PersistenceCapableTest {
+
+    private PolicyEvaluator evaluator;
+
+    @Before
+    public void initEvaluator() {
+        evaluator = new LicensePolicyEvaluator();
+        evaluator.setQueryManager(qm);
+    }
 
     @Test
     public void hasMatch() {
@@ -43,7 +52,6 @@ public class LicensePolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.LICENSE, PolicyCondition.Operator.IS, license.getUuid().toString());
         Component component = new Component();
         component.setResolvedLicense(license);
-        PolicyEvaluator evaluator = new LicensePolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
@@ -63,7 +71,6 @@ public class LicensePolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.LICENSE, PolicyCondition.Operator.IS, UUID.randomUUID().toString());
         Component component = new Component();
         component.setResolvedLicense(license);
-        PolicyEvaluator evaluator = new LicensePolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -80,7 +87,6 @@ public class LicensePolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.IS, license.getUuid().toString());
         Component component = new Component();
         component.setResolvedLicense(license);
-        PolicyEvaluator evaluator = new LicensePolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -97,7 +103,6 @@ public class LicensePolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.LICENSE, PolicyCondition.Operator.MATCHES, license.getUuid().toString());
         Component component = new Component();
         component.setResolvedLicense(license);
-        PolicyEvaluator evaluator = new LicensePolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -118,7 +123,6 @@ public class LicensePolicyEvaluatorTest extends PersistenceCapableTest {
 
         Component componentWithoutLicense = new Component();
 
-        PolicyEvaluator evaluator = new LicensePolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, componentWithLicense);
         Assert.assertEquals(0, violations.size());
 

--- a/src/test/java/org/dependencytrack/policy/PackageURLPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/PackageURLPolicyEvaluatorTest.java
@@ -24,10 +24,19 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import com.github.packageurl.PackageURL;
 
 public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
+
+    private PolicyEvaluator evaluator;
+
+    @Before
+    public void initEvaluator() {
+        evaluator = new PackageURLPolicyEvaluator();
+        evaluator.setQueryManager(qm);
+    }
 
     @Test
     public void hasMatch() throws Exception {
@@ -35,7 +44,6 @@ public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.MATCHES, "pkg:generic/acme/example-component@1.0");
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/acme/example-component@1.0"));
-        PolicyEvaluator evaluator = new PackageURLPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
@@ -49,7 +57,6 @@ public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.NO_MATCH, ".+");
         Component component = new Component();
         component.setPurl((PackageURL)null);
-        PolicyEvaluator evaluator = new PackageURLPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
@@ -63,7 +70,6 @@ public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.MATCHES, "pkg:generic/acme/example-component@1.0");
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/acme/web-component@6.9"));
-        PolicyEvaluator evaluator = new PackageURLPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -74,7 +80,6 @@ public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, "pkg:generic/acme/example-component@1.0");
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/acme/example-component@1.0"));
-        PolicyEvaluator evaluator = new PackageURLPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -85,7 +90,6 @@ public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.IS, "pkg:generic/acme/example-component@1.0");
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/acme/example-component@1.0"));
-        PolicyEvaluator evaluator = new PackageURLPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -97,7 +101,6 @@ public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/acme/example-component@1.0?type=jar"));
         component.setPurlCoordinates(new PackageURL("pkg:generic/acme/example-component@1.0"));
-        PolicyEvaluator evaluator = new PackageURLPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
@@ -112,7 +115,6 @@ public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/acme/example-component@1.0?type=jar"));
         component.setPurlCoordinates(new PackageURL("pkg:generic/acme/example-component@1.0"));
-        PolicyEvaluator evaluator = new PackageURLPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -124,7 +126,6 @@ public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/com/acme/example-component@1.0?type=jar"));
         component.setPurlCoordinates(new PackageURL("pkg:generic/com/acme/example-component@1.0"));
-        PolicyEvaluator evaluator = new PackageURLPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
@@ -139,7 +140,6 @@ public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/com/acme/example-component@1.0?type=jar"));
         component.setPurlCoordinates(new PackageURL("pkg:generic/com/acme/example-component@1.0"));
-        PolicyEvaluator evaluator = new PackageURLPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
@@ -154,7 +154,6 @@ public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/com/acme/example-component@1.0?type=jar"));
         component.setPurlCoordinates(new PackageURL("pkg:generic/com/acme/example-component@1.0"));
-        PolicyEvaluator evaluator = new PackageURLPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
@@ -169,7 +168,6 @@ public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/com/acme/example-component@1.0?type=jar"));
         component.setPurlCoordinates(new PackageURL("pkg:generic/com/acme/example-component@1.0"));
-        PolicyEvaluator evaluator = new PackageURLPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
@@ -184,7 +182,6 @@ public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/com/acme/example-component@1.0-myCompanyFix-1?type=jar"));
         component.setPurlCoordinates(new PackageURL("pkg:generic/com/acme/example-component@1.0-myCompanyFix-1"));
-        PolicyEvaluator evaluator = new PackageURLPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
@@ -199,7 +196,6 @@ public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/com/acme/example-component@1.0?type=jar"));
         component.setPurlCoordinates(new PackageURL("pkg:generic/com/acme/example-component@1.0"));
-        PolicyEvaluator evaluator = new PackageURLPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);

--- a/src/test/java/org/dependencytrack/policy/SwidTagIdPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/SwidTagIdPolicyEvaluatorTest.java
@@ -24,9 +24,18 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class SwidTagIdPolicyEvaluatorTest extends PersistenceCapableTest {
+
+    private PolicyEvaluator evaluator;
+
+    @Before
+    public void initEvaluator() {
+        evaluator = new SwidTagIdPolicyEvaluator();
+        evaluator.setQueryManager(qm);
+    }
 
     @Test
     public void hasMatch() {
@@ -34,7 +43,6 @@ public class SwidTagIdPolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.SWID_TAGID, PolicyCondition.Operator.MATCHES, "0123456789");
         Component component = new Component();
         component.setSwidTagId("0123456789");
-        PolicyEvaluator evaluator = new SwidTagIdPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
@@ -48,7 +56,6 @@ public class SwidTagIdPolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.SWID_TAGID, PolicyCondition.Operator.NO_MATCH, ".+");
         Component component = new Component();
         component.setSwidTagId(null);
-        PolicyEvaluator evaluator = new SwidTagIdPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
@@ -62,7 +69,6 @@ public class SwidTagIdPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.SWID_TAGID, PolicyCondition.Operator.MATCHES, "0123456789");
         Component component = new Component();
         component.setSwidTagId("0000000000");
-        PolicyEvaluator evaluator = new SwidTagIdPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -73,7 +79,6 @@ public class SwidTagIdPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, "0123456789");
         Component component = new Component();
         component.setSwidTagId("0123456789");
-        PolicyEvaluator evaluator = new SwidTagIdPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
@@ -84,7 +89,6 @@ public class SwidTagIdPolicyEvaluatorTest extends PersistenceCapableTest {
         qm.createPolicyCondition(policy, PolicyCondition.Subject.SWID_TAGID, PolicyCondition.Operator.IS, "0123456789");
         Component component = new Component();
         component.setSwidTagId("0123456789");
-        PolicyEvaluator evaluator = new SwidTagIdPolicyEvaluator();
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }

--- a/src/test/java/org/dependencytrack/policy/VersionPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/VersionPolicyEvaluatorTest.java
@@ -15,6 +15,7 @@ public class VersionPolicyEvaluatorTest extends PersistenceCapableTest {
     @Before
     public void setUp() {
         evaluator = new VersionPolicyEvaluator();
+        evaluator.setQueryManager(qm);
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->
In `org.dependencytrack.policy.AbstractPolicyEvaluator`, there is a `QueryManager` created while instance initialization, https://github.com/DependencyTrack/dependency-track/blob/a7e512235c33b650decc90a8c12ceedc5234c6d9/src/main/java/org/dependencytrack/policy/AbstractPolicyEvaluator.java#L37-L41

and later overwrite by it's setter which is called in `VulnerabilityAnalysisTask` execution, therefor the older instance of `QueryManager` will never get closed, so it leads to a memory leak.
https://github.com/DependencyTrack/dependency-track/blob/a7e512235c33b650decc90a8c12ceedc5234c6d9/src/main/java/org/dependencytrack/policy/PolicyEngine.java#L88

### Addressed Issue

https://github.com/DependencyTrack/dependency-track/issues/2785#issuecomment-1621497318
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
