### PR TITLE
Gracefully handle `NotSortableException`s

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/exception/NotSortableExceptionMapper.java
+++ b/src/main/java/org/dependencytrack/resources/v1/exception/NotSortableExceptionMapper.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.exception;
+
+import alpine.persistence.NotSortableException;
+import org.dependencytrack.resources.v1.problems.ProblemDetails;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * @since 4.12.0
+ */
+@Provider
+public class NotSortableExceptionMapper implements ExceptionMapper<NotSortableException> {
+
+    @Override
+    public Response toResponse(final NotSortableException exception) {
+        final var problemDetails = new ProblemDetails();
+        problemDetails.setStatus(400);
+        problemDetails.setTitle("Field not sortable");
+        problemDetails.setDetail(exception.getMessage());
+
+        return Response
+                .status(Response.Status.BAD_REQUEST)
+                .type(ProblemDetails.MEDIA_TYPE_JSON)
+                .entity(problemDetails)
+                .build();
+    }
+
+}

--- a/src/test/java/org/dependencytrack/resources/v1/exception/NotSortableExceptionMapperTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/exception/NotSortableExceptionMapperTest.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.exception;
+
+import alpine.persistence.PaginatedResult;
+import alpine.server.auth.AuthenticationNotRequired;
+import alpine.server.filters.ApiFilter;
+import alpine.server.resources.AlpineResource;
+import org.dependencytrack.JerseyTestRule;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.persistence.QueryManager;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NotSortableExceptionMapperTest extends ResourceTest {
+
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(TestResource.class)
+                    .register(ApiFilter.class)
+                    .register(NotSortableExceptionMapper.class));
+
+    @Test
+    public void testFieldDoesNotExist() {
+        final Response response = jersey.target("/")
+                .queryParam("sortName", "foo")
+                .queryParam("sortOrder", "asc")
+                .request()
+                .get();
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getHeaderString("Content-Type")).isEqualTo("application/problem+json");
+        assertThatJson(getPlainTextBody(response))
+                .isEqualTo("""
+                        {
+                          "status": 400,
+                          "title": "Field not sortable",
+                          "detail": "Can not sort by Project#foo: The field does not exist"
+                        }
+                        """);
+    }
+
+    @Test
+    public void testTransientField() {
+        final Response response = jersey.target("/")
+                .queryParam("sortName", "bomRef")
+                .queryParam("sortOrder", "asc")
+                .request()
+                .get();
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getHeaderString("Content-Type")).isEqualTo("application/problem+json");
+        assertThatJson(getPlainTextBody(response))
+                .isEqualTo("""
+                        {
+                          "status": 400,
+                          "title": "Field not sortable",
+                          "detail": "Can not sort by Project#bomRef: The field is computed and can not be queried or sorted by"
+                        }
+                        """);
+    }
+
+    @Test
+    public void testPersistentField() {
+        final Response response = jersey.target("/")
+                .queryParam("sortName", "name")
+                .queryParam("sortOrder", "asc")
+                .request()
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString("Content-Type")).isEqualTo("application/json");
+        assertThatJson(getPlainTextBody(response))
+                .isEqualTo("[]");
+    }
+
+    @Path("/")
+    public static class TestResource extends AlpineResource {
+
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        @AuthenticationNotRequired
+        public Response get() {
+            try (final var qm = new QueryManager(getAlpineRequest())) {
+                final PaginatedResult projects = qm.getProjects();
+                return Response
+                        .status(Response.Status.OK)
+                        .header("X-Total-Count", projects.getTotal())
+                        .entity(projects.getObjects())
+                        .build();
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds a JAX-RS `ExceptionMapper` for `NotSortableException`, which was introduced in https://github.com/stevespringett/Alpine/pull/554.

In previous versions of Dependency-Track, attempts to sort by fields that are not sortable were silently ignored. As of Alpine 2.2.6, an exception will be raised instead.

This PR handles those exceptions gracefully, and returns a response in RFC 9457 format to the client.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
