### PR TITLE
Adds audit trail comments for all fields of new analysis

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
@@ -35,7 +35,6 @@ import io.swagger.annotations.Authorization;
 import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Analysis;
-import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vulnerability;
@@ -166,9 +165,10 @@ public class AnalysisResource extends AlpineResource {
             } else {
                 analysis = qm.makeAnalysis(component, vulnerability, request.getAnalysisState(), request.getAnalysisJustification(), request.getAnalysisResponse(), request.getAnalysisDetails(), request.isSuppressed());
                 analysisStateChange = true; // this is a new analysis - so set to true because it was previously null
-                if (AnalysisState.NOT_SET != request.getAnalysisState()) {
-                    qm.makeAnalysisComment(analysis, String.format("Analysis: %s → %s", AnalysisState.NOT_SET, request.getAnalysisState()), commenter);
-                }
+                AnalysisCommentUtil.makeFirstStateComment(qm, analysis, commenter);
+                AnalysisCommentUtil.makeFirstJustificationComment(qm, analysis, commenter);
+                AnalysisCommentUtil.makeFirstAnalysisResponseComment(qm, analysis, commenter);
+                AnalysisCommentUtil.makeFirstDetailsComment(qm, analysis, commenter);
             }
 
             final String comment = StringUtils.trimToNull(request.getComment());

--- a/src/main/java/org/dependencytrack/resources/v1/vo/AnalysisRequest.java
+++ b/src/main/java/org/dependencytrack/resources/v1/vo/AnalysisRequest.java
@@ -54,7 +54,7 @@ public class AnalysisRequest {
     private final String comment;
 
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
-    @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS_PLUS, message = "The comment may only contain printable characters")
+    @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS_PLUS, message = "The analysis details may only contain printable characters")
     private final String analysisDetails;
 
     private final AnalysisState analysisState;

