### PR TITLE
Generate SARIF File Of Project Vulnerability Findings

### DIFF
--- a/src/main/resources/templates/findings/sarif.peb
+++ b/src/main/resources/templates/findings/sarif.peb
@@ -1,0 +1,54 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "OWASP Dependency-Track",
+          "version": "{{ dependencyTrackVersion }}",
+          "informationUri": "https://dependencytrack.org/",
+          "rules": [{% for finding in findings %}
+            {
+              "id": "{{ finding.vulnerability.vulnId }}",
+              "name": "{{ finding.component.name }} - {{ finding.vulnerability.cweName }}",
+              "shortDescription": {
+                "text": "{{ finding.vulnerability.description | split('\n') | join(' ') | trim }}"
+              }
+            }{% if not loop.last %},{% endif %}{% endfor %}
+          ]
+        }
+      },
+      "results": [{% for finding in findings %}
+        {
+          "ruleId": "{{ finding.vulnerability.vulnId }}",
+          "message": {
+            "text": "{{ finding.vulnerability.description | split('\n') | join(' ') | trim }}"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "{{ finding.component.purl }}"
+                }
+              }
+            }
+          ],
+          "level": {% if ['LOW', 'INFO'] contains finding.vulnerability.severity %}"note",{% elseif finding.vulnerability.severity == 'MEDIUM' %}"warning",{% elseif ['HIGH', 'CRITICAL'] contains finding.vulnerability.severity %}"error",{% else %}"none",{% endif %}
+          "properties": {
+            "name": "{{ finding.component.name }}",
+            "group": "{{ finding.component.group }}",
+            "version": "{{ finding.component.version }}",
+            "source": "{{ finding.vulnerability.source }}",
+            "cweId": "{{ finding.vulnerability.cweId }}",
+            "cvssV3BaseScore": "{{ finding.vulnerability.cvssV3BaseScore }}",
+            "epssScore": "{{ finding.vulnerability.epssScore }}",
+            "epssPercentile": "{{ finding.vulnerability.epssPercentile }}",
+            "severityRank": "{{ finding.vulnerability.severityRank }}",
+            "recommendation": "{{ finding.vulnerability.recommendation | split('\n') | join(' ') | trim }}"
+          }
+        }{% if not loop.last %},{% endif %}{% endfor %}
+      ]
+    }
+  ]
+}

--- a/src/main/resources/templates/findings/sarif.peb
+++ b/src/main/resources/templates/findings/sarif.peb
@@ -8,12 +8,12 @@
           "name": "OWASP Dependency-Track",
           "version": "{{ dependencyTrackVersion }}",
           "informationUri": "https://dependencytrack.org/",
-          "rules": [{% for finding in findings %}
+          "rules": [{% for vuln in uniqueVulnerabilities %}
             {
-              "id": "{{ finding.vulnerability.vulnId }}",
-              "name": "{{ finding.component.name }} - {{ finding.vulnerability.cweName }}",
+              "id": "{{ vuln.vulnId }}",
+              "name": "{{ vuln.cweName }}",
               "shortDescription": {
-                "text": "{{ finding.vulnerability.description | split('\n') | join(' ') | trim }}"
+                "text": "{{ vuln.description | trim }}"
               }
             }{% if not loop.last %},{% endif %}{% endfor %}
           ]
@@ -23,15 +23,15 @@
         {
           "ruleId": "{{ finding.vulnerability.vulnId }}",
           "message": {
-            "text": "{{ finding.vulnerability.description | split('\n') | join(' ') | trim }}"
+            "text": "{{ finding.vulnerability.description | trim }}"
           },
           "locations": [
             {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "{{ finding.component.purl }}"
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "{{ finding.component.purl }}"
                 }
-              }
+              ]
             }
           ],
           "level": {% if ['LOW', 'INFO'] contains finding.vulnerability.severity %}"note",{% elseif finding.vulnerability.severity == 'MEDIUM' %}"warning",{% elseif ['HIGH', 'CRITICAL'] contains finding.vulnerability.severity %}"error",{% else %}"none",{% endif %}
