### PR TITLE
Fix infinite recursion during policy condition serialization

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/PolicyConditionResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/PolicyConditionResource.java
@@ -93,6 +93,11 @@ public class PolicyConditionResource extends AlpineResource {
             if (policy != null) {
                 final PolicyCondition pc = qm.createPolicyCondition(policy, jsonPolicyCondition.getSubject(),
                         jsonPolicyCondition.getOperator(), StringUtils.trimToNull(jsonPolicyCondition.getValue()));
+
+                // Prevent infinite recursion during JSON serialization.
+                qm.makeTransient(pc);
+                pc.setPolicy(null);
+
                 return Response.status(Response.Status.CREATED).entity(pc).build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the policy could not be found.").build();
@@ -127,7 +132,12 @@ public class PolicyConditionResource extends AlpineResource {
             PolicyCondition pc = qm.getObjectByUuid(PolicyCondition.class, jsonPolicyCondition.getUuid());
             if (pc != null) {
                 pc = qm.updatePolicyCondition(jsonPolicyCondition);
-                return Response.status(Response.Status.CREATED).entity(pc).build();
+
+                // Prevent infinite recursion during JSON serialization.
+                qm.makeTransient(pc);
+                pc.setPolicy(null);
+
+                return Response.status(Response.Status.OK).entity(pc).build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the policy condition could not be found.").build();
             }

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyConditionResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyConditionResourceTest.java
@@ -1,0 +1,226 @@
+package org.dependencytrack.resources.v1;
+
+import alpine.server.filters.ApiFilter;
+import alpine.server.filters.AuthenticationFilter;
+import alpine.server.filters.AuthorizationFilter;
+import org.dependencytrack.JerseyTestRule;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.Policy;
+import org.dependencytrack.model.Policy.Operator;
+import org.dependencytrack.model.Policy.ViolationState;
+import org.dependencytrack.model.PolicyCondition;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import javax.jdo.JDOObjectNotFoundException;
+import java.util.UUID;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class PolicyConditionResourceTest extends ResourceTest {
+
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(PolicyConditionResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class)
+                    .register(AuthorizationFilter.class));
+
+    @Test
+    public void testCreateCondition() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final var policy = new Policy();
+        policy.setName("foo");
+        policy.setOperator(Operator.ANY);
+        policy.setViolationState(ViolationState.INFO);
+        qm.persist(policy);
+
+        final Response response = jersey.target("%s/%s/condition".formatted(V1_POLICY, policy.getUuid()))
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "subject": "PACKAGE_URL",
+                          "operator": "MATCHES",
+                          "value": "pkg:maven/foo/bar"
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(201);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "uuid": "${json-unit.any-string}",
+                  "subject": "PACKAGE_URL",
+                  "operator": "MATCHES",
+                  "value": "pkg:maven/foo/bar"
+                }
+                """);
+    }
+
+    @Test
+    public void testCreateConditionWhenPolicyDoesNotExist() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final Response response = jersey.target("%s/cec42e01-62a7-4c86-9b8f-cd6650be2888/condition".formatted(V1_POLICY))
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "subject": "PACKAGE_URL",
+                          "operator": "MATCHES",
+                          "value": "pkg:maven/foo/bar"
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(getPlainTextBody(response)).isEqualTo("The UUID of the policy could not be found.");
+    }
+
+    @Test
+    public void testCreateConditionWhenUnauthorized() {
+        final Response response = jersey.target("%s/cec42e01-62a7-4c86-9b8f-cd6650be2888/condition".formatted(V1_POLICY))
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "subject": "PACKAGE_URL",
+                          "operator": "MATCHES",
+                          "value": "pkg:maven/foo/bar"
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    public void testUpdateCondition() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final var policy = new Policy();
+        policy.setName("foo");
+        policy.setOperator(Operator.ANY);
+        policy.setViolationState(ViolationState.INFO);
+        qm.persist(policy);
+
+        final var condition = new PolicyCondition();
+        condition.setPolicy(policy);
+        condition.setSubject(PolicyCondition.Subject.PACKAGE_URL);
+        condition.setOperator(PolicyCondition.Operator.MATCHES);
+        condition.setValue("pkg:maven/foo/bar");
+        qm.persist(condition);
+
+        final Response response = jersey.target("%s/condition".formatted(V1_POLICY))
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "uuid": "%s",
+                          "subject": "SEVERITY",
+                          "operator": "IS",
+                          "value": "HIGH"
+                        }
+                        """.formatted(condition.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .withMatcher("conditionUuid", equalTo(condition.getUuid().toString()))
+                .isEqualTo(/* language=JSON */ """
+                        {
+                          "uuid": "${json-unit.matches:conditionUuid}",
+                          "subject": "SEVERITY",
+                          "operator": "IS",
+                          "value": "HIGH"
+                        }
+                        """);
+    }
+
+    @Test
+    public void testUpdateConditionWhenConditionDoesNotExist() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final Response response = jersey.target("%s/condition".formatted(V1_POLICY))
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "uuid": "8683b1db-96a3-4014-baf8-03e8cab8c647",
+                          "subject": "SEVERITY",
+                          "operator": "IS",
+                          "value": "HIGH"
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(getPlainTextBody(response)).isEqualTo("The UUID of the policy condition could not be found.");
+    }
+
+    @Test
+    public void testUpdateConditionWhenUnauthorized() {
+        final Response response = jersey.target("%s/condition".formatted(V1_POLICY))
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "uuid": "8683b1db-96a3-4014-baf8-03e8cab8c647",
+                          "subject": "SEVERITY",
+                          "operator": "IS",
+                          "value": "HIGH"
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    public void testDeleteCondition() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final var policy = new Policy();
+        policy.setName("foo");
+        policy.setOperator(Operator.ANY);
+        policy.setViolationState(ViolationState.INFO);
+        qm.persist(policy);
+
+        final var condition = new PolicyCondition();
+        condition.setPolicy(policy);
+        condition.setSubject(PolicyCondition.Subject.PACKAGE_URL);
+        condition.setOperator(PolicyCondition.Operator.MATCHES);
+        condition.setValue("pkg:maven/foo/bar");
+        qm.persist(condition);
+
+        final Response response = jersey.target("%s/condition/%s".formatted(V1_POLICY, condition.getUuid()))
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+        assertThat(response.getStatus()).isEqualTo(204);
+        assertThat(getPlainTextBody(response)).isEmpty();
+
+        qm.getPersistenceManager().evictAll();
+        assertThatExceptionOfType(JDOObjectNotFoundException.class)
+                .isThrownBy(() -> qm.getObjectById(PolicyCondition.class, condition.getId()));
+    }
+
+    @Test
+    public void testDeleteConditionWhenConditionDoesNotExist() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final Response response = jersey.target("%s/condition/%s".formatted(V1_POLICY, UUID.randomUUID()))
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(getPlainTextBody(response)).isEqualTo("The UUID of the policy condition could not be found.");
+    }
+
+    @Test
+    public void testDeleteConditionWhenUnauthorized() {
+        final Response response = jersey.target("%s/condition/%s".formatted(V1_POLICY, UUID.randomUUID()))
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes infinite recursion during policy condition serialization.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

As of Alpine v3, objects are no longer unloaded and refreshed (with fetch groups) during `QueryManager#persist`.

In case of the `PolicyCondition` REST endpoints, the previous behavior caused `PolicyCondition#policy` to be unloaded, prior to serializing the `PolicyCondition` response.

With persistent objects no longer being unloaded and refreshed in `QueryManager#persist`, that behavior changed, leading to infinite recursion when serializing `PolicyCondition#policy`.

Resolved the issue by restoring the previous behavior of not returning policy data in any of the condition endpoints.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
