### PR TITLE
Enhance badge API to require authorization

### DIFF
--- a/docs/_docs/integrations/badges.md
+++ b/docs/_docs/integrations/badges.md
@@ -11,6 +11,9 @@ basis via permission.
 To enable badges for a team, activate the permission `VIEW_BADGES`. To deactivate badges, remove the permission. To 
 retrieve a badge, use a team's API key either in the badge API header `X-API-Key` or in the URI parameter `apiKey`.
 
+Dependency-Track ships with a default team "_Badge Viewers_" dedicated to badges that already has the necessary
+permission and an API key.
+
 > As badges are typically embedded in places that more people have access to than to Dependency-Track, the API key used
 > for the badge request should have minimal scope to prevent unintended access beyond that badge. Ideally, the API
 > key belongs to a single-purpose team, having just the `VIEW_BADGES` permission, with only one API key and access to 

--- a/docs/_docs/integrations/badges.md
+++ b/docs/_docs/integrations/badges.md
@@ -5,14 +5,21 @@ chapter: 6
 order: 10
 ---
 
-Dependency-Track supports badges in Scalable Vector Graphics (SVG) format. Support for badges is a globally configurable
-option and is disabled by default.
+Dependency-Track supports badges in Scalable Vector Graphics (SVG) format. Support for badges is configurable on a team
+basis via permission. 
 
-> Enabling badge support will provide vulnerability and policy violation metric information to unauthenticated users.
-> Any anonymous user with network access to Dependency-Track and knowledge of a projects information will be able
-> to view the SVG badge.
+To enable badges for a team, activate the permission `VIEW_BADGES`. To deactivate badges, remove the permission. To 
+retrieve a badge, use a team's API key either in the badge API header `X-API-Key` or in the URI parameter `apiKey`.
 
-In all following examples, replace `{name}`, `{version}`, and `{uuid}` with their respective values.
+> As badges are typically embedded in places that more people have access to than to Dependency-Track, the API key used
+> for the badge request should have minimal scope to prevent unintended access beyond that badge. Ideally, the API
+> key belongs to a single-purpose team, having just the `VIEW_BADGES` permission, with only one API key and access to 
+> only the projects/project versions whose badges are displayed at one site--the latter requiring _Portfolio Access 
+> Control_. 
+
+In all following examples, replace `{name}`, `{version}`, `{uuid}`, and `{apiKey}` with their respective values. For
+brevity, the examples use the URI query parameter as the method of authentication, however, they also work with
+authentication by header.
 
 ### Vulnerable components
 Create a badge for vulnerable components of the project. It either shows:
@@ -33,8 +40,8 @@ name and version.
 
 #### Examples
 ```
-https://dtrack.example.com/api/v1/badge/vulns/project/{name}/{version}
-https://dtrack.example.com/api/v1/badge/vulns/project/{uuid}
+https://dtrack.example.com/api/v1/badge/vulns/project/{name}/{version}?apiKey={apiKey}
+https://dtrack.example.com/api/v1/badge/vulns/project/{uuid}?apiKey={apiKey}
 ```
 
 ### Policy violations
@@ -57,8 +64,8 @@ projects name and version.
 #### Examples
 
 ```
-https://dtrack.example.com/api/v1/badge/violations/project/{name}/{version}
-https://dtrack.example.com/api/v1/badge/violations/project/{uuid}
+https://dtrack.example.com/api/v1/badge/violations/project/{name}/{version}?apiKey={apiKey}
+https://dtrack.example.com/api/v1/badge/violations/project/{uuid}?apiKey={apiKey}
 ```
 
 
@@ -67,17 +74,17 @@ You can embed the badges in other documents. It allows you to display a badge in
 
 #### HTML Examples
 ```html
-<img src="https://dtrack.example.com/api/v1/badge/vulns/project/{name}/{version}">
-<img src="https://dtrack.example.com/api/v1/badge/vulns/project/{uuid}">
-<img src="https://dtrack.example.com/api/v1/badge/violations/project/{name}/{version}">
-<img src="https://dtrack.example.com/api/v1/badge/violations/project/{uuid}">
+<img src="https://dtrack.example.com/api/v1/badge/vulns/project/{name}/{version}?apiKey={apiKey}">
+<img src="https://dtrack.example.com/api/v1/badge/vulns/project/{uuid}?apiKey={apiKey}">
+<img src="https://dtrack.example.com/api/v1/badge/violations/project/{name}/{version}?apiKey={apiKey}">
+<img src="https://dtrack.example.com/api/v1/badge/violations/project/{uuid}?apiKey={apiKey}">
 ```
 
 #### Markdown Examples
 ```markdown
-![alt text](https://dtrack.example.com/api/v1/badge/vulns/project/{name}/{version})
-![alt text](https://dtrack.example.com/api/v1/badge/vulns/project/{uuid})
-![alt text](https://dtrack.example.com/api/v1/badge/violations/project/{name}/{version})
-![alt text](https://dtrack.example.com/api/v1/badge/violations/project/{uuid})
+![alt text](https://dtrack.example.com/api/v1/badge/vulns/project/{name}/{version}?apiKey={apiKey})
+![alt text](https://dtrack.example.com/api/v1/badge/vulns/project/{uuid}?apiKey={apiKey})
+![alt text](https://dtrack.example.com/api/v1/badge/violations/project/{name}/{version}?apiKey={apiKey})
+![alt text](https://dtrack.example.com/api/v1/badge/violations/project/{uuid}?apiKey={apiKey})
 ```
 

--- a/docs/_docs/integrations/badges.md
+++ b/docs/_docs/integrations/badges.md
@@ -6,10 +6,24 @@ order: 10
 ---
 
 Dependency-Track supports badges in Scalable Vector Graphics (SVG) format. Support for badges is configurable on a team
-basis via permission. 
+basis via permission or globally for unauthenticated access.
+
+> **Deprecation Notice**
+> 
+> Unauthenticated access to badges as a global configuration is deprecated and slated for removal in Dependency-Track
+> v4.12.
 
 To enable badges for a team, activate the permission `VIEW_BADGES`. To deactivate badges, remove the permission. To 
 retrieve a badge, use a team's API key either in the badge API header `X-API-Key` or in the URI parameter `apiKey`.
