### PR TITLE
Fix NVD API's last modified timestamp requiring restart to be applied

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/NistApiMirrorTask.java
+++ b/src/main/java/org/dependencytrack/tasks/NistApiMirrorTask.java
@@ -395,7 +395,7 @@ public class NistApiMirrorTask implements Subscriber {
         }
 
         LOGGER.debug("Latest captured modification date: %s".formatted(lastModifiedDateTime));
-        try (final var qm = new QueryManager().withL2CacheDisabled()) {
+        try (final var qm = new QueryManager()) {
             qm.runInTransaction(() -> {
                 final ConfigProperty property = qm.getConfigProperty(
                         VULNERABILITY_SOURCE_NVD_API_LAST_MODIFIED_EPOCH_SECONDS.getGroupName(),

--- a/src/test/java/org/dependencytrack/tasks/NistApiMirrorTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/NistApiMirrorTaskTest.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.tasks;
 
+import alpine.model.ConfigProperty;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.event.NistApiMirrorEvent;
@@ -233,6 +234,16 @@ public class NistApiMirrorTaskTest extends PersistenceCapableTest {
                     assertThat(qm.hasAffectedVersionAttribution(vuln, vs, Source.NVD)).isTrue();
                 }
         );
+
+        // Property is in L1 cache because it was created in the test's setUp method.
+        // Evict L1 cache to reach L2 cache / datastore instead.
+        qm.getPersistenceManager().evictAll();
+        final ConfigProperty lastModifiedProperty = qm.getConfigProperty(
+                VULNERABILITY_SOURCE_NVD_API_LAST_MODIFIED_EPOCH_SECONDS.getGroupName(),
+                VULNERABILITY_SOURCE_NVD_API_LAST_MODIFIED_EPOCH_SECONDS.getPropertyName()
+        );
+        assertThat(lastModifiedProperty).isNotNull();
+        assertThat(lastModifiedProperty.getPropertyValue()).isEqualTo("1691504544");
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes an issue that caused the "last modified" timestamp for NVD mirroring via REST API to not be effective, unless the application is restarted.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

https://github.com/DependencyTrack/dependency-track/issues/3293#issuecomment-1860699842

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

The timestamp is created with value `null` in a context where L2 caching is enabled (`DefaultObjectGenerator`), but updated in one where L2 caching is disabled (`NistApiMirrorTask#updateLastModified`). What's more, it's queried in a context with L2 caching enabled (`NistApiMirrorTask#inform`). This causes the property to be updated, but the cache not being invalidated, thus still serving queries.

To not have similar inconsistencies in other areas of the application, re-enable L2 caching when updating the property.

Eventually, L2 caching should be disabled system-wide.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
