### PR TITLE
Avoid duplicates with alias BACKEND

### DIFF
--- a/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
+++ b/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
@@ -43,6 +43,8 @@ public enum ConfigPropertyConstants {
     SCANNER_INTERNAL_FUZZY_ENABLED("scanner", "internal.fuzzy.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable non-exact fuzzy matching using the internal analyzer"),
     SCANNER_INTERNAL_FUZZY_EXCLUDE_PURL("scanner", "internal.fuzzy.exclude.purl", "true", PropertyType.BOOLEAN, "Flag to enable/disable fuzzy matching on components that have a Package URL (PURL) defined"),
     SCANNER_INTERNAL_FUZZY_EXCLUDE_INTERNAL("scanner", "internal.fuzzy.exclude.internal", "true", PropertyType.BOOLEAN, "Flag to enable/disable fuzzy matching on components that are marked internal."),
+    SCANNER_INTERNAL_DEDUPLICATES_ENABLED("scanner", "internal.deduplication.enabled", null, PropertyType.BOOLEAN, "Flag to enable/disable alias-based deduplication"),
+    SCANNER_INTERNAL_DEDUPLICATES("scanner", "internal.deduplication.list", "true", PropertyType.STRING, "List of source priorities for alias-based deduplication"),
     SCANNER_NPMAUDIT_ENABLED("scanner", "npmaudit.enabled", "true", PropertyType.BOOLEAN, "Flag to enable/disable NPM Audit"),
     SCANNER_OSSINDEX_ENABLED("scanner", "ossindex.enabled", "true", PropertyType.BOOLEAN, "Flag to enable/disable Sonatype OSS Index"),
     SCANNER_OSSINDEX_ALIAS_SYNC_ENABLED("scanner", "ossindex.alias.sync.enabled", "true", PropertyType.BOOLEAN, "Flag to enable/disable alias synchronization for OSS Index"),

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -348,6 +348,11 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
         final Component result = persist(component);
         Event.dispatch(new IndexEvent(IndexEvent.Action.CREATE, result));
         commitSearchIndex(commitIndex, Component.class);
+        //Update PriorityList with new Enabled/Disabled Sources to avoid conflicts
+        ConfigPropertyQueryManager configPropertyQueryManager = new ConfigPropertyQueryManager();
+        if(configPropertyQueryManager.isDedupEnabled()){
+            configPropertyQueryManager.updatePropertiesFromEnabledSources();
+        }
         return result;
     }
 

