### PR TITLE
Set license name instead of ID when using custom license

### DIFF
--- a/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
@@ -567,7 +567,11 @@ public class ModelConverter {
         final LicenseChoice licenseChoice = new LicenseChoice();
         if (component.getResolvedLicense() != null) {
             final org.cyclonedx.model.License license = new org.cyclonedx.model.License();
-            license.setId(component.getResolvedLicense().getLicenseId());
+            if(!component.getResolvedLicense().isCustomLicense()){
+                license.setId(component.getResolvedLicense().getLicenseId());
+            } else{
+                license.setName(component.getResolvedLicense().getName());
+            }
             license.setUrl(component.getLicenseUrl());
             licenseChoice.addLicense(license);
             cycloneComponent.setLicenseChoice(licenseChoice);

--- a/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidatorTest.java
+++ b/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidatorTest.java
@@ -278,4 +278,30 @@ public class CycloneDxValidatorTest {
         }
     }
 
+    @Test
+    public void testValidateJsonWithCustomLicense() {
+        assertThatExceptionOfType(InvalidBomException.class)
+                .isThrownBy(() -> validator.validate("""
+                        {
+                          "bomFormat": "CycloneDX",
+                          "specVersion": "1.5",
+                          "components": [
+                            {
+                              "type": "library",
+                              "name": "acme-library",
+                              "version": "1.0.0",
+                              "licenses" : [
+                                {
+                                  "license" : {
+                                    "id" : "CustomLicense"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                        """.getBytes()))
+                        .withMessage("Schema validation failed");
+    }
+
 }

--- a/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidatorTest.java
+++ b/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidatorTest.java
@@ -278,30 +278,4 @@ public class CycloneDxValidatorTest {
         }
     }
 
-    @Test
-    public void testValidateJsonWithCustomLicense() {
-        assertThatExceptionOfType(InvalidBomException.class)
-                .isThrownBy(() -> validator.validate("""
-                        {
-                          "bomFormat": "CycloneDX",
-                          "specVersion": "1.5",
-                          "components": [
-                            {
-                              "type": "library",
-                              "name": "acme-library",
-                              "version": "1.0.0",
-                              "licenses" : [
-                                {
-                                  "license" : {
-                                    "id" : "CustomLicense"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                        """.getBytes()))
-                        .withMessage("Schema validation failed");
-    }
-
 }


### PR DESCRIPTION
### Description
A valid SPDX is required when using the ID field for licenses. If the license is a custom license, use the name field instead.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue
#3897 
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->



### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
