### PR TITLE
Add /v1/project/batchDelete API method

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -56,11 +56,9 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.security.Principal;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -496,44 +494,6 @@ public class ProjectResource extends AlpineResource {
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the project could not be found.").build();
             }
-        }
-    }
-
-    @POST
-    @Path("/batchDelete")
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(
-            value = "Deletes a list of projects specified by their UUIDs",
-            code = 204
-    )
-    @ApiResponses(value = {
-            @ApiResponse(code = 401, message = "Unauthorized"),
-            @ApiResponse(code = 403, message = "Access to one or more of the specified projects is forbidden")
-    })
-    @PermissionRequired(Permissions.Constants.PORTFOLIO_MANAGEMENT)
-    public Response deleteProjects(
-            @ApiParam(value = "A list of one or more project UUIDs", required = true)
-            List<UUID> uuids) {
-        List<UUID> inaccessibleProjects = new ArrayList<>();
-        try (QueryManager qm = new QueryManager()) {
-            for (UUID uuid : uuids) {
-                final Project project = qm.getObjectByUuid(Project.class, uuid, Project.FetchGroup.ALL.name());
-                if (project != null) {
-                    if (qm.hasAccess(super.getPrincipal(), project)) {
-                        LOGGER.info("Project " + project + " deletion request by " + super.getPrincipal().getName());
-                        qm.recursivelyDelete(project, true);
-                    } else {
-                        inaccessibleProjects.add(uuid);
-                    }
-                } else {
-                    LOGGER.warn("No project found by UUID " + uuid);
-                }
-            }
-            if (!inaccessibleProjects.isEmpty()) {
-                return Response.status(Response.Status.FORBIDDEN).entity("Access to the following project(s) is forbidden: " + inaccessibleProjects).build();
-            }
-            return Response.status(Response.Status.NO_CONTENT).build();
         }
     }
 

--- a/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -56,9 +56,11 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -494,6 +496,44 @@ public class ProjectResource extends AlpineResource {
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the project could not be found.").build();
             }
+        }
+    }
+
+    @POST
+    @Path("/batchDelete")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Deletes a list of projects specified by their UUIDs",
+            code = 204
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Access to one or more of the specified projects is forbidden")
+    })
+    @PermissionRequired(Permissions.Constants.PORTFOLIO_MANAGEMENT)
+    public Response deleteProjects(
+            @ApiParam(value = "A list of one or more project UUIDs", required = true)
+            List<UUID> uuids) {
+        List<UUID> inaccessibleProjects = new ArrayList<>();
+        try (QueryManager qm = new QueryManager()) {
+            for (UUID uuid : uuids) {
+                final Project project = qm.getObjectByUuid(Project.class, uuid, Project.FetchGroup.ALL.name());
+                if (project != null) {
+                    if (qm.hasAccess(super.getPrincipal(), project)) {
+                        LOGGER.info("Project " + project + " deletion request by " + super.getPrincipal().getName());
+                        qm.recursivelyDelete(project, true);
+                    } else {
+                        inaccessibleProjects.add(uuid);
+                    }
+                } else {
+                    LOGGER.warn("No project found by UUID " + uuid);
+                }
+            }
+            if (!inaccessibleProjects.isEmpty()) {
+                return Response.status(Response.Status.FORBIDDEN).entity("Access to the following project(s) is forbidden: " + inaccessibleProjects).build();
+            }
+            return Response.status(Response.Status.NO_CONTENT).build();
         }
     }
 

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -531,63 +531,6 @@ public class ProjectResourceTest extends ResourceTest {
         Assert.assertEquals(204, response.getStatus(), 0);
     }
 
-    List<UUID> createProjects(int size, boolean accessible) {
-        List<UUID> projectUUIDs = new ArrayList<>();
-        for (int i=0; i<size; i++) {
-            Project project = qm.createProject("ABC", null, String.valueOf(i)+".0", null, null, null, true, false);
-            if (accessible) {
-                project.setAccessTeams(List.of(team));
-            }
-            projectUUIDs.add(project.getUuid());
-            qm.persist(project);
-        }
-        return projectUUIDs;
-    }
-
-    @Test
-    public void batchDeleteProjectsWithFullAccessTest() {
-        // Enable portfolio access control.
-        qm.createConfigProperty(
-                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
-                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
-                "true",
-                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyType(),
-                null
-        );
-
-        List<UUID> uuidsOfAccessibleProjects = createProjects(9, true);
-        List<UUID> uuidsOfInaccessibleProjects = createProjects(1, false);
-
-        // Delete only accessible projects
-        Response response = target(V1_PROJECT + "/batchDelete")
-                .request()
-                .header(X_API_KEY, apiKey)
-                .method("POST", Entity.json(uuidsOfAccessibleProjects));
-        Assert.assertEquals(204, response.getStatus(), 0);
-
-        // Delete only inaccessible projects
-        response = target(V1_PROJECT + "/batchDelete")
-                .request()
-                .header(X_API_KEY, apiKey)
-                .method("POST", Entity.json(uuidsOfInaccessibleProjects));
-        Assert.assertEquals(403, response.getStatus(), 0);
-        String output = response.readEntity(String.class);
-        Assert.assertEquals("", "Access to the following project(s) is forbidden: " + uuidsOfInaccessibleProjects, output);
-
-        // Delete mixed accessible + inaccessible projects
-        List<UUID> uuidsOfMixedProjects = new ArrayList<>();
-        uuidsOfAccessibleProjects = createProjects(9, true);
-        uuidsOfMixedProjects.addAll(uuidsOfAccessibleProjects);
-        uuidsOfMixedProjects.addAll(uuidsOfInaccessibleProjects);
-        response = target(V1_PROJECT + "/batchDelete")
-                .request()
-                .header(X_API_KEY, apiKey)
-                .method("POST", Entity.json(uuidsOfMixedProjects));
-        Assert.assertEquals(403, response.getStatus(), 0);
-        output = response.readEntity(String.class);
-        Assert.assertEquals("", "Access to the following project(s) is forbidden: " + uuidsOfInaccessibleProjects, output);
-    }
-
     @Test
     public void deleteProjectInvalidUuidTest() {
         qm.createProject("ABC", null, "1.0", null, null, null, true, false);


### PR DESCRIPTION
### Description

This patch adds a `/v1/project/batchDelete` method that makes project life-cycle management more effective since more than 1 project can be deleted with one request.

### Addressed Issue

This fixes https://github.com/DependencyTrack/dependency-track/issues/3361

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
~- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
~- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic]~(https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