--- a/src/main/java/org/dependencytrack/persistence/ConfigPropertyQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ConfigPropertyQueryManager.java
@@ -1,0 +1,162 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence;
+
+import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_INTERNAL_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_NPMAUDIT_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_OSSINDEX_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_OSSINDEX_ALIAS_SYNC_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_SNYK_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_SNYK_ALIAS_SYNC_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_TRIVY_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_VULNDB_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ALIAS_SYNC_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ALIAS_SYNC_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_NVD_API_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES;
+import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES_ENABLED;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+
+import org.dependencytrack.model.ConfigPropertyConstants;
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.resources.v1.ConfigPropertyResource;
+
+import alpine.model.ConfigProperty;
+
+public class ConfigPropertyQueryManager extends ConfigPropertyResource{
+    private static final ConfigPropertyConstants[] constantFlags = {
+        SCANNER_INTERNAL_ENABLED,
+        SCANNER_NPMAUDIT_ENABLED,
+        SCANNER_OSSINDEX_ALIAS_SYNC_ENABLED, //NEEDS SCANNER_OSSINDEX_ENABLED
+        SCANNER_VULNDB_ENABLED,
+        SCANNER_SNYK_ALIAS_SYNC_ENABLED, //NEEDS SCANNER_SNYK_ENABLED
+        SCANNER_TRIVY_ENABLED,
+        VULNERABILITY_SOURCE_NVD_API_ENABLED, //VULNERABILITY_SOURCE_NVD_ENABLED
+        VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ALIAS_SYNC_ENABLED, //NEEDS VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED
+        VULNERABILITY_SOURCE_GOOGLE_OSV_ALIAS_SYNC_ENABLED //NEEDS VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED
+    };
+
+    private static final Map<ConfigPropertyConstants, ConfigPropertyConstants> needsDependency = new HashMap<ConfigPropertyConstants, ConfigPropertyConstants>() {{
+        put(SCANNER_OSSINDEX_ALIAS_SYNC_ENABLED, SCANNER_OSSINDEX_ENABLED);
+        put(SCANNER_SNYK_ALIAS_SYNC_ENABLED, SCANNER_SNYK_ENABLED);
+        put(VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ALIAS_SYNC_ENABLED, VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED);
+        put(VULNERABILITY_SOURCE_GOOGLE_OSV_ALIAS_SYNC_ENABLED, VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED);
+    }};
+
+    public void updatePropertiesFromEnabledSources(){
+        List<String> sourcesList = retrieveEnabledSources()
+        .stream()
+        .map(Vulnerability.Source::toString)
+        .collect(Collectors.toList());
+
+        updateProperties(sourcesList);
+    }
+
+    public List<Vulnerability.Source> retrieveEnabledSources(){
+        Map<ConfigPropertyConstants, Vulnerability.Source> constantsMap = createConstantsMapFromEnum();
+        List<Vulnerability.Source> enabledSources = new ArrayList<>();
+        try (final QueryManager qm = new QueryManager()) {
+            for ( ConfigPropertyConstants constantFlag : constantsMap.keySet()){
+                if(isEnabled(qm,constantFlag)){
+                    enabledSources.add(constantsMap.get(constantFlag));
+                }
+            }
+            return enabledSources;
+        }
+
+    }
+
+    private boolean isEnabled(QueryManager qm, ConfigPropertyConstants constantFlag) {
+        boolean flagEnabled = qm.isEnabled(constantFlag);
+        ConfigPropertyConstants dependentFlag = needsDependency.get(constantFlag);
+        return flagEnabled && (dependentFlag != null ? qm.isEnabled(dependentFlag) : true);
+    }
+
+    public void updateProperties(List<String> sourcesList) {
+        try (final QueryManager qm = new QueryManager()) {
+            final ConfigProperty property = makeQuery(qm, SCANNER_INTERNAL_DEDUPLICATES);
+            List<String> priorityList = Arrays.stream(property.getPropertyValue().split(";"))
+                    .collect(Collectors.toList());
+            priorityList = Stream.concat(priorityList.stream(), sourcesList.stream())
+                    .distinct()
+                    .filter(sourcesList::contains)
+                    .collect(Collectors.toList());
+            property.setPropertyValue(String.join(";", priorityList));
+            qm.persist(property);
+        }
+    }
+
+    public boolean isDedupEnabled(){
+        try (final QueryManager qm = new QueryManager()) {
+            return qm.isEnabled(SCANNER_INTERNAL_DEDUPLICATES_ENABLED);
+        }
+    }
+
+    public List<Vulnerability.Source> parsePriorityList() {
+        try (final QueryManager qm = new QueryManager()) {
+            String result = makeQuery(qm, SCANNER_INTERNAL_DEDUPLICATES).getPropertyValue();
+
+            if (result == null || result.isEmpty() || !isDedupEnabled()) {
+                return new ArrayList<>();
+            }
+
+            return Arrays.stream(result.split(";"))
+                    .map(String::trim)
+                    .map(String::toUpperCase)
+                    .map(Vulnerability.Source::valueOf)
+                    .collect(Collectors.toList());
+        }
+    }
+
+    private static Map<ConfigPropertyConstants, Vulnerability.Source> createConstantsMapFromEnum() {
+        Map<ConfigPropertyConstants, Vulnerability.Source> constantsMap = new HashMap<>();
+        for (Vulnerability.Source source : Vulnerability.Source.values()) {
+            ConfigPropertyConstants constantFlag = findMatchingConstantFlag(source);
+            if (constantFlag != null) {
+                constantsMap.put(constantFlag, source);
+            }
+        }
+        return constantsMap;
+    }
+
+    private static ConfigPropertyConstants findMatchingConstantFlag(Vulnerability.Source source) {
+        for (ConfigPropertyConstants constantFlag : constantFlags) {
+            if (constantFlag.toString().contains(source.toString())) {
+                return constantFlag;
+            }
+        }
+        return null;
+    }
+
+    private ConfigProperty makeQuery(QueryManager qm, ConfigPropertyConstants constantFlag) {
+        final ConfigProperty configProperty = qm.getConfigProperty(constantFlag.getGroupName(), constantFlag.getPropertyName());
+        return configProperty;
+    }
+}

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.persistence;
 
