### PR TITLE
Adds possibility to limit notification rules to tags

### DIFF
--- a/docs/_docs/integrations/notifications.md
+++ b/docs/_docs/integrations/notifications.md
@@ -473,7 +473,7 @@ to notify on. Then specify the destination:
 ![configure notification](/images/screenshots/notifications-configure.png)
 
 By default, portfolio notifications are published regardless of which project is affected. This behavior can be altered
-by optionally limiting the projects. Expand the 'Limit To' button to reveal and configure the list of projects.
+by optionally limiting the projects or limiting to tags. Expand the 'Limit To' button to reveal and configure the list of projects or tags.
 
 ## Outbound Webhooks
 With outbound webhooks, notifications and all of their relevant details can be delivered via HTTP to an endpoint

--- a/src/main/java/org/dependencytrack/model/NotificationRule.java
+++ b/src/main/java/org/dependencytrack/model/NotificationRule.java
@@ -116,6 +116,12 @@ public class NotificationRule implements Serializable {
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC, version ASC"))
     private List<Project> projects;
 
+    @Persistent(table = "NOTIFICATIONRULE_TAGS", defaultFetchGroup = "true")
+    @Join(column = "NOTIFICATIONRULE_ID")
+    @Element(column = "TAG_ID")
+    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
+    private List<Tag> tags;
+
     @Persistent(table = "NOTIFICATIONRULE_TEAMS", defaultFetchGroup = "true")
     @Join(column = "NOTIFICATIONRULE_ID")
     @Element(column = "TEAM_ID")
@@ -212,6 +218,14 @@ public class NotificationRule implements Serializable {
 
     public void setProjects(List<Project> projects) {
         this.projects = projects;
+    }
+
+    public List<Tag> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<Tag> tags) {
+        this.tags = tags;
     }
 
     public List<Team> getTeams() {

--- a/src/main/java/org/dependencytrack/notification/NotificationRouter.java
+++ b/src/main/java/org/dependencytrack/notification/NotificationRouter.java
@@ -23,9 +23,10 @@ import alpine.notification.Notification;
 import alpine.notification.NotificationLevel;
 import alpine.notification.Subscriber;
 import org.dependencytrack.exception.PublisherException;
-import org.dependencytrack.model.NotificationPublisher;
 import org.dependencytrack.model.NotificationRule;
+import org.dependencytrack.model.NotificationPublisher;
 import org.dependencytrack.model.Project;
+import org.dependencytrack.model.Tag;
 import org.dependencytrack.notification.publisher.PublishContext;
 import org.dependencytrack.notification.publisher.Publisher;
 import org.dependencytrack.notification.publisher.SendMailPublisher;
@@ -38,7 +39,10 @@ import org.dependencytrack.notification.vo.PolicyViolationIdentified;
 import org.dependencytrack.notification.vo.VexConsumedOrProcessed;
 import org.dependencytrack.notification.vo.ViolationAnalysisDecisionChange;
 import org.dependencytrack.persistence.QueryManager;
-
+import java.util.Set;
+import java.util.UUID;
+import java.util.List;
+import java.util.ArrayList;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import javax.json.Json;
@@ -46,10 +50,7 @@ import javax.json.JsonObject;
 import javax.json.JsonReader;
 import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+
 import java.util.stream.Collectors;
 
 import static org.dependencytrack.notification.publisher.Publisher.CONFIG_TEMPLATE_KEY;
@@ -106,6 +107,22 @@ public class NotificationRouter implements Subscriber {
         Notification restrictedNotification = initialNotification;
         if (canRestrictNotificationToRuleProjects(initialNotification, rule)) {
             Set<String> ruleProjectsUuids = rule.getProjects().stream().map(Project::getUuid).map(UUID::toString).collect(Collectors.toSet());
+            try (QueryManager qm = new QueryManager()) {
+                // Add all projects related to listed tags.
+                // FIXME: qm.getProjects(Tag t) returns nothing for unit test org.dependencytrack.notification.NotificationRouterTest.testValidMatchingProjectAndTagLimitingRule
+//                ruleProjectsUuids.addAll(rule.getTags().stream()
+//                        .map(t -> qm.getProjects(t, false, true, true).getList(Project.class)) // get all projects associated to a tag
+//                        .flatMap(Collection::stream)
+//                        .map(Project::getUuid)
+//                        .map(UUID::toString)
+//                        .collect(Collectors.toSet()));
+                ruleProjectsUuids.addAll(qm.getProjects().getList(Project.class)
+                        .stream()
+                        .filter(p -> p.getTags().stream().anyMatch(t-> rule.getTags().contains(t)))
+                        .map(Project::getUuid)
+                        .map(UUID::toString).collect(Collectors.toSet()));
+
+            }
             restrictedNotification = new Notification();
             restrictedNotification.setGroup(initialNotification.getGroup());
             restrictedNotification.setLevel(initialNotification.getLevel());
@@ -124,8 +141,7 @@ public class NotificationRouter implements Subscriber {
 
     private boolean canRestrictNotificationToRuleProjects(final Notification initialNotification, final NotificationRule rule) {
         return initialNotification.getSubject() instanceof NewVulnerabilityIdentified
-                && rule.getProjects() != null
-                && !rule.getProjects().isEmpty();
+                && isNotificationRestricted(rule);
     }
 
     List<NotificationRule> resolveRules(final PublishContext ctx, final Notification notification) {
@@ -157,61 +173,68 @@ public class NotificationRouter implements Subscriber {
             pm.detachCopyAll(result);
             LOGGER.debug("Matched %d notification rules (%s)".formatted(result.size(), ctx));
 
-            if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
-                    && notification.getSubject() instanceof final NewVulnerabilityIdentified subject) {
-                // If the rule specified one or more projects as targets, reduce the execution
-                // of the notification down to those projects that the rule matches and which
-                // also match project the component is included in.
-                // NOTE: This logic is slightly different from what is implemented in limitToProject()
-                for (final NotificationRule rule : result) {
-                    if (rule.getNotifyOn().contains(NotificationGroup.valueOf(notification.getGroup()))) {
-                        if (rule.getProjects() != null && !rule.getProjects().isEmpty()
-                                && subject.getComponent() != null && subject.getComponent().getProject() != null) {
-                            for (final Project project : rule.getProjects()) {
-                                if (subject.getComponent().getProject().getUuid().equals(project.getUuid()) || (Boolean.TRUE.equals(rule.isNotifyChildren() && checkIfChildrenAreAffected(project, subject.getComponent().getProject().getUuid())))) {
-                                    rules.add(rule);
-                                }
-                            }
-                        } else {
-                            rules.add(rule);
-                        }
-                    }
-                }
-            } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
-                    && notification.getSubject() instanceof final NewVulnerableDependency subject) {
-                limitToProject(ctx, rules, result, notification, subject.getComponent().getProject());
-            } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
-                    && notification.getSubject() instanceof final BomConsumedOrProcessed subject) {
-                limitToProject(ctx, rules, result, notification, subject.getProject());
-            } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
-                    && notification.getSubject() instanceof final BomProcessingFailed subject) {
-                limitToProject(ctx, rules, result, notification, subject.getProject());
-            } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
-                    && notification.getSubject() instanceof final VexConsumedOrProcessed subject) {
-                limitToProject(ctx, rules, result, notification, subject.getProject());
-            } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
-                    && notification.getSubject() instanceof final PolicyViolationIdentified subject) {
-                limitToProject(ctx, rules, result, notification, subject.getProject());
-            } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
-                    && notification.getSubject() instanceof final AnalysisDecisionChange subject) {
-                limitToProject(ctx, rules, result, notification, subject.getProject());
-            } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
-                    && notification.getSubject() instanceof final ViolationAnalysisDecisionChange subject) {
-                limitToProject(ctx, rules, result, notification, subject.getComponent().getProject());
-            } else {
-                for (final NotificationRule rule : result) {
-                    if (rule.getNotifyOn().contains(NotificationGroup.valueOf(notification.getGroup()))) {
-                        rules.add(rule);
-                    }
-                }
+            if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())) {
+                applyLimitations(ctx, rules, result, notification);
             }
         }
         return rules;
     }
 
