### PR TITLE
Improve performance of findings retrieval

### DIFF
--- a/src/main/java/org/dependencytrack/model/VulnIdAndSource.java
+++ b/src/main/java/org/dependencytrack/model/VulnIdAndSource.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.model;
+
+/**
+ * @param vulnId {@link Vulnerability#getVulnId()}
+ * @param source {@link Vulnerability#getSource()}
+ * @since 4.12.0
+ */
+public record VulnIdAndSource(String vulnId, Vulnerability.Source source) {
+
+    public VulnIdAndSource(String vulnId, String source) {
+        this(vulnId, Vulnerability.Source.valueOf(source));
+    }
+
+}

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -72,6 +72,7 @@ import org.dependencytrack.model.Vex;
 import org.dependencytrack.model.ViolationAnalysis;
 import org.dependencytrack.model.ViolationAnalysisComment;
 import org.dependencytrack.model.ViolationAnalysisState;
+import org.dependencytrack.model.VulnIdAndSource;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
 import org.dependencytrack.model.VulnerabilityMetrics;
@@ -88,6 +89,7 @@ import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -1066,6 +1068,10 @@ public class QueryManager extends AlpineQueryManager {
         return getVulnerabilityQueryManager().getVulnerabilityAliases(vulnerability);
     }
 
+    public Map<VulnIdAndSource, List<VulnerabilityAlias>> getVulnerabilityAliases(final Collection<VulnIdAndSource> vulnIdAndSources) {
+        return getVulnerabilityQueryManager().getVulnerabilityAliases(vulnIdAndSources);
+    }
+
     List<Analysis> getAnalyses(Project project) {
         return getFindingsQueryManager().getAnalyses(project);
     }
@@ -1467,5 +1473,9 @@ public class QueryManager extends AlpineQueryManager {
         }
 
         return results;
+    }
+
+    public List<RepositoryMetaComponent> getRepositoryMetaComponents(final List<RepositoryQueryManager.RepositoryMetaComponentSearch> list) {
+        return getRepositoryQueryManager().getRepositoryMetaComponents(list);
     }
 }

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -28,6 +28,7 @@ import org.dependencytrack.model.Analysis;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.FindingAttribution;
 import org.dependencytrack.model.Project;
+import org.dependencytrack.model.VulnIdAndSource;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
 import org.dependencytrack.model.VulnerableSoftware;
@@ -45,6 +46,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 final class VulnerabilityQueryManager extends QueryManager implements IQueryManager {
@@ -655,6 +657,90 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
             query = pm.newQuery(VulnerabilityAlias.class, "internalId == :internalId");
         }
             return (List<VulnerabilityAlias>)query.execute(vulnerability.getVulnId());
