### PR TITLE
3585: Adds new rest end point to fetch the version of a project with the most recent bom upload

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -61,6 +61,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 final class ProjectQueryManager extends QueryManager implements IQueryManager {
@@ -373,6 +374,23 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
     @Override
     public PaginatedResult getProjects(final Tag tag) {
         return getProjects(tag, false, false, false);
+    }
+
+    /**
+     * Returns an optional containing the project version with the latest BOM import date.
+     * @param name the name of the project
+     * @return the version of the project with the latest BOM update date
+     */
+    @Override
+    public Optional getLastImportedVersionProject(final String name) {
+        final PaginatedResult result = getProjects(name, false, false, null);
+        return result.getObjects()
+                .stream()
+                .min((o1, o2) -> {
+                    Project p1 = (Project) o1;
+                    Project p2 = (Project) o2;
+                    return p2.getLastBomImport().compareTo(p1.getLastBomImport());
+                });
     }
 
     /**

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -383,7 +383,6 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
      */
     @Override
     public Optional<Project> getLastImportedVersionProject(final String name) {
-        final PaginatedResult result = getProjects(name, false, false, null);
         Query<Project> query = pm.newQuery(Project.class);
         query.setFilter("name == :name");
         query.setParameters(name);

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -382,15 +382,14 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
      * @return the version of the project with the latest BOM update date
      */
     @Override
-    public Optional getLastImportedVersionProject(final String name) {
+    public Optional<Project> getLastImportedVersionProject(final String name) {
         final PaginatedResult result = getProjects(name, false, false, null);
-        return result.getObjects()
-                .stream()
-                .min((o1, o2) -> {
-                    Project p1 = (Project) o1;
-                    Project p2 = (Project) o2;
-                    return p2.getLastBomImport().compareTo(p1.getLastBomImport());
-                });
+        Query<Project> query = pm.newQuery(Project.class);
+        query.setFilter("name == :name");
+        query.setParameters(name);
+        query.setOrdering("lastBomImport DESC");
+        query.setRange(0, 1);
+        return Optional.ofNullable(query.executeUnique());
     }
 
     /**

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -90,6 +90,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -384,6 +385,10 @@ public class QueryManager extends AlpineQueryManager {
 
     public Project getProject(final String name, final String version) {
         return getProjectQueryManager().getProject(name, version);
+    }
+
+    public Optional getLastImportedVersionProject(final String name) {
+        return getProjectQueryManager().getLastImportedVersionProject(name);
     }
 
     public PaginatedResult getProjects(final Team team, final boolean excludeInactive, final boolean bypass, final boolean onlyRoot) {

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -387,7 +387,7 @@ public class QueryManager extends AlpineQueryManager {
         return getProjectQueryManager().getProject(name, version);
     }
 
-    public Optional getLastImportedVersionProject(final String name) {
+    public Optional<Project> getLastImportedVersionProject(final String name) {
         return getProjectQueryManager().getLastImportedVersionProject(name);
     }
 

--- a/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -160,9 +160,9 @@ public class ProjectResource extends AlpineResource {
             @ApiParam(value = "The name of the project to retrieve", required = true)
             @PathParam("name") String name) {
         try (QueryManager qm = new QueryManager()) {
-            final Optional projectOption = qm.getLastImportedVersionProject(name);
+            final Optional<Project> projectOption = qm.getLastImportedVersionProject(name);
             if (projectOption.isPresent()) {
-                Project project = (Project) projectOption.get();
+                Project project = projectOption.get();
                 if (qm.hasAccess(super.getPrincipal(), project)) {
                     return Response.ok(project).build();
                 } else {

--- a/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -143,10 +143,10 @@ public class ProjectResource extends AlpineResource {
     }
 
     @GET
-    @Path("/latestUpdated/{name}")
+    @Path("/latestImportedBom/{name}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
-            value = "Returns the most recently updated version of a project by name",
+            value = "Returns the version with the most recent bom upload given a project name",
             response = Project.class,
             notes = "<p>Requires permission <strong>VIEW_PORTFOLIO</strong></p>"
     )

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -1089,7 +1089,7 @@ public class ProjectResourceTest extends ResourceTest {
             Project project = qm.createProject("Acme Example", null, String.valueOf(i), null, null, null, true, false);
             qm.updateLastBomImport(project, new Date(), "CycloneDX 1.5");
         }
-        Response response = target(V1_PROJECT + "/latestUpdated/Acme%20Example")
+        Response response = target(V1_PROJECT + "/latestImportedBom/Acme%20Example")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -1107,7 +1107,7 @@ public class ProjectResourceTest extends ResourceTest {
             Project project = qm.createProject("Acme Example", null, String.valueOf(i), null, null, null, true, false);
             qm.updateLastBomImport(project, new Date(), "CycloneDX 1.5");
         }
-        Response response = target(V1_PROJECT + "/latestUpdated/Unknown")
+        Response response = target(V1_PROJECT + "/latestImportedBom/Unknown")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);


### PR DESCRIPTION
### Description

Adds new endpoint : /latestUpdated/{name} to fetch the version of a project with the most recent bom update.

### Addressed Issue

#3585 

### Additional Details

I tried to keep the endpoint's name somewhat short, but I remain open for a renaming if anyone has a better idea.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
