### PR TITLE
Backport: Add date format to support offset in NuGet timestamps

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/repositories/NugetMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/NugetMetaAnalyzer.java
@@ -46,7 +46,8 @@ public class NugetMetaAnalyzer extends AbstractMetaAnalyzer {
 
     public static final DateFormat[] SUPPORTED_DATE_FORMATS = new DateFormat[]{
             new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"),
-            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'"),
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
     };
     private static final Logger LOGGER = Logger.getLogger(NugetMetaAnalyzer.class);
     private static final String DEFAULT_BASE_URL = "https://api.nuget.org";

--- a/src/test/java/org/dependencytrack/tasks/repositories/NugetMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/NugetMetaAnalyzerTest.java
@@ -31,7 +31,12 @@ import org.mockserver.integration.ClientAndServer;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
+import static org.dependencytrack.tasks.repositories.NugetMetaAnalyzer.SUPPORTED_DATE_FORMATS;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
@@ -121,6 +126,19 @@ public class NugetMetaAnalyzerTest {
         Assert.assertEquals("5.0.2", metaModel.getLatestVersion());
         Assert.assertNotNull(metaModel.getPublishedTimestamp());
     }
+
+    @Test
+    public void testPublishedDateTimeFormat() throws ParseException {
+        Date dateParsed = null;
+        for (DateFormat dateFormat : SUPPORTED_DATE_FORMATS) {
+            try {
+                dateParsed = dateFormat.parse("1900-01-01T00:00:00+00:00");
+            } catch (ParseException e) {}
+        }
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        Assert.assertEquals(dateFormat.parse("1900-01-01T00:00:00+00:00"), dateParsed);
+    }
+
     private String readResourceFileToString(String fileName) throws Exception {
         return Files.readString(Paths.get(getClass().getResource(fileName).toURI()));
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Nuget Analyzer has list of two supported SimpleDateFormat which are allowed for parsing the dates being received from the repository, based on limited test data.

Now, as seen in logs, below date format is also received from the nugget repo. This date has offset dateTime and needs to be added to the list of supported formats in order to avoid the ParseException.

Date example: 1900-01-01T00:00:00+00:00
Format needed: yyyy-MM-dd'T'HH:mm:ss

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #3736

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
