### PR TITLE
Deprecate `/api/v1/tag/{policyUuid}` in favor of `/api/v1/tag/policy/{uuid}`

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1340,8 +1340,8 @@ public class QueryManager extends AlpineQueryManager {
         return getTagQueryManager().getTaggedPolicies(tagName);
     }
 
-    public PaginatedResult getTags(String policyUuid) {
-        return getTagQueryManager().getTags(policyUuid);
+    public PaginatedResult getTagsForPolicy(String policyUuid) {
+        return getTagQueryManager().getTagsForPolicy(policyUuid);
     }
 
     /**

--- a/src/main/java/org/dependencytrack/persistence/TagQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/TagQueryManager.java
@@ -251,7 +251,7 @@ public class TagQueryManager extends QueryManager implements IQueryManager {
     }
 
     @Override
-    public PaginatedResult getTags(String policyUuid) {
+    public PaginatedResult getTagsForPolicy(String policyUuid) {
 
         LOGGER.debug("Retrieving tags under policy " + policyUuid);
 

--- a/src/main/java/org/dependencytrack/resources/v1/TagResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/TagResource.java
@@ -157,7 +157,7 @@ public class TagResource extends AlpineResource {
     }
 
     @GET
-    @Path("/{policyUuid}")
+    @Path("/policy/{uuid}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Returns a list of all tags associated with a given policy",
@@ -174,11 +174,43 @@ public class TagResource extends AlpineResource {
             @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
     @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
-    public Response getTags(@Parameter(description = "The UUID of the policy", schema = @Schema(type = "string", format = "uuid"), required = true)
-                            @PathParam("policyUuid") @ValidUuid String policyUuid) {
+    public Response getTagsForPolicy(
+            @Parameter(description = "The UUID of the policy", schema = @Schema(type = "string", format = "uuid"), required = true)
+            @PathParam("uuid") @ValidUuid final String uuid
+    ) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
-            final PaginatedResult result = qm.getTags(policyUuid);
+            final PaginatedResult result = qm.getTagsForPolicy(uuid);
             return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
         }
     }
+
+    @GET
+    @Path("/{policyUuid}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Returns a list of all tags associated with a given policy",
+            description = """
+                    <p><strong>Deprecated</strong>. Use <code>/api/v1/tag/policy/{uuid}</code> instead.</p>
+                    <p>Requires permission <strong>VIEW_PORTFOLIO</strong></p>
+                    """
+    )
+    @PaginatedApi
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "A list of all tags associated with a given policy",
+                    headers = @Header(name = TOTAL_COUNT_HEADER, description = "The total number of tags", schema = @Schema(format = "integer")),
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = Tag.class)))
+            ),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
+    @Deprecated(forRemoval = true)
+    public Response getTags(
+            @Parameter(description = "The UUID of the policy", required = true)
+            @PathParam("policyUuid") final UUID policyUuid
+    ) {
+        return getTagsForPolicy(String.valueOf(policyUuid));
+    }
+
 }

--- a/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
@@ -487,7 +487,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getAllTagsWithOrderingTest() {
+    public void getTagsForPolicyWithOrderingTest() {
         for (int i = 1; i < 5; i++) {
             qm.createTag("Tag " + i);
         }
@@ -495,7 +495,7 @@ public class TagResourceTest extends ResourceTest {
         qm.createProject("Project B", null, "1", List.of(qm.getTagByName("Tag 2"), qm.getTagByName("Tag 3"), qm.getTagByName("Tag 4")), null, null, true, false);
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
 
-        Response response = jersey.target(V1_TAG + "/" + policy.getUuid())
+        Response response = jersey.target(V1_TAG + "/policy/" + policy.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -509,7 +509,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTagsWithPolicyProjectsFilterTest() {
+    public void getTagsForPolicyWithPolicyProjectsFilterTest() {
         for (int i = 1; i < 5; i++) {
             qm.createTag("Tag " + i);
         }
@@ -520,7 +520,7 @@ public class TagResourceTest extends ResourceTest {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         policy.setProjects(List.of(qm.getProject("Project A", "1"), qm.getProject("Project C", "1")));
 
-        Response response = jersey.target(V1_TAG + "/" + policy.getUuid())
+        Response response = jersey.target(V1_TAG + "/policy/" + policy.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -532,4 +532,20 @@ public class TagResourceTest extends ResourceTest {
         Assert.assertEquals(3, json.size());
         Assert.assertEquals("tag 1", json.getJsonObject(0).getString("name"));
     }
+
+    @Test
+    public void getTagWithNonUuidNameTest() {
+        // NB: This is just to ensure that requests to /api/v1/tag/<value>
+        // are not matched with the deprecated "getTagsForPolicy" endpoint.
+        // Once we implement an endpoint to request individual tags,
+        // this test should fail and adjusted accordingly.
+        qm.createTag("not-a-uuid");
+
+        final Response response = jersey.target(V1_TAG + "/not-a-uuid")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(404);
+    }
+
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Deprecates `/api/v1/tag/{policyUuid}` in favor of `/api/v1/tag/policy/{uuid}`.

The deprecated endpoint is ambiguous.

See https://github.com/DependencyTrack/dependency-track/issues/586#issuecomment-1867101927

![image](https://github.com/DependencyTrack/dependency-track/assets/5693141/84031f97-a388-4436-98c0-23d3e2bfee39)

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/dependency-track/issues/586

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
