### PR TITLE
add project name and group to bomupload logs

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -20,6 +20,7 @@ package org.dependencytrack.resources.v1;
 
 import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
+import alpine.model.ApiKey;
 import alpine.server.auth.PermissionRequired;
 import alpine.server.resources.AlpineResource;
 import io.swagger.annotations.Api;
@@ -362,6 +363,8 @@ public class BomResource extends AlpineResource {
                         project = qm.createProject(trimmedProjectName, null, trimmedProjectVersion, null, parent, null, true, true);
                         Principal principal = getPrincipal();
                         qm.updateNewProjectACL(project, principal);
+                        ApiKey apikey = ApiKey.class.cast(principal);
+                        LOGGER.info("Project " + project.toString() + " created" + (apikey.getTeams().isEmpty() ? "" : " by group " + apikey.getTeams().get(0).getName()));
                     } else {
                         return Response.status(Response.Status.UNAUTHORIZED).entity("The principal does not have permission to create project.").build();
                     }

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -753,6 +753,7 @@ public class BomResourceTest extends ResourceTest {
         Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
         Assert.assertEquals("The project could not be found.", body);
+        Assert.assertEquals("Test Users", qm.getApiKey(apiKey).getTeams().get(0).getName());
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -65,7 +65,6 @@ import static org.apache.commons.io.IOUtils.resourceToByteArray;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_ENABLED;
 
 public class BomResourceTest extends ResourceTest {

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.resources.v1;
 
 import alpine.common.util.UuidUtil;
+import alpine.model.ApiKey;
 import alpine.model.IConfigProperty;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
@@ -64,6 +65,7 @@ import static org.apache.commons.io.IOUtils.resourceToByteArray;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_ENABLED;
 
 public class BomResourceTest extends ResourceTest {
@@ -739,7 +741,6 @@ public class BomResourceTest extends ResourceTest {
         Assert.assertNotNull(json);
         Assert.assertNotNull(json.getString("token"));
         Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
-        Assert.assertEquals("Test Users", qm.getApiKey(apiKey).getTeams().get(0).getName());
     }
 
     @Test
@@ -771,6 +772,8 @@ public class BomResourceTest extends ResourceTest {
         Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
         Project project = qm.getProject("Acme Example", "1.0");
         Assert.assertNotNull(project);
+        Assert.assertTrue(qm.getApiKey(apiKey) instanceof ApiKey);
+        Assert.assertEquals("Test Users", qm.getApiKey(apiKey).getTeams().get(0).getName());
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -739,6 +739,7 @@ public class BomResourceTest extends ResourceTest {
         Assert.assertNotNull(json);
         Assert.assertNotNull(json.getString("token"));
         Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
+        Assert.assertEquals("Test Users", qm.getApiKey(apiKey).getTeams().get(0).getName());
     }
 
     @Test
@@ -753,7 +754,6 @@ public class BomResourceTest extends ResourceTest {
         Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
         Assert.assertEquals("The project could not be found.", body);
-        Assert.assertEquals("Test Users", qm.getApiKey(apiKey).getTeams().get(0).getName());
     }
 
     @Test


### PR DESCRIPTION
### Description

Currently there is no logs printed to display which group is creating the new project when uploading a bom using curl.

This change finds the group associated with the api-key and prints it in the logs along with the project name.
<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

closes #3642 

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
