### PR TITLE
Added a default value for the Project `active` field if it is null

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -497,6 +497,9 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         if (project.getParent() != null && !Boolean.TRUE.equals(project.getParent().isActive())){
             throw new IllegalArgumentException("An inactive Parent cannot be selected as parent");
         }
+        if (project.isActive() == null) {
+            project.setActive(Boolean.TRUE);
+        }
         final Project result = persist(project);
         final List<Tag> resolvedTags = resolveTags(tags);
         bind(project, resolvedTags);

--- a/src/test/java/org/dependencytrack/model/ProjectTest.java
+++ b/src/test/java/org/dependencytrack/model/ProjectTest.java
@@ -47,4 +47,19 @@ public class ProjectTest extends PersistenceCapableTest {
         Assert.assertNotNull(bom.getUuid());
         Assert.assertNotNull(bom.getImported());
     }
+
+    @Test
+    public void testProjectPersistActiveFieldDefaultsToTrue() {
+
+        Project project = new Project();
+        project.setName("Example Project 1");
+        project.setDescription("Description 1");
+        project.setVersion("1.0");
+        project.setActive(null);
+
+        Project persistedProject = qm.createProject(project, null, false);
+
+        Assert.assertNotNull(persistedProject.isActive());
+        Assert.assertTrue(persistedProject.isActive());
+    }
 }


### PR DESCRIPTION
### Description

When creating a project from the API, which deserializes a JSON object into a Project object, if you do not specify the `active` field in your JSON payload it will default to null - this causes problems with projects being marked as inactive when they are supposed to be active.

To fix this issue I have added a default value for a Project's `active` field just before it is persisted to the database.

### Addressed Issue

This Fixes issue #2935 where projects are not assignable as parent projects because they are reported as inactive.

### Additional Details

I tried to set a default value on the persistence layer but was not able to do so for some reason - I am not too familiar with JDO but I tried following the official documentation but still could not get it to behave as expected.

I then opted for my current solution where I assign the default value inside of the ProjectQueryManager just before it persists the object. The reason why I added it here and not in the API layer is because I wanted this fix to be available to any area of the app that tries to create a project using this method.

I added a test to confirm that it works and I also made sure that I didn't break any existing tests.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