+import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
 import alpine.persistence.PaginatedResult;
 import alpine.resources.AlpineRequest;
@@ -42,12 +43,17 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.UUID;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 final class VulnerabilityQueryManager extends QueryManager implements IQueryManager {
+
+    private static final Logger LOGGER = Logger.getLogger(VulnerabilityQueryManager.class);
+    private static List<Vulnerability.Source> priorityList;
 
     /**
      * Constructs a new QueryManager.
@@ -226,7 +232,19 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
      */
     public void addVulnerability(Vulnerability vulnerability, Component component, AnalyzerIdentity analyzerIdentity,
                                  String alternateIdentifier, String referenceUrl, Date attributedOn) {
-        if (!contains(vulnerability, component)) {
+
+        ConfigPropertyQueryManager configPropertyQueryManager = new ConfigPropertyQueryManager();
+
+        try {
+            priorityList = configPropertyQueryManager.parsePriorityList();
+
+        } catch (Exception ex) {
+            LOGGER.warn("An unexpected error occurred while retrieving the preference list for alias duplicates", ex);
+        }
+        setVulnerabilityAliasesIfNull(vulnerability);
+        boolean vulnerabilityExists = checkVulnerabilityExists(vulnerability, component);
+
+        if (!vulnerabilityExists){
             component.addVulnerability(vulnerability);
             component = persist(component);
             FindingAttribution findingAttribution = new FindingAttribution(component, vulnerability, analyzerIdentity, alternateIdentifier, referenceUrl);
@@ -235,6 +253,31 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
             }
             persist(findingAttribution);
         }
+    }
+
+    /**
+     * Set Alias from getVulnerabilityAliases.
+     * @param vulnerability Vulnerability with aliases
+    */
+    private void setVulnerabilityAliasesIfNull(Vulnerability vulnerability) {
+        if (vulnerability.getAliases() == null && getVulnerabilityAliases(vulnerability) != null) {
+            vulnerability.setAliases(getVulnerabilityAliases(vulnerability));
+        }
+    }
+
+    /**
+     * Determines if a Component is affected by a specific Vulnerability or an associated Alias
+     * by checking {@link #contains()} and {@link #containsAlias()}.
+     * @param vulnerability The vulnerability to check if associated with component
+     * @param component The component to check against
+     * @return true if vulnerability or Alias is associated with the component, false if not
+     */
+    private boolean checkVulnerabilityExists(Vulnerability vulnerability, Component component) {
+        boolean vulnerabilityExists = contains(vulnerability, component);
+        if (!priorityList.isEmpty()) {
+            vulnerabilityExists |= containsAlias(vulnerability, component);
+        }
+        return vulnerabilityExists;
     }
 
     /**
@@ -298,6 +341,56 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
             if (vuln.getSource() != null && vuln.getSource().equals(vulnerability.getSource())
                     && vuln.getVulnId() != null && vuln.getVulnId().equals(vulnerability.getVulnId())) {
                 return true;
+            }
+        }
+        return false;
+    }
+    /**
+     * This function checks if a given vulnerability has an alias value that matches any
+     * of the vulnerabilities associated with a specific component.
+     * @param vulnerability - The vulnerability to check for aliases.
+     * @param component - The component to check for matching aliases.
+     * @return boolean - True if the vulnerability has an alias value that matches any of the vulnerabilities
+     *                   associated with the component, false otherwise.
+     */
+    public boolean containsAlias(Vulnerability vulnerability, Component component) {
+        List<VulnerabilityAlias> aliases = vulnerability.getAliases();
+
+        if (hasLowerPriority(aliases, vulnerability.getSource())) {
+            return true;
+        }
+
+        Set<String> aliasValues = aliases.stream()
+            .flatMap(alias -> alias.getAllBySource().values().stream())
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+        return component.getVulnerabilities().stream()
+            .map(Vulnerability::getVulnId)
+            .anyMatch(aliasValues::contains);
+    }
+
+    /**
+     * This function checks if the given vulnerability source has a lower priority
+     * than any non-null sources in the provided list of vulnerability aliases.
+     * @param aliases - List of vulnerability aliases containing sources and their corresponding values.
+     * @param vulnSource - The vulnerability source to compare with the priorityList.
+     * @return boolean - True if the vulnSource has a lower priority than the order of the priorityList Source,
+     *                   false otherwise.
+     */
+    public boolean hasLowerPriority(List<VulnerabilityAlias> aliases, String vulnSource){
+        Set<Vulnerability.Source> nonNullSources = aliases.stream()
+        .flatMap(alias -> alias.getAllBySource().entrySet().stream())
+        .filter(entry -> entry.getValue() != null)
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toSet());
+
+        for (Vulnerability.Source source : priorityList)  {
+        //To implement priority over sources, we need to verify if the source with the highest priority
+        //is included in the alias.
+            if (nonNullSources.contains(source)) {
+        //This line returns true if the vulnSource is not equal to the current source element.
+                return Vulnerability.Source.valueOf(vulnSource) != source;
             }
         }
         return false;

--- a/src/main/java/org/dependencytrack/resources/v1/IntegrationResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/IntegrationResource.java
@@ -25,8 +25,11 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
+
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.tasks.OsvDownloadTask;
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.persistence.ConfigPropertyQueryManager;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -80,4 +83,30 @@ public class IntegrationResource extends AlpineResource {
                 .collect(Collectors.toList());
         return Response.ok(ecosystems).build();
     }
+
+    @GET
+    @Path("/sources")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Return a list of available vulnerability sources",
+            response = String.class,
+            responseContainer = "List",
+            notes = "<p>Requires permission <strong>SYSTEM_CONFIGURATION</strong></p>"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 404, message = "Vulnerability sources is empty")
+    })
+    public Response sendSources() {
+        ConfigPropertyQueryManager configPropertyQueryManager = new ConfigPropertyQueryManager();
+        List<String> sourcesList = configPropertyQueryManager.retrieveEnabledSources()
+        .stream()
+        .map(Vulnerability.Source::toString)
+        .collect(Collectors.toList());
+
+        configPropertyQueryManager.updateProperties(sourcesList);
+
+        return Response.ok(sourcesList).build();
+    }
+
 }