+    private void applyLimitations(final PublishContext ctx, final List<NotificationRule> applicableRules,
+                                  final List<NotificationRule> rules, final Notification notification) {
+        if (notification.getSubject() instanceof final NewVulnerabilityIdentified subject) {
+            // If the rule specified one or more projects as targets, reduce the execution
+            // of the notification down to those projects that the rule matches and which
+            // also match project the component is included in.
+            // NOTE: This logic is slightly different from what is implemented in limitToProject()
+            for (final NotificationRule rule : rules) {
+                if (rule.getNotifyOn().contains(NotificationGroup.valueOf(notification.getGroup()))) {
+                    if (isNotificationRestricted(rule)) {
+                        if (rule.getProjects() != null && !rule.getProjects().isEmpty()
+                                && subject.getAffectedProjects() != null && !subject.getAffectedProjects().isEmpty()) {
+                            for (final Project project : rule.getProjects()) {
+                                boolean atLeastOneAffectedProjectConcerned = subject.getAffectedProjects().stream().anyMatch(p -> p.getUuid().equals(project.getUuid()));
+                                boolean atLeastOneChildProjectConcerned = rule.isNotifyChildren() && subject.getAffectedProjects().stream().anyMatch(p->checkIfChildrenAreAffected(project, p.getUuid()));
+                                if (atLeastOneAffectedProjectConcerned || atLeastOneChildProjectConcerned) {
+                                    applicableRules.add(rule);
+                                    break; // no need to add the same rule multiple times.
+                                }
+                            }
+                        } else if (!applicableRules.contains(rule) && rule.getTags() != null
+                                && !rule.getTags().isEmpty() && isRuleLimitedToProjectsTag(rule, subject.getAffectedProjects())) {
+                            applicableRules.add(rule);
+                        }
+                    } else {
+                        applicableRules.add(rule);
+                    }
+                }
+            }
+        } else if (notification.getSubject() instanceof final NewVulnerableDependency subject) {
+            limitToProject(ctx, applicableRules, rules, notification, subject.getComponent().getProject());
+        } else if (notification.getSubject() instanceof final BomConsumedOrProcessed subject) {
+            limitToProject(ctx, applicableRules, rules, notification, subject.getProject());
+        } else if (notification.getSubject() instanceof final BomProcessingFailed subject) {
+            limitToProject(ctx, applicableRules, rules, notification, subject.getProject());
+        } else if (notification.getSubject() instanceof final VexConsumedOrProcessed subject) {
+            limitToProject(ctx, applicableRules, rules, notification, subject.getProject());
+        } else if (notification.getSubject() instanceof final PolicyViolationIdentified subject) {
+            limitToProject(ctx, applicableRules, rules, notification, subject.getProject());
+        } else if (notification.getSubject() instanceof final AnalysisDecisionChange subject) {
+            limitToProject(ctx, applicableRules, rules, notification, subject.getProject());
+        } else if (notification.getSubject() instanceof final ViolationAnalysisDecisionChange subject) {
+            limitToProject(ctx, applicableRules, rules, notification, subject.getComponent().getProject());
+        } else {
+            for (final NotificationRule rule : rules) {
+                if (rule.getNotifyOn().contains(NotificationGroup.valueOf(notification.getGroup()))) {
+                    applicableRules.add(rule);
+                }
+            }
+        }
+    }
+
     /**
-     * if the rule specified one or more projects as targets, reduce the execution
-     * of the notification down to those projects that the rule matches and which
+     * if the rule specifies one or more projects or tags as targets, reduce the execution
+     * of the notification down to those that the rule matches and which
      * also match projects affected by the vulnerability.
      */
     private void limitToProject(final PublishContext ctx, final List<NotificationRule> applicableRules,
@@ -220,35 +243,76 @@ public class NotificationRouter implements Subscriber {
         for (final NotificationRule rule : rules) {
             final PublishContext ruleCtx = ctx.withRule(rule);
             if (rule.getNotifyOn().contains(NotificationGroup.valueOf(notification.getGroup()))) {
-                if (rule.getProjects() != null && !rule.getProjects().isEmpty()) {
-                    for (final Project project : rule.getProjects()) {
-                        if (project.getUuid().equals(limitToProject.getUuid())) {
-                            LOGGER.debug("Project %s is part of the \"limit to\" list of the rule; Rule is applicable (%s)"
-                                    .formatted(limitToProject.getUuid(), ruleCtx));
-                            applicableRules.add(rule);
-                        } else if (rule.isNotifyChildren()) {
-                            final boolean isChildOfLimitToProject = checkIfChildrenAreAffected(project, limitToProject.getUuid());
-                            if (isChildOfLimitToProject) {
-                                LOGGER.debug("Project %s is child of \"limit to\" project %s; Rule is applicable (%s)"
-                                        .formatted(limitToProject.getUuid(), project.getUuid(), ruleCtx));
+                if (isNotificationRestricted(rule)) {
+                    if (rule.getProjects() != null && !rule.getProjects().isEmpty()) {
+                        for (final Project project : rule.getProjects()) {
+                            if (project.getUuid().equals(limitToProject.getUuid())) {
+                                LOGGER.debug("Project %s is part of the \"limit to\" list of the rule; Rule is applicable (%s)"
+                                        .formatted(limitToProject.getUuid(), ruleCtx));
                                 applicableRules.add(rule);
+                            } else if (rule.isNotifyChildren()) {
+                                final boolean isChildOfLimitToProject = checkIfChildrenAreAffected(project, limitToProject.getUuid());
+                                if (isChildOfLimitToProject) {
+                                    LOGGER.debug("Project %s is child of \"limit to\" project %s; Rule is applicable (%s)"
+                                            .formatted(limitToProject.getUuid(), project.getUuid(), ruleCtx));
+                                    applicableRules.add(rule);
+                                } else {
+                                    LOGGER.debug("Project %s is not a child of \"limit to\" project %s; Rule is not applicable (%s)"
+                                            .formatted(limitToProject.getUuid(), project.getUuid(), ruleCtx));
+                                }
                             } else {
-                                LOGGER.debug("Project %s is not a child of \"limit to\" project %s; Rule is not applicable (%s)"
-                                        .formatted(limitToProject.getUuid(), project.getUuid(), ruleCtx));
+                                LOGGER.debug("Project %s is not part of the \"limit to\" list of the rule; Rule is not applicable (%s)"
+                                        .formatted(limitToProject.getUuid(), ruleCtx));
                             }
-                        } else {
-                            LOGGER.debug("Project %s is not part of the \"limit to\" list of the rule; Rule is not applicable (%s)"
-                                    .formatted(limitToProject.getUuid(), ruleCtx));
                         }
+                    } else if (!applicableRules.contains(rule) && rule.getTags() != null && !rule.getTags().isEmpty() && isRuleLimitedToProjectTag(rule, limitToProject)) {
+                        LOGGER.debug("Project %s has tags that are part of the \"limit to\" tags list; Rule is applicable (%s)"
+                                .formatted(limitToProject.getUuid(), ruleCtx));
+                        applicableRules.add(rule);
                     }
+
                 } else {
-                    LOGGER.debug("Rule is not limited to projects; Rule is applicable (%s)".formatted(ruleCtx));
+                    LOGGER.debug("Rule is not limited to projects or tags; Rule is applicable (%s)".formatted(ruleCtx));
                     applicableRules.add(rule);
                 }
             }
         }
+
         LOGGER.debug("Applicable rules: %s (%s)"
                 .formatted(applicableRules.stream().map(NotificationRule::getName).collect(Collectors.joining(", ")), ctx));
+    }
+
+    private boolean isNotificationRestricted(NotificationRule rule) {
+        boolean isLimitedToProjects = rule.getProjects() != null && !rule.getProjects().isEmpty();
+        boolean isLimitedToTags = rule.getTags() != null && !rule.getTags().isEmpty();
+        return isLimitedToProjects || isLimitedToTags;
+    }
+
+    private boolean isRuleLimitedToProjectTag(NotificationRule rule, Project project) {
+        if (project == null) {
+            return false;
+        }
+        if (rule.getTags() == null || rule.getTags().isEmpty()) {
+            return false;
+        }
+        boolean flag = false;
+        for (Tag projectTag : project.getTags()) {
+            flag = rule.getTags().stream().anyMatch(ruleTag -> ruleTag.getId() == projectTag.getId());
+            if (flag) {
+                break;
+            }
+        }
+        return flag;
+    }
+
+    private boolean isRuleLimitedToProjectsTag(NotificationRule rule, Set<Project> projects) {
+        if (projects == null || projects.isEmpty()) {
+            return false;
+        }
+        if (rule.getTags() == null || rule.getTags().isEmpty()) {
+            return false;
+        }
+        return projects.stream().anyMatch(p -> isRuleLimitedToProjectTag(rule, p));
     }
 
     private boolean checkIfChildrenAreAffected(Project parent, UUID uuid) {

--- a/src/main/java/org/dependencytrack/persistence/NotificationQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/NotificationQueryManager.java
@@ -107,6 +107,15 @@ public class NotificationQueryManager extends QueryManager implements IQueryMana
     }
 
     /**
+     * Returns a notification rule by it's uuid.
+     * @param uuid the uuid of the notification rule (required)
+     * @return a NotificationRule object, or null if not found
+     */
+    public NotificationRule getNotificationRule(String uuid) {
+        return getObjectByUuid(NotificationRule.class, uuid);
+    }
+
+    /**
      * Retrieves all NotificationPublishers.
      * This method if designed NOT to provide paginated results.
      * @return list of all NotificationPublisher objects

--- a/src/main/java/org/dependencytrack/persistence/PolicyQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/PolicyQueryManager.java
@@ -98,6 +98,15 @@ final class PolicyQueryManager extends QueryManager implements IQueryManager {
     }
 
     /**
+     * Returns a policy by it's uuid.
+     * @param uuid the uuid of the policy (required)
+     * @return a Policy object, or null if not found
+     */
+    public Policy getPolicyByUuid(final String uuid) {
+        return getObjectByUuid(Policy.class, uuid);
+    }
+
+    /**
      * Creates a new Policy.
      * @param name the name of the policy to create
      * @param operator the operator

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -598,6 +598,10 @@ public class QueryManager extends AlpineQueryManager {
         return getPolicyQueryManager().getPolicy(name);
     }
 
+    public Policy getPolicyByUuid(final String uuid) {
+        return getPolicyQueryManager().getPolicyByUuid(uuid);
+    }
+
     public Policy createPolicy(String name, Policy.Operator operator, Policy.ViolationState violationState) {
         return getPolicyQueryManager().createPolicy(name, operator, violationState);
     }
@@ -1166,6 +1170,10 @@ public class QueryManager extends AlpineQueryManager {
         return getNotificationQueryManager().getNotificationRules();
     }
 
+    public NotificationRule getNotificationRule(String uuid) {
+        return getNotificationQueryManager().getNotificationRule(uuid);
+    }
+
     public List<NotificationPublisher> getAllNotificationPublishers() {
         return getNotificationQueryManager().getAllNotificationPublishers();
     }
@@ -1266,8 +1274,8 @@ public class QueryManager extends AlpineQueryManager {
         return getProjectQueryManager().hasAccessManagementPermission(apiKey);
     }
 
-    public PaginatedResult getTags(String policyUuid) {
-        return getTagQueryManager().getTags(policyUuid);
+    public PaginatedResult getTags(List<Project> projects) {
+        return getTagQueryManager().getTags(projects);
     }
 
     /**

--- a/src/main/java/org/dependencytrack/persistence/TagQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/TagQueryManager.java
@@ -21,7 +21,6 @@ package org.dependencytrack.persistence;
 import alpine.common.logging.Logger;
 import alpine.persistence.PaginatedResult;
 import alpine.resources.AlpineRequest;
-import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Tag;
 
@@ -54,12 +53,7 @@ public class TagQueryManager extends QueryManager implements IQueryManager {
         super(pm, request);
     }
 
-    public PaginatedResult getTags(String policyUuid) {
-
-        LOGGER.debug("Retrieving tags under policy " + policyUuid);
-
-        Policy policy = getObjectByUuid(Policy.class, policyUuid);
-        List<Project> projects = policy.getProjects();
+    public PaginatedResult getTags(List<Project> projects) {
 
         final Stream<Tag> tags;
         if (projects != null && !projects.isEmpty()) {

--- a/src/main/java/org/dependencytrack/resources/v1/NotificationRuleResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/NotificationRuleResource.java
@@ -35,7 +35,6 @@ import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.NotificationPublisher;
 import org.dependencytrack.model.NotificationRule;
 import org.dependencytrack.model.Project;
-import org.dependencytrack.model.Tag;
 import org.dependencytrack.model.validation.ValidUuid;
 import org.dependencytrack.notification.NotificationScope;
 import org.dependencytrack.notification.publisher.SendMailPublisher;

--- a/src/main/java/org/dependencytrack/resources/v1/NotificationRuleResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/NotificationRuleResource.java
@@ -35,6 +35,7 @@ import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.NotificationPublisher;
 import org.dependencytrack.model.NotificationRule;
 import org.dependencytrack.model.Project;
+import org.dependencytrack.model.Tag;
 import org.dependencytrack.model.validation.ValidUuid;
 import org.dependencytrack.notification.NotificationScope;
 import org.dependencytrack.notification.publisher.SendMailPublisher;
@@ -325,7 +326,7 @@ public class NotificationRuleResource extends AlpineResource {
     public Response removeTeamFromRule(
             @ApiParam(value = "The UUID of the rule to remove the project from", format = "uuid", required = true)
             @PathParam("ruleUuid") @ValidUuid String ruleUuid,
-            @ApiParam(value = "The UUID of the project to remove from the rule", format = "uuid", required = true)
+            @ApiParam(value = "The UUID of the team to remove from the rule", format = "uuid", required = true)
             @PathParam("teamUuid") @ValidUuid String teamUuid) {
         try (QueryManager qm = new QueryManager()) {
             final NotificationRule rule = qm.getObjectByUuid(NotificationRule.class, ruleUuid);

--- a/src/main/java/org/dependencytrack/resources/v1/TagResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/TagResource.java
@@ -41,10 +41,12 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.List;
 
 @Path("/v1/tag")
 @Api(value = "tag", authorizations = @Authorization(value = "X-Api-Key"))
 public class TagResource extends AlpineResource {
+
 
     @GET
     @Path("/policy/{policyUuid}")
@@ -91,8 +93,8 @@ public class TagResource extends AlpineResource {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             NotificationRule rule = qm.getNotificationRule(uuid);
             if (rule != null) {
-                final PaginatedResult result = qm.getTags(rule.getProjects());
-                return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
+                List<Tag> tags = rule.getTags();
+                return Response.ok(tags).header(TOTAL_COUNT_HEADER, tags.size()).build();
             }
             // SDE: refine this part
             return Response.ok().header(TOTAL_COUNT_HEADER, 0).build();

--- a/src/test/java/org/dependencytrack/model/NotificationRuleTest.java
+++ b/src/test/java/org/dependencytrack/model/NotificationRuleTest.java
@@ -180,4 +180,15 @@ public class NotificationRuleTest {
         Assert.assertEquals(team, rule.getTeams().get(0));
         Assert.assertEquals(oidcUser, rule.getTeams().get(0).getOidcUsers().get(0));
     }
+
+    @Test
+    public void testTags(){
+        List<Tag> tags = new ArrayList<>();
+        Tag tag = new Tag();
+        tags.add(tag);
+        NotificationRule rule = new NotificationRule();
+        rule.setTags(tags);
+        Assert.assertEquals(1, rule.getTags().size());
+        Assert.assertEquals(tag, rule.getTags().get(0));
+    }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
@@ -426,8 +426,10 @@ public class NotificationRuleResourceTest extends ResourceTest {
                           "notifyChildren": true,
                           "logSuccessfulPublish": false,
                           "scope": "PORTFOLIO",
+                          "tags":[],
                           "notificationLevel": "INFORMATIONAL",
                           "projects": [],
+                          "tags": [],
                           "teams": [
                             {
                               "uuid": "${json-unit.matches:teamUuid}",


### PR DESCRIPTION
### Description
Adds tags to limitations of notification rules (alerts)
- adds tags to the NotificationRule db schema
- adds rest api resources to manage them
- adds management of tags when filtering notifications

### Addressed Issue
Fixes #2975

### Additional Details
I wanted to use `qm.getProjects(tag, false, true, true)` but during tests, it failed to retrieved the proper data. This part may need to be redone. (see org.dependencytrack.notification.NotificationRouter#restrictNotificationToRuleProjects fixme comment)
Manual tests performed: 
* When an alert on 'bom consumed' limited to a tag is configured, if I upload a bom on the tagged project, then notification is triggered
* When an alert on 'bom consumed' limited to a project is configured, if I upload a bom on the project, then notification is triggered
* When an alert on 'bom consumed' limited to a project with children included is configured, if I upload a bom on a child project, then notification is triggered

No upgrade logic added for additional column.
 
### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