+
+As a legacy feature, badges can also be accessed without authentication. On new Dependency-Track installations, this is
+disabled by default. On Dependency-Track installations updated from &leq; v4.11, where (unauthenticated) badge support 
+was enabled, badges will remain accessible for unauthenticated requests. If this is disabled, badges will be accessible
+for authenticated and authorized requests.
+
+> Enabling unauthenticated access to badges will provide vulnerability and policy violation metric information to
+> unauthenticated users. Any anonymous user with network access to Dependency-Track and knowledge of a projects
+> information will be able to view the SVG badge.
 
 Dependency-Track ships with a default team "_Badge Viewers_" dedicated to badges that already has the necessary
 permission and an API key.

--- a/src/main/java/org/dependencytrack/auth/Permissions.java
+++ b/src/main/java/org/dependencytrack/auth/Permissions.java
@@ -38,7 +38,8 @@ public enum Permissions {
     SYSTEM_CONFIGURATION("Allows the configuration of the system including notifications, repositories, and email settings"),
     PROJECT_CREATION_UPLOAD("Provides the ability to optionally create project (if non-existent) on BOM or scan upload"),
     POLICY_MANAGEMENT("Allows the creation, modification, and deletion of policy"),
-    TAG_MANAGEMENT("Allows the modification and deletion of tags");
+    TAG_MANAGEMENT("Allows the modification and deletion of tags"),
+    VIEW_BADGES("Provides the ability to view badges");
 
     private final String description;
 
@@ -64,6 +65,7 @@ public enum Permissions {
         public static final String PROJECT_CREATION_UPLOAD = "PROJECT_CREATION_UPLOAD";
         public static final String POLICY_MANAGEMENT = "POLICY_MANAGEMENT";
         public static final String TAG_MANAGEMENT = "TAG_MANAGEMENT";
+        public static final String VIEW_BADGES = "VIEW_BADGES";
     }
 
 }