+    }
+
+
+
+    /**
+     * Bulk-load {@link VulnerabilityAlias}es for one or more {@link VulnIdAndSource}s.
+     *
+     * @param vulnIdAndSources The Vulnerability ID - Source pairs to load {@link VulnerabilityAlias}es for
+     * @return {@link VulnerabilityAlias}es, grouped by {@link VulnIdAndSource}
+     * @since 4.12.0
+     */
+    public Map<VulnIdAndSource, List<VulnerabilityAlias>> getVulnerabilityAliases(final Collection<VulnIdAndSource> vulnIdAndSources) {
+        if (vulnIdAndSources == null || vulnIdAndSources.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        var subQueryIndex = 0;
+        final var subQueries = new ArrayList<String>(vulnIdAndSources.size());
+        final var params = new HashMap<String, Object>(vulnIdAndSources.size());
+        for (final VulnIdAndSource vulnIdAndSource : vulnIdAndSources) {
+            subQueryIndex++;
+            final String vulnIdParamName = "vulnId" + subQueryIndex;
+
+            final String filter = switch (vulnIdAndSource.source()) {
+                case GITHUB -> "\"GHSA_ID\" = :" + vulnIdParamName;
+                case INTERNAL -> "\"INTERNAL_ID\" = :" + vulnIdParamName;
+                case NVD -> "\"CVE_ID\" = :" + vulnIdParamName;
+                case OSSINDEX -> "\"SONATYPE_ID\" = :" + vulnIdParamName;
+                case OSV -> "\"OSV_ID\" = :" + vulnIdParamName;
+                case SNYK -> "\"SNYK_ID\" = :" + vulnIdParamName;
+                case VULNDB -> "\"VULNDB_ID\" = :" + vulnIdParamName;
+                default -> null;
+            };
+            if (filter == null) {
+                continue;
+            }
+
+            // We'll need to correlate query results with VulnIdAndSource objects
+            // later, so prepend an identifier for them to the result set.
+            // NB: DataNucleus doesn't support usage of query parameters
+            // in the SELECT statement. Use hashCode of vulnIdAndSource instead
+            // of string literals (which could be susceptible to SQL injection).
+            subQueries.add("""
+                    SELECT %d
+                         , "GHSA_ID"
+                         , "INTERNAL_ID"
+                         , "CVE_ID"
+                         , "SONATYPE_ID"
+                         , "OSV_ID"
+                         , "SNYK_ID"
+                         , "VULNDB_ID"
+                      FROM "VULNERABILITYALIAS"
+                     WHERE %s
+                    """.formatted(vulnIdAndSource.hashCode(), filter));
+            params.put(vulnIdParamName, vulnIdAndSource.vulnId());
+        }
+
+        final Query<Object[]> query = pm.newQuery(Query.SQL, String.join(" UNION ALL ", subQueries));
+        query.setNamedParameters(params);
+        final List<Object[]> queryResultRows = executeAndCloseList(query);
+        if (queryResultRows.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        final Map<Integer, VulnIdAndSource> vulnIdAndSourceByHashCode = vulnIdAndSources.stream()
+                .collect(Collectors.toMap(Record::hashCode, Function.identity()));
+
+        return queryResultRows.stream()
+                .map(row -> {
+                    final var vulnIdAndSource = vulnIdAndSourceByHashCode.get((Integer) row[0]);
+                    final var alias = new VulnerabilityAlias();
+                    alias.setGhsaId((String) row[1]);
+                    alias.setInternalId((String) row[2]);
+                    alias.setCveId((String) row[3]);
+                    alias.setSonatypeId((String) row[4]);
+                    alias.setOsvId((String) row[5]);
+                    alias.setSnykId((String) row[6]);
+                    alias.setVulnDbId((String) row[7]);
+                    return Map.entry(vulnIdAndSource, alias);
+                })
+                .collect(Collectors.groupingBy(
+                        Map.Entry::getKey,
+                        Collectors.mapping(Map.Entry::getValue, Collectors.toList())
+                ));
     }
 
     /**

--- a/src/main/java/org/dependencytrack/util/PurlUtil.java
+++ b/src/main/java/org/dependencytrack/util/PurlUtil.java
@@ -52,4 +52,23 @@ public class PurlUtil {
         }
     }
 
+    /**
+     * Attempt to parse a given package URL.
+     *
+     * @param purl The package URL to parse
+     * @return The parsed {@link PackageURL}, or {@code null} when parsing failed
+     * @since 4.12.0
+     */
+    public static PackageURL silentPurl(final String purl) {
+        if (purl == null) {
+            return null;
+        }
+
+        try {
+            return new PackageURL(purl);
+        } catch (MalformedPackageURLException ignored) {
+            return null;
+        }
+    }
+
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

The `/v1/finding/{projectUuid}` endpoint has historically been slow to respond (#3811). While the "main" query behind it is somewhat optimized SQL already, it still suffered from various performance killers:

* Filtering of suppressed findings was done in-memory, and required fetching of individual `Analysis` records *for every single finding*.
* `Clob` fields were not mapped directly from the SQL query result, but instead by re-fetching `Component` and `Vulnerability` records *for every single finding*, such that the ORM would provide properly `String`-ified field values.
* Aliases were fetched *for every single finding* individually.
* Latest component versions were fetched *for every single finding* individually.

Performance was improved via the following changes:

1. Filtering of suppressed findings is moved to the main SQL query, voiding the need to fetch individual `Analysis` records later. This also reduces the overall result set that needs to be transferred and mapped.
2. Mapping of `Clob` fields is done within the `Finding` constructor, voiding the need to re-fetch `Vulnerability` records in order to retrieve `String` values for them.
3. Aliases are loaded in bulk, and in a way that avoids redundant queries if the same `Vulnerability` appears multiple times within a list of `Finding`s.
4. Latest component versions are loaded in bulk, and in a way that avoids redundant queries if the same `Component` appears multiple times within a list of `Finding`s.

Because the modified functionality is re-used across the code base, multiple features benefit from this enhancement:

* `/v1/finding/{projectUuid}` endpoint
    * Corresponds to the *Audit Vulnerabilities* tab in the UI
* `/v1/project/{projectUuid}/export` endpoint
* CycloneDX exports for *Inventory with Vulnerabilities*, *VDR*, and *VEX*
* Fortify, Kenna, and DefectDojo integrations

> [!NOTE]
> Tested with H2, MSSQL, and PostgreSQL.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #3811

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Performance comparison with local Docker Compose setup:

```shell
cd dev
docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d
```

Details about the setup:

* Internal analyzer enabled
* OSS Index enabled
* NVD mirrored completely
* GitHub Advisories mirrored completely; Alias sync enabled
* Uploaded [`bom-bloated.json`](https://github.com/DependencyTrack/dependency-track/blob/master/src/test/resources/unit/bom-bloated.json) (9056 unique components)
* 1652 vulnerabilities identified

API server images compared:

* `snapshot@sha256:42b94f37ad5d4c9965fc89d48524bddb84c6142ee574a0c01c72ab3b667d321f`
* `local` (local build of this PR)

Load tested the `/api/v1/finding/${projectUuid}` endpoint using [`hey`](https://github.com/rakyll/hey):

```shell
hey -H "X-Api-Key: $APIKEY" \
    http://localhost:8080/api/v1/finding/project/d7b6156e-c58b-4b85-b3ef-db61e9667cd4
```

<details>
<summary>Results for <code>snapshot</code></summary>

```
Summary:
  Total:	41.4942 secs
  Slowest:	11.3247 secs
  Fastest:	9.3886 secs
  Average:	10.3208 secs
  Requests/sec:	4.8199


Response time histogram:
  9.389 [1]	|■
  9.582 [3]	|■■■
  9.776 [11]	|■■■■■■■■■■
  9.969 [20]	|■■■■■■■■■■■■■■■■■■
  10.163 [35]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  10.357 [44]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  10.550 [34]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  10.744 [18]	|■■■■■■■■■■■■■■■■
  10.937 [17]	|■■■■■■■■■■■■■■■
  11.131 [11]	|■■■■■■■■■■
  11.325 [6]	|■■■■■


Latency distribution:
  10% in 9.8559 secs
  25% in 10.0557 secs
  50% in 10.2913 secs
  75% in 10.5717 secs
  90% in 10.9142 secs
  95% in 11.0154 secs
  99% in 11.2493 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0010 secs, 9.3886 secs, 11.3247 secs
  DNS-lookup:	0.0004 secs, 0.0000 secs, 0.0025 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0008 secs
  resp wait:	10.2449 secs, 9.3476 secs, 11.2671 secs
  resp read:	0.0749 secs, 0.0295 secs, 0.1779 secs

Status code distribution:
  [200]	200 responses
```

</details>

<details>
<summary>Results for <code>local</code></summary>

```
Summary:
  Total:	3.6591 secs
  Slowest:	1.5565 secs
  Fastest:	0.1958 secs
  Average:	0.8520 secs
  Requests/sec:	54.6580


Response time histogram:
  0.196 [1]	|■
  0.332 [4]	|■■■■
  0.468 [10]	|■■■■■■■■■■
  0.604 [16]	|■■■■■■■■■■■■■■■
  0.740 [39]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.876 [31]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  1.012 [42]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  1.148 [35]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  1.284 [14]	|■■■■■■■■■■■■■
  1.420 [7]	|■■■■■■■
  1.557 [1]	|■


Latency distribution:
  10% in 0.5335 secs
  25% in 0.6879 secs
  50% in 0.8691 secs
  75% in 1.0409 secs
  90% in 1.1557 secs
  95% in 1.2686 secs
  99% in 1.4125 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0010 secs, 0.1958 secs, 1.5565 secs
  DNS-lookup:	0.0005 secs, 0.0000 secs, 0.0025 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0008 secs
  resp wait:	0.6837 secs, 0.1470 secs, 1.4515 secs
  resp read:	0.1673 secs, 0.0281 secs, 0.5001 secs

Status code distribution:
  [200]	200 responses
```

</details>

**Summary**

* Requests per second: `4.8` -> `54.7`
* p99 latency: `11.2s` -> `1.4s`
* p75 latency: `10.5s` -> `1s`
* p50 latency: `10.3s` -> `0.9s`

Coming out to a fairly consistent 10x improvement.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
