### PR TITLE
Expand OIDC docs

### DIFF
--- a/docs/_docs/getting-started/openidconnect-configuration.md
+++ b/docs/_docs/getting-started/openidconnect-configuration.md
@@ -22,6 +22,14 @@ If configured properly, users will be able to sign in by clicking the _OpenID_ b
 > which means that Dependency-Track will no longer request the `/userinfo` endpoint if all required claims  
 > are present in the ID token's payload already.
 
+## How OpenID Connect claims are mapped
+
+When someone authenticates using OIDC, the claims provided in the ID token or `/userinfo` API response will be mapped to existing OIDC Groups and the user will be added to any teams which have those groups mapped. To have OIDC users added to a team, you must perform the following steps:
+
+1. Login to Dependency-Track as an administrator and navigate to _Administration_ -> _Access Management_ -> _OpenID Connect Groups_.
+2. Create a group with the name used in the OIDC team claim configured below. The value _must_ match exactly, including case.
+3. If the team you want members of the OIDC group to join already exists, use the _Mapped Teams_ menu to select it. If the team does not exist, open _Administration_ -> _Access Management_ -> _Teams_ to create it and, after having done so, add the OIDC group to the _Mapped OpenID Connect Groups_ list.
+
 ### Example Configurations
 
 Generally, Dependency-Track can be used with any identity provider that implements the [OpenID Connect](https://openid.net/connect/) standard.
@@ -197,7 +205,7 @@ $ curl https://auth.example.com/auth/realms/example/protocol/openid-connect/user
 
 6. Login to Dependency-Track as `admin` and navigate to _Administration -> Access Management -> OpenID Connect Groups_
 
-- Create groups with names equivalent to those in Keycloak
+- Create groups with names equivalent to those in Keycloak (these must match exactly, including case)
 - Add teams that the groups should be mapped to
 
   ![Group mappings](/images/screenshots/oidc-groups.png)


### PR DESCRIPTION
### Description

This clarifies what you have to configure when setting up OIDC authentication for DT - I had been hoping that the OpenID Connect groups list would automatically populate and missed that the group list was case-sensitive in my first test.

### Addressed Issue

https://github.com/DependencyTrack/dependency-track/discussions/3188

### Additional Details

As an alternative, would it make sense to make the group to team mapping case-insensitive? Automatically populating the OIDC groups list would be a little more work since that could potentially be both large and some users might reasonably want that behaviour to be optional, but matching the group names case-insensitively should be less controversial. We have close to half a century of evidence with filesystems that distinct names differing only in case is rarely what people want.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~[ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~[ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~[ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~[ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~