### PR TITLE
Finding Attributed On date is not retained when cloning projects

### DIFF
--- a/dev/scripts/data-nist-generate-dummy.sh
+++ b/dev/scripts/data-nist-generate-dummy.sh
@@ -32,7 +32,7 @@ done
 rm -rf "$NIST_DIR"
 mkdir -p "$NIST_DIR"
 
-for feed in $(seq "2023" "2002"); do
+for feed in $(seq "2024" "2002"); do
   touch "$NIST_DIR/nvdcve-1.1-$feed.json.gz"
   echo "9999999999999" > "$NIST_DIR/nvdcve-1.1-$feed.json.gz.ts"
 done

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -648,7 +648,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                     // Add vulnerabilties and finding attribution from the source component to the cloned component
                     for (Vulnerability vuln: sourceComponent.getVulnerabilities()) {
                         final FindingAttribution sourceAttribution = this.getFindingAttribution(vuln, sourceComponent);
-                        this.addVulnerability(vuln, clonedComponent, sourceAttribution.getAnalyzerIdentity(), sourceAttribution.getAlternateIdentifier(), sourceAttribution.getReferenceUrl());
+                        this.addVulnerability(vuln, clonedComponent, sourceAttribution.getAnalyzerIdentity(), sourceAttribution.getAlternateIdentifier(), sourceAttribution.getReferenceUrl(), sourceAttribution.getAttributedOn());
                     }
                     clonedComponents.put(sourceComponent.getId(), clonedComponent);
                 }

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -757,6 +757,11 @@ public class QueryManager extends AlpineQueryManager {
         getVulnerabilityQueryManager().addVulnerability(vulnerability, component, analyzerIdentity, alternateIdentifier, referenceUrl);
     }
 
+    public void addVulnerability(Vulnerability vulnerability, Component component, AnalyzerIdentity analyzerIdentity,
+                                 String alternateIdentifier, String referenceUrl, Date attributedOn) {
+        getVulnerabilityQueryManager().addVulnerability(vulnerability, component, analyzerIdentity, alternateIdentifier, referenceUrl, attributedOn);
+    }
+
     public void removeVulnerability(Vulnerability vulnerability, Component component) {
         getVulnerabilityQueryManager().removeVulnerability(vulnerability, component);
     }

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -199,7 +199,7 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
      * @param analyzerIdentity the identify of the analyzer
      */
     public void addVulnerability(Vulnerability vulnerability, Component component, AnalyzerIdentity analyzerIdentity) {
-        this.addVulnerability(vulnerability, component, analyzerIdentity, null, null);
+        this.addVulnerability(vulnerability, component, analyzerIdentity, null, null, null);
     }
 
     /**
@@ -212,10 +212,28 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
      */
     public void addVulnerability(Vulnerability vulnerability, Component component, AnalyzerIdentity analyzerIdentity,
                                  String alternateIdentifier, String referenceUrl) {
+        this.addVulnerability(vulnerability, component, analyzerIdentity, alternateIdentifier, referenceUrl, null);
+    }
+
+    /**
+     * Adds a vulnerability to a component.
+     * @param vulnerability the vulnerability to add
+     * @param component the component affected by the vulnerability
+     * @param analyzerIdentity the identify of the analyzer
+     * @param alternateIdentifier the optional identifier if the analyzer refers to the vulnerability by an alternative identifier
+     * @param referenceUrl the optional URL that references the occurrence of the vulnerability if uniquely identified
+     * @param attributedOn the optional attribution date of the vulnerability. Used primarily when cloning projects, leave null when adding a new one.
+     */
+    public void addVulnerability(Vulnerability vulnerability, Component component, AnalyzerIdentity analyzerIdentity,
+                                 String alternateIdentifier, String referenceUrl, Date attributedOn) {
         if (!contains(vulnerability, component)) {
             component.addVulnerability(vulnerability);
             component = persist(component);
-            persist(new FindingAttribution(component, vulnerability, analyzerIdentity, alternateIdentifier, referenceUrl));
+            FindingAttribution findingAttribution = new FindingAttribution(component, vulnerability, analyzerIdentity, alternateIdentifier, referenceUrl);
+            if (attributedOn != null) {
+                findingAttribution.setAttributedOn(attributedOn);
+            }
+            persist(findingAttribution);
         }
     }
 

--- a/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.persistence;
+
+import alpine.persistence.PaginatedResult;
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.*;
+import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProjectQueryManagerTest extends PersistenceCapableTest {
+
+    @Test
+    public void testCloneProjectPreservesVulnerabilityAttributionDate() throws Exception {
+        Project project = qm.createProject("Example Project 1", "Description 1", "1.0", null, null, null, true, false);
+        Component comp = new Component();
+        comp.setId(111L);
+        comp.setName("name");
+        comp.setProject(project);
+        comp.setVersion("1.0");
+        comp.setCopyright("Copyright Acme");
+        qm.createComponent(comp, true);
+        Vulnerability vuln = new Vulnerability();
+        vuln.setVulnId("INT-123");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        qm.persist(vuln);
+        qm.addVulnerability(vuln, comp, AnalyzerIdentity.INTERNAL_ANALYZER, "Vuln1", "http://vuln.com/vuln1", new Date(1708559165229L));
+        Project clonedProject = qm.clone(project.getUuid(), "1.1.0", false, false, true, false, false, false, false);
+        List<Finding> findings = qm.getFindings(clonedProject);
+        Assert.assertEquals(1, findings.size());
+        Finding finding = findings.get(0);
+        Assert.assertNotNull(finding);
+        Assert.assertFalse(finding.getAttribution().isEmpty());
+        Assert.assertEquals(new Date(1708559165229L),finding.getAttribution().get("attributedOn"));
+    }
+
+}


### PR DESCRIPTION
Adds possibility to enter an attribution date value when adding a vulnerability to a project, used in cloning operation.

### Description
attribution dates where not passed on when cloning a project. This lead to all cloned vulnerabilities having attribution dates equals to that of the action performed. The attribution date has been added to all necessary methods and can be nullified if not needed.

### Addressed Issue
Fixes #3464

### Checklist


- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
