### PR TITLE
Store computed severities in the database

### DIFF
--- a/src/main/java/org/dependencytrack/model/Vulnerability.java
+++ b/src/main/java/org/dependencytrack/model/Vulnerability.java
@@ -32,7 +32,6 @@ import org.dependencytrack.resources.v1.serializers.CweDeserializer;
 import org.dependencytrack.resources.v1.serializers.CweSerializer;
 import org.dependencytrack.resources.v1.serializers.Iso8601DateSerializer;
 import org.dependencytrack.resources.v1.vo.AffectedComponent;
-import org.dependencytrack.util.VulnerabilityUtil;
 
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Convert;
@@ -326,36 +325,11 @@ public class Vulnerability implements Serializable {
         this.id = id;
     }
 
-    /**
-     * Returns the value of the severity field (if specified), otherwise, will
-     * return the severity based on the numerical CVSS or OWASP score.
-     *
-     * This method properly accounts for vulnerabilities that may have a subset or all of (CVSSv2, CVSSv3, OWASP RR)
-     * score. The highest severity is returned.
-     * @return the severity of the vulnerability
-     * @see VulnerabilityUtil#getSeverity(BigDecimal, BigDecimal, BigDecimal, BigDecimal, BigDecimal)
-     */
     public Severity getSeverity() {
-        return (this.severity != null) ? severity : VulnerabilityUtil.getSeverity(cvssV2BaseScore, cvssV3BaseScore, owaspRRLikelihoodScore, owaspRRTechnicalImpactScore, owaspRRBusinessImpactScore);
+        return severity;
     }
 
-    /**
-     * Sets the severity. This should only be set if CVSSv2, CVSSv3 or OWASP RR scores
-     * are not used.
-     * @param severity the severity of the vulnerability
-     */
     public void setSeverity(Severity severity) {
-        cvssV2BaseScore = null;
-        cvssV2ImpactSubScore = null;
-        cvssV2ExploitabilitySubScore = null;
-        cvssV2Vector = null;
-        cvssV3BaseScore = null;
-        cvssV3ImpactSubScore = null;
-        cvssV3ExploitabilitySubScore = null;
-        cvssV3Vector = null;
-        owaspRRLikelihoodScore = null;
-        owaspRRBusinessImpactScore = null;
-        owaspRRTechnicalImpactScore = null;
         this.severity = severity;
     }
 

--- a/src/main/java/org/dependencytrack/parser/nvd/NvdParser.java
+++ b/src/main/java/org/dependencytrack/parser/nvd/NvdParser.java
@@ -34,6 +34,7 @@ import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.parser.common.resolver.CweResolver;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.util.VulnerabilityUtil;
 import us.springett.cvss.Cvss;
 import us.springett.parsers.cpe.exceptions.CpeEncodingException;
 import us.springett.parsers.cpe.exceptions.CpeParsingException;
@@ -291,6 +292,14 @@ public final class NvdParser {
             vuln.setCvssV3ExploitabilitySubScore(BigDecimal.valueOf(imp3.get("exploitabilityScore").asDouble()));
             vuln.setCvssV3ImpactSubScore(BigDecimal.valueOf(imp3.get("impactScore").asDouble()));
         }
+
+        vuln.setSeverity(VulnerabilityUtil.getSeverity(
+                vuln.getCvssV2BaseScore(),
+                vuln.getCvssV3BaseScore(),
+                vuln.getOwaspRRLikelihoodScore(),
+                vuln.getOwaspRRTechnicalImpactScore(),
+                vuln.getOwaspRRBusinessImpactScore()
+        ));
     }
 
     private List<VulnerableSoftware> parseCpes(final QueryManager qm, final ObjectNode node) {

--- a/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
@@ -297,7 +297,7 @@ public class VulnerabilityResource extends AlpineResource {
                         }
                     }
                 }
-                recalculateScoresFromVector(jsonVulnerability);
+                recalculateScoresAndSeverityFromVectors(jsonVulnerability);
                 jsonVulnerability.setSource(Vulnerability.Source.INTERNAL);
                 vulnerability = qm.createVulnerability(jsonVulnerability, true);
                 qm.persist(vsList);
@@ -372,7 +372,7 @@ public class VulnerabilityResource extends AlpineResource {
                         }
                     }
                 }
-                recalculateScoresFromVector(jsonVuln);
+                recalculateScoresAndSeverityFromVectors(jsonVuln);
                 vulnerability = qm.updateVulnerability(jsonVuln, true);
                 qm.persist(vsList);
                 vsList = qm.reconcileVulnerableSoftware(vulnerability, vsListOld, vsList, Vulnerability.Source.INTERNAL);
@@ -441,7 +441,7 @@ public class VulnerabilityResource extends AlpineResource {
         return Response.ok(vulnId).build();
     }
 
