### PR TITLE
Fix #2955: Import components that are located under 'metadata.component.components'

### DIFF
--- a/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
@@ -92,6 +92,14 @@ public class ModelConverter {
                 }
             }
         }
+        if (bom.getMetadata() != null && bom.getMetadata().getComponent() != null && bom.getMetadata().getComponent().getComponents() != null) {
+            for (int i = 0; i < bom.getMetadata().getComponent().getComponents().size(); i++) {
+                final org.cyclonedx.model.Component cycloneDxComponent = bom.getMetadata().getComponent().getComponents().get(i);
+                if (cycloneDxComponent != null) {
+                    components.add(convert(qm, cycloneDxComponent, project));
+                }
+            }
+        }
         return components;
     }
 


### PR DESCRIPTION
### Description

Certain SBOM-generators save sub-projects or -modules as part of the component, instead of in the list of dependencies. This change makes sure to also import these as components, so a correct dependency-tree can be generated.

### Addressed Issue

Fixes #2955

### Checklist

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [X] This PR fixes a defect, ~and I have provided tests to verify that the fix is effective~
- [ ] ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~

Testing was done manually, since no tests for this part of the code exists and I wasn't sure on how to add them there.