### PR TITLE
Extend length of `PURL` and `PURLCOORDINATES` columns from 255 to 786

### DIFF
--- a/docs/_posts/2024-xx-xx-v4.11.0.md
+++ b/docs/_posts/2024-xx-xx-v4.11.0.md
@@ -80,6 +80,7 @@ environment variable `BOM_VALIDATION_ENABLED` to `false`.
 * Fix `bom` and `vex` request fields not being visible in OpenAPI spec - [apiserver/#3557]
 * Fix unclear error response when base64 encoded `bom` and `vex` values exceed character limit - [apiserver/#3558]
 * Fix unhandled `NotFoundException`s causing a `HTTP 500` response - [apiserver/#3559]
+* Fix inability to store PURLs longer than 255 characters - [apiserver/#3560]
 * Fix `VUE_APP_SERVER_URL` being ignored - [frontend/#682]
 * Fix visibility of "Vulnerabilities" and "Policy Violations" columns not being toggle-able individually - [frontend/#686]
 * Fix finding search routes - [frontend/#689]
@@ -112,6 +113,11 @@ and updated automatically upon upgrade, based on CVSSv2, CVSSv3, and OWASP Risk 
 * The following default values for configuration properties have changed:
   * `ossindex.retry.backoff.max.duration.ms`: 600000ms (10min) → 60000ms (1min)
 * The `name` tag of the `resilience4j_retry_calls_total` for OSS Index has changed from `ossIndexRetryer` to `ossindex-api`
+* The types of the following columns are changed from `VARCHAR(255)` to `VARCHAR(786)` automatically upon upgrade:
+  * `COMPONENT.PURL`
+  * `COMPONENT.PURLCOORDINATES`
+  * `COMPONENTANALYSISCACHE.TARGET`
+  * `PROJECT.PURL`
 
 For a complete list of changes, refer to the respective GitHub milestones:
 
@@ -184,6 +190,7 @@ Special thanks to everyone who contributed code to implement enhancements and fi
 [apiserver/#3557]: https://github.com/DependencyTrack/dependency-track/pull/3557
 [apiserver/#3558]: https://github.com/DependencyTrack/dependency-track/pull/3558
 [apiserver/#3559]: https://github.com/DependencyTrack/dependency-track/pull/3559
+[apiserver/#3560]: https://github.com/DependencyTrack/dependency-track/pull/3560
 
 [frontend/#682]: https://github.com/DependencyTrack/frontend/pull/682
 [frontend/#683]: https://github.com/DependencyTrack/frontend/pull/683

--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -248,7 +248,8 @@ public class Component implements Serializable {
 
     @Persistent(defaultFetchGroup = "true")
     @Index(name = "COMPONENT_PURL_IDX")
-    @Size(max = 255)
+    @Column(name = "PURL", length = 786)
+    @Size(max = 786)
     @com.github.packageurl.validator.PackageURL
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @ApiModelProperty(dataType = "string")
@@ -256,7 +257,8 @@ public class Component implements Serializable {
 
     @Persistent(defaultFetchGroup = "true")
     @Index(name = "COMPONENT_PURL_COORDINATES_IDX")
-    @Size(max = 255)
+    @Column(name = "PURLCOORDINATES", length = 786)
+    @Size(max = 786)
     @com.github.packageurl.validator.PackageURL
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     private String purlCoordinates; // Field should contain only type, namespace, name, and version. Everything up to the qualifiers

--- a/src/main/java/org/dependencytrack/model/ComponentAnalysisCache.java
+++ b/src/main/java/org/dependencytrack/model/ComponentAnalysisCache.java
@@ -84,7 +84,7 @@ public class ComponentAnalysisCache implements Serializable {
     private String targetType;
 
     @Persistent
-    @Column(name = "TARGET", allowsNull = "false")
+    @Column(name = "TARGET", allowsNull = "false", length = 786)
     @NotNull
     private String target;
 

--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -195,7 +195,8 @@ public class Project implements Serializable {
 
     @Persistent
     @Index(name = "PROJECT_PURL_IDX")
-    @Size(max = 255)
+    @Column(name = "PURL", length = 786)
+    @Size(max = 786)
     @com.github.packageurl.validator.PackageURL
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @ApiModelProperty(dataType = "string")


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Extends length of `PURL` and `PURLCOORDINATES` columns from 255 to 786.

Because PURLs are also used to populate the `TARGET` column of `COMPONENTANALYSISCACHE`, that column's length also has to be extended.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #2076

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

The length of 786 was chosen as a middle ground between the current 255 and the more optimal 1024. Mainly because MSSQL versions before 2016 have a maximum index key length of 900 (https://github.com/DependencyTrack/dependency-track/issues/2076#issuecomment-2002606197).

We don't want to break anything in that respect at the moment, and 786 should still be plenty of space.

Running DT with MySQL already takes manual effort, due to MySQL's even more restrictive key length limits (https://github.com/DependencyTrack/dependency-track/issues/271#issuecomment-1108923693). We're not making it worse by increasing the column length even more.

Tested upgrade from DT v4.10.1 to v4.11.0-SNAPSHOT for:

* H2
* MSSQL
* PostgreSQL

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [x] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