@@ -45,7 +45,7 @@
             "epssScore": "{{ finding.vulnerability.epssScore }}",
             "epssPercentile": "{{ finding.vulnerability.epssPercentile }}",
             "severityRank": "{{ finding.vulnerability.severityRank }}",
-            "recommendation": "{{ finding.vulnerability.recommendation | split('\n') | join(' ') | trim }}"
+            "recommendation": "{{ finding.vulnerability.recommendation | trim }}"
           }
         }{% if not loop.last %},{% endif %}{% endfor %}
       ]

--- a/src/main/resources/templates/findings/sarif.peb
+++ b/src/main/resources/templates/findings/sarif.peb
@@ -6,6 +6,7 @@
       "tool": {
         "driver": {
           "name": "OWASP Dependency-Track",
+          "fullName": "OWASP Dependency-Track - {{ dependencyTrackVersion }}",
           "version": "{{ dependencyTrackVersion }}",
           "informationUri": "https://dependencytrack.org/",
           "rules": [{% for vuln in uniqueVulnerabilities %}
@@ -13,6 +14,9 @@
               "id": "{{ vuln.vulnId }}",
               "name": "{{ vuln.cweName }}",
               "shortDescription": {
+                "text": "{{ vuln.vulnId }}"
+              },
+              "fullDescription": {
                 "text": "{{ vuln.description | trim }}"
               }
             }{% if not loop.last %},{% endif %}{% endfor %}

--- a/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -627,6 +627,7 @@ public class FindingResourceTest extends ResourceTest {
 
         assertThatJson(jsonResponse)
             .withMatcher("version", equalTo(new About().getVersion()))
+            .withMatcher("fullName", equalTo("OWASP Dependency-Track - " + new About().getVersion()))
             .withMatcher("vuln1Id", equalTo(v1.getVulnId()))
             .withMatcher("vuln2Id", equalTo(v2.getVulnId()))
             .withMatcher("vuln3Id", equalTo(v3.getVulnId()))
@@ -657,6 +658,7 @@ public class FindingResourceTest extends ResourceTest {
                             "tool": {
                               "driver": {
                                 "name": "OWASP Dependency-Track",
+                                "fullName": "${json-unit.matches:fullName}",
                                 "version": "${json-unit.matches:version}",
                                 "informationUri": "https://dependencytrack.org/",
                                 "rules": [
@@ -664,6 +666,9 @@ public class FindingResourceTest extends ResourceTest {
                                     "id": "${json-unit.matches:vuln1Id}",
                                     "name": "ImproperNeutralizationOfScript-relatedHtmlTagsInAWebPage(basicXss)",
                                     "shortDescription": {
+                                      "text": "${json-unit.matches:vuln1Id}"
+                                    },
+                                    "fullDescription": {
                                       "text": "${json-unit.matches:vuln1Desc}"
                                     }
                                   },
@@ -671,6 +676,9 @@ public class FindingResourceTest extends ResourceTest {
                                     "id": "${json-unit.matches:vuln2Id}",
                                     "name": "PathEquivalence:'filename'(trailingSpace)",
                                     "shortDescription": {
+                                      "text": "${json-unit.matches:vuln2Id}"
+                                    },
+                                    "fullDescription": {
                                       "text": "${json-unit.matches:vuln2Desc}"
                                     }
                                   },
@@ -678,6 +686,9 @@ public class FindingResourceTest extends ResourceTest {
                                     "id": "${json-unit.matches:vuln3Id}",
                                     "name": "RelativePathTraversal",
                                     "shortDescription": {
+                                      "text": "${json-unit.matches:vuln3Id}"
+                                    },
+                                    "fullDescription": {
                                       "text": "${json-unit.matches:vuln3Desc}"
                                     }
                                   }

--- a/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -628,27 +628,6 @@ public class FindingResourceTest extends ResourceTest {
         assertThatJson(jsonResponse)
             .withMatcher("version", equalTo(new About().getVersion()))
             .withMatcher("fullName", equalTo("OWASP Dependency-Track - " + new About().getVersion()))
-            .withMatcher("vuln1Id", equalTo(v1.getVulnId()))
-            .withMatcher("vuln2Id", equalTo(v2.getVulnId()))
-            .withMatcher("vuln3Id", equalTo(v3.getVulnId()))
-            .withMatcher("vuln1CweId", equalTo(v1.getCwes().get(0).toString()))
-            .withMatcher("vuln2CweId", equalTo(v2.getCwes().get(0).toString()))
-            .withMatcher("vuln3CweId", equalTo(v3.getCwes().get(0).toString()))
-            .withMatcher("vuln1Desc", equalTo(v1.getDescription().trim()))
-            .withMatcher("vuln2Desc", equalTo(v2.getDescription().trim()))
-            .withMatcher("vuln3Desc", equalTo(v3.getDescription().trim()))
-            .withMatcher("vuln1Level", equalTo(getSARIFLevelFromSeverity(v1.getSeverity())))
-            .withMatcher("vuln2Level", equalTo(getSARIFLevelFromSeverity(v2.getSeverity())))
-            .withMatcher("vuln3Level", equalTo(getSARIFLevelFromSeverity(v3.getSeverity())))
-            .withMatcher("vuln3Recommendation", equalTo(v3.getRecommendation().trim()))
-            .withMatcher("comp1Purl", equalTo(c1.getPurl().toString()))
-            .withMatcher("comp2Purl", equalTo(c2.getPurl().toString()))
-            .withMatcher("comp1Name", equalTo(c1.getName()))
-            .withMatcher("comp2Name", equalTo(c2.getName()))
-            .withMatcher("comp1Group", equalTo(c1.getGroup()))
-            .withMatcher("comp2Group", equalTo(c2.getGroup()))
-            .withMatcher("comp1Version", equalTo(c1.getVersion()))
-            .withMatcher("comp2Version", equalTo(c2.getVersion()))
             .isEqualTo(json("""
                 {
                         "version": "2.1.0",
@@ -663,33 +642,33 @@ public class FindingResourceTest extends ResourceTest {
                                 "informationUri": "https://dependencytrack.org/",
                                 "rules": [
                                   {
-                                    "id": "${json-unit.matches:vuln1Id}",
+                                    "id": "Vuln-1",
                                     "name": "ImproperNeutralizationOfScript-relatedHtmlTagsInAWebPage(basicXss)",
                                     "shortDescription": {
-                                      "text": "${json-unit.matches:vuln1Id}"
+                                      "text": "Vuln-1"
                                     },
                                     "fullDescription": {
-                                      "text": "${json-unit.matches:vuln1Desc}"
+                                      "text": "This is a description"
                                     }
                                   },
                                   {
-                                    "id": "${json-unit.matches:vuln2Id}",
+                                    "id": "Vuln-2",
                                     "name": "PathEquivalence:'filename'(trailingSpace)",
                                     "shortDescription": {
-                                      "text": "${json-unit.matches:vuln2Id}"
+                                      "text": "Vuln-2"
                                     },
                                     "fullDescription": {
-                                      "text": "${json-unit.matches:vuln2Desc}"
+                                      "text": "Yet another description but with surrounding whitespaces"
                                     }
                                   },
                                   {
-                                    "id": "${json-unit.matches:vuln3Id}",
+                                    "id": "Vuln-3",
                                     "name": "RelativePathTraversal",
                                     "shortDescription": {
-                                      "text": "${json-unit.matches:vuln3Id}"
+                                      "text": "Vuln-3"
                                     },
                                     "fullDescription": {
-                                      "text": "${json-unit.matches:vuln3Desc}"
+                                      "text": "A description-with-hyphens-(and parentheses)"
                                     }
                                   }
                                 ]
@@ -697,26 +676,26 @@ public class FindingResourceTest extends ResourceTest {
                             },
                             "results": [
                               {
-                                "ruleId": "${json-unit.matches:vuln1Id}",
+                                "ruleId": "Vuln-1",
                                 "message": {
-                                  "text": "${json-unit.matches:vuln1Desc}"
+                                  "text": "This is a description"
                                 },
                                 "locations": [
                                   {
                                     "logicalLocations": [
                                       {
-                                        "fullyQualifiedName": "${json-unit.matches:comp1Purl}"
+                                        "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
                                       }
                                     ]
                                   }
                                 ],
-                                "level": "${json-unit.matches:vuln1Level}",
+                                "level": "error",
                                 "properties": {
-                                  "name": "${json-unit.matches:comp1Name}",
+                                  "name": "Component 1",
                                   "group": "org.acme",
-                                  "version": "${json-unit.matches:comp1Version}",
+                                  "version": "1.1.4",
                                   "source": "INTERNAL",
-                                  "cweId": "${json-unit.matches:vuln1CweId}",
+                                  "cweId": "80",
                                   "cvssV3BaseScore": "",
                                   "epssScore": "",
                                   "epssPercentile": "",
@@ -725,26 +704,26 @@ public class FindingResourceTest extends ResourceTest {
                                 }
                               },
                               {
-                                "ruleId": "${json-unit.matches:vuln2Id}",
+                                "ruleId": "Vuln-2",
                                 "message": {
-                                  "text": "${json-unit.matches:vuln2Desc}"
+                                  "text": "Yet another description but with surrounding whitespaces"
                                 },
                                 "locations": [
                                   {
                                     "logicalLocations": [
                                       {
-                                        "fullyQualifiedName": "${json-unit.matches:comp1Purl}"
+                                        "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
                                       }
                                     ]
                                   }
                                 ],
-                                "level": "${json-unit.matches:vuln2Level}",
+                                "level": "error",
                                 "properties": {
-                                  "name": "${json-unit.matches:comp1Name}",
-                                  "group": "${json-unit.matches:comp1Group}",
-                                  "version": "${json-unit.matches:comp1Version}",
+                                  "name": "Component 1",
+                                  "group": "org.acme",
+                                  "version": "1.1.4",
                                   "source": "INTERNAL",
-                                  "cweId": "${json-unit.matches:vuln2CweId}",
+                                  "cweId": "46",
                                   "cvssV3BaseScore": "",
                                   "epssScore": "",
                                   "epssPercentile": "",
@@ -753,59 +732,59 @@ public class FindingResourceTest extends ResourceTest {
                                 }
                               },
                               {
-                                "ruleId": "${json-unit.matches:vuln3Id}",
+                                "ruleId": "Vuln-3",
                                 "message": {
-                                  "text": "${json-unit.matches:vuln3Desc}"
+                                  "text": "A description-with-hyphens-(and parentheses)"
                                 },
                                 "locations": [
                                   {
                                     "logicalLocations": [
                                       {
-                                        "fullyQualifiedName": "${json-unit.matches:comp1Purl}"
+                                        "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
                                       }
                                     ]
                                   }
                                 ],
-                                "level": "${json-unit.matches:vuln3Level}",
+                                "level": "note",
                                 "properties": {
-                                  "name": "${json-unit.matches:comp1Name}",
-                                  "group": "${json-unit.matches:comp1Group}",
-                                  "version": "${json-unit.matches:comp1Version}",
+                                  "name": "Component 1",
+                                  "group": "org.acme",
+                                  "version": "1.1.4",
                                   "source": "INTERNAL",
-                                  "cweId": "${json-unit.matches:vuln3CweId}",
+                                  "cweId": "23",
                                   "cvssV3BaseScore": "",
                                   "epssScore": "",
                                   "epssPercentile": "",
                                   "severityRank": "3",
-                                  "recommendation": "${json-unit.matches:vuln3Recommendation}"
+                                  "recommendation": "Recommendation with whitespaces"
                                 }
                               },
                               {
-                                "ruleId": "${json-unit.matches:vuln3Id}",
+                                "ruleId": "Vuln-3",
                                 "message": {
-                                  "text": "${json-unit.matches:vuln3Desc}"
+                                  "text": "A description-with-hyphens-(and parentheses)"
                                 },
                                 "locations": [
                                   {
                                     "logicalLocations": [
                                       {
-                                        "fullyQualifiedName": "${json-unit.matches:comp2Purl}"
+                                        "fullyQualifiedName": "pkg:maven/com.xyz/component2@2.78.123?type=jar"
                                       }
                                     ]
                                   }
                                 ],
-                                "level": "${json-unit.matches:vuln3Level}",
+                                "level": "note",
                                 "properties": {
-                                  "name": "${json-unit.matches:comp2Name}",
-                                  "group": "${json-unit.matches:comp2Group}",
-                                  "version": "${json-unit.matches:comp2Version}",
+                                  "name": "Component 2",
+                                  "group": "com.xyz",
+                                  "version": "2.78.123",
                                   "source": "INTERNAL",
-                                  "cweId": "${json-unit.matches:vuln3CweId}",
+                                  "cweId": "23",
                                   "cvssV3BaseScore": "",
                                   "epssScore": "",
                                   "epssPercentile": "",
                                   "severityRank": "3",
-                                  "recommendation": "${json-unit.matches:vuln3Recommendation}"
+                                  "recommendation": "Recommendation with whitespaces"
                                 }
                               }
                             ]


### PR DESCRIPTION
### Description
If request header `Accept: application/sarif+json` is provided to the GET Finding By Project UUID API, it will now return a SARIF file with the vulnerability findings in that project.

SARIF file is generated based on a pebble template.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue
Closes #909 
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details
In the  GET `/v1/finding/project/{uuid}` API, added a new Media Type `application/sarif+json` to the `@Produces`, to indicate the new response `Content-Type`.

Added a `sarif.peb` template file to a new directory under `templates/findings/sarif.peb`

Sample `bom.json` and it's resulting `.sarif` file is attached below:
[bom-and-sarif.zip](https://github.com/DependencyTrack/dependency-track/files/14631413/bom-and-sarif.zip)

I have tried to include most of the fields from `Finding.java` into a meaningful field in the `SARIF` file based on the `SARIF` schema [here](https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json). Those fields for which I could not find an adequate mapping I have kept under the `properties` object (fields such as `epssScore`, `severityRank` etc).

Have tested the generated `SARIF` files against the validator [here](https://sarifweb.azurewebsites.net/Validation) with "GitHub Ingestion Rules" enabled as well. Looks like most of the violations are geared towards static analysis results (like, `region`, `helpUri` etc missing).

### Feedback Needed

1. Would appreciate if the `sarif.peb` template is scrutinized so that I am not making any blatant mistakes with the field mappings (from `Finding.java` to the `SARIF` schema). Perhaps there are more meaningful fields in the sarif schema that we could possibly assign a finding field to. 

A picture showing the fields in `Finding.java` and its mapped field on the `SARIF` file is shown below. The green comments are the target fields in the `SARIF` schema.

`results.properties` mean that the finding field is added as a key/value pair into the `properties` object of the schema.

![image](https://github.com/DependencyTrack/dependency-track/assets/43161107/941c6813-83bc-4a3d-8b23-8ec27bcf73fd)


2. I have added logic to calculate the `results.level` field of the `SARIF` schema like below:
```
if finding.vulnerability.severity in ('LOW', 'INFO')
  level = "note"
else if finding.vulnerability.severity == 'MEDIUM':
  level = "warning"
else if finding.vulnerability.severity in ('HIGH', 'CRITICAL'):
  level = "error"
else:
  level = "none"
```
Do let me know in case we need to modify it

3. Even though we have set `content-disposition` header in the response, I was not able to confirm that a file named `findings-{{uuid}}.sarif` was indeed being downloaded locally via cURL or Postman testing. It just displays the sarif json on the terminal now. Please let me know in case there is a way to test the actual file download. (I hope we do not have to change the media type to octet stream instead?)

4. For `rules.name`, I have concatenated `finding.component.name` and `finding.vulnerability.cweName`, hoping that it's more friendly to consume for an end-user. Please do let me know if this needs to be changed.

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
