### PR TITLE
Fix unhandled `NotFoundException`s causing a `HTTP 500` response

### DIFF
--- a/docs/_posts/2024-xx-xx-v4.11.0.md
+++ b/docs/_posts/2024-xx-xx-v4.11.0.md
@@ -79,6 +79,7 @@ environment variable `BOM_VALIDATION_ENABLED` to `false`.
 * Fix CI build status badge - [apiserver/#3513]
 * Fix `bom` and `vex` request fields not being visible in OpenAPI spec - [apiserver/#3557]
 * Fix unclear error response when base64 encoded `bom` and `vex` values exceed character limit - [apiserver/#3558]
+* Fix unhandled `NotFoundException`s causing a `HTTP 500` response - [apiserver/#3559]
 * Fix `VUE_APP_SERVER_URL` being ignored - [frontend/#682]
 * Fix visibility of "Vulnerabilities" and "Policy Violations" columns not being toggle-able individually - [frontend/#686]
 * Fix finding search routes - [frontend/#689]
@@ -182,6 +183,7 @@ Special thanks to everyone who contributed code to implement enhancements and fi
 [apiserver/#3522]: https://github.com/DependencyTrack/dependency-track/pull/3522
 [apiserver/#3557]: https://github.com/DependencyTrack/dependency-track/pull/3557
 [apiserver/#3558]: https://github.com/DependencyTrack/dependency-track/pull/3558
+[apiserver/#3559]: https://github.com/DependencyTrack/dependency-track/pull/3559
 
 [frontend/#682]: https://github.com/DependencyTrack/frontend/pull/682
 [frontend/#683]: https://github.com/DependencyTrack/frontend/pull/683

--- a/src/main/java/org/dependencytrack/resources/v1/exception/NotFoundExceptionMapper.java
+++ b/src/main/java/org/dependencytrack/resources/v1/exception/NotFoundExceptionMapper.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.exception;
+
+import alpine.server.resources.GlobalExceptionHandler;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * An {@link ExceptionMapper} to handle {@link NotFoundException}, that would otherwise be
+ * handled by Alpine's {@link GlobalExceptionHandler}, resulting in a misleading {@code HTTP 500} response.
+ *
+ * @since 4.11.0
+ */
+@Provider
+public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundException> {
+
+    @Override
+    public Response toResponse(final NotFoundException exception) {
+        return Response.status(Response.Status.NOT_FOUND).build();
+    }
+
+}

--- a/src/test/java/org/dependencytrack/resources/v1/exception/NotFoundExceptionMapperTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/exception/NotFoundExceptionMapperTest.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.exception;
+
+import org.junit.Test;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.Response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NotFoundExceptionMapperTest {
+
+    @Test
+    @SuppressWarnings("resource")
+    public void testToResponse() {
+        final Response response = new NotFoundExceptionMapper().toResponse(new NotFoundException());
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(response.getEntity()).isNull();
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fix unhandled `NotFoundException`s causing a `HTTP 500` response

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Previously, requests to routes that had no explicit servlet mapping ended up being handled by the `GlobalExceptionHandler` of Alpine, which logs the exception as `error`, and returns a `HTTP 500 Internal Server Error` response. This behavior was misleading and could flood the logs unnecessarily.

We now only return a `HTTP 404 Not Found` response, without emitting any logs.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
