### PR TITLE
Provide meaningful error message for `bom` and `vex` exceeding Jackson's character limit

### DIFF
--- a/docs/_posts/2024-xx-xx-v4.11.0.md
+++ b/docs/_posts/2024-xx-xx-v4.11.0.md
@@ -78,6 +78,7 @@ environment variable `BOM_VALIDATION_ENABLED` to `false`.
 * Fix type of `purl` fields in Swagger docs - [apiserver/#3512]
 * Fix CI build status badge - [apiserver/#3513]
 * Fix `bom` and `vex` request fields not being visible in OpenAPI spec - [apiserver/#3557]
+* Fix unclear error response when base64 encoded `bom` and `vex` values exceed character limit - [apiserver/#3558]
 * Fix `VUE_APP_SERVER_URL` being ignored - [frontend/#682]
 * Fix visibility of "Vulnerabilities" and "Policy Violations" columns not being toggle-able individually - [frontend/#686]
 * Fix finding search routes - [frontend/#689]
@@ -180,6 +181,7 @@ Special thanks to everyone who contributed code to implement enhancements and fi
 [apiserver/#3513]: https://github.com/DependencyTrack/dependency-track/pull/3513
 [apiserver/#3522]: https://github.com/DependencyTrack/dependency-track/pull/3522
 [apiserver/#3557]: https://github.com/DependencyTrack/dependency-track/pull/3557
+[apiserver/#3558]: https://github.com/DependencyTrack/dependency-track/pull/3558
 
 [frontend/#682]: https://github.com/DependencyTrack/frontend/pull/682
 [frontend/#683]: https://github.com/DependencyTrack/frontend/pull/683

--- a/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -221,6 +221,11 @@ public class BomResource extends AlpineResource {
                       a response with problem details in RFC 9457 format will be returned. In this case,
                       the response's content type will be <code>application/problem+json</code>.
                     </p>
+                    <p>
+                      The maximum allowed length of the <code>bom</code> value is 20'000'000 characters.
+                      When uploading large BOMs, the <code>POST</code> endpoint is preferred,
+                      as it does not have this limit.
+                    </p>
                     <p>Requires permission <strong>BOM_UPLOAD</strong></p>""",
             response = BomUploadResponse.class,
             nickname = "UploadBomBase64Encoded"

--- a/src/main/java/org/dependencytrack/resources/v1/VexResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/VexResource.java
@@ -133,6 +133,11 @@ public class VexResource extends AlpineResource {
                       a response with problem details in RFC 9457 format will be returned. In this case,
                       the response's content type will be <code>application/problem+json</code>.
                     </p>
+                    <p>
+                      The maximum allowed length of the <code>vex</code> value is 20'000'000 characters.
+                      When uploading large VEX files, the <code>POST</code> endpoint is preferred,
+                      as it does not have this limit.
+                    </p>
                     <p>Requires permission <strong>VULNERABILITY_ANALYSIS</strong></p>"""
     )
     @ApiResponses(value = {

--- a/src/main/java/org/dependencytrack/resources/v1/exception/JsonMappingExceptionMapper.java
+++ b/src/main/java/org/dependencytrack/resources/v1/exception/JsonMappingExceptionMapper.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.exception;
+
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import org.dependencytrack.resources.v1.problems.ProblemDetails;
+import org.dependencytrack.resources.v1.vo.BomSubmitRequest;
+import org.dependencytrack.resources.v1.vo.VexSubmitRequest;
+
+import javax.annotation.Priority;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import java.util.Objects;
+
+/**
+ * @since 4.11.0
+ */
+@Provider
+@Priority(1)
+public class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingException> {
+
+    @Context
+    private HttpServletRequest request;
+
+    @Context
+    private ResourceInfo resourceInfo;
+
+    @Override
+    public Response toResponse(final JsonMappingException exception) {
+        final var problemDetails = new ProblemDetails();
+        problemDetails.setStatus(400);
+        problemDetails.setTitle("The provided JSON payload could not be mapped");
+        problemDetails.setDetail(createDetail(exception));
+
+        return Response
+                .status(Response.Status.BAD_REQUEST)
+                .type(ProblemDetails.MEDIA_TYPE_JSON)
+                .entity(problemDetails)
+                .build();
+    }
+
+    private static String createDetail(final JsonMappingException exception) {
+        if (!(exception.getCause() instanceof StreamConstraintsException)) {
+            return exception.getMessage();
+        }
+
+        final JsonMappingException.Reference reference = exception.getPath().get(0);
+        if (Objects.equals(reference.getFrom(), BomSubmitRequest.class)
+            && "bom".equals(reference.getFieldName())) {
+            return """
+                    The BOM is too large to be transmitted safely via Base64 encoded JSON value. \
+                    Please use the "POST /api/v1/bom" endpoint with Content-Type "multipart/form-data" instead. \
+                    Original cause: %s""".formatted(exception.getMessage());
+        } else if (Objects.equals(reference.getFrom(), VexSubmitRequest.class)
+                   && "vex".equals(reference.getFieldName())) {
+            return """
+                    The VEX is too large to be transmitted safely via Base64 encoded JSON value. \
+                    Please use the "POST /api/v1/vex" endpoint with Content-Type "multipart/form-data" instead. \
+                    Original cause: %s""".formatted(exception.getMessage());
+        }
+
+        return exception.getMessage();
+    }
+
+}

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -21,6 +21,7 @@ package org.dependencytrack.resources.v1;
 import alpine.common.util.UuidUtil;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import org.apache.http.HttpStatus;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
@@ -35,6 +36,7 @@ import org.dependencytrack.model.ProjectMetadata;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.parser.cyclonedx.CycloneDxValidator;
+import org.dependencytrack.resources.v1.exception.JsonMappingExceptionMapper;
 import org.dependencytrack.resources.v1.vo.BomSubmitRequest;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
@@ -68,7 +70,8 @@ public class BomResourceTest extends ResourceTest {
                 new ResourceConfig(BomResource.class)
                         .register(ApiFilter.class)
                         .register(AuthenticationFilter.class)
-                        .register(MultiPartFeature.class)))
+                        .register(MultiPartFeature.class)
+                        .register(JsonMappingExceptionMapper.class)))
                 .build();
     }
 
@@ -926,6 +929,37 @@ public class BomResourceTest extends ResourceTest {
                     "cvc-enumeration-valid: Value 'foo' is not facet-valid with respect to enumeration '[application, framework, library, container, operating-system, device, firmware, file]'. It must be a value from the enumeration.",
                     "cvc-attribute.3: The value 'foo' of attribute 'type' on element 'component' is not valid with respect to its type, 'classification'."
                   ]
+                }
+                """);
+    }
+
+    @Test
+    public void uploadBomTooLargeViaPutTest() {
+        initializeWithPermissions(Permissions.BOM_UPLOAD);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final String bom = "a".repeat(StreamReadConstraints.DEFAULT_MAX_STRING_LEN + 1);
+
+        final Response response = target(V1_BOM).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity("""
+                        {
+                          "projectName": "acme-app",
+                          "projectVersion": "1.0.0",
+                          "bom": "%s"
+                        }
+                        """.formatted(bom), MediaType.APPLICATION_JSON));
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getHeaderString("Content-Type")).isEqualTo("application/problem+json");
+        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+                {
+                  "status": 400,
+                  "title": "The provided JSON payload could not be mapped",
+                  "detail": "The BOM is too large to be transmitted safely via Base64 encoded JSON value. Please use the \\"POST /api/v1/bom\\" endpoint with Content-Type \\"multipart/form-data\\" instead. Original cause: String length (20000001) exceeds the maximum length (20000000) (through reference chain: org.dependencytrack.resources.v1.vo.BomSubmitRequest[\\"bom\\"])"
                 }
                 """);
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Provides a meaningful error message for `bom` and `vex` exceeding Jackson's character limit.

Also document the limitation in the OpenAPI spec of the respective `PUT` methods that accept JSON payloads.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #3182

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Example response for the `PUT /api/v1/bom` endpoint:

```json
{
  "status": 400,
  "title": "The provided JSON payload could not be mapped",
  "detail": "The BOM is too large to be transmitted safely via Base64 encoded JSON value. Please use the \"POST /api/v1/bom\" endpoint with Content-Type \"multipart/form-data\" instead. Original cause: String length (20000001) exceeds the maximum length (20000000) (through reference chain: org.dependencytrack.resources.v1.vo.BomSubmitRequest[\"bom\"])"
}
```

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
