### PR TITLE
perf: Handle Trivy scan results asynchronously

### DIFF
--- a/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -32,6 +32,7 @@ public enum ConfigKey implements Config.Key {
     SNYK_RETRY_BACKOFF_MULTIPLIER("snyk.retry.backoff.multiplier", 2),
     SNYK_RETRY_BACKOFF_INITIAL_DURATION_MS("snyk.retry.backoff.initial.duration.ms", 1000),
     SNYK_RETRY_BACKOFF_MAX_DURATION_MS("snyk.retry.backoff.max.duration.ms", 60_000),
+    TRIVY_THREAD_POOL_SIZE("trivy.thread.pool.size", 10),
     TRIVY_RETRY_MAX_ATTEMPTS("trivy.retry.max.attempts", 10),
     TRIVY_RETRY_BACKOFF_MULTIPLIER("trivy.retry.backoff.multiplier", 2),
     TRIVY_RETRY_BACKOFF_INITIAL_DURATION_MS("trivy.retry.backoff.initial.duration.ms", 1000),


### PR DESCRIPTION
Use CompletableFutures with a FixedThreadPool Executor to asynchronously handle each scan result from Trivy

### Description

This change allows the `TrivyAnalysisTask` to handle scan results asynchronously by borrowing the existing `CompletableFutures` / `CountDownLatch` pattern being used in the `SnykAnalysisTask`. The `FixedThreadPool` can be configured using `TRIVY_THREAD_POOL_SIZE` (default: 10).

### Addressed Issue

fixes #3570

### Additional Details

- The check for `SCANNER_TRIVY_IGNORE_UNFIXED` is no longer done for each vulnerability, as this is expensive and seemingly is not necessary. Instead it is checked once per analysis task.

- I wasn't sure if a ForkJoinPool would do better here for the work stealing capabilities?

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
