### PR TITLE
Log debug information upon possible secret key corruption

### DIFF
--- a/src/main/java/org/dependencytrack/integrations/fortifyssc/FortifySscUploader.java
+++ b/src/main/java/org/dependencytrack/integrations/fortifyssc/FortifySscUploader.java
@@ -20,13 +20,13 @@ package org.dependencytrack.integrations.fortifyssc;
 
 import alpine.common.logging.Logger;
 import alpine.model.ConfigProperty;
-import alpine.security.crypto.DataEncryption;
 import org.dependencytrack.integrations.AbstractIntegrationPoint;
 import org.dependencytrack.integrations.FindingPackagingFormat;
 import org.dependencytrack.integrations.ProjectFindingUploader;
 import org.dependencytrack.model.Finding;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectProperty;
+import org.dependencytrack.util.DebugDataEncryption;
 import org.json.JSONObject;
 
 import java.io.ByteArrayInputStream;
@@ -35,9 +35,8 @@ import java.net.URL;
 import java.util.List;
 
 import static org.dependencytrack.model.ConfigPropertyConstants.FORTIFY_SSC_ENABLED;
-
-import static org.dependencytrack.model.ConfigPropertyConstants.FORTIFY_SSC_URL;
 import static org.dependencytrack.model.ConfigPropertyConstants.FORTIFY_SSC_TOKEN;
