### PR TITLE
Fix `JDOUserException` when multiple licenses match a component's license name

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/LicenseQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/LicenseQueryManager.java
@@ -28,6 +28,7 @@ import org.dependencytrack.model.PolicyCondition;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import java.util.List;
+import java.util.Map;
 
 final class LicenseQueryManager extends QueryManager implements IQueryManager {
 
@@ -94,6 +95,20 @@ final class LicenseQueryManager extends QueryManager implements IQueryManager {
     }
 
     /**
+     * @since 4.12.0
+     */
+    @Override
+    public License getLicenseByIdOrName(final String licenseIdOrName) {
+        final Query<License> query = pm.newQuery(License.class);
+        query.setFilter("licenseId == :licenseIdOrName || name == :licenseIdOrName");
+        query.setNamedParameters(Map.of("licenseIdOrName", licenseIdOrName));
+        query.setOrdering("licenseId asc"); // Ensure result is consistent.
+        query.setRange(0, 1); // Multiple licenses can have the same name; Pick the first one.
+        final License license = executeAndCloseUnique(query);
+        return license != null ? license : License.UNRESOLVED;
+    }
+
+    /**
      * Returns a Custom License object from the specified name
      * @param licenseName license name of custom license
      * @return a License object, or null if not found
@@ -103,6 +118,20 @@ final class LicenseQueryManager extends QueryManager implements IQueryManager {
         query.getFetchPlan().addGroup(License.FetchGroup.ALL.name());
         query.setRange(0, 1);
         return singleResult(query.execute(licenseName));
+    }
+
+    /**
+     * @since 4.12.0
+     */
+    @Override
+    public License getCustomLicenseByName(final String licenseName) {
+        final Query<License> query = pm.newQuery(License.class);
+        query.setFilter("name == :name && customLicense == true");
+        query.setParameters(licenseName);
+        query.setOrdering("licenseId asc"); // Ensure result is consistent.
+        query.setRange(0, 1); // Multiple licenses can have the same name; Pick the first one.
+        final License license = executeAndCloseUnique(query);
+        return license != null ? license : License.UNRESOLVED;
     }
 
     /**

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -33,6 +33,7 @@ import alpine.resources.AlpineRequest;
 import alpine.server.util.DbUtil;
 import com.github.packageurl.PackageURL;
 import com.google.common.collect.Lists;
+import jakarta.json.JsonObject;
 import org.apache.commons.lang3.ClassUtils;
 import org.datanucleus.PropertyNames;
 import org.datanucleus.api.jdo.JDOQuery;
@@ -84,7 +85,6 @@ import org.dependencytrack.resources.v1.vo.AffectedProject;
 import org.dependencytrack.resources.v1.vo.DependencyGraphResponse;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
 
-import jakarta.json.JsonObject;
 import javax.jdo.FetchPlan;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
@@ -629,8 +629,16 @@ public class QueryManager extends AlpineQueryManager {
         return getLicenseQueryManager().getLicense(licenseId);
     }
 
+    public License getLicenseByIdOrName(final String licenseIdOrName) {
+        return getLicenseQueryManager().getLicenseByIdOrName(licenseIdOrName);
+    }
+
     public License getCustomLicense(String licenseName) {
         return getLicenseQueryManager().getCustomLicense(licenseName);
+    }
+
+    public License getCustomLicenseByName(final String licenseName) {
+        return getLicenseQueryManager().getCustomLicenseByName(licenseName);
     }
 
     public License synchronizeLicense(License license, boolean commitIndex) {

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -1167,6 +1167,55 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
         }
     }
 
+    @Test // https://github.com/DependencyTrack/dependency-track/issues/3957
+    public void informIssue3957Test() {
+        final var licenseA = new License();
+        licenseA.setLicenseId("GPL-1.0");
+        licenseA.setName("GNU General Public License v1.0 only");
+        qm.persist(licenseA);
+
+        final var licenseB = new License();
+        licenseB.setLicenseId("GPL-1.0-only");
+        licenseB.setName("GNU General Public License v1.0 only");
+        qm.persist(licenseB);
+
+        final var project = new Project();
+        project.setName("acme-license-app");
+        qm.persist(project);
+
+        final byte[] bomBytes = """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.4",
+                  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b80",
+                  "version": 1,
+                  "components": [
+                    {
+                      "type": "library",
+                      "name": "acme-lib-x",
+                      "licenses": [
+                        {
+                          "license": {
+                            "name": "GNU General Public License v1.0 only"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+
+        final var bomUploadEvent = new BomUploadEvent(qm.detach(Project.class, project.getId()), bomBytes);
+        new BomUploadProcessingTask().inform(bomUploadEvent);
+        awaitBomProcessedNotification(bomUploadEvent);
+
+        qm.getPersistenceManager().evictAll();
+        assertThat(qm.getAllComponents(project)).satisfiesExactly(component -> {
+            assertThat(component.getResolvedLicense()).isNotNull();
+            assertThat(component.getResolvedLicense().getLicenseId()).isEqualTo("GPL-1.0");
+        });
+    }
+
     private void awaitBomProcessedNotification(final BomUploadEvent bomUploadEvent) {
         try {
             await("BOM Processed Notification")


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes `JDOUserException` when multiple licenses match a component's license name.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #3957

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
