### PR TITLE
Handle empty component and service names

### DIFF
--- a/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
@@ -75,6 +75,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static java.util.Objects.requireNonNullElse;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.trim;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
@@ -167,7 +168,7 @@ public class ModelConverter {
         component.setSupplier(convert(cdxComponent.getSupplier()));
         component.setClassifier(convertClassifier(cdxComponent.getType()).orElse(Classifier.LIBRARY));
         component.setGroup(trimToNull(cdxComponent.getGroup()));
-        component.setName(trimToNull(cdxComponent.getName()));
+        component.setName(requireNonNullElse(trimToNull(cdxComponent.getName()), "-"));
         component.setVersion(trimToNull(cdxComponent.getVersion()));
         component.setDescription(trimToNull(cdxComponent.getDescription()));
         component.setCopyright(trimToNull(cdxComponent.getCopyright()));
@@ -325,7 +326,7 @@ public class ModelConverter {
         final var service = new ServiceComponent();
         service.setBomRef(useOrGenerateRandomBomRef(cdxService.getBomRef()));
         service.setGroup(trimToNull(cdxService.getGroup()));
-        service.setName(trimToNull(cdxService.getName()));
+        service.setName(requireNonNullElse(trimToNull(cdxService.getName()), "-"));
         service.setVersion(trimToNull(cdxService.getVersion()));
         service.setDescription(trimToNull(cdxService.getDescription()));
         service.setAuthenticated(cdxService.getAuthenticated());


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Handles empty component and service names.

`component.name` and `service.name` are required as per CycloneDX specification, but the schema doesn't sufficiently enforce this requirement (https://github.com/CycloneDX/specification/issues/461).

Because DT trims names from the BOM during model conversion, empty or blank names end up becoming `null`. Since the respective database columns have a `NOT NULL` constraint on them, inserting or updating such components will always fail.

Usually we would not want to try to "repair" data, but the name being empty appears to be so common that there's no other sensible way for us to deal with it.

With this change, empty names will end up being saved as `-` instead, to signal the absence of a proper value.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #2821

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