--- a/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
@@ -18,19 +18,92 @@
  */
 package org.dependencytrack.persistence;
 
-import alpine.persistence.PaginatedResult;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.*;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Date;
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.*;
+import java.util.function.Consumer;
+
+
 public class ProjectQueryManagerTest extends PersistenceCapableTest {
+
+    Project project;
+
+    private VulnerabilityAlias createAlias(final Consumer<VulnerabilityAlias> customizer) {
+        final var alias = new VulnerabilityAlias();
+        customizer.accept(alias);
+        return alias;
+    }
+
+    VulnerabilityAlias alias = createAlias(alias -> {
+        alias.setId(1);
+        alias.setCveId("CVE-1234-123");
+        alias.setGhsaId("GHSA-002");
+    });
+
+    private void createConfig(ConfigPropertyConstants constantFlag, String value){
+        qm.createConfigProperty(constantFlag.getGroupName(),
+        constantFlag.getPropertyName(),
+        value,
+        constantFlag.getPropertyType(),
+        constantFlag.getDescription());
+    }
+
+    private Component setUp() {
+        List<VulnerabilityAlias> vulnerabilityAliases = new ArrayList<>();
+        Component component = new Component();
+        Vulnerability vuln = new Vulnerability();
+        Vulnerability vuln2 = new Vulnerability();
+
+        vulnerabilityAliases.add(alias);
+
+        project = qm.createProject("Example Project 1", "Description 1", "1.0", null, null, null, true, false);
+
+        component.setId(111L);
+        component.setName("name");
+        component.setProject(project);
+        component.setVersion("1.0");
+        component.setCopyright("Copyright Acme");
+        qm.createComponent(component, true);
+
+        vuln.setId(124L);
+        vuln.setVulnId("CVE-1234-123");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setSeverity(Severity.HIGH);
+        vuln.setAliases(vulnerabilityAliases);
+
+        vuln2.setId(125L);
+        vuln2.setVulnId("GHSA-002");
+        vuln2.setSource(Vulnerability.Source.GITHUB);
+        vuln2.setSeverity(Severity.HIGH);
+        vuln2.setAliases(vulnerabilityAliases);
+
+        qm.persist(vuln);
+        qm.persist(vuln2);
+
+        List <Vulnerability> vulnerabilities = new ArrayList<>();
+        vulnerabilities.add(vuln);
+        vulnerabilities.add(vuln2);
+
+        for (Vulnerability vulnerability : vulnerabilities){
+            qm.addVulnerability(vulnerability, component, AnalyzerIdentity.INTERNAL_ANALYZER, "Vuln", "http://vuln.com/vuln", new Date(1708559165229L));
+        }
+
+        List<VulnerabilityAlias> aliases2 = vuln2.getAliases();
+        //Confirm Alias
+        Assert.assertTrue(aliases2.stream().anyMatch(alias -> "CVE-1234-123".equals(alias.getCveId())));
+        List<VulnerabilityAlias> aliases = vuln.getAliases();
+        //Confirm Alias
+        Assert.assertTrue(aliases.stream().anyMatch(alias -> "GHSA-002".equals(alias.getGhsaId())));
+
+        return component;
+    }
+
 
     @Test
     public void testCloneProjectPreservesVulnerabilityAttributionDate() throws Exception {
@@ -57,4 +130,237 @@ public class ProjectQueryManagerTest extends PersistenceCapableTest {
         Assert.assertEquals(new Date(1708559165229L),finding.getAttribution().get("attributedOn"));
     }
 
+    /*
+     * This test validates a normal behavior (Alias Duplication) when the feature is disabled
+     */
+    @Test
+    public void testDeDuplicatesIsNotEnable() throws Exception {
+
+        createConfig(ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES_ENABLED, "false");
+        createConfig(ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES, "NVD;GITHUB");
+
+        Component comp = setUp();
+
+        assertThat(comp.getVulnerabilities()).extracting(Vulnerability::getVulnId)
+        .contains("CVE-1234-123", "GHSA-002");
+
+        Project clonedProject = qm.clone(project.getUuid(), "1.1.0", false, false, true, false, false, false, false);
+        List<Finding> findings = qm.getFindings(clonedProject);
+
+        Assert.assertEquals(2, findings.size());
+    }
+
+    /*
+     * This test scenario is highly unlikely to occur because it is not possible
+     * to have no enabled sources on the list and encounter vulnerabilities from other sources simultaneously.
+     * The deduplication process will detect that the enabled sources (Priority List) is empty and will automatically change to false.
+     */
+    @Test
+    public void testDeDuplicatesNoEnabledSources() throws Exception {
+        createConfig(ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES, "");
+
+        Component comp = setUp();
+
+        assertThat(comp.getVulnerabilities()).extracting(Vulnerability::getVulnId)
+        .contains("CVE-1234-123", "GHSA-002");
+
+        Project clonedProject = qm.clone(project.getUuid(), "1.1.0", false, false, true, false, false, false, false);
+        List<Finding> findings = qm.getFindings(clonedProject);
+
+        Assert.assertEquals(2, findings.size());
+    }
+
+    /*
+     * This test validates that the NVD (National Vulnerability Database) vulnerability source
+     * has a higher priority than GHSA (GitHub Security Advisory).
+     * The test ensures the avoidance of duplicate aliases in components.
+     */
+    @Test
+    public void testAvoidAliasDuplicatesInComponentsNVDPriority() throws Exception {
+        createConfig(ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES, "VULNDB;NVD;GITHUB");
+
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ALIAS_SYNC_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.SCANNER_VULNDB_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_NVD_API_ENABLED, "true");
+
+        Component comp = setUp();
+
+        //Contains CVE, not GHSA
+        assertThat(comp.getVulnerabilities()).extracting(Vulnerability::getVulnId)
+        .containsOnly("CVE-1234-123")
+        .doesNotContain("GHSA-002");
+
+        Project clonedProject = qm.clone(project.getUuid(), "1.1.0", false, false, true, false, false, false, false);
+        List<Finding> findings = qm.getFindings(clonedProject);
+
+        Assert.assertEquals(1, findings.size());
+    }
+
+    /*
+     * This test validates that the GHSA (GitHub Security Advisory) vulnerability source
+     * has a higher priority than NVD (National Vulnerability Database).
+     * The test ensures the avoidance of duplicate aliases in components.
+     */
+    @Test
+    public void testAvoidAliasDuplicatesInComponentsGHSAPriority() throws Exception {
+        //In this test GHSA source has a higher priority that NVD
+        createConfig(ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES, "VULNDB;GITHUB;NVD");
+
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ALIAS_SYNC_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.SCANNER_VULNDB_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_NVD_API_ENABLED, "true");
+
+        Component comp = setUp();
+
+        //Contains GHSA, not CVE
+        assertThat(comp.getVulnerabilities()).extracting(Vulnerability::getVulnId)
+        .containsOnly("GHSA-002")
+        .doesNotContain("CVE-1234-123");
+
+        Project clonedProject = qm.clone(project.getUuid(), "1.1.0", false, false, true, false, false, false, false);
+        List<Finding> findings = qm.getFindings(clonedProject);
+
+        Assert.assertEquals(1, findings.size());
+    }
+
+    /*
+     * It is highly improbable for this test scenario to happen as it is not feasible to deactivate
+     * a source and then encounter a vulnerability from that same source.
+     */
+    @Test
+    public void testAvoidAliasDuplicatesInComponentsNonExistingPriority() throws Exception {
+        createConfig(ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES, "VULNDB");
+
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_NVD_API_ENABLED, "false");
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ALIAS_SYNC_ENABLED, "false");
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED, "false");
+        createConfig(ConfigPropertyConstants.SCANNER_VULNDB_ENABLED, "true");
+
+        Component comp = setUp();
+        // In the absence of a specified source in the priority list,
+        //the initial vulnerability that gets added will persist,
+        //while the others will merely serve as aliases for the first one.
+        //This follows a "First Come, First Serve" approach.
+         assertThat(comp.getVulnerabilities()).extracting(Vulnerability::getVulnId)
+         .containsOnly("CVE-1234-123")
+         .doesNotContain("GHSA-002");
+
+        Project clonedProject = qm.clone(project.getUuid(), "1.1.0", false, false, true, false, false, false, false);
+        List<Finding> findings = qm.getFindings(clonedProject);
+
+        Assert.assertEquals(1, findings.size());
+    }
+
+    /*
+     * This test verifies the behavior when enabling a new Vulnerability Source after setting
+     * the priority list of vulnerability sources.
+     */
+    @Test
+    public void testUpdatePriorityList() throws Exception {
+        createConfig(ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES_ENABLED, "true");
+        //Source GITHUB is not initialy specified on the list
+        createConfig(ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES, "VULNDB");
+
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_NVD_API_ENABLED, "false");
+        //Github alias is enabled afterwards
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ALIAS_SYNC_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.SCANNER_VULNDB_ENABLED, "true");
+
+        Component comp = setUp();
+
+        //Priority list will be updated from VULNDB -> VULNDB;GITHUB
+        //Only expecting a GITHUB Vulnerability
+         assertThat(comp.getVulnerabilities()).extracting(Vulnerability::getVulnId)
+         .containsOnly("GHSA-002")
+         .doesNotContain("CVE-1234-123");
+
+        Project clonedProject = qm.clone(project.getUuid(), "1.1.0", false, false, true, false, false, false, false);
+        List<Finding> findings = qm.getFindings(clonedProject);
+
+        Assert.assertEquals(1, findings.size());
+    }
+
+    /*
+     * This test verifies the behavior when disabling the Vulnerability Source after setting
+     * the priority list of vulnerability sources.
+     */
+    @Test
+    public void testUpdatePriorityList2() throws Exception {
+        createConfig(ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES_ENABLED, "true");
+        //PriorityList is specified, GITHUB has a higher priority than NVD
+        createConfig(ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES, "VULNDB;GITHUB;NVD");
+        //Shortly after the admin decided to not allow GITHUB SOURCES anymore
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ALIAS_SYNC_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED, "false");
+        //NVD is still enabled
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_NVD_API_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.SCANNER_VULNDB_ENABLED, "true");
+
+        Component comp = setUp();
+
+        //Priority list will be updated from "VULNDB;GITHUB;NVD" -> "VULNDB;NVD"
+        //Giving NVD a higher priority and not expecting any GITHUB vulnerability
+         assertThat(comp.getVulnerabilities()).extracting(Vulnerability::getVulnId)
+         .containsOnly("CVE-1234-123")
+         .doesNotContain("GHSA-002");
+
+        Project clonedProject = qm.clone(project.getUuid(), "1.1.0", false, false, true, false, false, false, false);
+        List<Finding> findings = qm.getFindings(clonedProject);
+
+        Assert.assertEquals(1, findings.size());
+    }
+
+    /*
+     *  This test verifies the behavior when avoiding duplicate aliases for vulnerabilities added later.
+     */
+    @Test
+    public void testAvoidAliasDuplicatesVulnerabilityAddedLater() throws Exception {
+        Vulnerability vuln3 = new Vulnerability();
+        List<VulnerabilityAlias> vulnerabilityAliases = new ArrayList<>();
+
+        vulnerabilityAliases.add(alias);
+
+        createConfig(ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.SCANNER_INTERNAL_DEDUPLICATES, "OSSINDEX;GITHUB;NVD");
+
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ALIAS_SYNC_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.SCANNER_OSSINDEX_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.SCANNER_OSSINDEX_ALIAS_SYNC_ENABLED, "true");
+        createConfig(ConfigPropertyConstants.VULNERABILITY_SOURCE_NVD_API_ENABLED, "true");
+
+        Component comp = setUp();
+
+        //Contains GHSA, not CVE
+        assertThat(comp.getVulnerabilities()).extracting(Vulnerability::getVulnId)
+        .containsOnly("GHSA-002")
+        .doesNotContain("CVE-1234-123");
+
+        vuln3.setId(128L);
+        vuln3.setVulnId("SONATYPE-003");
+        vuln3.setSource(Vulnerability.Source.OSSINDEX);
+        vuln3.setSeverity(Severity.HIGH);
+        vuln3.setAliases(vulnerabilityAliases);
+        qm.persist(vuln3);
+
+        qm.addVulnerability(vuln3, comp, AnalyzerIdentity.INTERNAL_ANALYZER, "Vuln2", "http://vuln.com/vuln", new Date(1708559165229L));
+
+        //Although OSSINDEX has a higher priority GITHUB was already added to the component, avoiding a duplication
+        assertThat(comp.getVulnerabilities()).extracting(Vulnerability::getVulnId)
+        .containsOnly("GHSA-002")
+        .doesNotContain("CVE-1234-123")
+        .doesNotContain("SONATYPE-003");
+
+        Project clonedProject = qm.clone(project.getUuid(), "1.1.0", false, false, true, false, false, false, false);
+        List<Finding> findings = qm.getFindings(clonedProject);
+
+        Assert.assertEquals(1, findings.size());
+    }
 }


### PR DESCRIPTION
### Description
This PR introduces a new functionality that addresses the issue of duplicate vulnerabilities by comparing the priority of sources and the aliases attached to a component.

The implementation required adding new database rows to support the changes.

To ensure the correctness of the implementation, tests have been added to validate the behavior of the updated functionality.

In addition, a new API endpoint has been added to get the actual Enabled Sources.

It is important to note that this update specifically affects the addVulnerability function and is not able to delete a vulnerability in any case.

I'm open to discussing any changes  or improvements👍🏽 

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue
This PR fixes #1994
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details
Add a new file named ConfigPropertyQueryManager.java to manage functions related to the EnabledSources

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [X] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [X] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
