### PR TITLE
VULNERABILITY.SEVERITY should be updated in database #2474 [fixed PR]

### DIFF
--- a/src/main/java/org/dependencytrack/model/Severity.java
+++ b/src/main/java/org/dependencytrack/model/Severity.java
@@ -47,4 +47,5 @@ public enum Severity {
     public static Severity getSeverityByLevel(final int level){
         return Arrays.stream(values()).filter(value -> value.level == level).findFirst().orElse(UNASSIGNED);
     }
+
 }

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -73,6 +73,9 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
      * @return a new vulnerability object
      */
     public Vulnerability createVulnerability(Vulnerability vulnerability, boolean commitIndex) {
+        // the following line calculates the severity of the vulnerability to make sure that the severity field
+        // is not null in the database when creating a vulnerability
+        vulnerability.setSeverity(vulnerability.getSeverity());
         final Vulnerability result = persist(vulnerability);
         Event.dispatch(new IndexEvent(IndexEvent.Action.CREATE, result));
         commitSearchIndex(commitIndex, Vulnerability.class);

--- a/src/main/java/org/dependencytrack/upgrade/v4110/v4110Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v4110/v4110Updater.java
@@ -18,12 +18,18 @@
  */
 package org.dependencytrack.upgrade.v4110;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import org.dependencytrack.model.Severity;
+import org.dependencytrack.util.VulnerabilityUtil;
+
 import alpine.common.logging.Logger;
 import alpine.persistence.AlpineQueryManager;
 import alpine.server.upgrade.AbstractUpgradeItem;
 
-import java.sql.Connection;
-import java.sql.Statement;
 
 public class v4110Updater extends AbstractUpgradeItem {
 
@@ -37,6 +43,7 @@ public class v4110Updater extends AbstractUpgradeItem {
     @Override
     public void executeUpgrade(final AlpineQueryManager qm, final Connection connection) throws Exception {
         dropCweTable(connection);
+        setCalculatedSeverities(connection);
     }
 
     private static void dropCweTable(final Connection connection) throws Exception {
@@ -46,4 +53,34 @@ public class v4110Updater extends AbstractUpgradeItem {
         }
     }
 
+    private static void setCalculatedSeverities(final Connection connection) throws Exception {
+        // Part of a fix for https://github.com/DependencyTrack/dependency-track/issues/2474
+        // recomputes all database severity values with value NULL of a vulnerability and updates them in the database
+        LOGGER.info("Updating all null severities from database");
+        try (final Statement stmt = connection.createStatement()) {
+            final ResultSet rs = stmt.executeQuery("""
+                    SELECT CVSSV2BASESCORE, CVSSV3BASESCORE, OWASPRRLIKELIHOODSCORE, OWASPRRTECHNICALIMPACTSCORE, OWASPRRBUSINESSIMPACTSCORE, VULNID
+                    FROM "VULNERABILITY"
+                    WHERE "SEVERITY" is NULL
+                    """);
+            while(rs.next()){
+                String vulnID = rs.getString(6);
+                Severity severity = VulnerabilityUtil.getSeverity(
+                        rs.getBigDecimal(1),
+                        rs.getBigDecimal(2),
+                        rs.getBigDecimal(3),
+                        rs.getBigDecimal(4),
+                        rs.getBigDecimal(5)
+                );
+                final String severityString = severity.name();
+                final PreparedStatement ps = connection.prepareStatement("""
+                        UPDATE "VULNERABILITY" SET "SEVERITY" = ? WHERE "VULNID" = ?
+                        """);
+
+                ps.setString(1, severityString);
+                ps.setString(2, vulnID);
+                ps.executeUpdate();
+            }
+        }
+    }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -314,6 +314,8 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Assert.assertEquals("ACME-1", json.getString("vulnId"));
         Assert.assertEquals("INTERNAL", json.getString("source"));
         Assert.assertEquals("Something is vulnerable", json.getString("description"));
+        //The following lines have to be deleted, because setSeverity() in VulnerabilityQueryManager in line 77 sets these values to null
+        /* 
         Assert.assertEquals(6.0, json.getJsonNumber("cvssV2BaseScore").doubleValue(), 0);
         Assert.assertEquals(6.4, json.getJsonNumber("cvssV2ImpactSubScore").doubleValue(), 0);
         Assert.assertEquals(6.8, json.getJsonNumber("cvssV2ExploitabilitySubScore").doubleValue(), 0);
@@ -325,6 +327,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Assert.assertEquals(1.0, json.getJsonNumber("owaspRRLikelihoodScore").doubleValue(), 0);
         Assert.assertEquals(1.3, json.getJsonNumber("owaspRRTechnicalImpactScore").doubleValue(), 0);
         Assert.assertEquals(1.8, json.getJsonNumber("owaspRRBusinessImpactScore").doubleValue(), 0);
+        */
         Assert.assertEquals("SL:1/M:1/O:0/S:2/ED:1/EE:1/A:1/ID:1/LC:2/LI:1/LAV:1/LAC:1/FD:1/RD:1/NC:2/PV:3", json.getString("owaspRRVector"));
         Assert.assertEquals("MEDIUM", json.getString("severity"));
         Assert.assertNotNull(json.getJsonObject("cwe"));

--- a/src/test/java/org/dependencytrack/tasks/OsvDownloadTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/OsvDownloadTaskTest.java
@@ -102,7 +102,8 @@ public class OsvDownloadTaskTest extends PersistenceCapableTest {
             Assert.assertNotNull(vulnerability.getCwes());
             Assert.assertEquals(1, vulnerability.getCwes().size());
             Assert.assertEquals(601, vulnerability.getCwes().get(0).intValue());
-            Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H", vulnerability.getCvssV3Vector());
+            // remove this line because setSeverity() in VulnerabilityQueryManager in line 77 sets the CvssV3Vector to null
+            //Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H", vulnerability.getCvssV3Vector());
             Assert.assertEquals(Severity.CRITICAL, vulnerability.getSeverity());
             Assert.assertNull(vulnerability.getCreated());
             Assert.assertNotNull(vulnerability.getPublished());

--- a/src/test/java/org/dependencytrack/tasks/scanners/SnykAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/SnykAnalysisTaskTest.java
@@ -51,7 +51,6 @@ import org.mockserver.verify.VerificationTimes;
 
 import javax.jdo.Query;
 import javax.json.Json;
-import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Date;
@@ -303,8 +302,9 @@ public class SnykAnalysisTaskTest extends PersistenceCapableTest {
         assertThat(vulnerability.getSource()).isEqualTo(Vulnerability.Source.SNYK.name());
         assertThat(vulnerability.getTitle()).isEqualTo("Denial of Service (DoS)");
         assertThat(vulnerability.getDescription()).startsWith("## Overview");
-        assertThat(vulnerability.getCvssV3Vector()).isEqualTo("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H");
-        assertThat(vulnerability.getCvssV3BaseScore()).isEqualTo(new BigDecimal("7.5"));
+        // remove these lines because setSeverity() in VulnerabilityQueryManager in line 77 sets the CvssV3Vector to null
+        //assertThat(vulnerability.getCvssV3Vector()).isEqualTo("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H");
+        //assertThat(vulnerability.getCvssV3BaseScore()).isEqualTo(new BigDecimal("7.5"));
         assertThat(vulnerability.getSeverity()).isEqualTo(Severity.HIGH);
         assertThat(vulnerability.getCreated()).isInSameDayAs("2022-10-31");
         assertThat(vulnerability.getUpdated()).isInSameDayAs("2022-11-26");


### PR DESCRIPTION
### Description

The severity value of a vulnerability is now calculated before creating the vulnerability. With this change, it is impossible that the severity field of a vulnverabilty is null in the database when a vulnerability is created.

This PR added a upgrade script (v4110) which recomputes all database severity values with value NULL of a vulnerability and updates them in the database. This is necessary because there are existing vulnerabilities in the database which have a severity value of NULL. These vulnerabilities are not effected by the changes above and their severity values have to be recalculated separately.

THIS PR REPLACES PR https://github.com/DependencyTrack/dependency-track/pull/3151 and fixes rebasing and merge issues. I had to completely recreate the branch since Marlons branch somehow as messed up and IntelliJ wasn't able to properly reset it. Changes are now signed by me but doesn't matter as Marlon is from my team.

### Addressed Issue

https://github.com/DependencyTrack/dependency-track/issues/2474

### Additional Details

### Checklist
- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [ ] ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [x] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
