### PR TITLE
feature: Adding proper logging to warn users when VEX data is not taken into account

### DIFF
--- a/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporter.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporter.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.parser.cyclonedx;
 
+import alpine.common.logging.Logger;
 import org.apache.commons.lang3.StringUtils;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.util.BomLink;
@@ -37,6 +38,8 @@ import org.dependencytrack.util.AnalysisCommentUtil;
 import java.util.List;
 
 public class CycloneDXVexImporter {
+
+    private static final Logger LOGGER = Logger.getLogger(CycloneDXVexImporter.class);
 
     private static final String COMMENTER = "CycloneDX VEX";
 
@@ -75,6 +78,8 @@ public class CycloneDXVexImporter {
                             // TODO add VEX support for services
                         }
                     }
+                } else {
+                    LOGGER.warn("Analysis data for vulnerability "+cdxVuln.getId()+" will be ignored because either the source is missing or there is a source/vulnid mismatch between VEX and Dependency Track database.");
                 }
             }
         }


### PR DESCRIPTION
### Description

Adding proper logging to warn users when VEX data is not taken into account because either :

- Vulnerability source/id on VEX does not match the one in DT database
- Vulnerability source on VEX is missing

### Addressed Issue

Fix #2977

### Additional Details

N/A

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~[] This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~[] This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~[] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~[] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
