### PR TITLE
Visible Endpoint returns only Visible Teams(name, uuid)

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
@@ -40,6 +40,7 @@ import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.validation.ValidUuid;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.v1.vo.TeamSelfResponse;
+import org.dependencytrack.resources.v1.vo.VisibleTeams;
 import org.owasp.security.logging.SecurityMarkers;
 
 import jakarta.validation.Validator;
@@ -228,7 +229,7 @@ public class TeamResource extends AlpineResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Returns a list of Teams that are visible", description = "<p></p>")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "The Visible Teams", content = @Content(array = @ArraySchema(schema = @Schema(implementation = Team.class)))),
+            @ApiResponse(responseCode = "200", description = "The Visible Teams", content = @Content(array = @ArraySchema(schema = @Schema(implementation = VisibleTeams.class)))),
             @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
     public Response availableTeams() {
@@ -246,7 +247,11 @@ public class TeamResource extends AlpineResource {
                 }
             }
 
-            return Response.ok(teams).build();
+            List<VisibleTeams> response = new ArrayList<VisibleTeams>();
+            for (Team team : teams) {
+                response.add(new VisibleTeams(team.getName(), team.getUuid()));
+            }
+            return Response.ok(response).build();
         }
     }
 

--- a/src/main/java/org/dependencytrack/resources/v1/vo/VisibleTeams.java
+++ b/src/main/java/org/dependencytrack/resources/v1/vo/VisibleTeams.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import java.util.UUID;
+
+public record VisibleTeams(String name, UUID uuid) {
+}


### PR DESCRIPTION
### Description

/team/visible Endpoints no longer returns hole team, but instead only name and uuid.

### Addressed Issue

Fixes [#4176](https://github.com/DependencyTrack/dependency-track/issues/4176)

### Additional Details
N/A
### Checklist


- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
~- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
~- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
