### PR TITLE
Fix `parent` field occasionally missing in `/api/v1/project/{uuid}` responses

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -217,7 +217,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
      */
     @Override
     public Project getProject(final String uuid) {
-        final Project project = getObjectByUuid(Project.class, uuid, Project.FetchGroup.ALL.name());
+        final Project project = getObjectByUuid(Project.class, UUID.fromString(uuid), List.of(Project.FetchGroup.ALL.name()));
         if (project != null) {
             // set Metrics to minimize the number of round trips a client needs to make
             project.setMetrics(getMostRecentProjectMetrics(project));

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1353,15 +1353,17 @@ public class QueryManager extends AlpineQueryManager {
      * @param fetchGroups Fetch groups to use for this operation
      * @return The object if found, otherwise {@code null}
      * @param <T> Type of the object
-     * @throws Exception When closing the query failed
      * @since 4.6.0
      */
-    public <T> T getObjectByUuid(final Class<T> clazz, final UUID uuid, final List<String> fetchGroups) throws Exception {
-        try (final Query<T> query = pm.newQuery(clazz)) {
-            query.setFilter("uuid == :uuid");
-            query.setParameters(uuid);
-            query.getFetchPlan().setGroups(fetchGroups);
+    public <T> T getObjectByUuid(final Class<T> clazz, final UUID uuid, final List<String> fetchGroups) {
+        final Query<T> query = pm.newQuery(clazz);
+        query.setFilter("uuid == :uuid");
+        query.setParameters(uuid);
+        query.getFetchPlan().setGroups(fetchGroups);
+        try {
             return query.executeUnique();
+        } finally {
+            query.closeAll();
         }
     }
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes the `parent` field occasionally missing in `/api/v1/project/{uuid}` responses.

> [!NOTE]
> This is already fixed in v4.12. Refer to https://github.com/DependencyTrack/dependency-track/issues/4048#issuecomment-2275716424 for details.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #4048

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
