### PR TITLE
Implement the hackage and nixpkgs meta analyzers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ target/
 .idea/*
 !.idea/icon.svg
 !.idea/runConfigurations/
+
+# nix 
+.direnv
+.pre-commit-config.yaml

--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,13 @@
             <scope>compile</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.brotli/dec -->
+        <dependency>
+            <groupId>org.brotli</groupId>
+            <artifactId>dec</artifactId>
+            <version>0.1.2</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
@@ -410,7 +417,6 @@
             <version>2.35.2</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>

--- a/src/main/java/org/dependencytrack/model/RepositoryType.java
+++ b/src/main/java/org/dependencytrack/model/RepositoryType.java
@@ -39,10 +39,13 @@ public enum RepositoryType {
     CARGO,
     GO_MODULES,
     GITHUB,
+    HACKAGE,
+    NIXPKGS,
     UNSUPPORTED;
 
     /**
      * Returns a RepositoryType for the specified PackageURL.
+     *
      * @param packageURL a package URL
      * @return a RepositoryType
      */
@@ -70,6 +73,8 @@ public enum RepositoryType {
             return GO_MODULES;
         } else if (PackageURL.StandardTypes.GITHUB.equals(type)) {
             return GITHUB;
+        } else if ("hackage".equals(type)) {
+            return HACKAGE;
         }
         return UNSUPPORTED;
     }

