### PR TITLE
Fix validation error when XML BOM declares multiple namespaces

### DIFF
--- a/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidator.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidator.java
@@ -195,6 +195,10 @@ public class CycloneDxValidator {
                         case NS_BOM_16 -> VERSION_16;
                         default -> null;
                     };
+
+                    if (schemaVersion != null) {
+                        break;
+                    }
                 }
 
                 if (schemaVersion == null) {

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -1146,4 +1146,10 @@ public class BomResourceTest extends ResourceTest {
                 """);
     }
 
+    @Test
+    public void validateCycloneDxBomWithMultipleNamespacesTest() throws Exception {
+        byte[] bom = resourceToByteArray("/unit/bom-issue4008.xml");
+        assertThatNoException().isThrownBy(() -> CycloneDxValidator.getInstance().validate(bom));
+    }
+
 }

--- a/src/test/resources/unit/bom-issue4008.xml
+++ b/src/test/resources/unit/bom-issue4008.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1">
+    <metadata>
+        <authors>
+            <author>
+                <name>Author</name>
+                <email>author@example.com</email>
+                <phone>123-456-7890</phone>
+            </author>
+        </authors>
+        <component type="application" bom-ref="acme">
+            <supplier>
+                <name>Foo Incorporated</name>
+                <url>https://foo.bar.com</url>
+                <contact>
+                    <name>Foo Jr.</name>
+                    <email>foojr@bar.com</email>
+                    <phone>123-456-7890</phone>
+                </contact>
+            </supplier>
+            <publisher>DependencyTrack</publisher>
+            <name>Acme example</name>
+            <externalReferences>
+                <reference type="build-system">
+                    <url>https://acme.example</url>
+                </reference>
+                <reference type="distribution">
+                    <url>https://acme.example</url>
+                </reference>
+                <reference type="issue-tracker">
+                    <url>https://acme.example</url>
+                </reference>
+                <reference type="vcs">
+                    <url>https://acme.example</url>
+                </reference>
+            </externalReferences>
+        </component>
+        <manufacture>
+            <name>Foo Incorporated</name>
+            <url>https://foo.bar.com</url>
+            <contact>
+                <name>Foo Sr.</name>
+                <email>foo@bar.com</email>
+                <phone>800-123-4567</phone>
+            </contact>
+        </manufacture>
+        <supplier>
+           <name>Foo Incorporated</name>
+            <url>https://foo.bar.com</url>
+            <contact>
+                <name>Foo Jr.</name>
+                <email>foojr@bar.com</email>
+                <phone>123-456-7890</phone>
+            </contact>
+        </supplier>
+    </metadata>
+    <components>
+        <component type="application">
+            <supplier>
+                <name>Foo Incorporated</name>
+                <url>https://foo.bar.com</url>
+                <contact>
+                    <name>Foo Jr.</name>
+                    <email>foojr@bar.com</email>
+                    <phone>123-456-7890</phone>
+                </contact>
+            </supplier>
+			<author>Sometimes this field is long because it is composed of a list of authors......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................</author>
+            <publisher>Example Incorporated</publisher>
+            <group>com.example</group>
+            <name>xmlutil</name>
+            <version>1.0.0</version>
+            <description>A makebelieve XML utility library</description>
+            <hashes>
+                <hash alg="MD5">2b67669c925048d1a5c7f124d9ba1d2a</hash>
+                <hash alg="SHA-1">72ca79908c814022905e86f8bbecd9b829352139</hash>
+                <hash alg="SHA-256">1389877662864d2bb0488b4b1e417ce5647a1687084341178a203b243dfe90e7</hash>
+            </hashes>
+            <licenses>
+                <license>
+                    <id>Apache-2.0</id>
+                    <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+                </license>
+            </licenses>
+            <copyright>Copyright Example Inc. All rights reserved.</copyright>
+            <cpe>cpe:/a:example:xmlutil:1.0.0</cpe>
+            <purl>pkg:maven/com.example/xmlutil@1.0.0?packaging=jar</purl>
+            <modified>false</modified>
+            <properties>
+                <property name="">foo</property>
+                <property name="foo">bar</property>
+                <property name="foo:bar">baz</property>
+                <property name="foo:bar">qux</property>
+                <property name="foo:bar">qux</property>
+                <property name="long">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</property>
+            </properties>
+        </component>
+    </components>
+</bom>


### PR DESCRIPTION
### Description

This PR contains a bugfix for gh-4008. I have also added a testcase, which was created by copying the bom-1.xml from another testcase.

### Addressed Issue

The commit fixes a validation error that occurs when multiple namespace declarations are present in the BOM (in the wrong order).

### Additional Details

n/a


### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
