### PR TITLE
Fix `AffectedComponent` format for CPEs with version ranges

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/vo/AffectedComponent.java
+++ b/src/main/java/org/dependencytrack/resources/v1/vo/AffectedComponent.java
@@ -96,15 +96,18 @@ public class AffectedComponent {
                 LOGGER.warn("Error assembling PURL", e);
             }
         }
-        if (vs.getVersion() != null) {
-            versionType = VersionType.EXACT;
-            version = vs.getVersion();
-        } else {
+        if (vs.getVersionStartIncluding() != null
+                || vs.getVersionStartExcluding() != null
+                || vs.getVersionEndIncluding() != null
+                || vs.getVersionEndExcluding() != null) {
             versionType = VersionType.RANGE;
             versionEndExcluding = vs.getVersionEndExcluding();
             versionEndIncluding = vs.getVersionEndIncluding();
             versionStartExcluding = vs.getVersionStartExcluding();
             versionStartIncluding = vs.getVersionStartIncluding();
+        } else if (vs.getVersion() != null) {
+            versionType = VersionType.EXACT;
+            version = vs.getVersion();
         }
         if (vs.getAffectedVersionAttributions() != null) {
             affectedVersionAttributions = vs.getAffectedVersionAttributions();

--- a/src/test/java/org/dependencytrack/resources/v1/vo/AffectedComponentTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/vo/AffectedComponentTest.java
@@ -173,6 +173,24 @@ public class AffectedComponentTest {
         }
 
         @Test
+        public void shouldUseVersionRangeWhenBothRangeAndExactVersionAreAvailable() {
+            final var vs = new VulnerableSoftware();
+            vs.setVersion("*"); // CPEs will have a version wildcard when ranges are defined
+            vs.setVersionStartIncluding("foo");
+            vs.setVersionStartExcluding("bar");
+            vs.setVersionEndIncluding("baz");
+            vs.setVersionEndExcluding("qux");
+
+            final var affectedComponent = new AffectedComponent(vs);
+            assertThat(affectedComponent.getVersionType()).isEqualTo(AffectedComponent.VersionType.RANGE);
+            assertThat(affectedComponent.getVersion()).isNull();
+            assertThat(affectedComponent.getVersionStartIncluding()).isEqualTo("foo");
+            assertThat(affectedComponent.getVersionStartExcluding()).isEqualTo("bar");
+            assertThat(affectedComponent.getVersionEndIncluding()).isEqualTo("baz");
+            assertThat(affectedComponent.getVersionEndExcluding()).isEqualTo("qux");
+        }
+
+        @Test
         public void shouldMapAffectedPackageAttribution() {
             final var vs = new VulnerableSoftware();
             AffectedVersionAttribution ava = new AffectedVersionAttribution();


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

For CPEs with ranges, `version` is set to a non-empty value (mostly the wildcard `*`).

For such cases, the API would previously return a JSON object that caused the frontend to render it as e.g. `cpe:2.3:o:apple:tvos:*:*:*:*:*:*@*`, whereas it should've been `cpe:2.3:o:apple:tvos:*:*:*:*:*:* (|<15.6)` instead.

![Screenshot 2023-08-20 221000](https://github.com/DependencyTrack/dependency-track/assets/5693141/4eb33ce5-6338-40e5-b245-0af9cbfb9f20)

![Screenshot 2023-08-20 220857](https://github.com/DependencyTrack/dependency-track/assets/5693141/93062456-8411-46ec-b30d-05d4c00e292c)

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

This issue was indirectly reported in Slack: https://owasp.slack.com/archives/C6R3R32H4/p1692113964318869

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