--- a/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
+++ b/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 public enum ConfigPropertyConstants {
 
     GENERAL_BASE_URL("general", "base.url", null, PropertyType.URL, "URL used to construct links back to Dependency-Track from external systems"),
+    GENERAL_BADGE_ENABLED("general", "badge.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable unauthenticated access to SVG badge from metrics"),
     EMAIL_SMTP_ENABLED("email", "smtp.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable SMTP"),
     EMAIL_SMTP_FROM_ADDR("email", "smtp.from.address", null, PropertyType.STRING, "The from email address to use to send output SMTP mail"),
     EMAIL_PREFIX("email", "subject.prefix", "[Dependency-Track]", PropertyType.STRING, "The Prefix Subject email to use"),

--- a/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
+++ b/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 public enum ConfigPropertyConstants {
 
     GENERAL_BASE_URL("general", "base.url", null, PropertyType.URL, "URL used to construct links back to Dependency-Track from external systems"),
-    GENERAL_BADGE_ENABLED("general", "badge.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable SVG badge support from metrics"),
     EMAIL_SMTP_ENABLED("email", "smtp.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable SMTP"),
     EMAIL_SMTP_FROM_ADDR("email", "smtp.from.address", null, PropertyType.STRING, "The from email address to use to send output SMTP mail"),
     EMAIL_PREFIX("email", "subject.prefix", "[Dependency-Track]", PropertyType.STRING, "The Prefix Subject email to use"),

--- a/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
+++ b/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
@@ -151,6 +151,8 @@ public class DefaultObjectGenerator implements ServletContextListener {
             final Team managers = qm.createTeam("Portfolio Managers", false);
             LOGGER.debug("Creating team: Automation");
             final Team automation = qm.createTeam("Automation", true);
+            LOGGER.debug("Creating team: Badge Viewers");
+            final Team badges = qm.createTeam("Badge Viewers", true);
 
             final List<Permission> fullList = qm.getPermissions();
 
@@ -158,10 +160,12 @@ public class DefaultObjectGenerator implements ServletContextListener {
             sysadmins.setPermissions(fullList);
             managers.setPermissions(getPortfolioManagersPermissions(fullList));
             automation.setPermissions(getAutomationPermissions(fullList));
+            badges.setPermissions(getBadgesPermissions(fullList));
 
             qm.persist(sysadmins);
             qm.persist(managers);
             qm.persist(automation);
+            qm.persist(badges);
 
             LOGGER.debug("Adding admin user to System Administrators");
             qm.addUserToTeam(admin, sysadmins);
@@ -188,6 +192,16 @@ public class DefaultObjectGenerator implements ServletContextListener {
         for (final Permission permission : fullList) {
             if (permission.getName().equals(Permissions.Constants.VIEW_PORTFOLIO) ||
                     permission.getName().equals(Permissions.Constants.BOM_UPLOAD)) {
+                permissions.add(permission);
+            }
+        }
+        return permissions;
+    }
+
+    private List<Permission> getBadgesPermissions(final List<Permission> fullList) {
+        final List<Permission> permissions = new ArrayList<>();
+        for (final Permission permission : fullList) {
+            if (permission.getName().equals(Permissions.Constants.VIEW_BADGES)) {
                 permissions.add(permission);
             }
         }

--- a/src/main/java/org/dependencytrack/resources/v1/BadgeResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BadgeResource.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.resources.v1;
 
+import alpine.server.auth.AllowApiKeyInQueryParameter;
 import alpine.server.auth.PermissionRequired;
 import alpine.server.resources.AlpineResource;
 import io.swagger.v3.oas.annotations.Operation;
@@ -52,7 +53,8 @@ import jakarta.ws.rs.core.Response;
 @Tag(name = "badge")
 @SecurityRequirements({
         @SecurityRequirement(name = "ApiKeyAuth"),
-        @SecurityRequirement(name = "BearerAuth")
+        @SecurityRequirement(name = "BearerAuth"),
+        @SecurityRequirement(name = "ApiKeyQueryAuth")
 })
 public class BadgeResource extends AlpineResource {
 
@@ -75,6 +77,7 @@ public class BadgeResource extends AlpineResource {
             @ApiResponse(responseCode = "404", description = "The project could not be found")
     })
     @PermissionRequired(Permissions.Constants.VIEW_BADGES)
+    @AllowApiKeyInQueryParameter
     public Response getProjectVulnerabilitiesBadge(
             @Parameter(description = "The UUID of the project to retrieve metrics for", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid) {
@@ -110,6 +113,7 @@ public class BadgeResource extends AlpineResource {
             @ApiResponse(responseCode = "404", description = "The project could not be found")
     })
     @PermissionRequired(Permissions.Constants.VIEW_BADGES)
+    @AllowApiKeyInQueryParameter
     public Response getProjectVulnerabilitiesBadge(
             @Parameter(description = "The name of the project to query on", required = true)
             @PathParam("name") String name,
@@ -147,6 +151,7 @@ public class BadgeResource extends AlpineResource {
             @ApiResponse(responseCode = "404", description = "The project could not be found")
     })
     @PermissionRequired(Permissions.Constants.VIEW_BADGES)
+    @AllowApiKeyInQueryParameter
     public Response getProjectPolicyViolationsBadge(
             @Parameter(description = "The UUID of the project to retrieve a badge for", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid) {
@@ -182,6 +187,7 @@ public class BadgeResource extends AlpineResource {
             @ApiResponse(responseCode = "404", description = "The project could not be found")
     })
     @PermissionRequired(Permissions.Constants.VIEW_BADGES)
+    @AllowApiKeyInQueryParameter
     public Response getProjectPolicyViolationsBadge(
             @Parameter(description = "The name of the project to query on", required = true)
             @PathParam("name") String name,

--- a/src/main/java/org/dependencytrack/resources/v1/BadgeResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BadgeResource.java
@@ -81,6 +81,9 @@ public class BadgeResource extends AlpineResource {
         try (QueryManager qm = new QueryManager()) {
             final Project project = qm.getObjectByUuid(Project.class, uuid);
             if (project != null) {
+                if (!qm.hasAccess(super.getPrincipal(), project)) {
+                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
+                }
                 final ProjectMetrics metrics = qm.getMostRecentProjectMetrics(project);
                 final Badger badger = new Badger();
                 return Response.ok(badger.generateVulnerabilities(metrics)).build();
@@ -115,6 +118,9 @@ public class BadgeResource extends AlpineResource {
         try (QueryManager qm = new QueryManager()) {
             final Project project = qm.getProject(name, version);
             if (project != null) {
+                if (!qm.hasAccess(super.getPrincipal(), project)) {
+                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
+                }
                 final ProjectMetrics metrics = qm.getMostRecentProjectMetrics(project);
                 final Badger badger = new Badger();
                 return Response.ok(badger.generateVulnerabilities(metrics)).build();
@@ -147,6 +153,9 @@ public class BadgeResource extends AlpineResource {
         try (QueryManager qm = new QueryManager()) {
             final Project project = qm.getObjectByUuid(Project.class, uuid);
             if (project != null) {
+                if (!qm.hasAccess(super.getPrincipal(), project)) {
+                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
+                }
                 final ProjectMetrics metrics = qm.getMostRecentProjectMetrics(project);
                 final Badger badger = new Badger();
                 return Response.ok(badger.generateViolations(metrics)).build();
@@ -181,6 +190,9 @@ public class BadgeResource extends AlpineResource {
         try (QueryManager qm = new QueryManager()) {
             final Project project = qm.getProject(name, version);
             if (project != null) {
+                if (!qm.hasAccess(super.getPrincipal(), project)) {
+                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
+                }
                 final ProjectMetrics metrics = qm.getMostRecentProjectMetrics(project);
                 final Badger badger = new Badger();
                 return Response.ok(badger.generateViolations(metrics)).build();

--- a/src/main/java/org/dependencytrack/resources/v1/BadgeResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BadgeResource.java
@@ -18,8 +18,18 @@
  */
 package org.dependencytrack.resources.v1;
 
-import alpine.server.auth.AllowApiKeyInQueryParameter;
-import alpine.server.auth.PermissionRequired;
+import alpine.common.logging.Logger;
+import alpine.common.util.BooleanUtil;
+import alpine.model.ApiKey;
+import alpine.model.ConfigProperty;
+import alpine.model.UserPrincipal;
+import alpine.model.LdapUser;
+import alpine.model.ManagedUser;
+import alpine.model.OidcUser;
+import alpine.server.auth.ApiKeyAuthenticationService;
+import alpine.server.auth.JwtAuthenticationService;
+import alpine.server.auth.AuthenticationNotRequired;
+import alpine.server.filters.AuthenticationFilter;
 import alpine.server.resources.AlpineResource;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -40,8 +50,16 @@ import org.dependencytrack.resources.v1.misc.Badger;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.owasp.security.logging.SecurityMarkers;
+
+import javax.naming.AuthenticationException;
+import java.security.Principal;
+
+import static org.dependencytrack.model.ConfigPropertyConstants.GENERAL_BADGE_ENABLED;
 
 /**
  * JAX-RS resources for processing metrics.
@@ -60,6 +78,97 @@ public class BadgeResource extends AlpineResource {
 
     private static final String SVG_MEDIA_TYPE = "image/svg+xml";
 
+    private final Logger LOGGER = Logger.getLogger(AuthenticationFilter.class);
+
+    private boolean isUnauthenticatedBadgeAccessEnabled(final QueryManager qm) {
+        ConfigProperty property = qm.getConfigProperty(
+                GENERAL_BADGE_ENABLED.getGroupName(), GENERAL_BADGE_ENABLED.getPropertyName());
+        return BooleanUtil.valueOf(property.getPropertyValue());
+    }
+
+    // Stand-in methods for alpine.server.filters.AuthenticationFilter and
+    // alpine.server.filters.AuthorizationFilter to allow enabling and disabling of
+    // unauthenticated access to the badges API during runtime, used solely to offer
+    // a deprecation period for unauthenticated access to badges.
+    private boolean passesAuthentication() {
+        ContainerRequest request = (ContainerRequest) super.getRequestContext().getRequest();
+
+        if (HttpMethod.OPTIONS.equals(request.getMethod())) {
+            return true;
+        }
+
+        Principal principal = null;
+
+        final ApiKeyAuthenticationService apiKeyAuthService = new ApiKeyAuthenticationService(request, true);
+        if (apiKeyAuthService.isSpecified()) {
+            try {
+                principal = apiKeyAuthService.authenticate();
+            } catch (AuthenticationException e) {
+                LOGGER.info(SecurityMarkers.SECURITY_FAILURE, "Invalid API key asserted");
+                return false;
+            }
+        }
+
+        final JwtAuthenticationService jwtAuthService = new JwtAuthenticationService(request);
+        if (jwtAuthService.isSpecified()) {
+            try {
+                principal = jwtAuthService.authenticate();
+            } catch (AuthenticationException e) {
+                LOGGER.info(SecurityMarkers.SECURITY_FAILURE, "Invalid JWT asserted");
+                return false;
+            }
+        }
+
+        if (principal == null) {
+            return false;
+        } else {
+            super.getRequestContext().setProperty("Principal", principal);
+            return true;
+        }
+    }
+
+    private boolean passesAuthorization(final QueryManager qm) {
+        final Principal principal = (Principal) super.getRequestContext().getProperty("Principal");
+        if (principal == null) {
+            LOGGER.info(SecurityMarkers.SECURITY_FAILURE, "A request was made without the assertion of a valid user principal");
+            return false;
+        }
+
+        final String[] permissions = { Permissions.Constants.VIEW_BADGES };
+
+        if (principal instanceof ApiKey) {
+            final ApiKey apiKey = (ApiKey)principal;
+            for (final String permission: permissions) {
+                if (qm.hasPermission(apiKey, permission)) {
+                    return true;
+                }
+            }
+            LOGGER.info(SecurityMarkers.SECURITY_FAILURE, "Unauthorized access attempt made by API Key "
+                    + apiKey.getMaskedKey() + " to " + ((ContainerRequest) super.getRequestContext()).getRequestUri().toString());
+        } else {
+            UserPrincipal user = null;
+            if (principal instanceof ManagedUser) {
+                user = qm.getManagedUser(((ManagedUser) principal).getUsername());
+            } else if (principal instanceof LdapUser) {
+                user = qm.getLdapUser(((LdapUser) principal).getUsername());
+            } else if (principal instanceof OidcUser) {
+                user = qm.getOidcUser(((OidcUser) principal).getUsername());
+            }
+            if (user == null) {
+                LOGGER.info(SecurityMarkers.SECURITY_FAILURE, "A request was made but the system in unable to find the user principal");
+                return false;
+            }
+            for (final String permission : permissions) {
+                if (qm.hasPermission(user, permission, true)) {
+                    return true;
+                }
+            }
+            LOGGER.info(SecurityMarkers.SECURITY_FAILURE, "Unauthorized access attempt made by "
+                    + user.getUsername() + " to " + ((ContainerRequest) super.getRequestContext()).getRequestUri().toString());
+        }
+        return false;
+    }
+
     @GET
     @Path("/vulns/project/{uuid}")
     @Produces(SVG_MEDIA_TYPE)
@@ -74,17 +183,23 @@ public class BadgeResource extends AlpineResource {
                     content = @Content(schema = @Schema(type = "string"))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
             @ApiResponse(responseCode = "404", description = "The project could not be found")
     })
-    @PermissionRequired(Permissions.Constants.VIEW_BADGES)
-    @AllowApiKeyInQueryParameter
+    @AuthenticationNotRequired
     public Response getProjectVulnerabilitiesBadge(
             @Parameter(description = "The UUID of the project to retrieve metrics for", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid) {
         try (QueryManager qm = new QueryManager()) {
+            if (!isUnauthenticatedBadgeAccessEnabled(qm) && !passesAuthentication()) {
+                return Response.status(Response.Status.UNAUTHORIZED).build();
+            }
+            if (!isUnauthenticatedBadgeAccessEnabled(qm) && !passesAuthorization(qm)) {
+                return Response.status(Response.Status.FORBIDDEN).build();
+            }
             final Project project = qm.getObjectByUuid(Project.class, uuid);
             if (project != null) {
-                if (!qm.hasAccess(super.getPrincipal(), project)) {
+                if (!isUnauthenticatedBadgeAccessEnabled(qm) && !qm.hasAccess(super.getPrincipal(), project)) {
                     return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
                 }
                 final ProjectMetrics metrics = qm.getMostRecentProjectMetrics(project);
@@ -110,19 +225,25 @@ public class BadgeResource extends AlpineResource {
                     content = @Content(schema = @Schema(type = "string"))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
             @ApiResponse(responseCode = "404", description = "The project could not be found")
     })
-    @PermissionRequired(Permissions.Constants.VIEW_BADGES)
-    @AllowApiKeyInQueryParameter
+    @AuthenticationNotRequired
     public Response getProjectVulnerabilitiesBadge(
             @Parameter(description = "The name of the project to query on", required = true)
             @PathParam("name") String name,
             @Parameter(description = "The version of the project to query on", required = true)
             @PathParam("version") String version) {
         try (QueryManager qm = new QueryManager()) {
+            if (!isUnauthenticatedBadgeAccessEnabled(qm) && !passesAuthentication()) {
+                return Response.status(Response.Status.UNAUTHORIZED).build();
+            }
+            if (!isUnauthenticatedBadgeAccessEnabled(qm) && !passesAuthorization(qm)) {
+                return Response.status(Response.Status.FORBIDDEN).build();
+            }
             final Project project = qm.getProject(name, version);
             if (project != null) {
-                if (!qm.hasAccess(super.getPrincipal(), project)) {
+                if (!isUnauthenticatedBadgeAccessEnabled(qm) && !qm.hasAccess(super.getPrincipal(), project)) {
                     return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
                 }
                 final ProjectMetrics metrics = qm.getMostRecentProjectMetrics(project);
@@ -148,17 +269,23 @@ public class BadgeResource extends AlpineResource {
                     content = @Content(schema = @Schema(type = "string"))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
             @ApiResponse(responseCode = "404", description = "The project could not be found")
     })
-    @PermissionRequired(Permissions.Constants.VIEW_BADGES)
-    @AllowApiKeyInQueryParameter
+    @AuthenticationNotRequired
     public Response getProjectPolicyViolationsBadge(
             @Parameter(description = "The UUID of the project to retrieve a badge for", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid) {
         try (QueryManager qm = new QueryManager()) {
+            if (!isUnauthenticatedBadgeAccessEnabled(qm) && !passesAuthentication()) {
+                return Response.status(Response.Status.UNAUTHORIZED).build();
+            }
+            if (!isUnauthenticatedBadgeAccessEnabled(qm) && !passesAuthorization(qm)) {
+                return Response.status(Response.Status.FORBIDDEN).build();
+            }
             final Project project = qm.getObjectByUuid(Project.class, uuid);
             if (project != null) {
-                if (!qm.hasAccess(super.getPrincipal(), project)) {
+                if (!isUnauthenticatedBadgeAccessEnabled(qm) && !qm.hasAccess(super.getPrincipal(), project)) {
                     return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
                 }
                 final ProjectMetrics metrics = qm.getMostRecentProjectMetrics(project);
@@ -184,19 +311,25 @@ public class BadgeResource extends AlpineResource {
                     content = @Content(schema = @Schema(type = "string"))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
             @ApiResponse(responseCode = "404", description = "The project could not be found")
     })
-    @PermissionRequired(Permissions.Constants.VIEW_BADGES)
-    @AllowApiKeyInQueryParameter
+    @AuthenticationNotRequired
     public Response getProjectPolicyViolationsBadge(
             @Parameter(description = "The name of the project to query on", required = true)
             @PathParam("name") String name,
             @Parameter(description = "The version of the project to query on", required = true)
             @PathParam("version") String version) {
         try (QueryManager qm = new QueryManager()) {
+            if (!isUnauthenticatedBadgeAccessEnabled(qm) && !passesAuthentication()) {
+                return Response.status(Response.Status.UNAUTHORIZED).build();
+            }
+            if (!isUnauthenticatedBadgeAccessEnabled(qm) && !passesAuthorization(qm)) {
+                return Response.status(Response.Status.FORBIDDEN).build();
+            }
             final Project project = qm.getProject(name, version);
             if (project != null) {
-                if (!qm.hasAccess(super.getPrincipal(), project)) {
+                if (!isUnauthenticatedBadgeAccessEnabled(qm) && !qm.hasAccess(super.getPrincipal(), project)) {
                     return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
                 }
                 final ProjectMetrics metrics = qm.getMostRecentProjectMetrics(project);

--- a/src/main/resources/openapi-configuration.yaml
+++ b/src/main/resources/openapi-configuration.yaml
@@ -23,6 +23,10 @@ openAPI:
       BearerAuth:
         type: http
         scheme: Bearer
+      ApiKeyQueryAuth:
+        name: apiKey
+        type: apiKey
+        in: query
 prettyPrint: true
 resourcePackages:
 - alpine.server.resources

--- a/src/test/java/org/dependencytrack/ResourceTest.java
+++ b/src/test/java/org/dependencytrack/ResourceTest.java
@@ -78,6 +78,7 @@ public abstract class ResourceTest {
     protected final String SIZE = "size";
     protected final String TOTAL_COUNT_HEADER = "X-Total-Count";
     protected final String X_API_KEY = "X-Api-Key";
+    protected final String API_KEY = "apiKey";
     protected final String V1_TAG = "/v1/tag";
 
     // Hashing is expensive. Do it once and re-use across tests as much as possible.

--- a/src/test/java/org/dependencytrack/auth/PermissionsTest.java
+++ b/src/test/java/org/dependencytrack/auth/PermissionsTest.java
@@ -34,11 +34,12 @@ import static org.dependencytrack.auth.Permissions.Constants.VIEW_PORTFOLIO;
 import static org.dependencytrack.auth.Permissions.Constants.VIEW_VULNERABILITY;
 import static org.dependencytrack.auth.Permissions.Constants.VULNERABILITY_ANALYSIS;
 import static org.dependencytrack.auth.Permissions.Constants.VULNERABILITY_MANAGEMENT;
+import static org.dependencytrack.auth.Permissions.Constants.VIEW_BADGES;
 public class PermissionsTest {
 
     @Test
     public void testPermissionEnums() {
-        Assert.assertEquals(13, Permissions.values().length);
+        Assert.assertEquals(14, Permissions.values().length);
         Assert.assertEquals("BOM_UPLOAD", Permissions.BOM_UPLOAD.name());
         Assert.assertEquals("VIEW_PORTFOLIO", Permissions.VIEW_PORTFOLIO.name());
         Assert.assertEquals("PORTFOLIO_MANAGEMENT", Permissions.PORTFOLIO_MANAGEMENT.name());
@@ -52,6 +53,7 @@ public class PermissionsTest {
         Assert.assertEquals("PROJECT_CREATION_UPLOAD", Permissions.PROJECT_CREATION_UPLOAD.name());
         Assert.assertEquals("POLICY_MANAGEMENT", Permissions.POLICY_MANAGEMENT.name());
         Assert.assertEquals("TAG_MANAGEMENT", Permissions.TAG_MANAGEMENT.name());
+        Assert.assertEquals("VIEW_BADGES", Permissions.VIEW_BADGES.name());
     }
 
     @Test
@@ -69,5 +71,6 @@ public class PermissionsTest {
         Assert.assertEquals("PROJECT_CREATION_UPLOAD", PROJECT_CREATION_UPLOAD);
         Assert.assertEquals("POLICY_MANAGEMENT", POLICY_MANAGEMENT);
         Assert.assertEquals("TAG_MANAGEMENT", TAG_MANAGEMENT);
+        Assert.assertEquals("VIEW_BADGES", VIEW_BADGES);
     }
 }

--- a/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
+++ b/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
@@ -93,7 +93,7 @@ public class DefaultObjectGeneratorTest extends PersistenceCapableTest {
         Method method = generator.getClass().getDeclaredMethod("loadDefaultPersonas");
         method.setAccessible(true);
         method.invoke(generator);
-        Assert.assertEquals(3, qm.getTeams().size());
+        Assert.assertEquals(4, qm.getTeams().size());
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/resources/v1/BadgeResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BadgeResourceTest.java
@@ -54,6 +54,20 @@ public class BadgeResourceTest extends ResourceTest {
         initializeWithPermissions(Permissions.VIEW_BADGES);
 
         Project project = qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
+        Response response = jersey.target(V1_BADGE + "/vulns/project/" + project.getUuid())
+                .queryParam(API_KEY, apiKey)
+                .request()
+                .get(Response.class);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        Assert.assertEquals("image/svg+xml", response.getHeaderString("Content-Type"));
+        Assert.assertTrue(isLikelySvg(getPlainTextBody(response)));
+    }
+
+    @Test
+    public void projectVulnerabilitiesByUuidWithHeaderAuthenticationTest() {
+        initializeWithPermissions(Permissions.VIEW_BADGES);
+
+        Project project = qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
         Response response = jersey.target(V1_BADGE + "/vulns/project/" + project.getUuid()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -66,8 +80,9 @@ public class BadgeResourceTest extends ResourceTest {
     public void projectVulnerabilitiesByUuidProjectNotFoundTest() {
         initializeWithPermissions(Permissions.VIEW_BADGES);
 
-        Response response = jersey.target(V1_BADGE + "/vulns/project/" + UUID.randomUUID()).request()
-                .header(X_API_KEY, apiKey)
+        Response response = jersey.target(V1_BADGE + "/vulns/project/" + UUID.randomUUID())
+                .queryParam(API_KEY, apiKey)
+                .request()
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
     }
@@ -85,14 +100,42 @@ public class BadgeResourceTest extends ResourceTest {
     @Test
     public void projectVulnerabilitiesByUuidMissingPermissionTest() {
         Project project = qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
-        Response response = jersey.target(V1_BADGE + "/vulns/project/" + project.getUuid()).request()
-                .header(X_API_KEY, apiKey)
+        Response response = jersey.target(V1_BADGE + "/vulns/project/" + project.getUuid())
+                .queryParam(API_KEY, apiKey)
+                .request()
                 .get(Response.class);
         Assert.assertEquals(403, response.getStatus(), 0);
     }
 
     @Test
     public void projectVulnerabilitiesByUuidWithAclAccessTest() {
+        initializeWithPermissions(Permissions.VIEW_BADGES);
+
+        qm.createConfigProperty(
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
+                "true",
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyType(),
+                null
+        );
+
+        Project project = new Project();
+        project.setName("Acme Example");
+        project.setVersion("1.0.0");
+        project.setAccessTeams(List.of(team));
+        qm.persist(project);
+
+        Response response = jersey.target(V1_BADGE + "/vulns/project/" + project.getUuid())
+                .queryParam(API_KEY, apiKey)
+                .request()
+                .get(Response.class);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        Assert.assertEquals("image/svg+xml", response.getHeaderString("Content-Type"));
+        Assert.assertTrue(isLikelySvg(getPlainTextBody(response)));
+    }
+
+    @Test
+    public void projectVulnerabilitiesByUuidWithAclAccessWithHeaderAuthenticationTest() {
         initializeWithPermissions(Permissions.VIEW_BADGES);
 
         qm.createConfigProperty(
@@ -134,14 +177,29 @@ public class BadgeResourceTest extends ResourceTest {
         project.setVersion("1.0.0");
         qm.persist(project);
 
-        Response response = jersey.target(V1_BADGE + "/vulns/project/" + project.getUuid()).request()
-                .header(X_API_KEY, apiKey)
+        Response response = jersey.target(V1_BADGE + "/vulns/project/" + project.getUuid())
+                .queryParam(API_KEY, apiKey)
+                .request()
                 .get(Response.class);
         Assert.assertEquals(403, response.getStatus(), 0);
     }
 
     @Test
     public void projectVulnerabilitiesByNameAndVersionTest() {
+        initializeWithPermissions(Permissions.VIEW_BADGES);
+
+        qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
+        Response response = jersey.target(V1_BADGE + "/vulns/project/Acme%20Example/1.0.0")
+                .queryParam(API_KEY, apiKey)
+                .request()
+                .get(Response.class);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        Assert.assertEquals("image/svg+xml", response.getHeaderString("Content-Type"));
+        Assert.assertTrue(isLikelySvg(getPlainTextBody(response)));
+    }
+
+    @Test
+    public void projectVulnerabilitiesByNameAndVersionWithHeaderAuthenticationTest() {
         initializeWithPermissions(Permissions.VIEW_BADGES);
 
         qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
@@ -157,8 +215,9 @@ public class BadgeResourceTest extends ResourceTest {
     public void projectVulnerabilitiesByNameAndVersionProjectNotFoundTest() {
         initializeWithPermissions(Permissions.VIEW_BADGES);
 
-        Response response = jersey.target(V1_BADGE + "/vulns/project/ProjectNameDoesNotExist/1.0.0").request()
-                .header(X_API_KEY, apiKey)
+        Response response = jersey.target(V1_BADGE + "/vulns/project/ProjectNameDoesNotExist/1.0.0")
+                .queryParam(API_KEY, apiKey)
+                .request()
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
     }
@@ -168,8 +227,9 @@ public class BadgeResourceTest extends ResourceTest {
         initializeWithPermissions(Permissions.VIEW_BADGES);
 
         qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
-        Response response = jersey.target(V1_BADGE + "/vulns/project/Acme%20Example/1.2.0").request()
-                .header(X_API_KEY, apiKey)
+        Response response = jersey.target(V1_BADGE + "/vulns/project/Acme%20Example/1.2.0")
+                .queryParam(API_KEY, apiKey)
+                .request()
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
     }
@@ -187,14 +247,42 @@ public class BadgeResourceTest extends ResourceTest {
     @Test
     public void projectVulnerabilitiesByNameAndVersionMissingPermissionTest() {
         qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
-        Response response = jersey.target(V1_BADGE + "/vulns/project/Acme%20Example/1.0.0").request()
-                .header(X_API_KEY, apiKey)
+        Response response = jersey.target(V1_BADGE + "/vulns/project/Acme%20Example/1.0.0")
+                .queryParam(API_KEY, apiKey)
+                .request()
                 .get(Response.class);
         Assert.assertEquals(403, response.getStatus(), 0);
     }
 
     @Test
     public void projectVulnerabilitiesByNameAndVersionWithAclAccessTest() {
+        initializeWithPermissions(Permissions.VIEW_BADGES);
+
+        qm.createConfigProperty(
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
+                "true",
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyType(),
+                null
+        );
+
+        Project project = new Project();
+        project.setName("Acme Example");
+        project.setVersion("1.0.0");
+        project.setAccessTeams(List.of(team));
+        qm.persist(project);
+
+        Response response = jersey.target(V1_BADGE + "/vulns/project/Acme%20Example/1.0.0")
+                .queryParam(API_KEY, apiKey)
+                .request()
+                .get(Response.class);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        Assert.assertEquals("image/svg+xml", response.getHeaderString("Content-Type"));
+        Assert.assertTrue(isLikelySvg(getPlainTextBody(response)));
+    }
+
+    @Test
+    public void projectVulnerabilitiesByNameAndVersionWithAclAccessWithHeaderAuthenticationTest() {
         initializeWithPermissions(Permissions.VIEW_BADGES);
 
         qm.createConfigProperty(
@@ -236,14 +324,29 @@ public class BadgeResourceTest extends ResourceTest {
         project.setVersion("1.0.0");
         qm.persist(project);
 
-        Response response = jersey.target(V1_BADGE + "/vulns/project/Acme%20Example/1.0.0").request()
-                .header(X_API_KEY, apiKey)
+        Response response = jersey.target(V1_BADGE + "/vulns/project/Acme%20Example/1.0.0")
+                .queryParam(API_KEY, apiKey)
+                .request()
                 .get(Response.class);
         Assert.assertEquals(403, response.getStatus(), 0);
     }
 
     @Test
     public void projectPolicyViolationsByUuidTest() {
+        initializeWithPermissions(Permissions.VIEW_BADGES);
+
+        Project project = qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
+        Response response = jersey.target(V1_BADGE + "/violations/project/" + project.getUuid())
+                .queryParam(API_KEY, apiKey)
+                .request()
+                .get(Response.class);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        Assert.assertEquals("image/svg+xml", response.getHeaderString("Content-Type"));
+        Assert.assertTrue(isLikelySvg(getPlainTextBody(response)));
+    }
+
+    @Test
+    public void projectPolicyViolationsByUuidWithHeaderAuthenticationTest() {
         initializeWithPermissions(Permissions.VIEW_BADGES);
 
         Project project = qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
@@ -259,8 +362,9 @@ public class BadgeResourceTest extends ResourceTest {
     public void projectPolicyViolationsByUuidProjectNotFoundTest() {
         initializeWithPermissions(Permissions.VIEW_BADGES);
 
-        Response response = jersey.target(V1_BADGE + "/violations/project/" + UUID.randomUUID()).request()
-                .header(X_API_KEY, apiKey)
+        Response response = jersey.target(V1_BADGE + "/violations/project/" + UUID.randomUUID())
+                .queryParam(API_KEY, apiKey)
+                .request()
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
     }
@@ -278,14 +382,42 @@ public class BadgeResourceTest extends ResourceTest {
     @Test
     public void projectPolicyViolationsByUuidMissingPermissionTest() {
         Project project = qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
-        Response response = jersey.target(V1_BADGE + "/violations/project/" + project.getUuid()).request()
-                .header(X_API_KEY, apiKey)
+        Response response = jersey.target(V1_BADGE + "/violations/project/" + project.getUuid())
+                .queryParam(API_KEY, apiKey)
+                .request()
                 .get(Response.class);
         Assert.assertEquals(403, response.getStatus(), 0);
     }
 
     @Test
     public void projectPolicyViolationsByUuidWithAclAccessTest() {
+        initializeWithPermissions(Permissions.VIEW_BADGES);
+
+        qm.createConfigProperty(
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
+                "true",
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyType(),
+                null
+        );
+
+        Project project = new Project();
+        project.setName("Acme Example");
+        project.setVersion("1.0.0");
+        project.setAccessTeams(List.of(team));
+        qm.persist(project);
+
+        Response response = jersey.target(V1_BADGE + "/violations/project/" + project.getUuid())
+                .queryParam(API_KEY, apiKey)
+                .request()
+                .get(Response.class);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        Assert.assertEquals("image/svg+xml", response.getHeaderString("Content-Type"));
+        Assert.assertTrue(isLikelySvg(getPlainTextBody(response)));
+    }
+
+    @Test
+    public void projectPolicyViolationsByUuidWithAclAccessWithHeaderAuthenticationTest() {
         initializeWithPermissions(Permissions.VIEW_BADGES);
 
         qm.createConfigProperty(
@@ -327,14 +459,29 @@ public class BadgeResourceTest extends ResourceTest {
         project.setVersion("1.0.0");
         qm.persist(project);
 
-        Response response = jersey.target(V1_BADGE + "/violations/project/" + project.getUuid()).request()
-                .header(X_API_KEY, apiKey)
+        Response response = jersey.target(V1_BADGE + "/violations/project/" + project.getUuid())
+                .queryParam(API_KEY, apiKey)
+                .request()
                 .get(Response.class);
         Assert.assertEquals(403, response.getStatus(), 0);
     }
 
     @Test
     public void projectPolicyViolationsByNameAndVersionTest() {
+        initializeWithPermissions(Permissions.VIEW_BADGES);
+
+        qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
+        Response response = jersey.target(V1_BADGE + "/violations/project/Acme%20Example/1.0.0")
+                .queryParam(API_KEY, apiKey)
+                .request()
+                .get(Response.class);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        Assert.assertEquals("image/svg+xml", response.getHeaderString("Content-Type"));
+        Assert.assertTrue(isLikelySvg(getPlainTextBody(response)));
+    }
+
+    @Test
+    public void projectPolicyViolationsByNameAndVersionWithHeaderAuthenticationTest() {
         initializeWithPermissions(Permissions.VIEW_BADGES);
 
         qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
@@ -350,8 +497,9 @@ public class BadgeResourceTest extends ResourceTest {
     public void projectPolicyViolationsByNameAndVersionProjectNotFoundTest() {
         initializeWithPermissions(Permissions.VIEW_BADGES);
 
-        Response response = jersey.target(V1_BADGE + "/violations/project/ProjectNameDoesNotExist/1.0.0").request()
-                .header(X_API_KEY, apiKey)
+        Response response = jersey.target(V1_BADGE + "/violations/project/ProjectNameDoesNotExist/1.0.0")
+                .queryParam(API_KEY, apiKey)
+                .request()
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
     }
@@ -361,8 +509,9 @@ public class BadgeResourceTest extends ResourceTest {
         initializeWithPermissions(Permissions.VIEW_BADGES);
 
         qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
-        Response response = jersey.target(V1_BADGE + "/violations/project/Acme%20Example/1.2.0").request()
-                .header(X_API_KEY, apiKey)
+        Response response = jersey.target(V1_BADGE + "/violations/project/Acme%20Example/1.2.0")
+                .queryParam(API_KEY, apiKey)
+                .request()
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
     }
@@ -380,14 +529,40 @@ public class BadgeResourceTest extends ResourceTest {
     @Test
     public void projectPolicyViolationsByNameAndVersionMissingPermissionTest() {
         qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
-        Response response = jersey.target(V1_BADGE + "/violations/project/Acme%20Example/1.0.0").request()
-                .header(X_API_KEY, apiKey)
+        Response response = jersey.target(V1_BADGE + "/violations/project/Acme%20Example/1.0.0")
+                .queryParam(API_KEY, apiKey)
+                .request()
                 .get(Response.class);
         Assert.assertEquals(403, response.getStatus(), 0);
     }
 
     @Test
     public void projectPolicyViolationsByNameAndVersionWithAclAccessTest() {
+        initializeWithPermissions(Permissions.VIEW_BADGES);
+
+        qm.createConfigProperty(
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
+                "true",
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyType(),
+                null
+        );
+
+        Project project = qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
+        project.setAccessTeams(List.of(team));
+        qm.persist(project);
+
+        Response response = jersey.target(V1_BADGE + "/violations/project/Acme%20Example/1.0.0")
+                .queryParam(API_KEY, apiKey)
+                .request()
+                .get(Response.class);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        Assert.assertEquals("image/svg+xml", response.getHeaderString("Content-Type"));
+        Assert.assertTrue(isLikelySvg(getPlainTextBody(response)));
+    }
+
+    @Test
+    public void projectPolicyViolationsByNameAndVersionWithAclAccessWithHeaderAuthenticationTest() {
         initializeWithPermissions(Permissions.VIEW_BADGES);
 
         qm.createConfigProperty(
@@ -427,8 +602,9 @@ public class BadgeResourceTest extends ResourceTest {
         project.setVersion("1.0.0");
         qm.persist(project);
 
-        Response response = jersey.target(V1_BADGE + "/violations/project/Acme%20Example/1.0.0").request()
-                .header(X_API_KEY, apiKey)
+        Response response = jersey.target(V1_BADGE + "/violations/project/Acme%20Example/1.0.0")
+                .queryParam(API_KEY, apiKey)
+                .request()
                 .get(Response.class);
         Assert.assertEquals(403, response.getStatus(), 0);
     }

--- a/src/test/java/org/dependencytrack/resources/v1/PermissionResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PermissionResourceTest.java
@@ -101,6 +101,10 @@ public class PermissionResourceTest extends ResourceTest {
                             "name": "TAG_MANAGEMENT"
                           },
                           {
+                            "description": "Provides the ability to view badges",
+                            "name": "VIEW_BADGES"
+                          },
+                          {
                             "description": "Provides the ability to view policy violations",
                             "name": "VIEW_POLICY_VIOLATION"
                           },


### PR DESCRIPTION
### Description

Enables Dependency-Track to offer badges in a secure manner and change the `badge` API from an opt-in-able, unauthenticated one into one requiring authentication with the new permission `VIEW_BADGES`, either via HTTP header or URI query parameter.

In the currently implementation, this as a breaking change (see Additional Details.)

### Addressed Issue

Closes #3596 

### Additional Details
<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->
As a first for DT's API, badges will allow authentication via URI query parameter, as badges are often retrieved from/embedded in clients that do not easily support an injection of headers.

The securing of badges behind API authentication and ACL can be done in two ways, either as a breaking change or gracefully with backwards compatibility: implement authentication with a new permission and
1. remove current checkbox enabling unauthenticated badges support entirely _(breaking change)_
2. keep a checkbox, but redo it to switch between the settings _(backwards compatible change)_:
   1. disable unauthenticated access (allows authenticated access only, corresponds to the previous "off" setting right after updating to the new DT version containing this PR)
   2. enable unauthenticated access (corresponds to the previous "on" setting)

A grace period is nice. But because the previous way of offering badges represents a security flaw, I would've preferred to make users switch to authenticated badges requests right away. 

#### Downstream changes
https://github.com/DependencyTrack/frontend/issues/967

#### Upstream requirements
https://github.com/stevespringett/Alpine/issues/641

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
