### PR TITLE
Fix `BOM_CONSUMED` and `BOM_PROCESSED` notifications being dispatched with wrong scope

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -789,7 +789,7 @@ public class BomUploadProcessingTask implements Subscriber {
 
     private static void dispatchBomConsumedNotification(final Context ctx) {
         Notification.dispatch(new Notification()
-                .scope(NotificationScope.SYSTEM)
+                .scope(NotificationScope.PORTFOLIO)
                 .group(NotificationGroup.BOM_CONSUMED)
                 .level(NotificationLevel.INFORMATIONAL)
                 .title(NotificationConstants.Title.BOM_CONSUMED)
@@ -799,7 +799,7 @@ public class BomUploadProcessingTask implements Subscriber {
 
     private static void dispatchBomProcessedNotification(final Context ctx) {
         Notification.dispatch(new Notification()
-                .scope(NotificationScope.SYSTEM)
+                .scope(NotificationScope.PORTFOLIO)
                 .group(NotificationGroup.BOM_PROCESSED)
                 .level(NotificationLevel.INFORMATIONAL)
                 .title(NotificationConstants.Title.BOM_CONSUMED)

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -1172,7 +1172,8 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
             await("BOM Processed Notification")
                     .atMost(Duration.ofSeconds(3))
                     .untilAsserted(() -> assertThat(NOTIFICATIONS)
-                            .anyMatch(n -> NotificationGroup.BOM_PROCESSED.name().equals(n.getGroup())));
+                            .anyMatch(n -> NotificationGroup.BOM_PROCESSED.name().equals(n.getGroup())
+                                           && NotificationScope.PORTFOLIO.name().equals(n.getScope())));
         } catch (ConditionTimeoutException e) {
             final Optional<Notification> optionalNotification = NOTIFICATIONS.stream()
                     .filter(n -> NotificationGroup.BOM_PROCESSING_FAILED.name().equals(n.getGroup()))


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes `BOM_CONSUMED` and `BOM_PROCESSED` notifications being dispatched with wrong scope.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
