### PR TITLE
Disable automatic API key generation for teams. Fixes part of issue #2552.

### DIFF
--- a/docs/_docs/integrations/rest-api.md
+++ b/docs/_docs/integrations/rest-api.md
@@ -15,7 +15,6 @@ FireFox extensions can be use to quickly use the Swagger UI Console.
 
 ![Swagger UI Console](/images/screenshots/swagger-ui-console.png)
 
-Prior to using the REST APIs, an API Key must be generated. By default, creating a team will also create a corresponding
-API key. A team may have multiple keys.
+Prior to using the REST APIs, an API Key must be generated. By default, creating a team will NOT create a an API key. A team may have multiple keys.
 
 ![Teams - API Key](/images/screenshots/teams.png)

--- a/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
@@ -132,7 +132,7 @@ public class TeamResource extends AlpineResource {
         );
 
         try (QueryManager qm = new QueryManager()) {
-            final Team team = qm.createTeam(jsonTeam.getName(), true);
+            final Team team = qm.createTeam(jsonTeam.getName(), false);
             super.logSecurityEvent(LOGGER, SecurityMarkers.SECURITY_AUDIT, "Team created: " + team.getName());
             return Response.status(Response.Status.CREATED).entity(team).build();
         }

--- a/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
@@ -134,6 +134,7 @@ public class TeamResourceTest extends ResourceTest {
         Assert.assertNotNull(json);
         Assert.assertEquals("My Team", json.getString("name"));
         Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
+        Assert.assertTrue(json.getJsonArray("apiKeys").isEmpty());
     }
 
     @Test


### PR DESCRIPTION
### Description

API keys should not be generated automatically for teams. Instead they should be generated manually when needed.

### Addressed Issue

Fixes part of issue #2552.

### Additional Details

Added unit test.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