-    public void recalculateScoresFromVector(Vulnerability vuln) throws MissingFactorException {
+    public void recalculateScoresAndSeverityFromVectors(Vulnerability vuln) throws MissingFactorException {
         // Recalculate V2 score based on vector passed to resource and normalize vector
         final Cvss v2 = Cvss.fromVector(vuln.getCvssV2Vector());
         if (v2 != null) {
@@ -470,6 +470,15 @@ public class VulnerabilityResource extends AlpineResource {
             vuln.setOwaspRRTechnicalImpactScore(BigDecimal.valueOf(score.getTechnicalImpactScore()));
             vuln.setOwaspRRBusinessImpactScore(BigDecimal.valueOf(score.getBusinessImpactScore()));
         }
+
+        vuln.setSeverity(VulnerabilityUtil.getSeverity(
+                vuln.getSeverity(),
+                vuln.getCvssV2BaseScore(),
+                vuln.getCvssV3BaseScore(),
+                vuln.getOwaspRRLikelihoodScore(),
+                vuln.getOwaspRRTechnicalImpactScore(),
+                vuln.getOwaspRRBusinessImpactScore()
+        ));
     }
 
     @POST

--- a/src/main/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTask.java
@@ -58,6 +58,7 @@ import org.dependencytrack.parser.ossindex.model.ComponentReportVulnerability;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.HttpUtil;
 import org.dependencytrack.util.NotificationUtil;
+import org.dependencytrack.util.VulnerabilityUtil;
 import org.json.JSONObject;
 import us.springett.cvss.Cvss;
 import us.springett.cvss.CvssV2;
@@ -397,6 +398,15 @@ public class OssIndexAnalysisTask extends BaseComponentAnalyzerTask implements C
                 }
             }
         }
+
+        vulnerability.setSeverity(VulnerabilityUtil.getSeverity(
+                vulnerability.getCvssV2BaseScore(),
+                vulnerability.getCvssV3BaseScore(),
+                vulnerability.getOwaspRRLikelihoodScore(),
+                vulnerability.getOwaspRRTechnicalImpactScore(),
+                vulnerability.getOwaspRRBusinessImpactScore()
+        ));
+
         return vulnerability;
     }
 

--- a/src/test/java/org/dependencytrack/model/VulnerabilityTest.java
+++ b/src/test/java/org/dependencytrack/model/VulnerabilityTest.java
@@ -38,6 +38,8 @@ public class VulnerabilityTest {
 
     @Test
     public void testSeverity() {
+        // NB: Before https://github.com/DependencyTrack/dependency-track/issues/2474,
+        // severity was computed in the getter based on the provided scores.
         Vulnerability vuln = new Vulnerability();
         vuln.setCvssV2Vector("Vector");
         vuln.setCvssV2BaseScore(new BigDecimal(5.0));
@@ -47,16 +49,19 @@ public class VulnerabilityTest {
         vuln.setCvssV3BaseScore(new BigDecimal(6.0));
         vuln.setCvssV3ImpactSubScore(new BigDecimal(6.1));
         vuln.setCvssV3ExploitabilitySubScore(new BigDecimal(6.2));
-        Assert.assertEquals(Severity.MEDIUM, vuln.getSeverity());
+        Assert.assertNull(vuln.getSeverity());
+
+        // NB: Before https://github.com/DependencyTrack/dependency-track/issues/2474,
+        // calling setSeverity cleared all score and vector fields.
         vuln.setSeverity(Severity.HIGH);
-        Assert.assertNull(vuln.getCvssV2Vector());
-        Assert.assertNull(vuln.getCvssV2BaseScore());
-        Assert.assertNull(vuln.getCvssV2ImpactSubScore());
-        Assert.assertNull(vuln.getCvssV2ExploitabilitySubScore());
-        Assert.assertNull(vuln.getCvssV3Vector());
-        Assert.assertNull(vuln.getCvssV3BaseScore());
-        Assert.assertNull(vuln.getCvssV3ImpactSubScore());
-        Assert.assertNull(vuln.getCvssV3ExploitabilitySubScore());
+        Assert.assertNotNull(vuln.getCvssV2Vector());
+        Assert.assertNotNull(vuln.getCvssV2BaseScore());
+        Assert.assertNotNull(vuln.getCvssV2ImpactSubScore());
+        Assert.assertNotNull(vuln.getCvssV2ExploitabilitySubScore());
+        Assert.assertNotNull(vuln.getCvssV3Vector());
+        Assert.assertNotNull(vuln.getCvssV3BaseScore());
+        Assert.assertNotNull(vuln.getCvssV3ImpactSubScore());
+        Assert.assertNotNull(vuln.getCvssV3ExploitabilitySubScore());
         Assert.assertEquals(Severity.HIGH, vuln.getSeverity());
     } 
 

--- a/src/test/java/org/dependencytrack/notification/publisher/AbstractPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/AbstractPublisherTest.java
@@ -27,6 +27,7 @@ import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.Bom;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
+import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Tag;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAnalysisLevel;
@@ -215,6 +216,7 @@ public abstract class AbstractPublisherTest<T extends Publisher> extends Persist
         vuln.setOwaspRRLikelihoodScore(BigDecimal.valueOf(1.1));
         vuln.setOwaspRRTechnicalImpactScore(BigDecimal.valueOf(2.2));
         vuln.setOwaspRRBusinessImpactScore(BigDecimal.valueOf(3.3));
+        vuln.setSeverity(Severity.MEDIUM);
         vuln.setCwes(List.of(666, 777));
         return vuln;
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Stores computed severities in the database, instead of calculating it in-memory.

This extends #3287 in the following ways:

* Alter the behavior of `Vulnerability#setSeverity` to *not* clear vectors and scores anymore
* Address more code areas that create or update vulnerability data, ensuring that severity is always being set
* During the migration from v4.10.x, update severities of existing vulnerabilities in batches of 500, drastically decreasing database round-trips

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #2474

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
