### PR TITLE
Add REST endpoints for bulk tagging & un-tagging of projects

### DIFF
--- a/src/main/java/org/dependencytrack/model/validation/ValidUuid.java
+++ b/src/main/java/org/dependencytrack/model/validation/ValidUuid.java
@@ -31,7 +31,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * @since 4.11.0
  */
-@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE_USE})
 @Constraint(validatedBy = {})
 @Retention(RUNTIME)
 @ReportAsSingleViolation

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -433,6 +433,10 @@ public class QueryManager extends AlpineQueryManager {
         return getProjectQueryManager().hasAccess(principal, project);
     }
 
+    void preprocessACLs(final Query<?> query, final String inputFilter, final Map<String, Object> params, final boolean bypass) {
+        getProjectQueryManager().preprocessACLs(query, inputFilter, params, bypass);
+    }
+
     public PaginatedResult getProjects(final Tag tag, final boolean includeMetrics, final boolean excludeInactive, final boolean onlyRoot) {
         return getProjectQueryManager().getProjects(tag, includeMetrics, excludeInactive, onlyRoot);
     }
@@ -1334,6 +1338,14 @@ public class QueryManager extends AlpineQueryManager {
 
     public List<TagQueryManager.TaggedProjectRow> getTaggedProjects(final String tagName) {
         return getTagQueryManager().getTaggedProjects(tagName);
+    }
+
+    public void tagProjects(final String tagName, final Collection<String> projectUuids) {
+        getTagQueryManager().tagProjects(tagName, projectUuids);
+    }
+
+    public void untagProjects(final String tagName, final Collection<String> projectUuids) {
+        getTagQueryManager().untagProjects(tagName, projectUuids);
     }
 
     public List<TagQueryManager.TaggedPolicyRow> getTaggedPolicies(final String tagName) {

--- a/src/main/java/org/dependencytrack/resources/v1/TagResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/TagResource.java
@@ -39,17 +39,24 @@ import org.dependencytrack.persistence.TagQueryManager.TagListRow;
 import org.dependencytrack.persistence.TagQueryManager.TaggedPolicyRow;
 import org.dependencytrack.persistence.TagQueryManager.TaggedProjectRow;
 import org.dependencytrack.resources.v1.openapi.PaginatedApi;
+import org.dependencytrack.resources.v1.problems.ProblemDetails;
 import org.dependencytrack.resources.v1.vo.TagListResponseItem;
 import org.dependencytrack.resources.v1.vo.TaggedPolicyListResponseItem;
 import org.dependencytrack.resources.v1.vo.TaggedProjectListResponseItem;
 
+import jakarta.validation.constraints.Size;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.UUID;
 
 @Path("/v1/tag")
@@ -124,6 +131,102 @@ public class TagResource extends AlpineResource {
                 .toList();
         final long totalCount = taggedProjectListRows.isEmpty() ? 0 : taggedProjectListRows.getFirst().totalCount();
         return Response.ok(tags).header(TOTAL_COUNT_HEADER, totalCount).build();
+    }
+
+    @POST
+    @Path("/{name}/project")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Tags one or more projects.",
+            description = "<p>Requires permission <strong>PORTFOLIO_MANAGEMENT</strong></p>"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "Projects tagged successfully."
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "A tag with the provided name does not exist.",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)
+            )
+    })
+    @PermissionRequired(Permissions.Constants.PORTFOLIO_MANAGEMENT)
+    public Response tagProjects(
+            @Parameter(description = "Name of the tag to assign", required = true)
+            @PathParam("name") final String tagName,
+            @Parameter(
+                    description = "UUIDs of projects to tag",
+                    required = true,
+                    array = @ArraySchema(schema = @Schema(type = "string", format = "uuid"))
+            )
+            @Size(min = 1, max = 100) final Set<@ValidUuid String> projectUuids
+    ) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
+            qm.tagProjects(tagName, projectUuids);
+        } catch (RuntimeException e) {
+            // TODO: Move this to an ExceptionMapper once https://github.com/stevespringett/Alpine/pull/588 is available.
+            if (e.getCause() instanceof final NoSuchElementException nseException) {
+                return Response
+                        .status(404)
+                        .header("Content-Type", ProblemDetails.MEDIA_TYPE_JSON)
+                        .entity(new ProblemDetails(404, "Resource does not exist", nseException.getMessage()))
+                        .build();
+            }
+
+            throw e;
+        }
+
+        return Response.noContent().build();
+    }
+
+    @DELETE
+    @Path("/{name}/project")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Untags one or more projects.",
+            description = "<p>Requires permission <strong>PORTFOLIO_MANAGEMENT</strong></p>"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "Projects untagged successfully."
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "A tag with the provided name does not exist.",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)
+            )
+    })
+    @PermissionRequired(Permissions.Constants.PORTFOLIO_MANAGEMENT)
+    public Response untagProjects(
+            @Parameter(description = "Name of the tag", required = true)
+            @PathParam("name") final String tagName,
+            @Parameter(
+                    description = "UUIDs of projects to untag",
+                    required = true,
+                    array = @ArraySchema(schema = @Schema(type = "string", format = "uuid"))
+            )
+            @Size(min = 1, max = 100) final Set<@ValidUuid String> projectUuids
+    ) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
+            qm.untagProjects(tagName, projectUuids);
+        } catch (RuntimeException e) {
+            // TODO: Move this to an ExceptionMapper once https://github.com/stevespringett/Alpine/pull/588 is available.
+            if (e.getCause() instanceof final NoSuchElementException nseException) {
+                return Response
+                        .status(404)
+                        .header("Content-Type", ProblemDetails.MEDIA_TYPE_JSON)
+                        .entity(new ProblemDetails(404, "Resource does not exist", nseException.getMessage()))
+                        .build();
+            }
+
+            throw e;
+        }
+
+        return Response.noContent().build();
     }
 
     @GET

--- a/src/main/java/org/dependencytrack/resources/v1/problems/ProblemDetails.java
+++ b/src/main/java/org/dependencytrack/resources/v1/problems/ProblemDetails.java
@@ -69,6 +69,15 @@ public class ProblemDetails {
     )
     private URI instance;
 
+    public ProblemDetails() {
+    }
+
+    public ProblemDetails(final int status, final String title, final String detail) {
+        this.status = status;
+        this.title = title;
+        this.detail = detail;
+    }
+
     public URI getType() {
         return type;
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds REST endpoints for bulk tagging & un-tagging of projects.

![image](https://github.com/DependencyTrack/dependency-track/assets/5693141/cc86518d-d127-468c-8b8c-7891b6934f90)

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #586 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Bulk operations are currently limited to 100 projects per request. We can raise this limit if users need it. But for a beginning it's better to stay conservative since limiting it later would mean a breaking change.

Both `POST` and `DELETE` endpoints are implemented to be atomic operations.

Portfolio ACLs are considered:

* Trying to tag projects the user has no access to is a no-op
* Trying to un-tag projects the user has no access to is a no-op

There will be no `HTTP 403` response if tagging or un-tagging of inaccessible projects is attempted.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