+import static org.dependencytrack.model.ConfigPropertyConstants.FORTIFY_SSC_URL;
 
 public class FortifySscUploader extends AbstractIntegrationPoint implements ProjectFindingUploader {
 
@@ -83,7 +82,7 @@ public class FortifySscUploader extends AbstractIntegrationPoint implements Proj
         }
         try {
             final FortifySscClient client = new FortifySscClient(this, new URL(sscUrl.getPropertyValue()));
-            final String token = client.generateOneTimeUploadToken(DataEncryption.decryptAsString(citoken.getPropertyValue()));
+            final String token = client.generateOneTimeUploadToken(DebugDataEncryption.decryptAsString(citoken.getPropertyValue()));
             if (token != null) {
                 client.uploadDependencyTrackFindings(token, applicationId.getPropertyValue(), payload);
             }

--- a/src/main/java/org/dependencytrack/integrations/kenna/KennaSecurityUploader.java
+++ b/src/main/java/org/dependencytrack/integrations/kenna/KennaSecurityUploader.java
@@ -20,7 +20,6 @@ package org.dependencytrack.integrations.kenna;
 
 import alpine.common.logging.Logger;
 import alpine.model.ConfigProperty;
-import alpine.security.crypto.DataEncryption;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
@@ -37,6 +36,7 @@ import org.dependencytrack.integrations.AbstractIntegrationPoint;
 import org.dependencytrack.integrations.PortfolioFindingUploader;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectProperty;
+import org.dependencytrack.util.DebugDataEncryption;
 import org.json.JSONObject;
 
 import java.io.ByteArrayInputStream;
@@ -98,7 +98,7 @@ public class KennaSecurityUploader extends AbstractIntegrationPoint implements P
         LOGGER.debug("Uploading payload to KennaSecurity");
         final ConfigProperty tokenProperty = qm.getConfigProperty(KENNA_TOKEN.getGroupName(), KENNA_TOKEN.getPropertyName());
         try {
-            final String token = DataEncryption.decryptAsString(tokenProperty.getPropertyValue());
+            final String token = DebugDataEncryption.decryptAsString(tokenProperty.getPropertyValue());
             HttpPost request = new HttpPost(String.format(CONNECTOR_UPLOAD_URL, connectorId));
             request.addHeader("X-Risk-Token", token);
             request.addHeader("accept", "application/json");

--- a/src/main/java/org/dependencytrack/notification/publisher/JiraPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/JiraPublisher.java
@@ -21,10 +21,10 @@ package org.dependencytrack.notification.publisher;
 import alpine.common.logging.Logger;
 import alpine.model.ConfigProperty;
 import alpine.notification.Notification;
-import alpine.security.crypto.DataEncryption;
 import io.pebbletemplates.pebble.PebbleEngine;
 import org.dependencytrack.exception.PublisherException;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.util.DebugDataEncryption;
 
 import javax.json.JsonObject;
 import java.util.Map;
@@ -90,7 +90,7 @@ public class JiraPublisher extends AbstractWebhookPublisher implements Publisher
             final ConfigProperty jiraUsernameProp = qm.getConfigProperty(JIRA_USERNAME.getGroupName(), JIRA_USERNAME.getPropertyName());
             final String jiraUsername = (jiraUsernameProp == null) ? null : jiraUsernameProp.getPropertyValue();
             final ConfigProperty jiraPasswordProp = qm.getConfigProperty(JIRA_PASSWORD.getGroupName(), JIRA_PASSWORD.getPropertyName());
-            final String jiraPassword = (jiraPasswordProp == null || jiraPasswordProp.getPropertyValue() == null) ? null : DataEncryption.decryptAsString(jiraPasswordProp.getPropertyValue());
+            final String jiraPassword = (jiraPasswordProp == null || jiraPasswordProp.getPropertyValue() == null) ? null : DebugDataEncryption.decryptAsString(jiraPasswordProp.getPropertyValue());
             return new AuthCredentials(jiraUsername, jiraPassword);
         } catch (final Exception e) {
             throw new PublisherException("An error occurred during the retrieval of Jira credentials", e);

--- a/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
@@ -24,12 +24,12 @@ import alpine.model.ManagedUser;
 import alpine.model.OidcUser;
 import alpine.model.Team;
 import alpine.notification.Notification;
-import alpine.security.crypto.DataEncryption;
 import alpine.server.mail.SendMail;
 import alpine.server.mail.SendMailException;
 import io.pebbletemplates.pebble.PebbleEngine;
 import io.pebbletemplates.pebble.template.PebbleTemplate;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.util.DebugDataEncryption;
 
 import javax.json.JsonObject;
 import javax.json.JsonString;
@@ -42,9 +42,9 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import static org.dependencytrack.model.ConfigPropertyConstants.EMAIL_PREFIX;
 import static org.dependencytrack.model.ConfigPropertyConstants.EMAIL_SMTP_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.EMAIL_SMTP_FROM_ADDR;
-import static org.dependencytrack.model.ConfigPropertyConstants.EMAIL_PREFIX;
 import static org.dependencytrack.model.ConfigPropertyConstants.EMAIL_SMTP_PASSWORD;
 import static org.dependencytrack.model.ConfigPropertyConstants.EMAIL_SMTP_SERVER_HOSTNAME;
 import static org.dependencytrack.model.ConfigPropertyConstants.EMAIL_SMTP_SERVER_PORT;
@@ -130,7 +130,7 @@ public class SendMailPublisher implements Publisher {
         final boolean smtpAuth = (smtpUser != null && encryptedSmtpPassword != null);
         final String decryptedSmtpPassword;
         try {
-            decryptedSmtpPassword = (encryptedSmtpPassword != null) ? DataEncryption.decryptAsString(encryptedSmtpPassword) : null;
+            decryptedSmtpPassword = (encryptedSmtpPassword != null) ? DebugDataEncryption.decryptAsString(encryptedSmtpPassword) : null;
         } catch (Exception e) {
             LOGGER.error("Failed to decrypt SMTP password (%s)".formatted(ctx), e);
             return;

--- a/src/main/java/org/dependencytrack/tasks/NistApiMirrorTask.java
+++ b/src/main/java/org/dependencytrack/tasks/NistApiMirrorTask.java
@@ -25,7 +25,6 @@ import alpine.event.framework.Event;
 import alpine.event.framework.LoggableUncaughtExceptionHandler;
 import alpine.event.framework.Subscriber;
 import alpine.model.ConfigProperty;
-import alpine.security.crypto.DataEncryption;
 import io.github.jeremylong.openvulnerability.client.HttpAsyncClientSupplier;
 import io.github.jeremylong.openvulnerability.client.nvd.CveItem;
 import io.github.jeremylong.openvulnerability.client.nvd.DefCveItem;
@@ -53,6 +52,7 @@ import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.Vulnerability.Source;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.util.DebugDataEncryption;
 import org.dependencytrack.util.PersistenceUtil.Diff;
 import org.dependencytrack.util.PersistenceUtil.Differ;
 
@@ -126,7 +126,7 @@ public class NistApiMirrorTask implements Subscriber {
                     .map(StringUtils::trimToNull)
                     .map(encryptedApiKey -> {
                         try {
-                            return DataEncryption.decryptAsString(encryptedApiKey);
+                            return DebugDataEncryption.decryptAsString(encryptedApiKey);
                         } catch (Exception ex) {
                             LOGGER.warn("Failed to decrypt API key; Continuing without authentication", ex);
                             return null;

--- a/src/main/java/org/dependencytrack/tasks/repositories/RepositoryMetaAnalyzerTask.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/RepositoryMetaAnalyzerTask.java
@@ -24,7 +24,6 @@ import alpine.common.metrics.Metrics;
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
 import alpine.model.ConfigProperty;
-import alpine.security.crypto.DataEncryption;
 import io.micrometer.core.instrument.Timer;
 import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.common.ConfigKey;
@@ -38,6 +37,7 @@ import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.CacheStampedeBlocker;
+import org.dependencytrack.util.DebugDataEncryption;
 import org.dependencytrack.util.PurlUtil;
 
 import javax.json.Json;
@@ -166,7 +166,7 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
                         try {
                             String decryptedPassword = null;
                             if (repository.getPassword() != null) {
-                                decryptedPassword = DataEncryption.decryptAsString(repository.getPassword());
+                                decryptedPassword = DebugDataEncryption.decryptAsString(repository.getPassword());
                             }
                             analyzer.setRepositoryUsernameAndPassword(repository.getUsername(), decryptedPassword);
                         } catch (Exception e) {

--- a/src/main/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTask.java
@@ -25,7 +25,6 @@ import alpine.common.util.Pageable;
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
 import alpine.model.ConfigProperty;
-import alpine.security.crypto.DataEncryption;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import io.github.resilience4j.micrometer.tagged.TaggedRetryMetrics;
@@ -55,6 +54,7 @@ import org.dependencytrack.parser.ossindex.OssIndexParser;
 import org.dependencytrack.parser.ossindex.model.ComponentReport;
 import org.dependencytrack.parser.ossindex.model.ComponentReportVulnerability;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.util.DebugDataEncryption;
 import org.dependencytrack.util.HttpUtil;
 import org.dependencytrack.util.NotificationUtil;
 import org.dependencytrack.util.VulnerabilityUtil;
@@ -156,7 +156,7 @@ public class OssIndexAnalysisTask extends BaseComponentAnalyzerTask implements C
                 } else {
                     try {
                         apiUsername = apiUsernameProperty.getPropertyValue();
-                        apiToken = DataEncryption.decryptAsString(apiTokenProperty.getPropertyValue());
+                        apiToken = DebugDataEncryption.decryptAsString(apiTokenProperty.getPropertyValue());
                     } catch (Exception ex) {
                         LOGGER.error("An error occurred decrypting the OSS Index API Token. Skipping", ex);
                         return;

--- a/src/main/java/org/dependencytrack/tasks/scanners/SnykAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/SnykAnalysisTask.java
@@ -28,7 +28,6 @@ import alpine.event.framework.Subscriber;
 import alpine.model.ConfigProperty;
 import alpine.notification.Notification;
 import alpine.notification.NotificationLevel;
-import alpine.security.crypto.DataEncryption;
 import com.github.packageurl.PackageURL;
 import io.github.resilience4j.micrometer.tagged.TaggedRetryMetrics;
 import io.github.resilience4j.retry.Retry;
@@ -58,6 +57,7 @@ import org.dependencytrack.notification.NotificationScope;
 import org.dependencytrack.parser.snyk.SnykParser;
 import org.dependencytrack.parser.snyk.model.SnykError;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.util.DebugDataEncryption;
 import org.dependencytrack.util.NotificationUtil;
 import org.dependencytrack.util.RoundRobinAccessor;
 import org.json.JSONArray;
@@ -196,7 +196,7 @@ public class SnykAnalysisTask extends BaseComponentAnalyzerTask implements Cache
                 apiVersion = apiVersionProperty.getPropertyValue();
 
                 try {
-                    final String decryptedToken = DataEncryption.decryptAsString(apiTokenProperty.getPropertyValue());
+                    final String decryptedToken = DebugDataEncryption.decryptAsString(apiTokenProperty.getPropertyValue());
                     apiTokenSupplier = createTokenSupplier(decryptedToken);
                 } catch (Exception ex) {
                     LOGGER.error("An error occurred decrypting the Snyk API Token; Skipping", ex);

--- a/src/main/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTask.java
@@ -25,7 +25,6 @@ import alpine.common.util.UrlUtil;
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
 import alpine.model.ConfigProperty;
-import alpine.security.crypto.DataEncryption;
 import com.github.packageurl.PackageURL;
 import com.google.gson.Gson;
 import io.github.resilience4j.micrometer.tagged.TaggedRetryMetrics;
@@ -65,6 +64,7 @@ import org.dependencytrack.parser.trivy.model.Result;
 import org.dependencytrack.parser.trivy.model.ScanRequest;
 import org.dependencytrack.parser.trivy.model.TrivyResponse;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.util.DebugDataEncryption;
 import org.dependencytrack.util.NotificationUtil;
 
 import java.nio.charset.StandardCharsets;
@@ -151,7 +151,7 @@ public class TrivyAnalysisTask extends BaseComponentAnalyzerTask implements Cach
                 apiBaseUrl = getApiBaseUrl().get();
 
                 try {
-                    apiToken = DataEncryption.decryptAsString(apiTokenProperty.getPropertyValue());
+                    apiToken = DebugDataEncryption.decryptAsString(apiTokenProperty.getPropertyValue());
                 } catch (Exception ex) {
                     LOGGER.error("An error occurred decrypting the Trivy API token; Skipping", ex);
                     return;

--- a/src/main/java/org/dependencytrack/tasks/scanners/VulnDbAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/VulnDbAnalysisTask.java
@@ -22,7 +22,6 @@ import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
 import alpine.model.ConfigProperty;
-import alpine.security.crypto.DataEncryption;
 import oauth.signpost.exception.OAuthCommunicationException;
 import oauth.signpost.exception.OAuthExpectationFailedException;
 import oauth.signpost.exception.OAuthMessageSignerException;
@@ -35,7 +34,9 @@ import org.dependencytrack.parser.vulndb.ModelConverter;
 import org.dependencytrack.parser.vulndb.VulnDbClient;
 import org.dependencytrack.parser.vulndb.model.Results;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.util.DebugDataEncryption;
 import org.dependencytrack.util.NotificationUtil;
+
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -103,7 +104,7 @@ public class VulnDbAnalysisTask extends BaseComponentAnalyzerTask implements Sub
                 }
                 this.apiConsumerKey = apiConsumerKey.getPropertyValue();
                 try {
-                    this.apiConsumerSecret = DataEncryption.decryptAsString(apiConsumerSecret.getPropertyValue());
+                    this.apiConsumerSecret = DebugDataEncryption.decryptAsString(apiConsumerSecret.getPropertyValue());
                 } catch (Exception ex) {
                     LOGGER.error("An error occurred decrypting the VulnDB consumer secret. Skipping", ex);
                     return;

--- a/src/main/java/org/dependencytrack/util/DebugDataEncryption.java
+++ b/src/main/java/org/dependencytrack/util/DebugDataEncryption.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.util;
+
+import alpine.common.logging.Logger;
+import alpine.security.crypto.DataEncryption;
+import alpine.security.crypto.KeyManager;
+import org.apache.commons.codec.digest.DigestUtils;
+
+import javax.crypto.BadPaddingException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * @since 4.11.0
+ */
+public class DebugDataEncryption {
+
+    private static final Logger LOGGER = Logger.getLogger(DataEncryption.class);
+    private static final ReentrantLock RELOAD_LOCK = new ReentrantLock();
+
+    /**
+     * Wrapper around {@link DataEncryption#decryptAsString(String)} to help with debugging
+     * and / or handling of {@link BadPaddingException}s some users are experiencing.
+     *
+     * @param encryptedText the text to decrypt
+     * @return the decrypted string
+     * @throws Exception a number of exceptions may be thrown
+     * @see <a href="https://github.com/DependencyTrack/dependency-track/issues/265">Issue 265</a>
+     * @see <a href="https://github.com/DependencyTrack/dependency-track/issues/2366">Issue 2366</a>
+     * @see <a href="https://owasp.slack.com/archives/C6R3R32H4/p1713945310408209">Slack Thread</a>
+     * @see DataEncryption#decryptAsString(String)
+     */
+    public static String decryptAsString(final String encryptedText) throws Exception {
+        return retryDecryptAsString(encryptedText, 0);
+    }
+
+    private static String retryDecryptAsString(final String encryptedText, final int attempt) throws Exception {
+        try {
+            return DataEncryption.decryptAsString(encryptedText);
+        } catch (BadPaddingException e) {
+            final byte[] currentKey = KeyManager.getInstance().getSecretKey().getEncoded();
+
+            RELOAD_LOCK.lock();
+            try {
+                reloadKeys();
+            } catch (NoSuchFieldException | NoSuchMethodException | InvocationTargetException
+                     | IllegalAccessException | RuntimeException ex) {
+                LOGGER.warn("Failed to reload keys while handling %s".formatted(e), ex);
+                throw e;
+            } finally {
+                RELOAD_LOCK.unlock();
+            }
+
+            final byte[] reloadedKey = KeyManager.getInstance().getSecretKey().getEncoded();
+            final boolean isKeyDifferent = !Arrays.equals(currentKey, reloadedKey);
+
+            if (isKeyDifferent && attempt < 1) {
+                LOGGER.warn("""
+                        Failed to decrypt value, possibly because the secret key in memory got corrupted. \
+                        Reloaded key from disk and detected it being different from the previously loaded key. \
+                        Please report this to https://github.com/DependencyTrack/dependency-track/issues/2366 \
+                        so the root cause can be identified. Additional information about the keys: \
+                        length{previous=%d, reloaded=%d}, sha256={previous=%s, reloaded=%s}"""
+                        .formatted(currentKey.length, reloadedKey.length, DigestUtils.sha256Hex(currentKey), DigestUtils.sha256Hex(reloadedKey)));
+                return retryDecryptAsString(encryptedText, attempt + 1);
+            } else if (!isKeyDifferent) {
+                LOGGER.warn("""
+                        Failed to decrypt value, possibly because it has been encrypted with a different key, \
+                        or the encrypted value is corrupted. To verify the latter, please check the respective \
+                        value in the database. For comparison, the base64-encoded value for which decryption \
+                        was attempted has a length of %d, and a sha256 digest of %s. If this is different to what's \
+                        stored in your database, please report this to https://github.com/DependencyTrack/dependency-track/issues/2366, \
+                        so the root cause can be identified.""".formatted(encryptedText.length(), DigestUtils.sha256Hex(encryptedText)));
+            }
+
+            throw e;
+        }
+    }
+
+    private static void reloadKeys() throws NoSuchFieldException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        final Field secretKeyField = KeyManager.class.getDeclaredField("secretKey");
+        secretKeyField.setAccessible(true);
+
+        final Method loadMethod = KeyManager.class.getDeclaredMethod("initialize");
+        loadMethod.setAccessible(true);
+
+        secretKeyField.set(KeyManager.getInstance(), null);
+        loadMethod.invoke(KeyManager.getInstance());
+    }
+
+}

--- a/src/test/java/org/dependencytrack/util/DebugDataEncryptionTest.java
+++ b/src/test/java/org/dependencytrack/util/DebugDataEncryptionTest.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.util;
+
+import alpine.security.crypto.DataEncryption;
+import alpine.security.crypto.KeyManager;
+import org.junit.Test;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import java.lang.reflect.Field;
+import java.security.SecureRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DebugDataEncryptionTest {
+
+    @Test
+    public void testReloadAndRetry() throws Exception {
+        final Field secretKeyField = KeyManager.class.getDeclaredField("secretKey");
+        secretKeyField.setAccessible(true);
+
+        // Encrypt a value with KeyManager's current secret key.
+        final String encryptedValue = DataEncryption.encryptAsString("foobarbaz");
+
+        // Generate a new secret key and replace KeyManager's current key with it.
+        final KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+        final SecureRandom random = SecureRandom.getInstance("SHA1PRNG");
+        keyGen.init(256, random);
+        final SecretKey newSecretKey = keyGen.generateKey();
+        secretKeyField.set(KeyManager.getInstance(), newSecretKey);
+
+        // Decrypt the value. This should work due to DebugDataEncryption
+        // reloading the secret key from disk upon decryption failure.
+        final String decryptedValue = DebugDataEncryption.decryptAsString(encryptedValue);
+        assertThat(decryptedValue).isEqualTo("foobarbaz");
+    }
+
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Logs debug information upon possible secret key corruption.

I was not able to reproduce the issue in question, so it's impossible to know why some users are experiencing secret decryption failures out of the blue.

If for whatever reason the secret key in-memory gets corrupted, we now try to reload it from disk once, and log a warning about it.

If on the other hand the encrypted value itself got corrupted (perhaps due to some bug in DataNucleus), we log a warning about that as well.

In both cases, the warning logs contain a reference to issue #2366.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #2366

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
