### PR TITLE
Backport: Fix failing JSON BOM validation when `specVersion` is not one of the first fields

### DIFF
--- a/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidator.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidator.java
@@ -126,7 +126,7 @@ public class CycloneDxValidator {
             }
 
             CycloneDxSchema.Version schemaVersion = null;
-            while (jsonParser.nextToken() != JsonToken.END_OBJECT) {
+            while (jsonParser.nextToken() != null) {
                 final String fieldName = jsonParser.getCurrentName();
                 if ("specVersion".equals(fieldName)) {
                     if (jsonParser.nextToken() == JsonToken.VALUE_STRING) {

--- a/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidatorTest.java
+++ b/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidatorTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 public class CycloneDxValidatorTest {
 
@@ -160,6 +161,19 @@ public class CycloneDxValidatorTest {
                         """
                                 cvc-attribute.3: The value 'foo' of attribute 'type' on element 'component' is not \
                                 valid with respect to its type, 'classification'.""");
+    }
+
+    @Test // https://github.com/DependencyTrack/dependency-track/issues/3696
+    public void testValidateJsonWithSpecVersionAtTheBottom() {
+        assertThatNoException()
+                .isThrownBy(() -> validator.validate("""
+                        {
+                          "metadata": {},
+                          "components": [],
+                          "bomFormat": "CycloneDX",
+                          "specVersion": "1.5"
+                        }
+                        """.getBytes()));
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes failing JSON BOM validation when `specVersion` is not one of the first fields.

Problem was that the search for `specVersion` was aborted upon encountering a `}` token. It should be `EOF` (or `null` in case of `JsonParser#nextToken`) instead.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #3696
Backports #3697 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
