### PR TITLE
Improve OIDC documentation

### DIFF
--- a/docs/_docs/getting-started/deploy-docker.md
+++ b/docs/_docs/getting-started/deploy-docker.md
@@ -52,6 +52,8 @@ docker stack deploy -c docker-compose.yml dtrack
 
 ### Quickstart (Manual Execution)
 
+> **NOTE:** the bundled container does _not_ support [OpenID Connect authentication]({{ site.baseurl }}{% link _docs/getting-started/openidconnect-configuration.md %}).
+
 ```bash
 # Pull the image from the Docker Hub OWASP repo
 docker pull dependencytrack/bundled

--- a/docs/_docs/getting-started/openidconnect-configuration.md
+++ b/docs/_docs/getting-started/openidconnect-configuration.md
@@ -15,6 +15,8 @@ If configured properly, users will be able to sign in by clicking the _OpenID_ b
 
 ![Login page with OpenID button](/images/screenshots/oidc-login-page.png)
 
+> **NOTE:** the front-end will *not* display the OIDC login button if the Dependency-Track service is unable to connect to your OIDC server's `.well-known/openid-configuration` endpoint. The server logs can help you identify whether this is an issue with firewall rules, internal TLS certificates, or other errors which may be preventing that communication.
+
 > Before v4.3.0, Dependency-Track exclusively used the `/userinfo` endpoint of the IdP to get user information.  
 > Since v4.3.0, [ID tokens](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) are validated and evaluated as well. They even take precedence over `/userinfo`,  
 > which means that Dependency-Track will no longer request the `/userinfo` endpoint if all required claims  

--- a/docs/_docs/getting-started/openidconnect-configuration.md
+++ b/docs/_docs/getting-started/openidconnect-configuration.md
@@ -9,7 +9,7 @@ order: 10
 
 In the context of OAuth2 / OIDC, Dependency-Track's frontend acts as _client_ while the API server acts as _resource server_ (see [OAuth2 roles](https://tools.ietf.org/html/rfc6749#section-1.1)).
 Due to this, the frontend requires additional configuration, which is currently only supported when deploying it separately from the API server.
-Refer to the [Configuration]({{ site.baseurl }}{% link _docs/getting-started/configuration.md %}) and [Docker deployment]({{ site.baseurl }}{% link _docs/getting-started/deploy-docker.md %}) pages for instructions. "Classic" Dependency-Track deployments using solely the [executable WAR]({{ site.baseurl }}{% link _docs/getting-started/deploy-exewar.md %}) are not supported!
+Refer to the [Configuration]({{ site.baseurl }}{% link _docs/getting-started/configuration.md %}) and [Docker deployment]({{ site.baseurl }}{% link _docs/getting-started/deploy-docker.md %}) pages for instructions. The “bundled” Docker image and "Classic" Dependency-Track deployments using solely the [executable WAR]({{ site.baseurl }}{% link _docs/getting-started/deploy-exewar.md %}) are not supported!
 
 If configured properly, users will be able to sign in by clicking the _OpenID_ button on the login page:
 


### PR DESCRIPTION
### Description

While deploying DependencyTrack I noticed a few areas where the documentation around OpenID Connect could save some time. The OpenID connect login button and lack of support in the bundled containers both required a trip to the issue tracker to confirm.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