--- a/src/main/java/org/dependencytrack/util/AnalysisCommentUtil.java
+++ b/src/main/java/org/dependencytrack/util/AnalysisCommentUtil.java
@@ -28,32 +28,70 @@ public final class AnalysisCommentUtil {
 
     private AnalysisCommentUtil() { }
 
+
+    public static void makeFirstStateComment(final QueryManager qm, final Analysis analysis, final String commenter) {
+        if (analysis.getAnalysisState() != null) {
+            addAnalysisStateComment(qm, analysis, null, analysis.getAnalysisState(), commenter);
+        }
+    }
+
     public static boolean makeStateComment(final QueryManager qm, final Analysis analysis, final AnalysisState analysisState, final String commenter) {
         boolean analysisStateChange = false;
         if (analysisState != null && analysisState != analysis.getAnalysisState()) {
             analysisStateChange = true;
-            qm.makeAnalysisComment(analysis, String.format("Analysis: %s → %s", analysis.getAnalysisState(), analysisState), commenter);
+            addAnalysisStateComment(qm, analysis, analysis.getAnalysisState(), analysisState, commenter);
         }
         return analysisStateChange;
+    }
+
+    private static void addAnalysisStateComment(QueryManager qm, Analysis analysis, AnalysisState before, AnalysisState after, String commenter) {
+        qm.makeAnalysisComment(analysis, String.format("Analysis: %s → %s", before, after), commenter);
+    }
+
+    public static void makeFirstJustificationComment(QueryManager qm, Analysis analysis, String commenter) {
+        if (analysis.getAnalysisJustification() != null) {
+            addAnalysisJustificationComment(qm, analysis, null, analysis.getAnalysisJustification(), commenter);
+        }
     }
 
     public static void makeJustificationComment(final QueryManager qm, final Analysis analysis, final AnalysisJustification analysisJustification, final String commenter) {
         if (analysisJustification != null) {
             if (analysis.getAnalysisJustification() == null && AnalysisJustification.NOT_SET != analysisJustification) {
-                qm.makeAnalysisComment(analysis, String.format("Justification: %s → %s", AnalysisJustification.NOT_SET, analysisJustification), commenter);
+                addAnalysisJustificationComment(qm, analysis, AnalysisJustification.NOT_SET, analysisJustification, commenter);
             } else if (analysis.getAnalysisJustification() != null && analysisJustification != analysis.getAnalysisJustification()) {
-                qm.makeAnalysisComment(analysis, String.format("Justification: %s → %s", analysis.getAnalysisJustification(), analysisJustification), commenter);
+                addAnalysisJustificationComment(qm, analysis, analysis.getAnalysisJustification(), analysisJustification, commenter);
             }
+        }
+    }
+
+    private static void addAnalysisJustificationComment(QueryManager qm, Analysis analysis, AnalysisJustification before, AnalysisJustification after, String commenter) {
+        qm.makeAnalysisComment(analysis, String.format("Justification: %s → %s", before, after), commenter);
+    }
+
+
+    public static void makeFirstAnalysisResponseComment(QueryManager qm, Analysis analysis, String commenter) {
+        if (analysis.getAnalysisResponse() != null) {
+            addAnalysisResponseComment(qm, analysis, null, analysis.getAnalysisResponse(), commenter);
         }
     }
 
     public static void makeAnalysisResponseComment(final QueryManager qm, final Analysis analysis, final AnalysisResponse analysisResponse, final String commenter) {
         if (analysisResponse != null) {
             if (analysis.getAnalysisResponse() == null && analysis.getAnalysisResponse() != analysisResponse) {
-                qm.makeAnalysisComment(analysis, String.format("Vendor Response: %s → %s", AnalysisResponse.NOT_SET, analysisResponse), commenter);
+                addAnalysisResponseComment(qm, analysis, AnalysisResponse.NOT_SET, analysisResponse, commenter);
             } else if (analysis.getAnalysisResponse() != null && analysis.getAnalysisResponse() != analysisResponse) {
-                qm.makeAnalysisComment(analysis, String.format("Vendor Response: %s → %s", analysis.getAnalysisResponse(), analysisResponse), commenter);
+                addAnalysisResponseComment(qm, analysis, analysis.getAnalysisResponse(), analysisResponse, commenter);
             }
+        }
+    }
+
+    private static void addAnalysisResponseComment(QueryManager qm, Analysis analysis, AnalysisResponse before, AnalysisResponse after, String commenter) {
+        qm.makeAnalysisComment(analysis, String.format("Vendor Response: %s → %s", before, after), commenter);
+    }
+
+    public static void makeFirstDetailsComment(QueryManager qm, Analysis analysis, String commenter) {
+        if (analysis.getAnalysisDetails() != null && !analysis.getAnalysisDetails().isEmpty()) {
+            addAnalysisDetailsComment(qm, analysis, commenter);
         }
     }
 
@@ -62,6 +100,11 @@ public final class AnalysisCommentUtil {
             final String message = "Details: " + analysisDetails.trim();
             qm.makeAnalysisComment(analysis, message, commenter);
         }
+    }
+
+    private static void addAnalysisDetailsComment(QueryManager qm, Analysis analysis, String commenter) {
+        final String message = "Details: " + analysis.getAnalysisDetails().trim();
+        qm.makeAnalysisComment(analysis, message, commenter);
     }
 
     public static boolean makeAnalysisSuppressionComment(final QueryManager qm, final Analysis analysis, final Boolean suppressed, final String commenter) {
@@ -73,4 +116,6 @@ public final class AnalysisCommentUtil {
         }
         return suppressionChange;
     }
+
+
 }


### PR DESCRIPTION
### Description
Adds audit comments for all properties of a newly created analysis entry.

### Addressed Issue
Fixes: #3470

### Additional Details
This fix proposition changes the current behavior a bit when audits are performed manually via the UI. At the moment, setting the Analysis state only adds a comment about this particular field even though justification and vendor response are also set with default values. The proposed fix would add comments for those too. 

This behavior seem coherent with what I understood from the Vex import feature (cf [CycloneDXVexImporter](https://github.com/DependencyTrack/dependency-track/blob/2182706921bd7d3932db1c6dad4aa1737675fa74/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporter.java#L140).

This is a quick fix solution, a better approach would be to create a dedicated AnalysisService that would be called from the CycloneDXVexImporter and the AnalysisResource. Currently these two classes have too many responsabilities. Moreover, they share the analysis creation responsability and do it in a different manner.

I'll be happy to discuss this refactor further if deemed interesting.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
