### PR TITLE
Fix: allow operator and violationState to be specified when create policy

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
@@ -124,9 +124,17 @@ public class PolicyResource extends AlpineResource {
         try (QueryManager qm = new QueryManager()) {
             Policy policy = qm.getPolicy(StringUtils.trimToNull(jsonPolicy.getName()));
             if (policy == null) {
+                Policy.Operator operator = jsonPolicy.getOperator();
+                if (operator == null) {
+                    operator = Policy.Operator.ANY;
+                }
+                Policy.ViolationState violationState = jsonPolicy.getViolationState();
+                if (violationState == null) {
+                    violationState = Policy.ViolationState.INFO;
+                }
                 policy = qm.createPolicy(
                         StringUtils.trimToNull(jsonPolicy.getName()),
-                        Policy.Operator.ANY, Policy.ViolationState.INFO);
+                        operator, violationState);
                 return Response.status(Response.Status.CREATED).entity(policy).build();
             } else {
                 return Response.status(Response.Status.CONFLICT).entity("A policy with the specified name already exists.").build();

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
@@ -117,6 +117,50 @@ public class PolicyResourceTest extends ResourceTest {
     }
 
     @Test
+    public void createPolicySpecifyOperatorAndViolationStateTest() {
+        final Policy policy = new Policy();
+        policy.setName("policy");
+        policy.setOperator(Policy.Operator.ALL);
+        policy.setViolationState(Policy.ViolationState.FAIL);
+
+        final Response response = target(V1_POLICY)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(policy, MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(201);
+
+        final JsonObject json = parseJsonObject(response);
+        assertThat(json).isNotNull();
+        assertThat(json.getString("name")).isEqualTo("policy");
+        assertThat(json.getString("operator")).isEqualTo("ALL");
+        assertThat(json.getString("violationState")).isEqualTo("FAIL");
+        assertThat(UuidUtil.isValidUUID(json.getString("uuid")));
+        assertThat(json.getBoolean("includeChildren")).isEqualTo(false);
+    }
+
+    @Test
+    public void createPolicyUseDefaultValueTest() {
+        final Policy policy = new Policy();
+        policy.setName("policy");
+
+        final Response response = target(V1_POLICY)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(policy, MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(201);
+
+        final JsonObject json = parseJsonObject(response);
+        assertThat(json).isNotNull();
+        assertThat(json.getString("name")).isEqualTo("policy");
+        assertThat(json.getString("operator")).isEqualTo("ANY");
+        assertThat(json.getString("violationState")).isEqualTo("INFO");
+        assertThat(UuidUtil.isValidUUID(json.getString("uuid")));
+        assertThat(json.getBoolean("includeChildren")).isEqualTo(false);
+    }
+
+    @Test
     public void updatePolicyTest() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
 


### PR DESCRIPTION
### Description

Allow `operator` and `violationState` to be specified when create policy.
In addition, to keep backward compatibility, default values are provided.

### Addressed Issue

Closes https://github.com/DependencyTrack/dependency-track/issues/2365

The `violationState` is problematic, but so is the `operator`.

### Additional Details

Currently, sending the `operator` and `violationState` parameters is ignored and the hard-coded values are used.

If these are to be changed to other values, a policy update is required, which is inefficient.

This is a problem specific to create policy since it is a required parameter in the model layer.

In order to maintain backward compatibility of create policy, a default value has been added.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
