### PR TITLE
Change the default DataNucleus flush mode to `QUERY`

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -146,6 +146,11 @@ alpine.database.pool.max.lifetime=600000
 # DO NOT CHANGE UNLESS THERE IS A GOOD REASON TO.
 # alpine.datanucleus.cache.level2.type=
 
+# Optional
+# Controls the flushing behavior of DataNucleus, the Object Relational Mapper (ORM).
+# See https://www.datanucleus.org/products/accessplatform_6_0/jdo/persistence.html#transaction_flushing
+alpine.datanucleus.flush.mode=QUERY
+
 # Required
 # Specifies the number of bcrypt rounds to use when hashing a users password.
 # The higher the number the more secure the password, at the expense of


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

The default flush mode is `AUTO`, which flushes changes to the datastore whenever they are made (i.e. when setters are called on a persistent object).

This behavior can lead to increased database load, in particular when setters are called without prior check if the value being set is indeed different from the object's current value.

Switching to flush mode `QUERY` will cause DataNucleus to only flush changes upon explicit `.flush()` or `.commit()` calls, *or* just before another query is executed. This should significantly reduce the database calls performed by the ORM.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #4036

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
