### PR TITLE
fix: do not increment amount of components

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
@@ -52,11 +52,6 @@ public class VulnerabilityAnalysisTask implements Subscriber {
 
     private static final Logger LOGGER = Logger.getLogger(VulnerabilityAnalysisTask.class);
 
-    private final List<Component> internalCandidates = new ArrayList<>();
-    private final List<Component> ossIndexCandidates = new ArrayList<>();
-    private final List<Component> vulnDbCandidates = new ArrayList<>();
-    private final List<Component> snykCandidates = new ArrayList<>();
-
     /**
      * {@inheritDoc}
      */
@@ -106,6 +101,10 @@ public class VulnerabilityAnalysisTask implements Subscriber {
         final OssIndexAnalysisTask ossIndexAnalysisTask = new OssIndexAnalysisTask();
         final VulnDbAnalysisTask vulnDbAnalysisTask = new VulnDbAnalysisTask();
         final SnykAnalysisTask snykAnalysisTask = new SnykAnalysisTask();
+        final List<Component> internalCandidates = new ArrayList<>();
+        final List<Component> ossIndexCandidates = new ArrayList<>();
+        final List<Component> vulnDbCandidates = new ArrayList<>();
+        final List<Component> snykCandidates = new ArrayList<>();
         for (final Component component : components) {
             inspectComponentReadiness(component, internalAnalysisTask, internalCandidates);
             inspectComponentReadiness(component, ossIndexAnalysisTask, ossIndexCandidates);

--- a/src/test/java/org/dependencytrack/tasks/VulnerabilityAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/VulnerabilityAnalysisTaskTest.java
@@ -1,0 +1,70 @@
+package org.dependencytrack.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.event.PortfolioVulnerabilityAnalysisEvent;
+import org.dependencytrack.event.ProjectMetricsUpdateEvent;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.ProjectMetrics;
+import org.dependencytrack.tasks.metrics.ProjectMetricsUpdateTask;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import alpine.event.framework.EventService;
+
+public class VulnerabilityAnalysisTaskTest extends PersistenceCapableTest {
+
+    @Before
+    public void registerEvents() {
+        EventService.getInstance().subscribe(ProjectMetricsUpdateEvent.class, ProjectMetricsUpdateTask.class);
+    }
+
+    @After
+    public void unregisterEvents() {
+        EventService.getInstance().unsubscribe(ProjectMetricsUpdateTask.class);
+    }
+
+    @Test
+    public void testPortfolioVulnerabilityAnalysis() {
+        final Project projectA = qm.createProject("Project A", null, "1.0", null, null, null, true, false);
+        var componentA = new Component();
+        componentA.setProject(projectA);
+        componentA.setName("Component A");
+        componentA = qm.createComponent(componentA, false);
+
+        final Project projectB = qm.createProject("Project B", null, "1.0", null, null, null, true, false);
+        var componentB = new Component();
+        componentB.setProject(projectB);
+        componentB.setName("Component B");
+        componentB = qm.createComponent(componentB, false);
+
+        List<Project> projects = Arrays.asList(projectA, projectB);
+
+        for (Project project : projects) {
+            ProjectMetrics projectMetrics = qm.getMostRecentProjectMetrics(project);
+            assertThat(projectMetrics).isNull();
+        }
+
+        VulnerabilityAnalysisTask task = new VulnerabilityAnalysisTask();
+        task.inform(new PortfolioVulnerabilityAnalysisEvent());
+
+        await("Metrics are updated")
+                .atMost(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    for (Project project : projects) {
+                        ProjectMetrics projectMetrics = qm.getMostRecentProjectMetrics(project);
+                        assertThat(projectMetrics).isNotNull();
+                    }
+                });
+
+    }
+
+}


### PR DESCRIPTION
### Description

The change fixes the issue that during the processing of the PortfolioVulnerabilityAnalysisEvent
which re-analyzes all existing projects one after other
every next project to analyze was leading to the analysis of its own components 
and additonaly of all the components of the projects analyzed before it.
The result was very bad performance in cases the Dependency Track instance contains many projects.

### Addressed Issue

Fixes #3219

### Additional Details

The issue was in the global declaration of the lists containing the components to analyse.
The fix declares the lists on the local level so they only exist for one project.
Additonaly a unit test was implemented which does not test explicit the fix but ensures
the PortfolioVulnerabilityAnalysisEvent processing functionalty generally. This test was missing before.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
~- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended~
~- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
