### PR TITLE
Perform License Resolution On Name Field During SBOM Import

### DIFF
--- a/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
@@ -526,9 +526,14 @@ public class ModelConverter {
                         }
                         else if (StringUtils.isNotBlank(cycloneLicense.getName()))
                         {
-                            final License license = qm.getCustomLicense(StringUtils.trimToNull(cycloneLicense.getName()));
+                            final License license = qm.getLicense(StringUtils.trimToNull(cycloneLicense.getName()));
                             if (license != null) {
                                 component.setResolvedLicense(license);
+                            } else {
+                                final License customLicense = qm.getCustomLicense(StringUtils.trimToNull(cycloneLicense.getName()));
+                                if (customLicense != null) {
+                                    component.setResolvedLicense(customLicense);
+                                }
                             }
                         }
                         component.setLicense(StringUtils.trimToNull(cycloneLicense.getName()));

--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTaskV2.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTaskV2.java
@@ -672,6 +672,14 @@ public class BomUploadProcessingTaskV2 implements Subscriber {
             }
 
             if (isNotBlank(licenseCandidate.getName())) {
+                final License resolvedLicense = licenseCache.computeIfAbsent(licenseCandidate.getName(),
+                    licenseName -> resolveLicense(qm, licenseName));
+                if (resolvedLicense != License.UNRESOLVED) {
+                    component.setResolvedLicense(resolvedLicense);
+                    component.setLicenseUrl(trimToNull(licenseCandidate.getUrl()));
+                    break;
+                }
+
                 final License resolvedCustomLicense = customLicenseCache.computeIfAbsent(licenseCandidate.getName(),
                         licenseName -> resolveCustomLicense(qm, licenseName));
                 if (resolvedCustomLicense != License.UNRESOLVED) {


### PR DESCRIPTION
### Description
On import of SBOMs with SPDX compliant license ID in the `name` field and with no `id` field, license resolution should first occur against standard licenses. 

If none found, only then should license resolution occur against custom licenses.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue
Fixes #3433 
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details
On SBOM import, if the license candidate/license option did not have an `id` field and only a `name` field, we were assuming the license to lookup would be a custom license (whereas in fact, the `name` field could contain a standard license ID and not a custom one)

In this change, during BOM upload, if license does not have an `id`, then we call `qm.getLicense()` with the `name` field first. If it returns no results, only then do we call `qm.getCustomLicense()`

Sample SBOM used for testing is attached to this PR:
[tiny-bom.json](https://github.com/DependencyTrack/dependency-track/files/14622478/tiny-bom.json)

Please do let me know if I am doing anything blatantly wrong :) 

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
