### PR TITLE
Improve logging for notification publishing

### DIFF
--- a/docs/_docs/integrations/notifications.md
+++ b/docs/_docs/integrations/notifications.md
@@ -9,34 +9,52 @@ Dependency-Track includes a robust and configurable notification framework capab
 to the presence of newly discovered vulnerabilities, previously known vulnerable components that are added to
 projects, as well as providing notifications on various system and error conditions.
 
+## Scopes
 
-Dependency-Track notifications come in two flavors:
+Dependency-Track notifications come in two flavors (scopes):
 
-| Scope | Description |
-| ------|-------------|
-| SYSTEM    | Notifications on system-level informational and error conditions |
+| Scope     | Description                                                                           |
+|-----------|---------------------------------------------------------------------------------------|
+| SYSTEM    | Notifications on system-level informational and error conditions                      |
 | PORTFOLIO | Notifications on objects in the portfolio such as vulnerabilities and audit decisions |
 
+## Levels
 
-Each scope contains a set of notification groups that can be used to subscribe to.
+Notifications can have one of three possible levels:
 
-| Scope | Group | Description                                                                                                                       |
-| ------|-------|-----------------------------------------------------------------------------------------------------------------------------------|
-| SYSTEM | ANALYZER | Notifications generated as a result of interacting with an external source of vulnerability intelligence                          |
-| SYSTEM | DATASOURCE_MIRRORING | Notifications generated when performing mirroring of one of the supported datasources such as the NVD                             |
-| SYSTEM | INDEXING_SERVICE | Notifications generated as a result of performing maintenance on Dependency-Tracks internal index used for global searching       |
-| SYSTEM | FILE_SYSTEM | Notifications generated as a result of a file system operation. These are typically only generated on error conditions            |
-| SYSTEM | REPOSITORY | Notifications generated as a result of interacting with one of the supported repositories such as Maven Central, RubyGems, or NPM |
-| PORTFOLIO | NEW_VULNERABILITY | Notifications generated whenever a new vulnerability is identified                                                                |
-| PORTFOLIO | NEW_VULNERABLE_DEPENDENCY | Notifications generated as a result of a vulnerable component becoming a dependency of a project                                  |
-| PORTFOLIO | GLOBAL_AUDIT_CHANGE | Notifications generated whenever an analysis or suppression state has changed on a finding from a component (global)              |
-| PORTFOLIO | PROJECT_AUDIT_CHANGE | Notifications generated whenever an analysis or suppression state has changed on a finding from a project                         |
-| PORTFOLIO | BOM_CONSUMED | Notifications generated whenever a supported BOM is ingested and identified                                                       |
-| PORTFOLIO | BOM_PROCESSED | Notifications generated after a supported BOM is ingested, identified, and successfully processed                                 |
-| PORTFOLIO | BOM_PROCESSING_FAILED | Notifications generated whenever a BOM upload process fails                                 |
-| PORTFOLIO | POLICY_VIOLATION | Notifications generated whenever a policy violation is identified                                                                 |
+* INFORMATIONAL
+* WARNING
+* ERROR
+
+Notification levels behave identical to logging levels:
+
+* Configuring a rule for level INFORMATIONAL will match notifications of level INFORMATIONAL, WARNING, and ERROR
+* Configuring a rule for level WARNING will match notifications of level WARNING and ERROR
+* Configuring a rule for level ERROR will match notifications of level ERROR
+
+## Groups
+
+Each scope contains a set of notification groups that can be subscribed to. Some groups contain notifications of
+multiple levels, while others can only ever have a single level.
+
+| Scope     | Group                     | Level(s)      | Description                                                                                                                       |
+|-----------|---------------------------|---------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| SYSTEM    | ANALYZER                  | (Any)         | Notifications generated as a result of interacting with an external source of vulnerability intelligence                          |
+| SYSTEM    | DATASOURCE_MIRRORING      | (Any)         | Notifications generated when performing mirroring of one of the supported datasources such as the NVD                             |
+| SYSTEM    | INDEXING_SERVICE          | (Any)         | Notifications generated as a result of performing maintenance on Dependency-Tracks internal index used for global searching       |
+| SYSTEM    | FILE_SYSTEM               | (Any)         | Notifications generated as a result of a file system operation. These are typically only generated on error conditions            |
+| SYSTEM    | REPOSITORY                | (Any)         | Notifications generated as a result of interacting with one of the supported repositories such as Maven Central, RubyGems, or NPM |
+| PORTFOLIO | NEW_VULNERABILITY         | INFORMATIONAL | Notifications generated whenever a new vulnerability is identified                                                                |
+| PORTFOLIO | NEW_VULNERABLE_DEPENDENCY | INFORMATIONAL | Notifications generated as a result of a vulnerable component becoming a dependency of a project                                  |
+| PORTFOLIO | GLOBAL_AUDIT_CHANGE       | INFORMATIONAL | Notifications generated whenever an analysis or suppression state has changed on a finding from a component (global)              |
+| PORTFOLIO | PROJECT_AUDIT_CHANGE      | INFORMATIONAL | Notifications generated whenever an analysis or suppression state has changed on a finding from a project                         |
+| PORTFOLIO | BOM_CONSUMED              | INFORMATIONAL | Notifications generated whenever a supported BOM is ingested and identified                                                       |
+| PORTFOLIO | BOM_PROCESSED             | INFORMATIONAL | Notifications generated after a supported BOM is ingested, identified, and successfully processed                                 |
+| PORTFOLIO | BOM_PROCESSING_FAILED     | ERROR         | Notifications generated whenever a BOM upload process fails                                                                       |
+| PORTFOLIO | POLICY_VIOLATION          | INFORMATIONAL | Notifications generated whenever a policy violation is identified                                                                 |
 
 ## Configuring Publishers
+
 A notification publisher is a Dependency-Track concept allowing users to describe the structure of a notification (i.e. MIME type, template) and how to send a notification (i.e. publisher class).
 The following notification publishers are included by default :
 
@@ -59,7 +77,7 @@ The template context is enhanced with the following variables :
 | Variable               | Type                  | Description                                                                                                                |
 |------------------------|-----------------------|----------------------------------------------------------------------------------------------------------------------------|
 | timestampEpochSecond   | long                  | The notification timestamp                                                                                                 |
-| timestamp              | string                | The notification local date time in ISO 8601 format (i.e. uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS)                                |
+| timestamp              | string                | The notification local date time in ISO 8601 format (i.e. uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS)                                 |
 | notification.level     | enum                  | One of INFORMATIONAL, WARNING, or ERROR                                                                                    |
 | notification.scope     | string                | The high-level type of notification. One of SYSTEM or PORTFOLIO                                                            |
 | notification.group     | string                | The specific type of notification                                                                                          |
@@ -69,7 +87,7 @@ The template context is enhanced with the following variables :
 | notification.subject   | Object                | An optional object containing specifics of the notification                                                                |
 | baseUrl                | string                | Dependency Track base url                                                                                                  |
 | subject                | Specific              | An optional object containing specifics of the notification. It is casted whereas notification.subject is a generic Object |
-| subjectJson            | javax.json.JsonObject | An optional JSON representation of the subject                                                                            |
+| subjectJson            | javax.json.JsonObject | An optional JSON representation of the subject                                                                             |
 
 > The format of the subject object will vary depending on the scope and group of notification. Not all fields in the
 > subject will be present at all times. Some fields are optional since the underlying fields in the datamodel are optional.

