### PR TITLE
Bump bundled frontend to v4.11.0

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -359,7 +359,7 @@ and giving the rest of the team write permissions to their repository.
 
 To address the use cases above, contributors to the Dependency-Track project can request a *feature branch*
 from a maintainer. Feature branches follow the `feature-*` naming pattern, and are subject to branch protection rules.
-Just like for the `maser` branch, changes pushed to a `feature` branch trigger a container image build.
+Just like for the `master` branch, changes pushed to a `feature` branch trigger a container image build.
 Images built from `feature` branches are tagged with the name of the branch, for example for a branch named `feature-foobar`:
 
 ```

--- a/docs/_posts/2024-05-07-v4.11.0.md
+++ b/docs/_posts/2024-05-07-v4.11.0.md
@@ -197,10 +197,10 @@ Special thanks to everyone who contributed code to implement enhancements and fi
 
 ###### frontend-dist.zip
 
-| Algorithm | Checksum |
-|:----------|:---------|
-| SHA-1     |          |
-| SHA-256   |          |
+| Algorithm | Checksum                                                                            |
+|:----------|:------------------------------------------------------------------------------------|
+| SHA-1     | 80cddddaf5c9c73676065d4ab6fe7b3eff3ec8de                                            |
+| SHA-256   | 9c51c337f4b2a7e78730c70473cd24070773a0982d1c0ee6c13f9a6f18a756d5  frontend-dist.zip |
 
 ###### Software Bill of Materials (SBOM)
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 
     <properties>
         <!-- Dependency Versions -->
-        <frontend.version>4.10.0</frontend.version>
+        <frontend.version>4.11.0</frontend.version>
         <lib.alpine.version>${project.parent.version}</lib.alpine.version>
         <lib.awaitility.version>4.2.1</lib.awaitility.version>
         <lib.brotli-decoder.version>0.1.2</lib.brotli-decoder.version>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Bumps the bundled frontend to version 4.11.0.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
