### PR TITLE
Return processing token when cloning project #2842

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -323,11 +323,12 @@ public class BomResource extends AlpineResource {
     @GET
     @Path("/token/{uuid}")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Determines if there are any tasks associated with the token that are being processed, or in the queue to be processed.", notes = "This endpoint is intended to be used in conjunction with uploading a supported BOM document. Upon upload, a token will be returned. The token can then be queried using this endpoint to determine if any tasks (such as vulnerability analysis) is being performed on the BOM. A value of true indicates processing is occurring. A value of false indicates that no processing is occurring for the specified token. However, a value of false also does not confirm the token is valid, only that no processing is associated with the specified token.", response = IsTokenBeingProcessedResponse.class)
+    @ApiOperation(value = "Determines if there are any tasks associated with the token that are being processed, or in the queue to be processed.", notes = "Deprecated. Use /v1/event/token/{uuid} instead.", response = IsTokenBeingProcessedResponse.class)
     @ApiResponses(value = {
             @ApiResponse(code = 401, message = "Unauthorized")
     })
     @PermissionRequired(Permissions.Constants.BOM_UPLOAD)
+    @Deprecated(since = "4.11.0")
     public Response isTokenBeingProcessed (
             @ApiParam(value = "The UUID of the token to query", required = true)
             @PathParam("uuid") String uuid) {

--- a/src/main/java/org/dependencytrack/resources/v1/EventResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/EventResource.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1;
+
+import alpine.event.framework.Event;
+import alpine.server.resources.AlpineResource;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import org.dependencytrack.resources.v1.vo.IsTokenBeingProcessedResponse;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.UUID;
+
+/**
+ * JAX-RS resources for processing Events
+ *
+ * @author Ralf King
+ * @since 4.11.0
+ */
+@Path("/v1/event")
+@Api(value = "event", authorizations = @Authorization(value = "X-Api-Key"))
+public class EventResource extends AlpineResource {
+
+    @GET
+    @Path("/token/{uuid}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Determines if there are any tasks associated with the token that are being processed, or in the queue to be processed.",
+            notes = "This endpoint is intended to be used in conjunction with other API calls which return a token for asynchronous tasks. " +
+                    "The token can then be queried using this endpoint to determine if the task is complete. " +
+                    "A value of true indicates processing is occurring. A value of false indicates that no processing is " +
+                    "occurring for the specified token. However, a value of false also does not confirm the token is valid, " +
+                    "only that no processing is associated with the specified token.", response = IsTokenBeingProcessedResponse.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Unauthorized")
+    })
+    public Response isTokenBeingProcessed (
+            @ApiParam(value = "The UUID of the token to query", required = true)
+            @PathParam("uuid") String uuid) {
+        final boolean value = Event.isEventBeingProcessed(UUID.fromString(uuid));
+        IsTokenBeingProcessedResponse response = new IsTokenBeingProcessedResponse();
+        response.setProcessing(value);
+        return Response.ok(response).build();
+    }
+}

--- a/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -39,7 +39,6 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Tag;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.v1.vo.CloneProjectRequest;
-import org.dependencytrack.resources.v1.vo.IsTokenBeingProcessedResponse;
 
 import javax.jdo.FetchGroup;
 import javax.validation.Validator;
@@ -59,7 +58,6 @@ import java.security.Principal;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -671,28 +669,5 @@ public class ProjectResource extends AlpineResource {
                 return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the project could not be found.").build();
             }
         }
-    }
-
-    @GET
-    @Path("/token/{uuid}")
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Determines if there are any tasks associated with the token that are being processed, or in the queue to be processed.",
-            notes = "This endpoint is intended to be used in conjunction with cloning a project which returns a token. " +
-                    "The token can then be queried using this endpoint to determine if cloning is complete. " +
-                    "A value of true indicates processing is occurring. A value of false indicates that no processing is " +
-                    "occurring for the specified token. However, a value of false also does not confirm the token is valid, " +
-                    "only that no processing is associated with the specified token.", response = IsTokenBeingProcessedResponse.class)
-    @ApiResponses(value = {
-            @ApiResponse(code = 401, message = "Unauthorized")
-    })
-    @PermissionRequired(Permissions.Constants.PORTFOLIO_MANAGEMENT)
-    public Response isTokenBeingProcessed (
-            @ApiParam(value = "The UUID of the token to query", required = true)
-            @PathParam("uuid") String uuid) {
-
-        final boolean value = Event.isEventBeingProcessed(UUID.fromString(uuid));
-        IsTokenBeingProcessedResponse response = new IsTokenBeingProcessedResponse();
-        response.setProcessing(value);
-        return Response.ok(response).build();
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -849,7 +849,10 @@ public class ProjectResourceTest extends ResourceTest {
                         """.formatted(project.getUuid())));
 
         assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(getPlainTextBody(response)).isEmpty();
+        JsonObject json = parseJsonObject(response);
+        Assert.assertNotNull(json);
+        Assert.assertNotNull(json.getString("token"));
+        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
 
         await("Cloning completion")
                 .atMost(Duration.ofSeconds(15))
@@ -959,7 +962,10 @@ public class ProjectResourceTest extends ResourceTest {
                         }
                         """.formatted(accessProject.getUuid())));
         assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(getPlainTextBody(response)).isEmpty();
+        JsonObject json = parseJsonObject(response);
+        Assert.assertNotNull(json);
+        Assert.assertNotNull(json.getString("token"));
+        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
     }
 
 }


### PR DESCRIPTION
### Description
Return a token when cloning projects which can be used to query clone processing status.
Add an endpoint to query clone processing status.

### Addressed Issue
Closes #2842 

### Additional Details
I did not find an obvious way to also implement wrapping cloning in a transaction while using the processing tokens, so this part is not implemented.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
