### PR TITLE
Backport: Fix NPE in VersionDistancePolicyEvaluator when project has no direct dependencies

### DIFF
--- a/src/main/java/org/dependencytrack/policy/VersionDistancePolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/VersionDistancePolicyEvaluator.java
@@ -164,13 +164,17 @@ public class VersionDistancePolicyEvaluator extends AbstractPolicyEvaluator {
     }
 
     /**
-     * Test if the components project direct dependencies contain a givven component
+     * Test if the components project direct dependencies contain a given component
      * If so, the component is a direct dependency of the project
      *
      * @param component component to test
      * @return If the components project direct dependencies contain the component
      */
     private boolean isDirectDependency(Component component) {
+        if (component.getProject().getDirectDependencies() == null) {
+            return false;
+        }
+
         return component.getProject().getDirectDependencies().contains("\"uuid\":\"" + component.getUuid().toString() + "\"");
     }
 

--- a/src/test/java/org/dependencytrack/policy/VersionDistancePolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/VersionDistancePolicyEvaluatorTest.java
@@ -157,6 +157,11 @@ public class VersionDistancePolicyEvaluatorTest extends PersistenceCapableTest {
             final PolicyConditionViolation violation = violations.get(0);
             assertThat(violation.getComponent()).isEqualTo(component);
             assertThat(violation.getPolicyCondition()).isEqualTo(condition);
+
+            // https://github.com/DependencyTrack/dependency-track/issues/3295
+            project.setDirectDependencies(null);
+            qm.persist(project);
+            assertThat(evaluator.evaluate(policy, component)).isEmpty();
         } else {
             assertThat(violations).isEmpty();
         }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Backports #3307 to 4.10.x.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #3295

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