--- a/src/main/java/org/dependencytrack/model/RepositoryType.java
+++ b/src/main/java/org/dependencytrack/model/RepositoryType.java
@@ -40,6 +40,7 @@ public enum RepositoryType {
     GO_MODULES,
     GITHUB,
     HACKAGE,
+    NIXPKGS,
     UNSUPPORTED;
 
     /**
@@ -74,6 +75,8 @@ public enum RepositoryType {
             return GITHUB;
         } else if ("hackage".equals(type)) {
             return HACKAGE;
+        } else if ("nixpkgs".equals(type)) {
+            return NIXPKGS;
         }
         return UNSUPPORTED;
     }

--- a/src/main/java/org/dependencytrack/model/RepositoryType.java
+++ b/src/main/java/org/dependencytrack/model/RepositoryType.java
@@ -40,7 +40,6 @@ public enum RepositoryType {
     GO_MODULES,
     GITHUB,
     HACKAGE,
-    NIXPKGS,
     UNSUPPORTED;
 
     /**

--- a/src/main/java/org/dependencytrack/tasks/repositories/HackageMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/HackageMetaAnalyzer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.tasks.repositories;
 

--- a/src/main/java/org/dependencytrack/tasks/repositories/HackageMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/HackageMetaAnalyzer.java
@@ -30,8 +30,8 @@ public class HackageMetaAnalyzer extends AbstractMetaAnalyzer {
      * {@inheritDoc}
      */
     public boolean isApplicable(Component component) {
-        // FUTUREWORK(mangoiv): add nixpkgs and hackage to https://github.com/package-url/packageurl-java/blob/master/src/main/java/com/github/packageurl/PackageURL.java
-        var purl = component.getPurl();
+        // FUTUREWORK(mangoiv): add hackage to https://github.com/package-url/packageurl-java/blob/master/src/main/java/com/github/packageurl/PackageURL.java
+        final var purl = component.getPurl();
         return purl != null && "hackage".equals(purl.getType());
     }
 
@@ -40,7 +40,7 @@ public class HackageMetaAnalyzer extends AbstractMetaAnalyzer {
      */
     public MetaModel analyze(final Component component) {
         final var meta = new MetaModel(component);
-        var purl = component.getPurl();
+        final var purl = component.getPurl();
         if (purl != null) {
             final var url = baseUrl + "/package/" + purl.getName() + "/preferred";
             try (final CloseableHttpResponse response = processHttpRequest(url)) {

--- a/src/main/java/org/dependencytrack/tasks/repositories/HackageMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/HackageMetaAnalyzer.java
@@ -1,0 +1,74 @@
+package org.dependencytrack.tasks.repositories;
+
+import alpine.common.logging.Logger;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.dependencytrack.exception.MetaAnalyzerException;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.RepositoryType;
+import org.json.JSONObject;
+
+import java.io.IOException;
+
+public class HackageMetaAnalyzer extends AbstractMetaAnalyzer {
+    private static final Logger LOGGER = Logger.getLogger(HackageMetaAnalyzer.class);
+    private static final String DEFAULT_BASE_URL = "https://hackage.haskell.org/";
+
+    HackageMetaAnalyzer() {
+        this.baseUrl = DEFAULT_BASE_URL;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public RepositoryType supportedRepositoryType() {
+        return RepositoryType.HACKAGE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isApplicable(Component component) {
+        // FUTUREWORK(mangoiv): add nixpkgs and hackage to https://github.com/package-url/packageurl-java/blob/master/src/main/java/com/github/packageurl/PackageURL.java
+        var purl = component.getPurl();
+        return purl != null && "hackage".equals(purl.getType());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public MetaModel analyze(final Component component) {
+        final var meta = new MetaModel(component);
+        var purl = component.getPurl();
+        if (purl != null) {
+            final var url = baseUrl + "/package/" + purl.getName() + "/preferred";
+            try (final CloseableHttpResponse response = processHttpRequest(url)) {
+                if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+                    final var entity = response.getEntity();
+                    if (entity != null) {
+                        String responseString = EntityUtils.toString(entity);
+                        final var deserialized = new JSONObject(responseString);
+                        final var preferred = deserialized.getJSONArray("normal-version");
+                        // the latest version is the first in the list
+                        if (preferred != null) {
+                            final var latest = preferred.getString(0);
+                            meta.setLatestVersion(latest);
+                        }
+                        // the hackage API doesn't expose the "published_at" information
+                        // we could use https://flora.pm/experimental/packages/{namespace}/{packageName}
+                        // but it appears this isn't reliable yet
+                    }
+                } else {
+                    var statusLine = response.getStatusLine();
+                    handleUnexpectedHttpResponse(LOGGER, url, statusLine.getStatusCode(), statusLine.getReasonPhrase(), component);
+                }
+            } catch (IOException ex) {
+                handleRequestException(LOGGER, ex);
+            } catch (Exception ex) {
+                throw new MetaAnalyzerException(ex);
+            }
+        }
+        return meta;
+    }
+}

--- a/src/main/java/org/dependencytrack/tasks/repositories/HackageMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/HackageMetaAnalyzer.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
 package org.dependencytrack.tasks.repositories;
 
 import alpine.common.logging.Logger;

--- a/src/main/java/org/dependencytrack/tasks/repositories/HackageMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/HackageMetaAnalyzer.java
@@ -48,7 +48,6 @@ public class HackageMetaAnalyzer extends AbstractMetaAnalyzer {
      * {@inheritDoc}
      */
     public boolean isApplicable(Component component) {
-        // FUTUREWORK(mangoiv): add hackage to https://github.com/package-url/packageurl-java/blob/master/src/main/java/com/github/packageurl/PackageURL.java
         final var purl = component.getPurl();
         return purl != null && "hackage".equals(purl.getType());
     }

--- a/src/main/java/org/dependencytrack/tasks/repositories/IMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/IMetaAnalyzer.java
@@ -135,6 +135,11 @@ public interface IMetaAnalyzer {
                 if (analyzer.isApplicable(component)) {
                     return analyzer;
                 }
+            } else if ("hackage".equals(component.getPurl().getType())) {
+                IMetaAnalyzer analyzer = new HackageMetaAnalyzer();
+                if (analyzer.isApplicable(component)) {
+                    return analyzer;
+                }
             }
         }
 

--- a/src/main/java/org/dependencytrack/tasks/repositories/IMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/IMetaAnalyzer.java
@@ -141,7 +141,7 @@ public interface IMetaAnalyzer {
                     return analyzer;
                 }
             } else if ("nixpkgs".equals(component.getPurl().getType())) {
-                IMetaAnalyzer analyzer = NixpkgsMetaAnalyzer.getNixpkgsMetaAnalyzer();
+                IMetaAnalyzer analyzer = new NixpkgsMetaAnalyzer();
                 if (analyzer.isApplicable(component)) {
                     return analyzer;
                 }

--- a/src/main/java/org/dependencytrack/tasks/repositories/IMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/IMetaAnalyzer.java
@@ -140,6 +140,11 @@ public interface IMetaAnalyzer {
                 if (analyzer.isApplicable(component)) {
                     return analyzer;
                 }
+            } else if ("nixpkgs".equals(component.getPurl().getType())) {
+                IMetaAnalyzer analyzer = NixpkgsMetaAnalyzer.getNixpkgsMetaAnalyzer();
+                if (analyzer.isApplicable(component)) {
+                    return analyzer;
+                }
             }
         }
 

--- a/src/main/java/org/dependencytrack/tasks/repositories/NixpkgsMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/NixpkgsMetaAnalyzer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (c) Steve Springett. All Rights Reserved.
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 package org.dependencytrack.tasks.repositories;
 

--- a/src/main/java/org/dependencytrack/tasks/repositories/NixpkgsMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/NixpkgsMetaAnalyzer.java
@@ -25,7 +25,6 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
-import org.brotli.dec.BrotliInputStream;
 import org.dependencytrack.exception.MetaAnalyzerException;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
@@ -37,7 +36,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.util.HashMap;
-import java.util.stream.Collectors;
 
 public class NixpkgsMetaAnalyzer extends AbstractMetaAnalyzer {
     private static final Logger LOGGER = Logger.getLogger(NixpkgsMetaAnalyzer.class);

--- a/src/main/java/org/dependencytrack/tasks/repositories/NixpkgsMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/NixpkgsMetaAnalyzer.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
 package org.dependencytrack.tasks.repositories;
 
 import alpine.common.logging.Logger;
@@ -43,7 +61,7 @@ public class NixpkgsMetaAnalyzer extends AbstractMetaAnalyzer {
                             if (pkg instanceof HashMap jsonPkg) {
                                 final var pname = jsonPkg.get("pname");
                                 final var version = jsonPkg.get("version");
-                                newLatestVersion.putIfAbsent((String)pname, (String)version);
+                                newLatestVersion.putIfAbsent((String) pname, (String) version);
                             }
                         });
                     }

--- a/src/main/java/org/dependencytrack/tasks/repositories/NixpkgsMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/NixpkgsMetaAnalyzer.java
@@ -1,0 +1,118 @@
+package org.dependencytrack.tasks.repositories;
+
+import alpine.common.logging.Logger;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.entity.BrotliInputStreamFactory;
+import org.apache.hc.client5.http.entity.DecompressingEntity;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.dependencytrack.exception.MetaAnalyzerException;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.RepositoryType;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+
+public class NixpkgsMetaAnalyzer extends AbstractMetaAnalyzer {
+    private static final Logger LOGGER = Logger.getLogger(NixpkgsMetaAnalyzer.class);
+    private static final String DEFAULT_CHANNEL_URL = "https://channels.nixos.org/nixpkgs-unstable/packages.json.br";
+    private static NixpkgsMetaAnalyzer nixpkgsMetaAnalyzer = new NixpkgsMetaAnalyzer();
+    // this doesn't really make sense wrt the "AbstractMetaAnalyzer"
+    // because this statically known url will just redirect us to
+    // the actual URL
+    private final HashMap<String, String> latestVersion;
+
+    private NixpkgsMetaAnalyzer() {
+        this.baseUrl = DEFAULT_CHANNEL_URL;
+        HashMap<String, String> newLatestVersion = new HashMap<>();
+
+        try (final CloseableHttpResponse packagesResponse = processHttpRequest5()) {
+            if (packagesResponse != null && packagesResponse.getCode() == HttpStatus.SC_OK) {
+                final var entity = packagesResponse.getEntity();
+                if (entity != null) {
+                    // TODO(mangoiv): is this the fastest way we can do this?
+                    final var entityString = EntityUtils.toString(new DecompressingEntity(entity, new BrotliInputStreamFactory()));
+                    final var packages = new JSONObject(entityString).getJSONObject("packages").toMap().values();
+                    packages.forEach(pkg -> {
+                        // FUTUREWORK(mangoiv): there are potentially packages with the same pname
+                        if (pkg instanceof JSONObject jsonPkg) {
+                            final var pname = jsonPkg.getString("pname");
+                            final var version = jsonPkg.getString("version");
+                            newLatestVersion.putIfAbsent(pname, version);
+                        }
+                    });
+                }
+
+            }
+        } catch (IOException ex) {
+            handleRequestException(LOGGER, ex);
+        } catch (Exception ex) {
+            throw new MetaAnalyzerException(ex);
+        }
+        this.latestVersion = newLatestVersion;
+        LOGGER.info("finished updating the nixpkgs meta analyzer");
+    }
+
+    public static NixpkgsMetaAnalyzer getNixpkgsMetaAnalyzer() {
+        return nixpkgsMetaAnalyzer;
+    }
+
+    private CloseableHttpResponse processHttpRequest5() throws IOException {
+        try {
+            URIBuilder uriBuilder = new URIBuilder(baseUrl);
+            final HttpGet request = new HttpGet(uriBuilder.build().toString());
+            request.addHeader("accept", "application/json");
+            try (final CloseableHttpClient client = HttpClients.createDefault()) {
+                return client.execute(request);
+            }
+        } catch (URISyntaxException ex) {
+            handleRequestException(LOGGER, ex);
+            return null;
+        }
+    }
+
+    /**
+     * updates the NixpkgsMetaAnalyzer asynchronously by fetching a new version
+     * of the standard channel
+     */
+    public void updateNixpkgsMetaAnalyzer() {
+        new Thread(() -> nixpkgsMetaAnalyzer = new NixpkgsMetaAnalyzer()).start();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public RepositoryType supportedRepositoryType() {
+        return RepositoryType.NIXPKGS;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isApplicable(Component component) {
+        // FUTUREWORK(mangoiv): add nixpkgs to https://github.com/package-url/packageurl-java/blob/master/src/main/java/com/github/packageurl/PackageURL.java
+        final var purl = component.getPurl();
+        return purl != null && "nixpkgs".equals(purl.getType());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public MetaModel analyze(Component component) {
+        final var meta = new MetaModel(component);
+        final var purl = component.getPurl();
+        if (purl != null) {
+            final var newerVersion = latestVersion.get(purl.getName());
+            if (newerVersion != null) {
+                meta.setLatestVersion(newerVersion);
+            }
+        }
+        return meta;
+    }
+}

--- a/src/test/java/org/dependencytrack/tasks/repositories/HackageMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/HackageMetaAnalyzerTest.java
@@ -1,0 +1,21 @@
+package org.dependencytrack.tasks.repositories;
+
+import com.github.packageurl.PackageURL;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.RepositoryType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HackageMetaAnalyzerTest {
+    @Test
+    public void testAnalyzer() throws Exception {
+        Component component = new Component();
+        component.setPurl(new PackageURL("pkg:hackage/singletons-th@3.1"));
+
+        HackageMetaAnalyzer analyzer = new HackageMetaAnalyzer();
+        Assert.assertTrue(analyzer.isApplicable(component));
+        Assert.assertEquals(RepositoryType.HACKAGE, analyzer.supportedRepositoryType());
+        MetaModel metaModel = analyzer.analyze(component);
+        Assert.assertNotNull(metaModel.getLatestVersion());
+    }
+}

--- a/src/test/java/org/dependencytrack/tasks/repositories/NixpkgsMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/NixpkgsMetaAnalyzerTest.java
@@ -13,7 +13,7 @@ public class NixpkgsMetaAnalyzerTest {
         final var component2 = new Component();
         component1.setPurl(new PackageURL("pkg:nixpkgs/SDL_sound@1.0.3"));
         component2.setPurl(new PackageURL("pkg:nixpkgs/amarok@2.9.71"));
-        final var analyzer = NixpkgsMetaAnalyzer.getNixpkgsMetaAnalyzer();
+        final var analyzer = new NixpkgsMetaAnalyzer();
         Assert.assertTrue(analyzer.isApplicable(component1));
         Assert.assertTrue(analyzer.isApplicable(component2));
         Assert.assertEquals(RepositoryType.NIXPKGS, analyzer.supportedRepositoryType());

--- a/src/test/java/org/dependencytrack/tasks/repositories/NixpkgsMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/NixpkgsMetaAnalyzerTest.java
@@ -1,0 +1,23 @@
+package org.dependencytrack.tasks.repositories;
+
+import com.github.packageurl.PackageURL;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.RepositoryType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NixpkgsMetaAnalyzerTest {
+    @Test
+    public void testAnalyzer() throws Exception {
+        final var component1 = new Component();
+        final var component2 = new Component();
+        component1.setPurl(new PackageURL("pkg:nixpkgs/SDL_sound@1.0.3"));
+        component2.setPurl(new PackageURL("pkg:nixpkgs/amarok@2.9.71"));
+        final var analyzer = NixpkgsMetaAnalyzer.getNixpkgsMetaAnalyzer();
+        Assert.assertTrue(analyzer.isApplicable(component1));
+        Assert.assertTrue(analyzer.isApplicable(component2));
+        Assert.assertEquals(RepositoryType.NIXPKGS, analyzer.supportedRepositoryType());
+        Assert.assertNotNull(analyzer.analyze(component1).getLatestVersion());
+        Assert.assertNotNull(analyzer.analyze(component2).getLatestVersion());
+    }
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This solves part 2 of #3545 

### Addressed Issue

#3545 

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

this depends on #3546 

the apache http client utils version 4 don't implement brotli decompression; I redid some of the common http client code to keep this scoped; a future refactoring could remove the extraneous code. 

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