--- a/docs/_posts/2023-xx-xx-v4.10.0.md
+++ b/docs/_posts/2023-xx-xx-v4.10.0.md
@@ -8,6 +8,7 @@ type: major
 * Add support for mirroring the NVD via its REST API - [apiserver/#3175]
   * Refer to the [NVD datasource documentation] for details
 * Improve efficiency of search index operations - [apiserver/#3116]
+* Add option to emit log for successfully published notifications, and improve logging around notifications in general - [apiserver/#3211]
 
 **Fixes:**
 
@@ -59,5 +60,6 @@ TBD
 [apiserver/#3117]: https://github.com/DependencyTrack/dependency-track/issues/3117
 [apiserver/#3175]: https://github.com/DependencyTrack/dependency-track/pull/3175
 [apiserver/#3209]: https://github.com/DependencyTrack/dependency-track/pull/3209
+[apiserver/#3211]: https://github.com/DependencyTrack/dependency-track/pull/3211
 
 [NVD datasource documentation]: {{ site.baseurl }}{% link _docs/datasources/nvd.md %}#mirroring-via-nvd-rest-api

--- a/src/main/java/org/dependencytrack/model/NotificationRule.java
+++ b/src/main/java/org/dependencytrack/model/NotificationRule.java
@@ -89,6 +89,18 @@ public class NotificationRule implements Serializable {
     @Column(name = "NOTIFY_CHILDREN", allowsNull = "true") // New column, must allow nulls on existing data bases)
     private boolean notifyChildren;
 
+    /**
+     * In addition to warnings and errors, also emit a log message upon successful publishing.
+     * <p>
+     * Intended to aid in debugging of missing notifications, or environments where notification
+     * delivery is critical and subject to auditing.
+     *
+     * @since 4.10.0
+     */
+    @Persistent
+    @Column(name = "LOG_SUCCESSFUL_PUBLISH", allowsNull = "true")
+    private boolean logSuccessfulPublish;
+
     @Persistent(defaultFetchGroup = "true")
     @Column(name = "SCOPE", jdbcType = "VARCHAR", allowsNull = "false")
     @NotNull
@@ -167,6 +179,14 @@ public class NotificationRule implements Serializable {
 
     public void setNotifyChildren(boolean notifyChildren) {
         this.notifyChildren = notifyChildren;
+    }
+
+    public boolean isLogSuccessfulPublish() {
+        return logSuccessfulPublish;
+    }
+
+    public void setLogSuccessfulPublish(final boolean logSuccessfulPublish) {
+        this.logSuccessfulPublish = logSuccessfulPublish;
     }
 
     @NotNull

--- a/src/main/java/org/dependencytrack/notification/NotificationRouter.java
+++ b/src/main/java/org/dependencytrack/notification/NotificationRouter.java
@@ -52,6 +52,9 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static org.dependencytrack.notification.publisher.Publisher.CONFIG_TEMPLATE_KEY;
+import static org.dependencytrack.notification.publisher.Publisher.CONFIG_TEMPLATE_MIME_TYPE_KEY;
+
 public class NotificationRouter implements Subscriber {
 
     private static final Logger LOGGER = Logger.getLogger(NotificationRouter.class);
@@ -59,7 +62,7 @@ public class NotificationRouter implements Subscriber {
     public void inform(final Notification notification) {
         final PublishContext ctx = PublishContext.from(notification);
 
-        for (final NotificationRule rule: resolveRules(notification)) {
+        for (final NotificationRule rule : resolveRules(ctx, notification)) {
             final PublishContext ruleCtx = ctx.withRule(rule);
 
             // Not all publishers need configuration (i.e. ConsolePublisher)
@@ -76,33 +79,32 @@ public class NotificationRouter implements Subscriber {
                 NotificationPublisher notificationPublisher = rule.getPublisher();
                 final Class<?> publisherClass = Class.forName(notificationPublisher.getPublisherClass());
                 if (Publisher.class.isAssignableFrom(publisherClass)) {
-                    final Publisher publisher = (Publisher)publisherClass.getDeclaredConstructor().newInstance();
+                    final Publisher publisher = (Publisher) publisherClass.getDeclaredConstructor().newInstance();
                     JsonObject notificationPublisherConfig = Json.createObjectBuilder()
-                                                                 .add(Publisher.CONFIG_TEMPLATE_MIME_TYPE_KEY, notificationPublisher.getTemplateMimeType())
-                                                                 .add(Publisher.CONFIG_TEMPLATE_KEY, notificationPublisher.getTemplate())
-                                                                 .addAll(Json.createObjectBuilder(config))
-                                                                         .build();
-                    if (publisherClass != SendMailPublisher.class || rule.getTeams().isEmpty() || rule.getTeams() == null){
+                            .add(CONFIG_TEMPLATE_MIME_TYPE_KEY, notificationPublisher.getTemplateMimeType())
+                            .add(CONFIG_TEMPLATE_KEY, notificationPublisher.getTemplate())
+                            .addAll(Json.createObjectBuilder(config))
+                            .build();
+                    if (publisherClass != SendMailPublisher.class || rule.getTeams().isEmpty() || rule.getTeams() == null) {
                         publisher.inform(ruleCtx, restrictNotificationToRuleProjects(notification, rule), notificationPublisherConfig);
                     } else {
-                        ((SendMailPublisher)publisher).inform(ruleCtx, restrictNotificationToRuleProjects(notification, rule), notificationPublisherConfig, rule.getTeams());
+                        ((SendMailPublisher) publisher).inform(ruleCtx, restrictNotificationToRuleProjects(notification, rule), notificationPublisherConfig, rule.getTeams());
                     }
-
-
                 } else {
                     LOGGER.error("The defined notification publisher is not assignable from " + Publisher.class.getCanonicalName() + " (%s)".formatted(ruleCtx));
                 }
-            } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | InvocationTargetException | IllegalAccessException e) {
+            } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException |
+                     InvocationTargetException | IllegalAccessException e) {
                 LOGGER.error("An error occurred while instantiating a notification publisher (%s)".formatted(ruleCtx), e);
             } catch (PublisherException publisherException) {
-                LOGGER.error("An error occured during the publication of the notification (%s)".formatted(ruleCtx), publisherException);
+                LOGGER.error("An error occurred during the publication of the notification (%s)".formatted(ruleCtx), publisherException);
             }
         }
     }
 
-    public Notification restrictNotificationToRuleProjects(Notification initialNotification, NotificationRule rule) {
+    public Notification restrictNotificationToRuleProjects(final Notification initialNotification, final NotificationRule rule) {
         Notification restrictedNotification = initialNotification;
-        if(canRestrictNotificationToRuleProjects(initialNotification, rule)) {
+        if (canRestrictNotificationToRuleProjects(initialNotification, rule)) {
             Set<String> ruleProjectsUuids = rule.getProjects().stream().map(Project::getUuid).map(UUID::toString).collect(Collectors.toSet());
             restrictedNotification = new Notification();
             restrictedNotification.setGroup(initialNotification.getGroup());
@@ -111,7 +113,7 @@ public class NotificationRouter implements Subscriber {
             restrictedNotification.setContent(initialNotification.getContent());
             restrictedNotification.setTitle(initialNotification.getTitle());
             restrictedNotification.setTimestamp(initialNotification.getTimestamp());
-            if(initialNotification.getSubject() instanceof final NewVulnerabilityIdentified subject) {
+            if (initialNotification.getSubject() instanceof final NewVulnerabilityIdentified subject) {
                 Set<Project> restrictedProjects = subject.getAffectedProjects().stream().filter(project -> ruleProjectsUuids.contains(project.getUuid().toString())).collect(Collectors.toSet());
                 NewVulnerabilityIdentified restrictedSubject = new NewVulnerabilityIdentified(subject.getVulnerability(), subject.getComponent(), restrictedProjects, null);
                 restrictedNotification.setSubject(restrictedSubject);
@@ -120,19 +122,19 @@ public class NotificationRouter implements Subscriber {
         return restrictedNotification;
     }
 
-    private boolean canRestrictNotificationToRuleProjects(Notification initialNotification, NotificationRule rule) {
-        return initialNotification.getSubject() instanceof NewVulnerabilityIdentified &&
-                rule.getProjects() != null
-                && rule.getProjects().size() > 0;
+    private boolean canRestrictNotificationToRuleProjects(final Notification initialNotification, final NotificationRule rule) {
+        return initialNotification.getSubject() instanceof NewVulnerabilityIdentified
+                && rule.getProjects() != null
+                && !rule.getProjects().isEmpty();
     }
 
-    List<NotificationRule> resolveRules(final Notification notification) {
-        // The notification rules to process for this specific notification
+    List<NotificationRule> resolveRules(final PublishContext ctx, final Notification notification) {
         final List<NotificationRule> rules = new ArrayList<>();
-
         if (notification == null || notification.getScope() == null || notification.getGroup() == null || notification.getLevel() == null) {
+            LOGGER.debug("Mandatory fields of notification are missing; Unable to resolve rules (%s)".formatted(ctx));
             return rules;
         }
+
         try (QueryManager qm = new QueryManager()) {
             final PersistenceManager pm = qm.getPersistenceManager();
             final Query<NotificationRule> query = pm.newQuery(NotificationRule.class);
@@ -153,6 +155,7 @@ public class NotificationRouter implements Subscriber {
             query.setParameters(NotificationScope.valueOf(notification.getScope()));
             final List<NotificationRule> result = query.executeList();
             pm.detachCopyAll(result);
+            LOGGER.debug("Matched %d notification rules (%s)".formatted(result.size(), ctx));
 
             if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
                     && notification.getSubject() instanceof final NewVulnerabilityIdentified subject) {
@@ -160,10 +163,10 @@ public class NotificationRouter implements Subscriber {
                 // of the notification down to those projects that the rule matches and which
                 // also match project the component is included in.
                 // NOTE: This logic is slightly different from what is implemented in limitToProject()
-                for (final NotificationRule rule: result) {
+                for (final NotificationRule rule : result) {
                     if (rule.getNotifyOn().contains(NotificationGroup.valueOf(notification.getGroup()))) {
-                        if (rule.getProjects() != null && rule.getProjects().size() > 0
-                            && subject.getComponent() != null && subject.getComponent().getProject() != null) {
+                        if (rule.getProjects() != null && !rule.getProjects().isEmpty()
+                                && subject.getComponent() != null && subject.getComponent().getProject() != null) {
                             for (final Project project : rule.getProjects()) {
                                 if (subject.getComponent().getProject().getUuid().equals(project.getUuid()) || (Boolean.TRUE.equals(rule.isNotifyChildren() && checkIfChildrenAreAffected(project, subject.getComponent().getProject().getUuid())))) {
                                     rules.add(rule);
@@ -176,27 +179,27 @@ public class NotificationRouter implements Subscriber {
                 }
             } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
                     && notification.getSubject() instanceof final NewVulnerableDependency subject) {
-                limitToProject(rules, result, notification, subject.getComponent().getProject());
+                limitToProject(ctx, rules, result, notification, subject.getComponent().getProject());
             } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
                     && notification.getSubject() instanceof final BomConsumedOrProcessed subject) {
-                limitToProject(rules, result, notification, subject.getProject());
+                limitToProject(ctx, rules, result, notification, subject.getProject());
             } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
                     && notification.getSubject() instanceof final BomProcessingFailed subject) {
-                limitToProject(rules, result, notification, subject.getProject());
+                limitToProject(ctx, rules, result, notification, subject.getProject());
             } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
                     && notification.getSubject() instanceof final VexConsumedOrProcessed subject) {
-                limitToProject(rules, result, notification, subject.getProject());
+                limitToProject(ctx, rules, result, notification, subject.getProject());
             } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
                     && notification.getSubject() instanceof final PolicyViolationIdentified subject) {
-                limitToProject(rules, result, notification, subject.getProject());
+                limitToProject(ctx, rules, result, notification, subject.getProject());
             } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
                     && notification.getSubject() instanceof final AnalysisDecisionChange subject) {
-                limitToProject(rules, result, notification, subject.getProject());
+                limitToProject(ctx, rules, result, notification, subject.getProject());
             } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
                     && notification.getSubject() instanceof final ViolationAnalysisDecisionChange subject) {
-                limitToProject(rules, result, notification, subject.getComponent().getProject());
+                limitToProject(ctx, rules, result, notification, subject.getComponent().getProject());
             } else {
-                for (final NotificationRule rule: result) {
+                for (final NotificationRule rule : result) {
                     if (rule.getNotifyOn().contains(NotificationGroup.valueOf(notification.getGroup()))) {
                         rules.add(rule);
                     }
@@ -210,22 +213,42 @@ public class NotificationRouter implements Subscriber {
      * if the rule specified one or more projects as targets, reduce the execution
      * of the notification down to those projects that the rule matches and which
      * also match projects affected by the vulnerability.
-     * */
-    private void limitToProject(final List<NotificationRule> applicableRules, final List<NotificationRule> rules,
-                                final Notification notification, final Project limitToProject) {
-        for (final NotificationRule rule: rules) {
+     */
+    private void limitToProject(final PublishContext ctx, final List<NotificationRule> applicableRules,
+                                final List<NotificationRule> rules, final Notification notification,
+                                final Project limitToProject) {
+        for (final NotificationRule rule : rules) {
+            final PublishContext ruleCtx = ctx.withRule(rule);
             if (rule.getNotifyOn().contains(NotificationGroup.valueOf(notification.getGroup()))) {
-                if (rule.getProjects() != null && rule.getProjects().size() > 0) {
+                if (rule.getProjects() != null && !rule.getProjects().isEmpty()) {
                     for (final Project project : rule.getProjects()) {
-                        if (project.getUuid().equals(limitToProject.getUuid()) || (Boolean.TRUE.equals(rule.isNotifyChildren()) && checkIfChildrenAreAffected(project, limitToProject.getUuid()))) {
+                        if (project.getUuid().equals(limitToProject.getUuid())) {
+                            LOGGER.debug("Project %s is part of the \"limit to\" list of the rule; Rule is applicable (%s)"
+                                    .formatted(limitToProject.getUuid(), ruleCtx));
                             applicableRules.add(rule);
+                        } else if (rule.isNotifyChildren()) {
+                            final boolean isChildOfLimitToProject = checkIfChildrenAreAffected(project, limitToProject.getUuid());
+                            if (isChildOfLimitToProject) {
+                                LOGGER.debug("Project %s is child of \"limit to\" project %s; Rule is applicable (%s)"
+                                        .formatted(limitToProject.getUuid(), project.getUuid(), ruleCtx));
+                                applicableRules.add(rule);
+                            } else {
+                                LOGGER.debug("Project %s is not a child of \"limit to\" project %s; Rule is not applicable (%s)"
+                                        .formatted(limitToProject.getUuid(), project.getUuid(), ruleCtx));
+                            }
+                        } else {
+                            LOGGER.debug("Project %s is not part of the \"limit to\" list of the rule; Rule is not applicable (%s)"
+                                    .formatted(limitToProject.getUuid(), ruleCtx));
                         }
                     }
                 } else {
+                    LOGGER.debug("Rule is not limited to projects; Rule is applicable (%s)".formatted(ruleCtx));
                     applicableRules.add(rule);
                 }
             }
         }
+        LOGGER.debug("Applicable rules: %s (%s)"
+                .formatted(applicableRules.stream().map(NotificationRule::getName).collect(Collectors.joining(", ")), ctx));
     }
 
     private boolean checkIfChildrenAreAffected(Project parent, UUID uuid) {

--- a/src/main/java/org/dependencytrack/notification/publisher/AbstractWebhookPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/AbstractWebhookPublisher.java
@@ -23,9 +23,7 @@ import io.pebbletemplates.pebble.template.PebbleTemplate;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.util.EntityUtils;
 import org.dependencytrack.common.HttpClientPool;
-import org.dependencytrack.exception.PublisherException;
 import org.dependencytrack.util.HttpUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,30 +32,43 @@ import javax.json.JsonObject;
 import java.io.IOException;
 
 public abstract class AbstractWebhookPublisher implements Publisher {
-    public void publish(final PublishContext ctx, final String publisherName, final PebbleTemplate template, final Notification notification, final JsonObject config) {
+
+    public void publish(final PublishContext ctx, final PebbleTemplate template, final Notification notification, final JsonObject config) {
         final Logger logger = LoggerFactory.getLogger(getClass());
-        logger.debug("Preparing to publish " + publisherName + " notification");
+
         if (config == null) {
-            logger.warn("No configuration found. Skipping notification. (%s)".formatted(ctx));
+            logger.warn("No publisher configuration found; Skipping notification (%s)".formatted(ctx));
             return;
         }
+
         final String destination = getDestinationUrl(config);
-        final String content = prepareTemplate(ctx, notification, template);
-        if (destination == null || content == null) {
-            logger.warn("A destination or template was not found. Skipping notification (%s)".formatted(ctx));
+        if (destination == null) {
+            logger.warn("No destination configured; Skipping notification (%s)".formatted(ctx));
             return;
         }
+
+        final AuthCredentials credentials;
+        try {
+            credentials = getAuthCredentials();
+        } catch (RuntimeException e) {
+            logger.warn("""
+                    An error occurred during the retrieval of credentials needed for notification \
+                    publication; Skipping notification (%s)""".formatted(ctx), e);
+            return;
+        }
+
+        final String content;
+        try {
+            content = prepareTemplate(notification, template);
+        } catch (IOException | RuntimeException e) {
+            logger.error("Failed to prepare notification content (%s)".formatted(ctx), e);
+            return;
+        }
+
         final String mimeType = getTemplateMimeType(config);
         var request = new HttpPost(destination);
         request.addHeader("content-type", mimeType);
         request.addHeader("accept", mimeType);
-        final AuthCredentials credentials;
-        try {
-            credentials = getAuthCredentials();
-        } catch (PublisherException e) {
-            logger.warn("An error occurred during the retrieval of credentials needed for notification publication. Skipping notification (%s)".formatted(ctx), e);
-            return;
-        }
         if (credentials != null) {
             if(credentials.user() != null) {
                 request.addHeader("Authorization", HttpUtil.basicAuthHeaderValue(credentials.user(), credentials.password()));
@@ -69,11 +80,13 @@ public abstract class AbstractWebhookPublisher implements Publisher {
         try {
             request.setEntity(new StringEntity(content));
             try (final CloseableHttpResponse response = HttpClientPool.getClient().execute(request)) {
-                if (response.getStatusLine().getStatusCode() < 200 || response.getStatusLine().getStatusCode() >= 300) {
-                    logger.error("An error was encountered publishing notification to " + publisherName +
-                            "with HTTP Status : " + response.getStatusLine().getStatusCode() + " " + response.getStatusLine().getReasonPhrase() +
-                            " Destination: " + destination + " Response: " + EntityUtils.toString(response.getEntity()));
-                    logger.debug(content);
+                final int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode < 200 || statusCode >= 300) {
+                    logger.warn("Destination %s responded with with status code %d, likely indicating a processing failure (%s)"
+                            .formatted(maybeSanitizeDestinationUrl(destination), statusCode, ctx));
+                } else if (ctx.logSuccess()) {
+                    logger.info("Destination %s acknowledged reception of notification with status code %d (%s)"
+                            .formatted(maybeSanitizeDestinationUrl(destination), statusCode, ctx));
                 }
             }
         } catch (IOException ex) {
@@ -82,9 +95,19 @@ public abstract class AbstractWebhookPublisher implements Publisher {
     }
 
     protected String getDestinationUrl(final JsonObject config) {
-        return config.getString(CONFIG_DESTINATION);
+        return config.getString(CONFIG_DESTINATION, null);
     }
 
+    /**
+     * Sanitize the destination URL from any secrets that are not supposed to be logged.
+     *
+     * @param destinationUrl The destination URL to sanitize
+     * @return The sanitized destination URL
+     * @since 4.10.0
+     */
+    protected String maybeSanitizeDestinationUrl(final String destinationUrl) {
+        return destinationUrl;
+    }
 
     protected AuthCredentials getAuthCredentials() {
         return null;
@@ -94,6 +117,7 @@ public abstract class AbstractWebhookPublisher implements Publisher {
     }
 
     protected void handleRequestException(final PublishContext ctx, final Logger logger, final Exception e) {
-        logger.error("Request failure (%s)".formatted(ctx), e);
+        logger.error("Failed to send notification request (%s)".formatted(ctx), e);
     }
+
 }

--- a/src/main/java/org/dependencytrack/notification/publisher/AbstractWebhookPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/AbstractWebhookPublisher.java
@@ -34,17 +34,17 @@ import javax.json.JsonObject;
 import java.io.IOException;
 
 public abstract class AbstractWebhookPublisher implements Publisher {
-    public void publish(final String publisherName, final PebbleTemplate template, final Notification notification, final JsonObject config) {
+    public void publish(final PublishContext ctx, final String publisherName, final PebbleTemplate template, final Notification notification, final JsonObject config) {
         final Logger logger = LoggerFactory.getLogger(getClass());
         logger.debug("Preparing to publish " + publisherName + " notification");
         if (config == null) {
-            logger.warn("No configuration found. Skipping notification.");
+            logger.warn("No configuration found. Skipping notification. (%s)".formatted(ctx));
             return;
         }
         final String destination = getDestinationUrl(config);
-        final String content = prepareTemplate(notification, template);
+        final String content = prepareTemplate(ctx, notification, template);
         if (destination == null || content == null) {
-            logger.warn("A destination or template was not found. Skipping notification");
+            logger.warn("A destination or template was not found. Skipping notification (%s)".formatted(ctx));
             return;
         }
         final String mimeType = getTemplateMimeType(config);
@@ -55,7 +55,7 @@ public abstract class AbstractWebhookPublisher implements Publisher {
         try {
             credentials = getAuthCredentials();
         } catch (PublisherException e) {
-            logger.warn("An error occurred during the retrieval of credentials needed for notification publication. Skipping notification", e);
+            logger.warn("An error occurred during the retrieval of credentials needed for notification publication. Skipping notification (%s)".formatted(ctx), e);
             return;
         }
         if (credentials != null) {
@@ -77,7 +77,7 @@ public abstract class AbstractWebhookPublisher implements Publisher {
                 }
             }
         } catch (IOException ex) {
-            handleRequestException(logger, ex);
+            handleRequestException(ctx, logger, ex);
         }
     }
 
@@ -93,7 +93,7 @@ public abstract class AbstractWebhookPublisher implements Publisher {
     protected record AuthCredentials(String user, String password) {
     }
 
-    protected void handleRequestException(final Logger logger, final Exception e) {
-        logger.error("Request failure", e);
+    protected void handleRequestException(final PublishContext ctx, final Logger logger, final Exception e) {
+        logger.error("Request failure (%s)".formatted(ctx), e);
     }
 }

--- a/src/main/java/org/dependencytrack/notification/publisher/ConsolePublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/ConsolePublisher.java
@@ -31,10 +31,10 @@ public class ConsolePublisher implements Publisher {
     private static final Logger LOGGER = Logger.getLogger(ConsolePublisher.class);
     private static final PebbleEngine ENGINE = new PebbleEngine.Builder().newLineTrimming(false).build();
 
-    public void inform(final Notification notification, final JsonObject config) {
-        final String content = prepareTemplate(notification, getTemplate(config));
+    public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
+        final String content = prepareTemplate(ctx, notification, getTemplate(config));
         if (content == null) {
-            LOGGER.warn("A template was not found. Skipping notification");
+            LOGGER.warn("A template was not found. Skipping notification (%s)".formatted(ctx));
             return;
         }
         final PrintStream ps;

--- a/src/main/java/org/dependencytrack/notification/publisher/ConsolePublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/ConsolePublisher.java
@@ -24,6 +24,7 @@ import alpine.notification.NotificationLevel;
 import io.pebbletemplates.pebble.PebbleEngine;
 
 import javax.json.JsonObject;
+import java.io.IOException;
 import java.io.PrintStream;
 
 public class ConsolePublisher implements Publisher {
@@ -32,9 +33,11 @@ public class ConsolePublisher implements Publisher {
     private static final PebbleEngine ENGINE = new PebbleEngine.Builder().newLineTrimming(false).build();
 
     public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
-        final String content = prepareTemplate(ctx, notification, getTemplate(config));
-        if (content == null) {
-            LOGGER.warn("A template was not found. Skipping notification (%s)".formatted(ctx));
+        final String content;
+        try {
+            content = prepareTemplate(notification, getTemplate(config));
+        } catch (IOException | RuntimeException e) {
+            LOGGER.error("Failed to prepare notification content (%s)".formatted(ctx), e);
             return;
         }
         final PrintStream ps;

--- a/src/main/java/org/dependencytrack/notification/publisher/CsWebexPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/CsWebexPublisher.java
@@ -28,7 +28,7 @@ public class CsWebexPublisher extends AbstractWebhookPublisher implements Publis
     private static final PebbleEngine ENGINE = new PebbleEngine.Builder().defaultEscapingStrategy("json").build();
 
     public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
-        publish(ctx, DefaultNotificationPublishers.CS_WEBEX.getPublisherName(), getTemplate(config), notification, config);
+        publish(ctx, getTemplate(config), notification, config);
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/notification/publisher/CsWebexPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/CsWebexPublisher.java
@@ -27,8 +27,8 @@ public class CsWebexPublisher extends AbstractWebhookPublisher implements Publis
 
     private static final PebbleEngine ENGINE = new PebbleEngine.Builder().defaultEscapingStrategy("json").build();
 
-    public void inform(final Notification notification, final JsonObject config) {
-        publish(DefaultNotificationPublishers.CS_WEBEX.getPublisherName(), getTemplate(config), notification, config);
+    public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
+        publish(ctx, DefaultNotificationPublishers.CS_WEBEX.getPublisherName(), getTemplate(config), notification, config);
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/notification/publisher/DefaultNotificationPublishers.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/DefaultNotificationPublishers.java
@@ -31,14 +31,14 @@ public enum DefaultNotificationPublishers {
     CS_WEBEX("Cisco Webex", "Publishes notifications to a Cisco Webex Teams channel", CsWebexPublisher.class, "/templates/notification/publisher/cswebex.peb", MediaType.APPLICATION_JSON, true),
     JIRA("Jira", "Creates a Jira issue in a configurable Jira instance and queue", JiraPublisher.class, "/templates/notification/publisher/jira.peb", MediaType.APPLICATION_JSON, true);
 
-    private String name;
-    private String description;
-    private Class publisherClass;
-    private String templateFile;
-    private String templateMimeType;
-    private boolean defaultPublisher;
+    private final String name;
+    private final String description;
+    private final Class<? extends Publisher> publisherClass;
+    private final String templateFile;
+    private final String templateMimeType;
+    private final boolean defaultPublisher;
 
-    DefaultNotificationPublishers(final String name, final String description, final Class publisherClass,
+    DefaultNotificationPublishers(final String name, final String description, final Class<? extends Publisher> publisherClass,
                                   final String templateFile, final String templateMimeType, final boolean defaultPublisher) {
         this.name = name;
         this.description = description;
@@ -56,7 +56,7 @@ public enum DefaultNotificationPublishers {
         return description;
     }
 
-    public Class getPublisherClass() {
+    public Class<? extends Publisher> getPublisherClass() {
         return publisherClass;
     }
 

--- a/src/main/java/org/dependencytrack/notification/publisher/JiraPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/JiraPublisher.java
@@ -40,16 +40,33 @@ import static org.dependencytrack.model.ConfigPropertyConstants.JIRA_USERNAME;
  * @since 4.7
  */
 public class JiraPublisher extends AbstractWebhookPublisher implements Publisher {
+
     private static final Logger LOGGER = Logger.getLogger(JiraPublisher.class);
     private static final PebbleEngine ENGINE = new PebbleEngine.Builder().defaultEscapingStrategy("json").build();
+
     private String jiraProjectKey;
     private String jiraTicketType;
 
     @Override
     public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
-        jiraTicketType = config.getString("jiraTicketType");
-        jiraProjectKey = config.getString(CONFIG_DESTINATION);
-        publish(ctx, DefaultNotificationPublishers.JIRA.getPublisherName(), getTemplate(config), notification, config);
+        if (config == null) {
+            LOGGER.warn("No publisher configuration provided; Skipping notification (%s)".formatted(ctx));
+            return;
+        }
+
+        jiraTicketType = config.getString("jiraTicketType", null);
+        if (jiraTicketType == null) {
+            LOGGER.warn("No JIRA ticket type configured; Skipping notification (%s)".formatted(ctx));
+            return;
+        }
+
+        jiraProjectKey = config.getString(CONFIG_DESTINATION, null);
+        if (jiraProjectKey == null) {
+            LOGGER.warn("No JIRA project key configured; Skipping notification (%s)".formatted(ctx));
+            return;
+        }
+
+        publish(ctx, getTemplate(config), notification, config);
     }
 
     @Override
@@ -68,7 +85,7 @@ public class JiraPublisher extends AbstractWebhookPublisher implements Publisher
     }
 
     @Override
-    public AuthCredentials getAuthCredentials() {
+    protected AuthCredentials getAuthCredentials() {
         try (final QueryManager qm = new QueryManager()) {
             final ConfigProperty jiraUsernameProp = qm.getConfigProperty(JIRA_USERNAME.getGroupName(), JIRA_USERNAME.getPropertyName());
             final String jiraUsername = (jiraUsernameProp == null) ? null : jiraUsernameProp.getPropertyValue();

--- a/src/main/java/org/dependencytrack/notification/publisher/JiraPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/JiraPublisher.java
@@ -46,10 +46,10 @@ public class JiraPublisher extends AbstractWebhookPublisher implements Publisher
     private String jiraTicketType;
 
     @Override
-    public void inform(final Notification notification, final JsonObject config) {
+    public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
         jiraTicketType = config.getString("jiraTicketType");
         jiraProjectKey = config.getString(CONFIG_DESTINATION);
-        publish(DefaultNotificationPublishers.JIRA.getPublisherName(), getTemplate(config), notification, config);
+        publish(ctx, DefaultNotificationPublishers.JIRA.getPublisherName(), getTemplate(config), notification, config);
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/notification/publisher/MattermostPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/MattermostPublisher.java
@@ -27,8 +27,8 @@ public class MattermostPublisher extends AbstractWebhookPublisher implements Pub
 
     private static final PebbleEngine ENGINE = new PebbleEngine.Builder().defaultEscapingStrategy("json").build();
 
-    public void inform(final Notification notification, final JsonObject config) {
-        publish(DefaultNotificationPublishers.MATTERMOST.getPublisherName(), getTemplate(config), notification, config);
+    public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
+        publish(ctx, DefaultNotificationPublishers.MATTERMOST.getPublisherName(), getTemplate(config), notification, config);
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/notification/publisher/MattermostPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/MattermostPublisher.java
@@ -28,7 +28,7 @@ public class MattermostPublisher extends AbstractWebhookPublisher implements Pub
     private static final PebbleEngine ENGINE = new PebbleEngine.Builder().defaultEscapingStrategy("json").build();
 
     public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
-        publish(ctx, DefaultNotificationPublishers.MATTERMOST.getPublisherName(), getTemplate(config), notification, config);
+        publish(ctx, getTemplate(config), notification, config);
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/notification/publisher/MsTeamsPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/MsTeamsPublisher.java
@@ -28,7 +28,7 @@ public class MsTeamsPublisher extends AbstractWebhookPublisher implements Publis
     private static final PebbleEngine ENGINE = new PebbleEngine.Builder().defaultEscapingStrategy("json").build();
 
     public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
-        publish(ctx, DefaultNotificationPublishers.MS_TEAMS.getPublisherName(), getTemplate(config), notification, config);
+        publish(ctx, getTemplate(config), notification, config);
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/notification/publisher/MsTeamsPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/MsTeamsPublisher.java
@@ -27,8 +27,8 @@ public class MsTeamsPublisher extends AbstractWebhookPublisher implements Publis
 
     private static final PebbleEngine ENGINE = new PebbleEngine.Builder().defaultEscapingStrategy("json").build();
 
-    public void inform(final Notification notification, final JsonObject config) {
-        publish(DefaultNotificationPublishers.MS_TEAMS.getPublisherName(), getTemplate(config), notification, config);
+    public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
+        publish(ctx, DefaultNotificationPublishers.MS_TEAMS.getPublisherName(), getTemplate(config), notification, config);
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/notification/publisher/PublishContext.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/PublishContext.java
@@ -134,7 +134,6 @@ public record PublishContext(String notificationGroup, String notificationLevel,
                 .add("ruleName", ruleName)
                 .add("ruleScope", ruleScope)
                 .add("ruleLevel", ruleLevel)
-                .add("logSuccess", logSuccess)
                 .omitNullValues()
                 .toString();
     }

--- a/src/main/java/org/dependencytrack/notification/publisher/PublishContext.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/PublishContext.java
@@ -48,6 +48,7 @@ import java.util.UUID;
  * @param ruleName              Name of the matched {@link NotificationRule}
  * @param ruleScope             Scope of the matched {@link NotificationRule}
  * @param ruleLevel             Level of the matched {@link NotificationRule}
+ * @param logSuccess            Whether the publisher shall emit a log message upon successful publishing
  * @since 4.10.0
  */
 public record PublishContext(String notificationGroup, String notificationLevel, String notificationScope,
@@ -107,6 +108,10 @@ public record PublishContext(String notificationGroup, String notificationLevel,
     public PublishContext withRule(final NotificationRule rule) {
         return new PublishContext(this.notificationGroup, this.notificationLevel, this.notificationScope, this.notificationTimestamp,
                 this.notificationSubjects, rule.getName(), rule.getScope().name(), rule.getNotificationLevel().name(), rule.isLogSuccessfulPublish());
+    }
+
+    public boolean shouldLogSuccess() {
+        return logSuccess != null && logSuccess;
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/notification/publisher/PublishContext.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/PublishContext.java
@@ -58,6 +58,8 @@ public record PublishContext(String notificationGroup, String notificationLevel,
     private static final String SUBJECT_COMPONENT = "component";
     private static final String SUBJECT_PROJECT = "project";
     private static final String SUBJECT_PROJECTS = "projects";
+    private static final String SUBJECT_VULNERABILITY = "vulnerability";
+    private static final String SUBJECT_VULNERABILITIES = "vulnerabilities";
 
     public static PublishContext from(final Notification notification) {
         if (notification == null) {
@@ -76,9 +78,15 @@ public record PublishContext(String notificationGroup, String notificationLevel,
             } else {
                 notificationSubjects.put(SUBJECT_PROJECTS, null);
             }
+            notificationSubjects.put(SUBJECT_VULNERABILITY, Vulnerability.convert(subject.getVulnerability()));
         } else if (notification.getSubject() instanceof final NewVulnerableDependency subject) {
             notificationSubjects.put(SUBJECT_COMPONENT, Component.convert(subject.getComponent()));
             notificationSubjects.put(SUBJECT_PROJECT, Project.convert(subject.getComponent().getProject()));
+            if (subject.getVulnerabilities() != null) {
+                notificationSubjects.put(SUBJECT_VULNERABILITIES, subject.getVulnerabilities().stream().map(Vulnerability::convert).toList());
+            } else {
+                notificationSubjects.put(SUBJECT_VULNERABILITIES, null);
+            }
         } else if (notification.getSubject() instanceof final org.dependencytrack.model.Project subject) {
             notificationSubjects.put(SUBJECT_PROJECT, Project.convert(subject));
         } else if (notification.getSubject() instanceof final PolicyViolationIdentified subject) {
@@ -90,6 +98,7 @@ public record PublishContext(String notificationGroup, String notificationLevel,
         } else if (notification.getSubject() instanceof final AnalysisDecisionChange subject) {
             notificationSubjects.put(SUBJECT_COMPONENT, Component.convert(subject.getComponent()));
             notificationSubjects.put(SUBJECT_PROJECT, Project.convert(subject.getProject()));
+            notificationSubjects.put(SUBJECT_VULNERABILITY, Vulnerability.convert(subject.getVulnerability()));
         } else if (notification.getSubject() instanceof final VexConsumedOrProcessed subject) {
             notificationSubjects.put(SUBJECT_PROJECT, Project.convert(subject.getProject()));
         }
@@ -157,6 +166,17 @@ public record PublishContext(String notificationGroup, String notificationLevel,
                     notificationProject.getName(),
                     notificationProject.getVersion()
             );
+        }
+
+    }
+
+    public record Vulnerability(String id, String source) {
+
+        private static Vulnerability convert(final org.dependencytrack.model.Vulnerability notificationVuln) {
+            if (notificationVuln == null) {
+                return null;
+            }
+            return new Vulnerability(notificationVuln.getVulnId(), notificationVuln.getSource());
         }
 
     }

--- a/src/main/java/org/dependencytrack/notification/publisher/PublishContext.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/PublishContext.java
@@ -1,0 +1,132 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.notification.publisher;
+
+import alpine.notification.Notification;
+import org.dependencytrack.model.NotificationRule;
+import org.dependencytrack.notification.vo.AnalysisDecisionChange;
+import org.dependencytrack.notification.vo.BomConsumedOrProcessed;
+import org.dependencytrack.notification.vo.BomProcessingFailed;
+import org.dependencytrack.notification.vo.NewVulnerabilityIdentified;
+import org.dependencytrack.notification.vo.NewVulnerableDependency;
+import org.dependencytrack.notification.vo.PolicyViolationIdentified;
+import org.dependencytrack.notification.vo.VexConsumedOrProcessed;
+import org.dependencytrack.notification.vo.ViolationAnalysisDecisionChange;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Context information about a {@link Notification} being published.
+ *
+ * @param notificationGroup     Group of the {@link Notification} being published
+ * @param notificationLevel     Level of the {@link Notification} being published
+ * @param notificationScope     Scope of the {@link Notification} being published
+ * @param notificationTimestamp UTC Timestamp in {@link DateTimeFormatter#ISO_DATE_TIME} of the {@link Notification} being published
+ * @param notificationSubjects  Subject(s) of the {@link Notification} being published
+ * @param ruleName              Name of the matched {@link NotificationRule}
+ * @param ruleScope             Scope of the matched {@link NotificationRule}
+ * @param ruleLevel             Level of the matched {@link NotificationRule}
+ * @since 4.10.0
+ */
+public record PublishContext(String notificationGroup, String notificationLevel, String notificationScope,
+                             String notificationTimestamp, Map<String, Object> notificationSubjects,
+                             String ruleName, String ruleScope, String ruleLevel) {
+
+    private static final String SUBJECT_COMPONENT = "component";
+    private static final String SUBJECT_PROJECT = "project";
+    private static final String SUBJECT_PROJECTS = "projects";
+
+    public static PublishContext from(final Notification notification) {
+        final var notificationSubjects = new HashMap<String, Object>();
+        if (notification.getSubject() instanceof final BomConsumedOrProcessed subject) {
+            notificationSubjects.put(SUBJECT_PROJECT, Project.convert(subject.getProject()));
+        } else if (notification.getSubject() instanceof final BomProcessingFailed subject) {
+            notificationSubjects.put(SUBJECT_PROJECT, Project.convert(subject.getProject()));
+        } else if (notification.getSubject() instanceof final NewVulnerabilityIdentified subject) {
+            notificationSubjects.put(SUBJECT_COMPONENT, Component.convert(subject.getComponent()));
+            notificationSubjects.put(SUBJECT_PROJECTS, subject.getAffectedProjects().stream().map(Project::convert).toList());
+        } else if (notification.getSubject() instanceof final NewVulnerableDependency subject) {
+            notificationSubjects.put(SUBJECT_COMPONENT, Component.convert(subject.getComponent()));
+            notificationSubjects.put(SUBJECT_PROJECT, Project.convert(subject.getComponent().getProject()));
+        } else if (notification.getSubject() instanceof final org.dependencytrack.model.Project subject) {
+            notificationSubjects.put(SUBJECT_PROJECT, Project.convert(subject));
+        } else if (notification.getSubject() instanceof final PolicyViolationIdentified subject) {
+            notificationSubjects.put(SUBJECT_COMPONENT, Component.convert(subject.getComponent()));
+            notificationSubjects.put(SUBJECT_PROJECT, Project.convert(subject.getProject()));
+        } else if (notification.getSubject() instanceof final ViolationAnalysisDecisionChange subject) {
+            notificationSubjects.put(SUBJECT_COMPONENT, Component.convert(subject.getComponent()));
+            notificationSubjects.put(SUBJECT_PROJECT, Project.convert(subject.getComponent().getProject()));
+        } else if (notification.getSubject() instanceof final AnalysisDecisionChange subject) {
+            notificationSubjects.put(SUBJECT_COMPONENT, Component.convert(subject.getComponent()));
+            notificationSubjects.put(SUBJECT_PROJECT, Project.convert(subject.getProject()));
+        } else if (notification.getSubject() instanceof final VexConsumedOrProcessed subject) {
+            notificationSubjects.put(SUBJECT_PROJECT, Project.convert(subject.getProject()));
+        }
+
+        return new PublishContext(notification.getGroup(), notification.getLevel().name(), notification.getScope(),
+                notification.getTimestamp().atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME), notificationSubjects,
+                /* ruleName */ null, /* ruleScope */ null, /* ruleLevel */ null);
+    }
+
+    /**
+     * Enrich the {@link PublishContext} with additional information about the {@link NotificationRule} once known.
+     *
+     * @param rule The applicable {@link NotificationRule}
+     * @return This {@link PublishContext}
+     */
+    public PublishContext withRule(final NotificationRule rule) {
+        return new PublishContext(this.notificationGroup, this.notificationLevel, this.notificationScope, this.notificationTimestamp,
+                this.notificationSubjects, rule.getName(), rule.getScope().name(), rule.getNotificationLevel().name());
+    }
+
+    public record Component(String uuid, String group, String name, String version) {
+
+        private static Component convert(final org.dependencytrack.model.Component notificationComponent) {
+            if (notificationComponent == null) {
+                return null;
+            }
+            return new Component(
+                    notificationComponent.getUuid().toString(),
+                    notificationComponent.getGroup(),
+                    notificationComponent.getName(),
+                    notificationComponent.getVersion()
+            );
+        }
+
+    }
+
+    public record Project(String uuid, String name, String version) {
+
+        private static Project convert(final org.dependencytrack.model.Project notificationProject) {
+            if (notificationProject == null) {
+                return null;
+            }
+            return new Project(
+                    notificationProject.getUuid().toString(),
+                    notificationProject.getName(),
+                    notificationProject.getVersion()
+            );
+        }
+
+    }
+
+}

--- a/src/main/java/org/dependencytrack/notification/publisher/PublishContext.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/PublishContext.java
@@ -33,6 +33,8 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Context information about a {@link Notification} being published.
@@ -63,7 +65,11 @@ public record PublishContext(String notificationGroup, String notificationLevel,
             notificationSubjects.put(SUBJECT_PROJECT, Project.convert(subject.getProject()));
         } else if (notification.getSubject() instanceof final NewVulnerabilityIdentified subject) {
             notificationSubjects.put(SUBJECT_COMPONENT, Component.convert(subject.getComponent()));
-            notificationSubjects.put(SUBJECT_PROJECTS, subject.getAffectedProjects().stream().map(Project::convert).toList());
+            if (subject.getAffectedProjects() != null) {
+                notificationSubjects.put(SUBJECT_PROJECTS, subject.getAffectedProjects().stream().map(Project::convert).toList());
+            } else {
+                notificationSubjects.put(SUBJECT_PROJECTS, null);
+            }
         } else if (notification.getSubject() instanceof final NewVulnerableDependency subject) {
             notificationSubjects.put(SUBJECT_COMPONENT, Component.convert(subject.getComponent()));
             notificationSubjects.put(SUBJECT_PROJECT, Project.convert(subject.getComponent().getProject()));
@@ -105,7 +111,7 @@ public record PublishContext(String notificationGroup, String notificationLevel,
                 return null;
             }
             return new Component(
-                    notificationComponent.getUuid().toString(),
+                    Optional.ofNullable(notificationComponent.getUuid()).map(UUID::toString).orElse(null),
                     notificationComponent.getGroup(),
                     notificationComponent.getName(),
                     notificationComponent.getVersion()
@@ -121,7 +127,7 @@ public record PublishContext(String notificationGroup, String notificationLevel,
                 return null;
             }
             return new Project(
-                    notificationProject.getUuid().toString(),
+                    Optional.ofNullable(notificationProject.getUuid()).map(UUID::toString).orElse(null),
                     notificationProject.getName(),
                     notificationProject.getVersion()
             );

--- a/src/main/java/org/dependencytrack/notification/publisher/Publisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/Publisher.java
@@ -54,7 +54,7 @@ public interface Publisher {
 
     String CONFIG_DESTINATION = "destination";
 
-    void inform(Notification notification, JsonObject config);
+    void inform(final PublishContext ctx, final Notification notification, final JsonObject config);
 
     PebbleEngine getTemplateEngine();
 
@@ -78,7 +78,7 @@ public interface Publisher {
     default void enrichTemplateContext(final Map<String, Object> context) {
     }
 
-    default String prepareTemplate(final Notification notification, final PebbleTemplate template) {
+    default String prepareTemplate(final PublishContext ctx, final Notification notification, final PebbleTemplate template) {
 
         try (QueryManager qm = new QueryManager()) {
             final ConfigProperty baseUrlProperty = qm.getConfigProperty(
@@ -133,7 +133,7 @@ public interface Publisher {
                 template.evaluate(writer, context);
                 return writer.toString();
             } catch (IOException e) {
-                Logger.getLogger(this.getClass()).error("An error was encountered evaluating template", e);
+                Logger.getLogger(this.getClass()).error("An error was encountered evaluating template (%s)".formatted(ctx), e);
                 return null;
             }
         }

--- a/src/main/java/org/dependencytrack/notification/publisher/Publisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/Publisher.java
@@ -18,7 +18,6 @@
  */
 package org.dependencytrack.notification.publisher;
 
-import alpine.common.logging.Logger;
 import alpine.common.util.UrlUtil;
 import alpine.model.ConfigProperty;
 import alpine.notification.Notification;
@@ -78,8 +77,7 @@ public interface Publisher {
     default void enrichTemplateContext(final Map<String, Object> context) {
     }
 
-    default String prepareTemplate(final PublishContext ctx, final Notification notification, final PebbleTemplate template) {
-
+    default String prepareTemplate(final Notification notification, final PebbleTemplate template) throws IOException {
         try (QueryManager qm = new QueryManager()) {
             final ConfigProperty baseUrlProperty = qm.getConfigProperty(
                     ConfigPropertyConstants.GENERAL_BASE_URL.getGroupName(),
@@ -132,9 +130,6 @@ public interface Publisher {
             try (final Writer writer = new StringWriter()) {
                 template.evaluate(writer, context);
                 return writer.toString();
-            } catch (IOException e) {
-                Logger.getLogger(this.getClass()).error("An error was encountered evaluating template (%s)".formatted(ctx), e);
-                return null;
             }
         }
     }

--- a/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
@@ -56,30 +56,30 @@ public class SendMailPublisher implements Publisher {
     private static final Logger LOGGER = Logger.getLogger(SendMailPublisher.class);
     private static final PebbleEngine ENGINE = new PebbleEngine.Builder().newLineTrimming(false).build();
 
-    public void inform(final Notification notification, final JsonObject config) {
+    public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
         if (config == null) {
-            LOGGER.warn("No configuration found. Skipping notification.");
+            LOGGER.warn("No configuration found. Skipping notification. (%s)".formatted(ctx));
             return;
         }
         final String[] destinations = parseDestination(config);
-        sendNotification(notification, config, destinations);
+        sendNotification(ctx, notification, config, destinations);
     }
 
-    public void inform(final Notification notification, final JsonObject config, List<Team> teams) {
+    public void inform(final PublishContext ctx, final Notification notification, final JsonObject config, List<Team> teams) {
         if (config == null) {
-            LOGGER.warn("No configuration found. Skipping notification.");
+            LOGGER.warn("No configuration found. Skipping notification. (%s)".formatted(ctx));
             return;
         }
         final String[] destinations = parseDestination(config, teams);
-        sendNotification(notification, config, destinations);
+        sendNotification(ctx, notification, config, destinations);
     }
 
-    private void sendNotification(Notification notification, JsonObject config, String[] destinations) {
+    private void sendNotification(final PublishContext ctx, Notification notification, JsonObject config, String[] destinations) {
         PebbleTemplate template = getTemplate(config);
         String mimeType = getTemplateMimeType(config);
-        final String content = prepareTemplate(notification, template);
+        final String content = prepareTemplate(ctx, notification, template);
         if (destinations == null || content == null) {
-            LOGGER.warn("A destination or template was not found. Skipping notification");
+            LOGGER.warn("A destination or template was not found. Skipping notification (%s)".formatted(ctx));
             return;
         }
         try (QueryManager qm = new QueryManager()) {
@@ -113,7 +113,7 @@ public class SendMailPublisher implements Publisher {
                     .trustCert(Boolean.valueOf(smtpTrustCert.getPropertyValue()));
             sendMail.send();
         } catch (Exception e) {
-            LOGGER.error("An error occurred sending output email notification", e);
+            LOGGER.error("An error occurred sending output email notification (%s)".formatted(ctx), e);
         }
   }
 

--- a/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
@@ -153,7 +153,7 @@ public class SendMailPublisher implements Publisher {
             return;
         }
 
-        if (ctx.logSuccess()) {
+        if (ctx.shouldLogSuccess()) {
             LOGGER.info("Notification email sent successfully via %s:%d (%s)"
                     .formatted(smtpHostname, smtpPort, ctx));
         }

--- a/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
@@ -19,8 +19,6 @@
 package org.dependencytrack.notification.publisher;
 
 import alpine.common.logging.Logger;
-import alpine.common.util.BooleanUtil;
-import alpine.model.ConfigProperty;
 import alpine.model.LdapUser;
 import alpine.model.ManagedUser;
 import alpine.model.OidcUser;
@@ -28,12 +26,14 @@ import alpine.model.Team;
 import alpine.notification.Notification;
 import alpine.security.crypto.DataEncryption;
 import alpine.server.mail.SendMail;
+import alpine.server.mail.SendMailException;
 import io.pebbletemplates.pebble.PebbleEngine;
 import io.pebbletemplates.pebble.template.PebbleTemplate;
 import org.dependencytrack.persistence.QueryManager;
 
 import javax.json.JsonObject;
 import javax.json.JsonString;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -58,7 +58,7 @@ public class SendMailPublisher implements Publisher {
 
     public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
         if (config == null) {
-            LOGGER.warn("No configuration found. Skipping notification. (%s)".formatted(ctx));
+            LOGGER.warn("No configuration found; Skipping notification (%s)".formatted(ctx));
             return;
         }
         final String[] destinations = parseDestination(config);
@@ -75,45 +75,87 @@ public class SendMailPublisher implements Publisher {
     }
 
     private void sendNotification(final PublishContext ctx, Notification notification, JsonObject config, String[] destinations) {
-        PebbleTemplate template = getTemplate(config);
-        String mimeType = getTemplateMimeType(config);
-        final String content = prepareTemplate(ctx, notification, template);
-        if (destinations == null || content == null) {
-            LOGGER.warn("A destination or template was not found. Skipping notification (%s)".formatted(ctx));
+        if (config == null) {
+            LOGGER.warn("No publisher configuration found; Skipping notification (%s)".formatted(ctx));
             return;
         }
-        try (QueryManager qm = new QueryManager()) {
-            final ConfigProperty smtpEnabled = qm.getConfigProperty(EMAIL_SMTP_ENABLED.getGroupName(), EMAIL_SMTP_ENABLED.getPropertyName());
-            final ConfigProperty smtpFrom = qm.getConfigProperty(EMAIL_SMTP_FROM_ADDR.getGroupName(), EMAIL_SMTP_FROM_ADDR.getPropertyName());
-            final ConfigProperty smtpHostname = qm.getConfigProperty(EMAIL_SMTP_SERVER_HOSTNAME.getGroupName(), EMAIL_SMTP_SERVER_HOSTNAME.getPropertyName());
-            final ConfigProperty smtpPort = qm.getConfigProperty(EMAIL_SMTP_SERVER_PORT.getGroupName(), EMAIL_SMTP_SERVER_PORT.getPropertyName());
-            final ConfigProperty smtpUser = qm.getConfigProperty(EMAIL_SMTP_USERNAME.getGroupName(), EMAIL_SMTP_USERNAME.getPropertyName());
-            final ConfigProperty smtpPass = qm.getConfigProperty(EMAIL_SMTP_PASSWORD.getGroupName(), EMAIL_SMTP_PASSWORD.getPropertyName());
-            final ConfigProperty smtpSslTls = qm.getConfigProperty(EMAIL_SMTP_SSLTLS.getGroupName(), EMAIL_SMTP_SSLTLS.getPropertyName());
-            final ConfigProperty smtpTrustCert = qm.getConfigProperty(EMAIL_SMTP_TRUSTCERT.getGroupName(), EMAIL_SMTP_TRUSTCERT.getPropertyName());
+        if (destinations == null) {
+            LOGGER.warn("No destination(s) provided; Skipping notification (%s)".formatted(ctx));
+            return;
+        }
 
-            if (!BooleanUtil.valueOf(smtpEnabled.getPropertyValue())) {
-                LOGGER.warn("SMTP is not enabled");
-                return; // smtp is not enabled
+        final String content;
+        final String mimeType;
+        try {
+            final PebbleTemplate template = getTemplate(config);
+            mimeType = getTemplateMimeType(config);
+            content = prepareTemplate(notification, template);
+        } catch (IOException | RuntimeException e) {
+            LOGGER.error("Failed to prepare notification content (%s)".formatted(ctx), e);
+            return;
+        }
+
+        final boolean smtpEnabled;
+        final String smtpFrom;
+        final String smtpHostname;
+        final int smtpPort;
+        final String smtpUser;
+        final String encryptedSmtpPassword;
+        final boolean smtpSslTls;
+        final boolean smtpTrustCert;
+
+        try (QueryManager qm = new QueryManager()) {
+            smtpEnabled = qm.isEnabled(EMAIL_SMTP_ENABLED);
+            if (!smtpEnabled) {
+                LOGGER.warn("SMTP is not enabled; Skipping notification (%s)".formatted(ctx));
+                return;
             }
-            final boolean smtpAuth = (smtpUser.getPropertyValue() != null && smtpPass.getPropertyValue() != null);
-            final String password = (smtpPass.getPropertyValue() != null) ? DataEncryption.decryptAsString(smtpPass.getPropertyValue()) : null;
+
+            smtpFrom = qm.getConfigProperty(EMAIL_SMTP_FROM_ADDR.getGroupName(), EMAIL_SMTP_FROM_ADDR.getPropertyName()).getPropertyValue();
+            smtpHostname = qm.getConfigProperty(EMAIL_SMTP_SERVER_HOSTNAME.getGroupName(), EMAIL_SMTP_SERVER_HOSTNAME.getPropertyName()).getPropertyValue();
+            smtpPort = Integer.parseInt(qm.getConfigProperty(EMAIL_SMTP_SERVER_PORT.getGroupName(), EMAIL_SMTP_SERVER_PORT.getPropertyName()).getPropertyValue());
+            smtpUser = qm.getConfigProperty(EMAIL_SMTP_USERNAME.getGroupName(), EMAIL_SMTP_USERNAME.getPropertyName()).getPropertyValue();
+            encryptedSmtpPassword = qm.getConfigProperty(EMAIL_SMTP_PASSWORD.getGroupName(), EMAIL_SMTP_PASSWORD.getPropertyName()).getPropertyValue();
+            smtpSslTls = qm.isEnabled(EMAIL_SMTP_SSLTLS);
+            smtpTrustCert = qm.isEnabled(EMAIL_SMTP_TRUSTCERT);
+        } catch (RuntimeException e) {
+            LOGGER.error("Failed to load SMTP configuration from datastore (%s)".formatted(ctx), e);
+            return;
+        }
+
+        final boolean smtpAuth = (smtpUser != null && encryptedSmtpPassword != null);
+        final String decryptedSmtpPassword;
+        try {
+            decryptedSmtpPassword = (encryptedSmtpPassword != null) ? DataEncryption.decryptAsString(encryptedSmtpPassword) : null;
+        } catch (Exception e) {
+            LOGGER.error("Failed to decrypt SMTP password (%s)".formatted(ctx), e);
+            return;
+        }
+
+        try {
             final SendMail sendMail = new SendMail()
-                    .from(smtpFrom.getPropertyValue())
+                    .from(smtpFrom)
                     .to(destinations)
                     .subject("[Dependency-Track] " + notification.getTitle())
                     .body(content)
                     .bodyMimeType(mimeType)
-                    .host(smtpHostname.getPropertyValue())
-                    .port(Integer.valueOf(smtpPort.getPropertyValue()))
-                    .username(smtpUser.getPropertyValue())
-                    .password(password)
+                    .host(smtpHostname)
+                    .port(smtpPort)
+                    .username(smtpUser)
+                    .password(decryptedSmtpPassword)
                     .smtpauth(smtpAuth)
-                    .useStartTLS(BooleanUtil.valueOf(smtpSslTls.getPropertyValue()))
-                    .trustCert(Boolean.valueOf(smtpTrustCert.getPropertyValue()));
+                    .useStartTLS(smtpSslTls)
+                    .trustCert(smtpTrustCert);
             sendMail.send();
-        } catch (Exception e) {
-            LOGGER.error("An error occurred sending output email notification (%s)".formatted(ctx), e);
+        } catch (SendMailException | RuntimeException e) {
+            LOGGER.error("Failed to send notification email via %s:%d (%s)"
+                    .formatted(smtpHostname, smtpPort, ctx), e);
+            return;
+        }
+
+        if (ctx.logSuccess()) {
+            LOGGER.info("Notification email sent successfully via %s:%d (%s)"
+                    .formatted(smtpHostname, smtpPort, ctx));
         }
   }
 

--- a/src/main/java/org/dependencytrack/notification/publisher/SlackPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/SlackPublisher.java
@@ -19,30 +19,13 @@
 package org.dependencytrack.notification.publisher;
 
 import alpine.notification.Notification;
-import alpine.server.cache.AbstractCacheManager;
-import alpine.server.cache.CacheManager;
 import io.pebbletemplates.pebble.PebbleEngine;
-import org.apache.commons.codec.digest.DigestUtils;
 
 import javax.json.JsonObject;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class SlackPublisher extends AbstractWebhookPublisher implements Publisher {
 
     private static final PebbleEngine ENGINE = new PebbleEngine.Builder().defaultEscapingStrategy("json").build();
-    private static final Pattern WEBHOOK_URL_PATTERN =
-            Pattern.compile("^(?<prefix>https://hooks\\.slack\\.com/services/T[A-Z0-9]+/B[A-Z0-9]+/)(?<secret>[A-Za-z0-9]{23,25})$");
-
-    private final AbstractCacheManager cacheManager;
-
-    public SlackPublisher() {
-        this(CacheManager.getInstance());
-    }
-
-    SlackPublisher(final AbstractCacheManager cacheManager) {
-        this.cacheManager = cacheManager;
-    }
 
     public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
         publish(ctx, getTemplate(config), notification, config);
@@ -51,27 +34,6 @@ public class SlackPublisher extends AbstractWebhookPublisher implements Publishe
     @Override
     public PebbleEngine getTemplateEngine() {
         return ENGINE;
-    }
-
-    @Override
-    protected String maybeSanitizeDestinationUrl(final String destinationUrl) {
-        if (destinationUrl == null) {
-            return null;
-        }
-
-        return cacheManager.get(String.class,
-                "%s-%s".formatted(getClass().getSimpleName(), DigestUtils.sha1Hex(destinationUrl)),
-                key -> {
-                    final Matcher matcher = WEBHOOK_URL_PATTERN.matcher(destinationUrl);
-                    if (matcher.find()) {
-                        final String prefix = matcher.group("prefix");
-                        final String secret = matcher.group("secret");
-                        final String maskedSecret = "*".repeat(secret.length() - 4) + secret.substring(secret.length() - 4);
-                        return prefix + maskedSecret;
-                    }
-
-                    return destinationUrl;
-                });
     }
 
 }

--- a/src/main/java/org/dependencytrack/notification/publisher/SlackPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/SlackPublisher.java
@@ -27,8 +27,8 @@ public class SlackPublisher extends AbstractWebhookPublisher implements Publishe
 
     private static final PebbleEngine ENGINE = new PebbleEngine.Builder().defaultEscapingStrategy("json").build();
 
-    public void inform(final Notification notification, final JsonObject config) {
-        publish(DefaultNotificationPublishers.SLACK.getPublisherName(), getTemplate(config), notification, config);
+    public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
+        publish(ctx, DefaultNotificationPublishers.SLACK.getPublisherName(), getTemplate(config), notification, config);
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/notification/publisher/SlackPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/SlackPublisher.java
@@ -19,21 +19,59 @@
 package org.dependencytrack.notification.publisher;
 
 import alpine.notification.Notification;
+import alpine.server.cache.AbstractCacheManager;
+import alpine.server.cache.CacheManager;
 import io.pebbletemplates.pebble.PebbleEngine;
+import org.apache.commons.codec.digest.DigestUtils;
 
 import javax.json.JsonObject;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class SlackPublisher extends AbstractWebhookPublisher implements Publisher {
 
     private static final PebbleEngine ENGINE = new PebbleEngine.Builder().defaultEscapingStrategy("json").build();
+    private static final Pattern WEBHOOK_URL_PATTERN =
+            Pattern.compile("^(?<prefix>https://hooks\\.slack\\.com/services/T[A-Z0-9]+/B[A-Z0-9]+/)(?<secret>[A-Za-z0-9]{23,25})$");
+
+    private final AbstractCacheManager cacheManager;
+
+    public SlackPublisher() {
+        this(CacheManager.getInstance());
+    }
+
+    SlackPublisher(final AbstractCacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
 
     public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
-        publish(ctx, DefaultNotificationPublishers.SLACK.getPublisherName(), getTemplate(config), notification, config);
+        publish(ctx, getTemplate(config), notification, config);
     }
 
     @Override
     public PebbleEngine getTemplateEngine() {
         return ENGINE;
+    }
+
+    @Override
+    protected String maybeSanitizeDestinationUrl(final String destinationUrl) {
+        if (destinationUrl == null) {
+            return null;
+        }
+
+        return cacheManager.get(String.class,
+                "%s-%s".formatted(getClass().getSimpleName(), DigestUtils.sha1Hex(destinationUrl)),
+                key -> {
+                    final Matcher matcher = WEBHOOK_URL_PATTERN.matcher(destinationUrl);
+                    if (matcher.find()) {
+                        final String prefix = matcher.group("prefix");
+                        final String secret = matcher.group("secret");
+                        final String maskedSecret = "*".repeat(secret.length() - 4) + secret.substring(secret.length() - 4);
+                        return prefix + maskedSecret;
+                    }
+
+                    return destinationUrl;
+                });
     }
 
 }

--- a/src/main/java/org/dependencytrack/notification/publisher/WebhookPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/WebhookPublisher.java
@@ -27,8 +27,8 @@ public class WebhookPublisher extends AbstractWebhookPublisher implements Publis
 
     private static final PebbleEngine ENGINE = new PebbleEngine.Builder().defaultEscapingStrategy("json").build();
 
-    public void inform(final Notification notification, final JsonObject config) {
-        publish(DefaultNotificationPublishers.WEBHOOK.getPublisherName(), getTemplate(config), notification, config);
+    public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
+        publish(ctx, DefaultNotificationPublishers.WEBHOOK.getPublisherName(), getTemplate(config), notification, config);
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/notification/publisher/WebhookPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/WebhookPublisher.java
@@ -28,7 +28,7 @@ public class WebhookPublisher extends AbstractWebhookPublisher implements Publis
     private static final PebbleEngine ENGINE = new PebbleEngine.Builder().defaultEscapingStrategy("json").build();
 
     public void inform(final PublishContext ctx, final Notification notification, final JsonObject config) {
-        publish(ctx, DefaultNotificationPublishers.WEBHOOK.getPublisherName(), getTemplate(config), notification, config);
+        publish(ctx, getTemplate(config), notification, config);
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/persistence/NotificationQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/NotificationQueryManager.java
@@ -68,6 +68,7 @@ public class NotificationQueryManager extends QueryManager implements IQueryMana
         rule.setPublisher(publisher);
         rule.setEnabled(true);
         rule.setNotifyChildren(true);
+        rule.setLogSuccessfulPublish(false);
         return persist(rule);
     }
 
@@ -81,6 +82,7 @@ public class NotificationQueryManager extends QueryManager implements IQueryMana
         rule.setName(transientRule.getName());
         rule.setEnabled(transientRule.isEnabled());
         rule.setNotifyChildren(transientRule.isNotifyChildren());
+        rule.setLogSuccessfulPublish(transientRule.isLogSuccessfulPublish());
         rule.setNotificationLevel(transientRule.getNotificationLevel());
         rule.setPublisherConfig(transientRule.getPublisherConfig());
         rule.setNotifyOn(transientRule.getNotifyOn());
@@ -133,7 +135,7 @@ public class NotificationQueryManager extends QueryManager implements IQueryMana
      * @param clazz The Class of the NotificationPublisher
      * @return a NotificationPublisher
      */
-    public NotificationPublisher getDefaultNotificationPublisher(final Class<Publisher> clazz) {
+    public NotificationPublisher getDefaultNotificationPublisher(final Class<? extends Publisher> clazz) {
         return getDefaultNotificationPublisher(clazz.getCanonicalName());
     }
 
@@ -155,7 +157,7 @@ public class NotificationQueryManager extends QueryManager implements IQueryMana
      * @return a NotificationPublisher
      */
     public NotificationPublisher createNotificationPublisher(final String name, final String description,
-                                                             final Class<Publisher> publisherClass, final String templateContent,
+                                                             final Class<? extends Publisher> publisherClass, final String templateContent,
                                                              final String templateMimeType, final boolean defaultPublisher) {
         pm.currentTransaction().begin();
         final NotificationPublisher publisher = new NotificationPublisher();

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1156,12 +1156,12 @@ public class QueryManager extends AlpineQueryManager {
         return getNotificationQueryManager().getNotificationPublisher(name);
     }
 
-    public NotificationPublisher getDefaultNotificationPublisher(final Class<Publisher> clazz) {
+    public NotificationPublisher getDefaultNotificationPublisher(final Class<? extends Publisher> clazz) {
         return getNotificationQueryManager().getDefaultNotificationPublisher(clazz);
     }
 
     public NotificationPublisher createNotificationPublisher(final String name, final String description,
-                                                             final Class<Publisher> publisherClass, final String templateContent,
+                                                             final Class<? extends Publisher> publisherClass, final String templateContent,
                                                              final String templateMimeType, final boolean defaultPublisher) {
         return getNotificationQueryManager().createNotificationPublisher(name, description, publisherClass, templateContent, templateMimeType, defaultPublisher);
     }

--- a/src/main/java/org/dependencytrack/resources/v1/NotificationPublisherResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/NotificationPublisherResource.java
@@ -24,13 +24,11 @@ import alpine.notification.Notification;
 import alpine.notification.NotificationLevel;
 import alpine.server.auth.PermissionRequired;
 import alpine.server.resources.AlpineResource;
-
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponses;
-import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Api;
-
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.ConfigPropertyConstants;
@@ -39,6 +37,7 @@ import org.dependencytrack.model.NotificationRule;
 import org.dependencytrack.notification.NotificationConstants;
 import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationScope;
+import org.dependencytrack.notification.publisher.PublishContext;
 import org.dependencytrack.notification.publisher.Publisher;
 import org.dependencytrack.notification.publisher.SendMailPublisher;
 import org.dependencytrack.persistence.QueryManager;
@@ -47,8 +46,6 @@ import org.dependencytrack.util.NotificationUtil;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.validation.Validator;
-
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.FormParam;
@@ -58,7 +55,6 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -295,7 +291,7 @@ public class NotificationPublisherResource extends AlpineResource {
                     .content("SMTP configuration test")
                     .level(NotificationLevel.INFORMATIONAL);
             // Bypass Notification.dispatch() and go directly to the publisher itself
-            emailPublisher.inform(notification, config);
+            emailPublisher.inform(PublishContext.from(notification), notification, config);
             return Response.ok().build();
         } catch (InvocationTargetException | InstantiationException | IllegalAccessException | NoSuchMethodException e) {
             LOGGER.error(e.getMessage(), e);

--- a/src/test/java/org/dependencytrack/notification/NotificationRouterTest.java
+++ b/src/test/java/org/dependencytrack/notification/NotificationRouterTest.java
@@ -30,6 +30,7 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vex;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.notification.publisher.DefaultNotificationPublishers;
+import org.dependencytrack.notification.publisher.PublishContext;
 import org.dependencytrack.notification.publisher.Publisher;
 import org.dependencytrack.notification.vo.AnalysisDecisionChange;
 import org.dependencytrack.notification.vo.BomConsumedOrProcessed;
@@ -697,7 +698,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         }
 
         @Override
-        public void inform(Notification notification, JsonObject config) {
+        public void inform(final PublishContext ctx, Notification notification, JsonObject config) {
             MockPublisher.config = config;
             MockPublisher.notification = notification;
         }

--- a/src/test/java/org/dependencytrack/notification/NotificationRouterTest.java
+++ b/src/test/java/org/dependencytrack/notification/NotificationRouterTest.java
@@ -58,7 +58,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
     public void testNullNotification() {
         Notification notification = null;
         NotificationRouter router = new NotificationRouter();
-        List<NotificationRule> rules = router.resolveRules(notification);
+        List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
         Assert.assertEquals(0, rules.size());
     }
 
@@ -66,7 +66,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
     public void testInvalidNotification() {
         Notification notification = new Notification();
         NotificationRouter router = new NotificationRouter();
-        List<NotificationRule> rules = router.resolveRules(notification);
+        List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
         Assert.assertEquals(0, rules.size());
     }
 
@@ -77,7 +77,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setGroup(NotificationGroup.NEW_VULNERABILITY.name());
         notification.setLevel(NotificationLevel.INFORMATIONAL);
         NotificationRouter router = new NotificationRouter();
-        List<NotificationRule> rules = router.resolveRules(notification);
+        List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
         Assert.assertEquals(0, rules.size());
     }
 
@@ -99,7 +99,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
-        List<NotificationRule> rules = router.resolveRules(notification);
+        List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
         Assert.assertEquals(1, rules.size());
     }
 
@@ -128,7 +128,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
-        List<NotificationRule> rules = router.resolveRules(notification);
+        List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
         Assert.assertEquals(1, rules.size());
     }
 
@@ -158,7 +158,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
-        List<NotificationRule> rules = router.resolveRules(notification);
+        List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
         Assert.assertEquals(1, rules.size());
     }
 
@@ -245,7 +245,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
-        List<NotificationRule> rules = router.resolveRules(notification);
+        List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
         Assert.assertEquals(0, rules.size());
     }
 
@@ -261,7 +261,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setLevel(NotificationLevel.WARNING); // Rule level is equal
 
         final var router = new NotificationRouter();
-        assertThat(router.resolveRules(notification)).hasSize(1);
+        assertThat(router.resolveRules(PublishContext.from(notification), notification)).hasSize(1);
     }
 
     @Test
@@ -276,7 +276,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setLevel(NotificationLevel.ERROR); // Rule level is lower
 
         final var router = new NotificationRouter();
-        assertThat(router.resolveRules(notification)).hasSize(1);
+        assertThat(router.resolveRules(PublishContext.from(notification), notification)).hasSize(1);
     }
 
     @Test
@@ -292,7 +292,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setLevel(NotificationLevel.INFORMATIONAL); // Rule level is higher
 
         final var router = new NotificationRouter();
-        assertThat(router.resolveRules(notification)).isEmpty();
+        assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
     }
 
     @Test
@@ -309,7 +309,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setLevel(NotificationLevel.INFORMATIONAL);
 
         final var router = new NotificationRouter();
-        assertThat(router.resolveRules(notification)).isEmpty();
+        assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
     }
 
     @Test
@@ -339,10 +339,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setSubject(new NewVulnerabilityIdentified(null, componentB, Set.of(), null));
 
         final var router = new NotificationRouter();
-        assertThat(router.resolveRules(notification)).isEmpty();
+        assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
 
         notification.setSubject(new NewVulnerabilityIdentified(null, componentA, Set.of(), null));
-        assertThat(router.resolveRules(notification))
+        assertThat(router.resolveRules(PublishContext.from(notification), notification))
                 .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
     }
 
@@ -373,10 +373,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setSubject(new NewVulnerableDependency(componentB, null));
 
         final var router = new NotificationRouter();
-        assertThat(router.resolveRules(notification)).isEmpty();
+        assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
 
         notification.setSubject(new NewVulnerableDependency(componentA, null));
-        assertThat(router.resolveRules(notification))
+        assertThat(router.resolveRules(PublishContext.from(notification), notification))
                 .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
     }
 
@@ -398,10 +398,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setSubject(new BomConsumedOrProcessed(projectB, "", Bom.Format.CYCLONEDX, ""));
 
         final var router = new NotificationRouter();
-        assertThat(router.resolveRules(notification)).isEmpty();
+        assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
 
         notification.setSubject(new BomConsumedOrProcessed(projectA, "", Bom.Format.CYCLONEDX, ""));
-        assertThat(router.resolveRules(notification))
+        assertThat(router.resolveRules(PublishContext.from(notification), notification))
                 .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
     }
 
@@ -423,10 +423,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setSubject(new BomProcessingFailed(projectB, "", null, Bom.Format.CYCLONEDX, ""));
 
         final var router = new NotificationRouter();
-        assertThat(router.resolveRules(notification)).isEmpty();
+        assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
 
         notification.setSubject(new BomProcessingFailed(projectA, "", null, Bom.Format.CYCLONEDX, ""));
-        assertThat(router.resolveRules(notification))
+        assertThat(router.resolveRules(PublishContext.from(notification), notification))
                 .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
     }
 
@@ -448,10 +448,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setSubject(new VexConsumedOrProcessed(projectB, "", Vex.Format.CYCLONEDX, ""));
 
         final var router = new NotificationRouter();
-        assertThat(router.resolveRules(notification)).isEmpty();
+        assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
 
         notification.setSubject(new VexConsumedOrProcessed(projectA, "", Vex.Format.CYCLONEDX, ""));
-        assertThat(router.resolveRules(notification))
+        assertThat(router.resolveRules(PublishContext.from(notification), notification))
                 .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
     }
 
@@ -482,10 +482,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setSubject(new PolicyViolationIdentified(null, componentB, projectB));
 
         final var router = new NotificationRouter();
-        assertThat(router.resolveRules(notification)).isEmpty();
+        assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
 
         notification.setSubject(new PolicyViolationIdentified(null, componentA, projectA));
-        assertThat(router.resolveRules(notification))
+        assertThat(router.resolveRules(PublishContext.from(notification), notification))
                 .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
     }
 
@@ -507,10 +507,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setSubject(new AnalysisDecisionChange(null, null, projectB, null));
 
         final var router = new NotificationRouter();
-        assertThat(router.resolveRules(notification)).isEmpty();
+        assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
 
         notification.setSubject(new AnalysisDecisionChange(null, null, projectA, null));
-        assertThat(router.resolveRules(notification))
+        assertThat(router.resolveRules(PublishContext.from(notification), notification))
                 .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
     }
 
@@ -541,10 +541,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setSubject(new ViolationAnalysisDecisionChange(null, componentB, null));
 
         final var router = new NotificationRouter();
-        assertThat(router.resolveRules(notification)).isEmpty();
+        assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
 
         notification.setSubject(new ViolationAnalysisDecisionChange(null, componentA, null));
-        assertThat(router.resolveRules(notification))
+        assertThat(router.resolveRules(PublishContext.from(notification), notification))
                 .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
     }
 
@@ -579,7 +579,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
-        List<NotificationRule> rules = router.resolveRules(notification);
+        List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
         Assert.assertTrue(rule.isNotifyChildren());
         Assert.assertEquals(1, rules.size());
     }
@@ -616,7 +616,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
-        List<NotificationRule> rules = router.resolveRules(notification);
+        List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
         Assert.assertFalse(rule.isNotifyChildren());
         Assert.assertEquals(0, rules.size());
     }
@@ -652,7 +652,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
-        List<NotificationRule> rules = router.resolveRules(notification);
+        List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
         Assert.assertTrue(rule.isNotifyChildren());
         Assert.assertEquals(0, rules.size());
     }
@@ -673,7 +673,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         return qm.createNotificationPublisher(
                 MockPublisher.MOCK_PUBLISHER_NAME,
                 MockPublisher.MOCK_PUBLISHER_DESCRIPTION,
-                (Class) NotificationRouterTest.MockPublisher.class,
+                NotificationRouterTest.MockPublisher.class,
                 MockPublisher.MOCK_PUBLISHER_TEMPLATE_CONTENT, MockPublisher.MOCK_PUBLISHER_TEMPLATE_MIME_TYPE,
                 true
         );

--- a/src/test/java/org/dependencytrack/notification/publisher/AbstractPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/AbstractPublisherTest.java
@@ -76,7 +76,7 @@ public abstract class AbstractPublisherTest<T extends Publisher> extends Persist
                 .subject(subject);
 
         assertThatNoException()
-                .isThrownBy(() -> publisherInstance.inform(notification, createConfig()));
+                .isThrownBy(() -> publisherInstance.inform(PublishContext.from(notification), notification, createConfig()));
     }
 
     @Test
@@ -93,7 +93,7 @@ public abstract class AbstractPublisherTest<T extends Publisher> extends Persist
                 .subject(subject);
 
         assertThatNoException()
-                .isThrownBy(() -> publisherInstance.inform(notification, createConfig()));
+                .isThrownBy(() -> publisherInstance.inform(PublishContext.from(notification), notification, createConfig()));
     }
 
     @Test // https://github.com/DependencyTrack/dependency-track/issues/3197
@@ -110,7 +110,7 @@ public abstract class AbstractPublisherTest<T extends Publisher> extends Persist
                 .subject(subject);
 
         assertThatNoException()
-                .isThrownBy(() -> publisherInstance.inform(notification, createConfig()));
+                .isThrownBy(() -> publisherInstance.inform(PublishContext.from(notification), notification, createConfig()));
     }
 
     @Test
@@ -124,7 +124,7 @@ public abstract class AbstractPublisherTest<T extends Publisher> extends Persist
                 .timestamp(LocalDateTime.ofEpochSecond(66666, 666, ZoneOffset.UTC));
 
         assertThatNoException()
-                .isThrownBy(() -> publisherInstance.inform(notification, createConfig()));
+                .isThrownBy(() -> publisherInstance.inform(PublishContext.from(notification), notification, createConfig()));
     }
 
     @Test
@@ -146,7 +146,7 @@ public abstract class AbstractPublisherTest<T extends Publisher> extends Persist
                 .subject(subject);
 
         assertThatNoException()
-                .isThrownBy(() -> publisherInstance.inform(notification, createConfig()));
+                .isThrownBy(() -> publisherInstance.inform(PublishContext.from(notification), notification, createConfig()));
     }
 
     @Test
@@ -168,7 +168,7 @@ public abstract class AbstractPublisherTest<T extends Publisher> extends Persist
                 .subject(subject);
 
         assertThatNoException()
-                .isThrownBy(() -> publisherInstance.inform(notification, createConfig()));
+                .isThrownBy(() -> publisherInstance.inform(PublishContext.from(notification), notification, createConfig()));
     }
 
     private static Component createComponent(final Project project) {

--- a/src/test/java/org/dependencytrack/notification/publisher/ConsolePublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/ConsolePublisherTest.java
@@ -60,7 +60,7 @@ public class ConsolePublisherTest extends PersistenceCapableTest implements Noti
         notification.setTitle("Test Notification");
         notification.setContent("This is only a test");
         ConsolePublisher publisher = new ConsolePublisher();
-        publisher.inform(notification, getConfig(DefaultNotificationPublishers.CONSOLE, ""));
+        publisher.inform(PublishContext.from(notification), notification, getConfig(DefaultNotificationPublishers.CONSOLE, ""));
         Assert.assertTrue(outContent.toString().contains(expectedResult(notification)));
     }
 
@@ -73,7 +73,7 @@ public class ConsolePublisherTest extends PersistenceCapableTest implements Noti
         notification.setTitle("Test Notification");
         notification.setContent("This is only a test");
         ConsolePublisher publisher = new ConsolePublisher();
-        publisher.inform(notification, getConfig(DefaultNotificationPublishers.CONSOLE, ""));
+        publisher.inform(PublishContext.from(notification), notification, getConfig(DefaultNotificationPublishers.CONSOLE, ""));
         Assert.assertTrue(errContent.toString().contains(expectedResult(notification)));
     }
 

--- a/src/test/java/org/dependencytrack/notification/publisher/CsWebexPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/CsWebexPublisherTest.java
@@ -72,6 +72,6 @@ public class CsWebexPublisherTest extends PersistenceCapableTest implements Noti
         notification.setTitle("Test Notification");
         notification.setContent("This is only a test");
         CsWebexPublisher publisher = new CsWebexPublisher();
-        publisher.inform(notification, config);
+        publisher.inform(PublishContext.from(notification), notification, config);
     }
 }

--- a/src/test/java/org/dependencytrack/notification/publisher/SlackPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/SlackPublisherTest.java
@@ -18,17 +18,11 @@
  */
 package org.dependencytrack.notification.publisher;
 
-import alpine.server.cache.AbstractCacheManager;
-import org.junit.Test;
-
-import java.util.concurrent.TimeUnit;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublisher> {
 
@@ -455,16 +449,6 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
                           ]
                         }
                         """)));
-    }
-
-    @Test
-    public void testMaybeSanitizeDestinationUrl() {
-        final var cacheManager = new AbstractCacheManager(5, TimeUnit.SECONDS, 1) {
-        };
-        cacheManager.put("1", "2"); // Ensure String cache exists
-
-        assertThat(new SlackPublisher(cacheManager).maybeSanitizeDestinationUrl("https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"))
-                .isEqualTo("https://hooks.slack.com/services/T00000000/B00000000/********************XXXX");
     }
 
 }

--- a/src/test/java/org/dependencytrack/notification/publisher/SlackPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/SlackPublisherTest.java
@@ -18,11 +18,17 @@
  */
 package org.dependencytrack.notification.publisher;
 
+import alpine.server.cache.AbstractCacheManager;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublisher> {
 
@@ -449,6 +455,16 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
                           ]
                         }
                         """)));
+    }
+
+    @Test
+    public void testMaybeSanitizeDestinationUrl() {
+        final var cacheManager = new AbstractCacheManager(5, TimeUnit.SECONDS, 1) {
+        };
+        cacheManager.put("1", "2"); // Ensure String cache exists
+
+        assertThat(new SlackPublisher(cacheManager).maybeSanitizeDestinationUrl("https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"))
+                .isEqualTo("https://hooks.slack.com/services/T00000000/B00000000/********************XXXX");
     }
 
 }

--- a/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
@@ -220,7 +220,7 @@ public class NotificationPublisherResourceTest extends ResourceTest {
 
     @Test
     public void updateExistingDefaultNotificationPublisherTest() {
-        NotificationPublisher notificationPublisher = qm.getDefaultNotificationPublisher((Class) SendMailPublisher.class);
+        NotificationPublisher notificationPublisher = qm.getDefaultNotificationPublisher(SendMailPublisher.class);
         notificationPublisher.setName(notificationPublisher.getName() + " Updated");
         Response response = target(V1_NOTIFICATION_PUBLISHER).request()
                 .header(X_API_KEY, apiKey)
@@ -235,7 +235,7 @@ public class NotificationPublisherResourceTest extends ResourceTest {
     public void updateNotificationPublisherWithNameOfAnotherNotificationPublisherTest() {
         NotificationPublisher notificationPublisher = qm.createNotificationPublisher(
                 "Example Publisher", "Publisher description",
-                (Class) SendMailPublisher.class, "template", "text/html",
+                SendMailPublisher.class, "template", "text/html",
                 false
         );
         notificationPublisher = qm.detach(NotificationPublisher.class, notificationPublisher.getId());


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

It's hard to debug missing notifications, because Dependency-Track only logs something when an error occurred during notification publishing. Further, error logs currently do not contain any information about the notification or alert rule involved, making it harder to pinpoint *where* something is broken.

This PR adds more information to log messages emitted during publishing. This is done in form of `PublishContext`, which includes:

* The group of the notification (e.g. `NEW_VULNERABILITY`)
* The level of the notification (e.g. `INFORMATIONAL`)
* The scope of the notification (e.g. `PORTFOLIO`)
* The timestamp of the notification
* The subjects of the notification
  * This is limited to "affected" project(s) (UUID, name, version), component (UUID, group, name, version), and  vulns (vulnId, source), as to not flood the logs
  * Aim is to provide just enough information to debug
* The name of the applicable alert rule
* The scope of the applicable alert rule
* The level of the applicable alert rule

Example log message:

```
Destination acknowledged reception of notification with status code 200 (PublishContext{notificationGroup=GROUP_BOM_PROCESSED, notificationLevel=LEVEL_INFORMATIONAL, notificationScope=SCOPE_PORTFOLIO, notificationTimestamp=2023-11-16T12:30:58.000Z, notificationSubjects={project=Project[uuid=8ebe0e60-0647-4f11-a048-a552ee8fe3df, name=Foo, version=123]}, ruleName=Example Rule, ruleScope=PORTFOLIO, ruleLevel=INFORMATIONAL})
```

This is a backport from Hyades, which already has this functionality: https://github.com/DependencyTrack/hyades/blob/v0.2.0/notification-publisher/src/main/java/org/hyades/notification/publisher/PublishContext.java

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

https://owasp.slack.com/archives/C6R3R32H4/p1699978082979659

#### TODOs

- [x] Emit a log message when notifications have been published successfully
- [x] Make the above configurable on a per-rule basis (required UI change)
- ~Implement mechanism to mask sensitive parts of destination URLs (e.g. for Slack Webhook URLs)~
  * Idea discarded; Trying to mask all possible URLs is a whack-a-mole game

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

![image](https://github.com/DependencyTrack/dependency-track/assets/5693141/616d19f5-b8d0-4156-8883-1a2b41257012)


### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
