### PR TITLE
feat#4148 introduce is latest project flag & allow policies to be limited to latest version

### DIFF
--- a/src/main/java/org/dependencytrack/model/Policy.java
+++ b/src/main/java/org/dependencytrack/model/Policy.java
@@ -142,6 +142,10 @@ public class Policy implements Serializable {
     @Column(name = "INCLUDE_CHILDREN", allowsNull = "true") // New column, must allow nulls on existing data bases)
     private boolean includeChildren;
 
+    @Persistent
+    @Column(name = "ONLY_FOR_LATEST_PROJECT_VERSION", allowsNull = "true") // New column, must allow nulls for existing data bases
+    private boolean onlyForLatestProjectVersion;
+
     public long getId() {
         return id;
     }
@@ -223,5 +227,13 @@ public class Policy implements Serializable {
 
     public void setIncludeChildren(boolean includeChildren) {
         this.includeChildren = includeChildren;
+    }
+
+    public boolean isOnlyForLatestProjectVersion() {
+        return onlyForLatestProjectVersion;
+    }
+
+    public void setOnlyForLatestProjectVersion(boolean onlyForLatestProjectVersion) {
+        this.onlyForLatestProjectVersion = onlyForLatestProjectVersion;
     }
 }

--- a/src/main/java/org/dependencytrack/model/Policy.java
+++ b/src/main/java/org/dependencytrack/model/Policy.java
@@ -143,8 +143,8 @@ public class Policy implements Serializable {
     private boolean includeChildren;
 
     @Persistent
-    @Column(name = "ONLY_FOR_LATEST_PROJECT_VERSION", allowsNull = "true") // New column, must allow nulls for existing data bases
-    private boolean onlyForLatestProjectVersion;
+    @Column(name = "ONLY_LATEST_PROJECT_VERSION", defaultValue = "false")
+    private boolean onlyLatestProjectVersion = false;
 
     public long getId() {
         return id;
@@ -229,11 +229,11 @@ public class Policy implements Serializable {
         this.includeChildren = includeChildren;
     }
 
-    public boolean isOnlyForLatestProjectVersion() {
-        return onlyForLatestProjectVersion;
+    public boolean isOnlyLatestProjectVersion() {
+        return onlyLatestProjectVersion;
     }
 
-    public void setOnlyForLatestProjectVersion(boolean onlyForLatestProjectVersion) {
-        this.onlyForLatestProjectVersion = onlyForLatestProjectVersion;
+    public void setOnlyLatestProjectVersion(boolean onlyLatestProjectVersion) {
+        this.onlyLatestProjectVersion = onlyLatestProjectVersion;
     }
 }

--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -24,6 +24,7 @@ import alpine.server.json.TrimmedStringDeserializer;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonIncludeProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -95,7 +96,8 @@ import java.util.UUID;
                 @Persistent(name = "properties"),
                 @Persistent(name = "tags"),
                 @Persistent(name = "accessTeams"),
-                @Persistent(name = "metadata")
+                @Persistent(name = "metadata"),
+                @Persistent(name = "isLatest")
         }),
         @FetchGroup(name = "METADATA", members = {
                 @Persistent(name = "metadata")
@@ -109,6 +111,7 @@ import java.util.UUID;
                 @Persistent(name = "parent")
         })
 })
+@Index(name = "PROJECT_NAME_IS_LATEST_IDX", members = {"name", "isLatest"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Project implements Serializable {
 
@@ -269,6 +272,11 @@ public class Project implements Serializable {
     @Column(name = "ACTIVE")
     @JsonSerialize(nullsUsing = BooleanDefaultTrueSerializer.class)
     private Boolean active; // Added in v3.6. Existing records need to be nullable on upgrade.
+
+    @Persistent
+    @Index(name = "PROJECT_IS_LATEST_IDX")
+    @Column(name = "IS_LATEST", defaultValue = "false")
+    private Boolean isLatest; // Added in v4.12. Needs to be nullable therefore
 
     @Persistent(table = "PROJECT_ACCESS_TEAMS", defaultFetchGroup = "true")
     @Join(column = "PROJECT_ID")
@@ -511,6 +519,15 @@ public class Project implements Serializable {
 
     public void setActive(Boolean active) {
         this.active = active;
+    }
+
+    @JsonProperty("isLatest")
+    public Boolean isLatest() {
+        return isLatest != null ? isLatest : false;
+    }
+
+    public void setIsLatest(Boolean latest) {
+        isLatest = latest != null ? latest : false;
     }
 
     public String getBomRef() {

--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -111,7 +111,6 @@ import java.util.UUID;
                 @Persistent(name = "parent")
         })
 })
-@Index(name = "PROJECT_NAME_IS_LATEST_IDX", members = {"name", "isLatest"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Project implements Serializable {
 
@@ -276,7 +275,7 @@ public class Project implements Serializable {
     @Persistent
     @Index(name = "PROJECT_IS_LATEST_IDX")
     @Column(name = "IS_LATEST", defaultValue = "false")
-    private Boolean isLatest; // Added in v4.12. Needs to be nullable therefore
+    private boolean isLatest = false; // Added in v4.12.
 
     @Persistent(table = "PROJECT_ACCESS_TEAMS", defaultFetchGroup = "true")
     @Join(column = "PROJECT_ID")
@@ -522,8 +521,8 @@ public class Project implements Serializable {
     }
 
     @JsonProperty("isLatest")
-    public Boolean isLatest() {
-        return isLatest != null ? isLatest : false;
+    public boolean isLatest() {
+        return isLatest;
     }
 
     public void setIsLatest(Boolean latest) {

--- a/src/main/java/org/dependencytrack/persistence/PolicyQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/PolicyQueryManager.java
@@ -117,11 +117,13 @@ final class PolicyQueryManager extends QueryManager implements IQueryManager {
      * @param violationState the violation state
      * @return the created Policy
      */
-    public Policy createPolicy(String name, Policy.Operator operator, Policy.ViolationState violationState) {
+    public Policy createPolicy(String name, Policy.Operator operator, Policy.ViolationState violationState,
+                               boolean onlyForLatestProjectVersion) {
         final Policy policy = new Policy();
         policy.setName(name);
         policy.setOperator(operator);
         policy.setViolationState(violationState);
+        policy.setOnlyForLatestProjectVersion(onlyForLatestProjectVersion);
         return persist(policy);
     }
 

--- a/src/main/java/org/dependencytrack/persistence/PolicyQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/PolicyQueryManager.java
@@ -118,12 +118,12 @@ final class PolicyQueryManager extends QueryManager implements IQueryManager {
      * @return the created Policy
      */
     public Policy createPolicy(String name, Policy.Operator operator, Policy.ViolationState violationState,
-                               boolean onlyForLatestProjectVersion) {
+                               boolean onlyLatestProjectVersion) {
         final Policy policy = new Policy();
         policy.setName(name);
         policy.setOperator(operator);
         policy.setViolationState(violationState);
-        policy.setOnlyForLatestProjectVersion(onlyForLatestProjectVersion);
+        policy.setOnlyLatestProjectVersion(onlyLatestProjectVersion);
         return persist(policy);
     }
 

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryFilterBuilder.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryFilterBuilder.java
@@ -115,6 +115,11 @@ class ProjectQueryFilterBuilder {
         return this;
     }
 
+    public ProjectQueryFilterBuilder onlyLatestVersion() {
+        filterCriteria.add("(isLatest == true)");
+        return this;
+    }
+
     String buildFilter() {
         return String.join(" && ", this.filterCriteria);
     }

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -592,22 +592,6 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
             final boolean includeServices,
             final boolean includeAuditHistory,
             final boolean includeACL,
-            final boolean includePolicyViolations
-    ) {
-        return clone(from, newVersion, includeTags, includeProperties, includeComponents, includeServices, includeAuditHistory,
-                includeACL, includePolicyViolations, false);
-    }
-
-    @Override
-    public Project clone(
-            final UUID from,
-            final String newVersion,
-            final boolean includeTags,
-            final boolean includeProperties,
-            final boolean includeComponents,
-            final boolean includeServices,
-            final boolean includeAuditHistory,
-            final boolean includeACL,
             final boolean includePolicyViolations,
             final boolean makeCloneLatest
     ) {

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -267,6 +267,38 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         return project;
     }
 
+
+    /**
+     * Returns the latest version of a project by its name.
+     *
+     * @param name the name of the Project (required)
+     * @return a Project object representing the latest version, or null if not found
+     */
+    @Override
+    public Project getLatestProjectVersion(final String name) {
+        final Query<Project> query = pm.newQuery(Project.class);
+
+        final var filterBuilder = new ProjectQueryFilterBuilder()
+                .withName(name)
+                .onlyLatestVersion();
+
+        final String queryFilter = filterBuilder.buildFilter();
+        final Map<String, Object> params = filterBuilder.getParams();
+
+        preprocessACLs(query, queryFilter, params, false);
+        query.setFilter(queryFilter);
+        query.setRange(0, 1);
+
+        final Project project = singleResult(query.executeWithMap(params));
+        if (project != null) {
+            // set Metrics to prevent extra round trip
+            project.setMetrics(getMostRecentProjectMetrics(project));
+            // set ProjectVersions to prevent extra round trip
+            project.setVersions(getProjectVersions(project));
+        }
+        return project;
+    }
+
     /**
      * Returns a list of projects that are accessible by the specified team.
      * @param team the team the has access to Projects
@@ -397,35 +429,35 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
      * @return the created Project
      */
     @Override
-    public Project createProject(String name, String description, String version, List<Tag> tags, Project parent, PackageURL purl, boolean active, boolean commitIndex) {
+    public Project createProject(String name, String description, String version, List<Tag> tags, Project parent,
+                                 PackageURL purl, boolean active, boolean commitIndex) {
+        return createProject(name, description, version, tags, parent, purl, active, false, commitIndex);
+    }
+
+    /**
+     * Creates a new Project.
+     * @param name the name of the project to create
+     * @param description a description of the project
+     * @param version the project version
+     * @param tags a List of Tags - these will be resolved if necessary
+     * @param parent an optional parent Project
+     * @param purl an optional Package URL
+     * @param active specified if the project is active
+     * @param commitIndex specifies if the search index should be committed (an expensive operation)
+     * @return the created Project
+     */
+    @Override
+    public Project createProject(String name, String description, String version, List<Tag> tags, Project parent,
+                                 PackageURL purl, boolean active, boolean isLatest, boolean commitIndex) {
         final Project project = new Project();
         project.setName(name);
         project.setDescription(description);
         project.setVersion(version);
-        if (parent != null ) {
-            if (!Boolean.TRUE.equals(parent.isActive())){
-                throw new IllegalArgumentException("An inactive Parent cannot be selected as parent");
-            }
-            project.setParent(parent);
-        }
+        project.setParent(parent);
         project.setPurl(purl);
         project.setActive(active);
-        final Project result = persist(project);
-
-        final List<Tag> resolvedTags = resolveTags(tags);
-        bind(project, resolvedTags);
-
-        Event.dispatch(new IndexEvent(IndexEvent.Action.CREATE, result));
-        Notification.dispatch(new Notification()
-                .scope(NotificationScope.PORTFOLIO)
-                .group(NotificationGroup.PROJECT_CREATED)
-                .title(NotificationConstants.Title.PROJECT_CREATED)
-                .level(NotificationLevel.INFORMATIONAL)
-                .content(result.getName() + " was created")
-                .subject(NotificationUtil.toJson(pm.detachCopy(result)))
-        );
-        commitSearchIndex(commitIndex, Project.class);
-        return result;
+        project.setIsLatest(isLatest);
+        return createProject(project, tags, commitIndex);
     }
 
     /**
@@ -443,11 +475,36 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         if (project.isActive() == null) {
             project.setActive(Boolean.TRUE);
         }
-        final Project result = persist(project);
-        final List<Tag> resolvedTags = resolveTags(tags);
-        bind(project, resolvedTags);
+        if (project.isLatest() == null) {
+            project.setIsLatest(Boolean.FALSE);
+        }
+        final Project oldLatestProject = project.isLatest() ? getLatestProjectVersion(project.getName()) : null;
+        final Project result = callInTransaction(() -> {
+            // Remove isLatest flag from current latest project version, if the new project will be the latest
+            if(oldLatestProject != null) {
+                oldLatestProject.setIsLatest(false);
+                persist(oldLatestProject);
+            }
 
+            final Project newProject = persist(project);
+            final List<Tag> resolvedTags = resolveTags(tags);
+            bind(project, resolvedTags);
+            return newProject;
+        });
+
+        if(oldLatestProject != null) {
+            // if we removed isLatest flag from old version, dispatch update event for the old version
+            Event.dispatch(new IndexEvent(IndexEvent.Action.UPDATE, oldLatestProject));
+        }
         Event.dispatch(new IndexEvent(IndexEvent.Action.CREATE, result));
+        Notification.dispatch(new Notification()
+                .scope(NotificationScope.PORTFOLIO)
+                .group(NotificationGroup.PROJECT_CREATED)
+                .title(NotificationConstants.Title.PROJECT_CREATED)
+                .level(NotificationLevel.INFORMATIONAL)
+                .content(result.getName() + " was created")
+                .subject(NotificationUtil.toJson(pm.detachCopy(result)))
+        );
         commitSearchIndex(commitIndex, Project.class);
         return result;
     }
@@ -480,6 +537,14 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         }
         project.setActive(transientProject.isActive());
 
+        final Project oldLatestProject;
+        if(Boolean.TRUE.equals(transientProject.isLatest()) && Boolean.FALSE.equals(project.isLatest())) {
+            oldLatestProject = getLatestProjectVersion(project.getName());
+        } else {
+            oldLatestProject = null;
+        }
+        project.setIsLatest(transientProject.isLatest());
+
         if (transientProject.getParent() != null && transientProject.getParent().getUuid() != null) {
             if (project.getUuid().equals(transientProject.getParent().getUuid())){
                 throw new IllegalArgumentException("A project cannot select itself as a parent");
@@ -497,10 +562,23 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
             project.setParent(null);
         }
 
-        final List<Tag> resolvedTags = resolveTags(transientProject.getTags());
-        bind(project, resolvedTags);
+        final Project result = callInTransaction(() -> {
+            // Remove isLatest flag from current latest project version, if this project will be the latest now
+            if(oldLatestProject != null) {
+                oldLatestProject.setIsLatest(false);
+                persist(oldLatestProject);
+            }
 
-        final Project result = persist(project);
+            final List<Tag> resolvedTags = resolveTags(transientProject.getTags());
+            bind(project, resolvedTags);
+
+            return persist(project);
+        });
+
+        if(oldLatestProject != null) {
+            // if we removed isLatest flag from old version, dispatch update event for the old version
+            Event.dispatch(new IndexEvent(IndexEvent.Action.UPDATE, oldLatestProject));
+        }
         Event.dispatch(new IndexEvent(IndexEvent.Action.UPDATE, result));
         commitSearchIndex(commitIndex, Project.class);
         return result;
@@ -518,21 +596,45 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
             final boolean includeACL,
             final boolean includePolicyViolations
     ) {
-        final var jsonMapper = new JsonMapper();
+        return clone(from, newVersion, includeTags, includeProperties, includeComponents, includeServices, includeAuditHistory,
+                includeACL, includePolicyViolations, false);
+    }
 
+    @Override
+    public Project clone(
+            final UUID from,
+            final String newVersion,
+            final boolean includeTags,
+            final boolean includeProperties,
+            final boolean includeComponents,
+            final boolean includeServices,
+            final boolean includeAuditHistory,
+            final boolean includeACL,
+            final boolean includePolicyViolations,
+            final boolean makeCloneLatest
+    ) {
+        final Project source = getObjectByUuid(Project.class, from, Project.FetchGroup.ALL.name());
+        if (source == null) {
+            LOGGER.warn("Project was supposed to be cloned, but it does not exist anymore");
+            return null;
+        }
+        if (doesProjectExist(source.getName(), newVersion)) {
+            // Project cloning is an asynchronous process. When receiving the clone request, we already perform
+            // this check. It is possible though that a project with the new version is created synchronously
+            // between the clone event being dispatched, and it being processed.
+            LOGGER.warn("Project was supposed to be cloned to version %s, but that version already exists".formatted(newVersion));
+            return null;
+        }
+
+        final Project oldLatestProject;
+        if(makeCloneLatest) {
+            oldLatestProject = source.isLatest() ? source : getLatestProjectVersion(source.getName());
+        } else {
+            oldLatestProject = null;
+        }
+
+        final var jsonMapper = new JsonMapper();
         final Project clonedProject = callInTransaction(() -> {
-            final Project source = getObjectByUuid(Project.class, from, Project.FetchGroup.ALL.name());
-            if (source == null) {
-                LOGGER.warn("Project was supposed to be cloned, but it does not exist anymore");
-                return null;
-            }
-            if (doesProjectExist(source.getName(), newVersion)) {
-                // Project cloning is an asynchronous process. When receiving the clone request, we already perform
-                // this check. It is possible though that a project with the new version is created synchronously
-                // between the clone event being dispatched, and it being processed.
-                LOGGER.warn("Project was supposed to be cloned to version %s, but that version already exists".formatted(newVersion));
-                return null;
-            }
             Project project = new Project();
             project.setAuthors(source.getAuthors());
             project.setManufacturer(source.getManufacturer());
@@ -544,6 +646,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
             project.setVersion(newVersion);
             project.setClassifier(source.getClassifier());
             project.setActive(source.isActive());
+            project.setIsLatest(makeCloneLatest);
             project.setCpe(source.getCpe());
             project.setPurl(source.getPurl());
             project.setSwidTagId(source.getSwidTagId());
@@ -551,6 +654,13 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                 project.setDirectDependencies(source.getDirectDependencies());
             }
             project.setParent(source.getParent());
+
+            // Remove isLatest flag from current latest project version, if this project will be the latest now
+            if(oldLatestProject != null) {
+                oldLatestProject.setIsLatest(false);
+                persist(oldLatestProject);
+            }
+
             project = persist(project);
 
             if (source.getMetadata() != null) {
@@ -703,6 +813,10 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
             return project;
         });
 
+        if(oldLatestProject != null) {
+            // if we removed isLatest flag from old version, dispatch update event for the old version
+            Event.dispatch(new IndexEvent(IndexEvent.Action.UPDATE, oldLatestProject));
+        }
         Event.dispatch(new IndexEvent(IndexEvent.Action.CREATE, clonedProject));
         commitSearchIndex(true, Project.class);
         return clonedProject;

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -692,8 +692,8 @@ public class QueryManager extends AlpineQueryManager {
     public Policy createPolicy(String name, Policy.Operator operator, Policy.ViolationState violationState) {
         return this.createPolicy(name, operator, violationState, false);
     }
-    public Policy createPolicy(String name, Policy.Operator operator, Policy.ViolationState violationState, boolean onlyForLatestProjectVersion) {
-        return getPolicyQueryManager().createPolicy(name, operator, violationState, onlyForLatestProjectVersion);
+    public Policy createPolicy(String name, Policy.Operator operator, Policy.ViolationState violationState, boolean onlyLatestProjectVersion) {
+        return getPolicyQueryManager().createPolicy(name, operator, violationState, onlyLatestProjectVersion);
     }
 
     public void removeProjectFromPolicies(final Project project) {

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -690,7 +690,10 @@ public class QueryManager extends AlpineQueryManager {
     }
 
     public Policy createPolicy(String name, Policy.Operator operator, Policy.ViolationState violationState) {
-        return getPolicyQueryManager().createPolicy(name, operator, violationState);
+        return this.createPolicy(name, operator, violationState, false);
+    }
+    public Policy createPolicy(String name, Policy.Operator operator, Policy.ViolationState violationState, boolean onlyForLatestProjectVersion) {
+        return getPolicyQueryManager().createPolicy(name, operator, violationState, onlyForLatestProjectVersion);
     }
 
     public void removeProjectFromPolicies(final Project project) {

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -417,6 +417,10 @@ public class QueryManager extends AlpineQueryManager {
         return getProjectQueryManager().getProject(name, version);
     }
 
+    public Project getLatestProjectVersion(final String name) {
+        return getProjectQueryManager().getLatestProjectVersion(name);
+    }
+
     public PaginatedResult getProjects(final Team team, final boolean excludeInactive, final boolean bypass, final boolean onlyRoot) {
         return getProjectQueryManager().getProjects(team, excludeInactive, bypass, onlyRoot);
     }
@@ -484,6 +488,10 @@ public class QueryManager extends AlpineQueryManager {
     public Project createProject(String name, String description, String version, List<Tag> tags, Project parent, PackageURL purl, boolean active, boolean commitIndex) {
         return getProjectQueryManager().createProject(name, description, version, tags, parent, purl, active, commitIndex);
     }
+    public Project createProject(String name, String description, String version, List<Tag> tags, Project parent,
+                                 PackageURL purl, boolean active, boolean isLatest, boolean commitIndex) {
+        return getProjectQueryManager().createProject(name, description, version, tags, parent, purl, active, isLatest, commitIndex);
+    }
 
     public Project createProject(final Project project, List<Tag> tags, boolean commitIndex) {
         return getProjectQueryManager().createProject(project, tags, commitIndex);
@@ -502,6 +510,13 @@ public class QueryManager extends AlpineQueryManager {
                          boolean includeACL, boolean includePolicyViolations) {
         return getProjectQueryManager().clone(from, newVersion, includeTags, includeProperties,
                 includeComponents, includeServices, includeAuditHistory, includeACL, includePolicyViolations);
+    }
+
+    public Project clone(UUID from, String newVersion, boolean includeTags, boolean includeProperties,
+                         boolean includeComponents, boolean includeServices, boolean includeAuditHistory,
+                         boolean includeACL, boolean includePolicyViolations, boolean makeCloneLatest) {
+        return getProjectQueryManager().clone(from, newVersion, includeTags, includeProperties,
+                includeComponents, includeServices, includeAuditHistory, includeACL, includePolicyViolations, makeCloneLatest);
     }
 
     public Project updateLastBomImport(Project p, Date date, String bomFormat) {

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -507,13 +507,6 @@ public class QueryManager extends AlpineQueryManager {
 
     public Project clone(UUID from, String newVersion, boolean includeTags, boolean includeProperties,
                          boolean includeComponents, boolean includeServices, boolean includeAuditHistory,
-                         boolean includeACL, boolean includePolicyViolations) {
-        return getProjectQueryManager().clone(from, newVersion, includeTags, includeProperties,
-                includeComponents, includeServices, includeAuditHistory, includeACL, includePolicyViolations);
-    }
-
-    public Project clone(UUID from, String newVersion, boolean includeTags, boolean includeProperties,
-                         boolean includeComponents, boolean includeServices, boolean includeAuditHistory,
                          boolean includeACL, boolean includePolicyViolations, boolean makeCloneLatest) {
         return getProjectQueryManager().clone(from, newVersion, includeTags, includeProperties,
                 includeComponents, includeServices, includeAuditHistory, includeACL, includePolicyViolations, makeCloneLatest);

--- a/src/main/java/org/dependencytrack/policy/PolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/PolicyEngine.java
@@ -80,6 +80,9 @@ public class PolicyEngine {
         final List<PolicyViolation> policyViolations = new ArrayList<>();
         final List<PolicyViolation> existingPolicyViolations = qm.detach(qm.getAllPolicyViolations(component));
         for (final Policy policy : policies) {
+            if(policy.isOnlyForLatestProjectVersion() && Boolean.FALSE.equals(component.getProject().isLatest())) {
+                continue;
+            }
             if (policy.isGlobal() || isPolicyAssignedToProject(policy, component.getProject())
                     || isPolicyAssignedToProjectTag(policy, component.getProject())) {
                 LOGGER.debug("Evaluating component (" + component.getUuid() + ") against policy (" + policy.getUuid() + ")");

--- a/src/main/java/org/dependencytrack/policy/PolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/PolicyEngine.java
@@ -80,7 +80,7 @@ public class PolicyEngine {
         final List<PolicyViolation> policyViolations = new ArrayList<>();
         final List<PolicyViolation> existingPolicyViolations = qm.detach(qm.getAllPolicyViolations(component));
         for (final Policy policy : policies) {
-            if(policy.isOnlyForLatestProjectVersion() && Boolean.FALSE.equals(component.getProject().isLatest())) {
+            if(policy.isOnlyLatestProjectVersion() && Boolean.FALSE.equals(component.getProject().isLatest())) {
                 continue;
             }
             if (policy.isGlobal() || isPolicyAssignedToProject(policy, component.getProject())

--- a/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
@@ -157,7 +157,7 @@ public class PolicyResource extends AlpineResource {
                 }
                 policy = qm.createPolicy(
                         StringUtils.trimToNull(jsonPolicy.getName()),
-                        operator, violationState);
+                        operator, violationState, jsonPolicy.isOnlyForLatestProjectVersion());
                 return Response.status(Response.Status.CREATED).entity(policy).build();
             } else {
                 return Response.status(Response.Status.CONFLICT).entity("A policy with the specified name already exists.").build();
@@ -194,6 +194,7 @@ public class PolicyResource extends AlpineResource {
                 policy.setOperator(jsonPolicy.getOperator());
                 policy.setViolationState(jsonPolicy.getViolationState());
                 policy.setIncludeChildren(jsonPolicy.isIncludeChildren());
+                policy.setOnlyForLatestProjectVersion(jsonPolicy.isOnlyForLatestProjectVersion());
                 policy = qm.persist(policy);
                 return Response.ok(policy).build();
             } else {

--- a/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
@@ -157,7 +157,7 @@ public class PolicyResource extends AlpineResource {
                 }
                 policy = qm.createPolicy(
                         StringUtils.trimToNull(jsonPolicy.getName()),
-                        operator, violationState, jsonPolicy.isOnlyForLatestProjectVersion());
+                        operator, violationState, jsonPolicy.isOnlyLatestProjectVersion());
                 return Response.status(Response.Status.CREATED).entity(policy).build();
             } else {
                 return Response.status(Response.Status.CONFLICT).entity("A policy with the specified name already exists.").build();
@@ -194,7 +194,7 @@ public class PolicyResource extends AlpineResource {
                 policy.setOperator(jsonPolicy.getOperator());
                 policy.setViolationState(jsonPolicy.getViolationState());
                 policy.setIncludeChildren(jsonPolicy.isIncludeChildren());
-                policy.setOnlyForLatestProjectVersion(jsonPolicy.isOnlyForLatestProjectVersion());
+                policy.setOnlyLatestProjectVersion(jsonPolicy.isOnlyLatestProjectVersion());
                 policy = qm.persist(policy);
                 return Response.ok(policy).build();
             } else {

--- a/src/main/java/org/dependencytrack/resources/v1/vo/BomSubmitRequest.java
+++ b/src/main/java/org/dependencytrack/resources/v1/vo/BomSubmitRequest.java
@@ -72,13 +72,16 @@ public final class BomSubmitRequest {
 
     private final boolean autoCreate;
 
+    private final boolean isLatestProjectVersion;
+
     public BomSubmitRequest(String project,
                             String projectName,
                             String projectVersion,
                             List<Tag> projectTags,
                             boolean autoCreate,
+                            boolean isLatestProjectVersion,
                             String bom) {
-        this(project, projectName, projectVersion, projectTags, autoCreate, null, null, null, bom);
+        this(project, projectName, projectVersion, projectTags, autoCreate, null, null, null, isLatestProjectVersion, bom);
     }
 
     @JsonCreator
@@ -90,6 +93,7 @@ public final class BomSubmitRequest {
                             @JsonProperty(value = "parentUUID") String parentUUID,
                             @JsonProperty(value = "parentName") String parentName,
                             @JsonProperty(value = "parentVersion") String parentVersion,
+                            @JsonProperty(value = "isLatestProjectVersion", defaultValue = "false") boolean isLatestProjectVersion,
                             @JsonProperty(value = "bom", required = true) String bom) {
         this.project = project;
         this.projectName = projectName;
@@ -99,6 +103,7 @@ public final class BomSubmitRequest {
         this.parentUUID = parentUUID;
         this.parentName = parentName;
         this.parentVersion = parentVersion;
+        this.isLatestProjectVersion = isLatestProjectVersion;
         this.bom = bom;
     }
 
@@ -140,6 +145,9 @@ public final class BomSubmitRequest {
     public boolean isAutoCreate() {
         return autoCreate;
     }
+
+    @JsonProperty("isLatestProjectVersion")
+    public boolean isLatestProjectVersion() { return isLatestProjectVersion; }
 
     @Schema(
             description = "Base64 encoded BOM",

--- a/src/main/java/org/dependencytrack/resources/v1/vo/CloneProjectRequest.java
+++ b/src/main/java/org/dependencytrack/resources/v1/vo/CloneProjectRequest.java
@@ -61,6 +61,8 @@ public class CloneProjectRequest {
 
     private final boolean includePolicyViolations;
 
+    private final boolean makeCloneLatest;
+
     @JsonCreator
     public CloneProjectRequest(@JsonProperty(value = "project", required = true) String project,
                                @JsonProperty(value = "version", required = true) String version,
@@ -71,8 +73,10 @@ public class CloneProjectRequest {
                                @JsonProperty(value = "includeServices") boolean includeServices,
                                @JsonProperty(value = "includeAuditHistory") boolean includeAuditHistory,
                                @JsonProperty(value = "includeACL") boolean includeACL,
-                               @JsonProperty(value = "includePolicyViolations") boolean includePolicyViolations) {
-                                    if (includeDependencies) { // For backward compatibility
+                               @JsonProperty(value = "includePolicyViolations") boolean includePolicyViolations,
+                               @JsonProperty(value = "makeCloneLatest", defaultValue = "false") boolean makeCloneLatest) {
+
+        if (includeDependencies) { // For backward compatibility
             includeComponents = true;
         }
         this.project = project;
@@ -85,6 +89,7 @@ public class CloneProjectRequest {
         this.includeAuditHistory = includeAuditHistory;
         this.includeACL = includeACL;
         this.includePolicyViolations = includePolicyViolations;
+        this.makeCloneLatest = makeCloneLatest;
     }
 
     public String getProject() {
@@ -127,4 +132,7 @@ public class CloneProjectRequest {
         return includePolicyViolations;
     }
 
+    public boolean makeCloneLatest() {
+        return makeCloneLatest;
+    }
 }

--- a/src/main/java/org/dependencytrack/tasks/CloneProjectTask.java
+++ b/src/main/java/org/dependencytrack/tasks/CloneProjectTask.java
@@ -55,7 +55,8 @@ public class CloneProjectTask implements Subscriber {
                         request.includeServices(),
                         request.includeAuditHistory(),
                         request.includeACL(),
-                        request.includePolicyViolations()
+                        request.includePolicyViolations(),
+                        request.makeCloneLatest()
                 );
                 LOGGER.info("Cloned project for version %s into project %s".formatted(project.getVersion(), project.getUuid()));
             } catch (RuntimeException ex) {

--- a/src/main/java/org/dependencytrack/upgrade/v4120/v4120Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v4120/v4120Updater.java
@@ -295,6 +295,9 @@ public class v4120Updater extends AbstractUpgradeItem {
             stmt.executeUpdate("""
                     UPDATE "PROJECT" SET "IS_LATEST" = false
                     """);
+            stmt.executeUpdate("""
+                    UPDATE "POLICY" SET "ONLY_FOR_LATEST_PROJECT_VERSION" = false
+                    """);
         }
     }
 

--- a/src/main/java/org/dependencytrack/upgrade/v4120/v4120Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v4120/v4120Updater.java
@@ -48,7 +48,8 @@ public class v4120Updater extends AbstractUpgradeItem {
         migrateBomValidationConfigProperty(connection);
         extendTeamNameColumnMaxLength(connection);
         migrateAuthorToAuthors(connection);
-        dropAuthorColumns(connection);
+        dropAuthorColumns(connection);        
+        setInitialIsLatestFlags(connection);
     }
 
     private static void removeExperimentalBomUploadProcessingV2ConfigProperty(final Connection connection) throws SQLException {
@@ -282,6 +283,17 @@ public class v4120Updater extends AbstractUpgradeItem {
                     """);
             stmt.executeUpdate("""
                     ALTER TABLE "COMPONENT" DROP COLUMN "AUTHOR"
+                    """);
+        }
+    }
+
+
+
+    private void setInitialIsLatestFlags(Connection connection) throws SQLException {
+        LOGGER.info("Setting IS_LATEST flag to false for all Project entries");
+        try (final Statement stmt = connection.createStatement()) {
+            stmt.executeUpdate("""
+                    UPDATE "PROJECT" SET "IS_LATEST" = false
                     """);
         }
     }

--- a/src/main/java/org/dependencytrack/upgrade/v4120/v4120Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v4120/v4120Updater.java
@@ -48,8 +48,7 @@ public class v4120Updater extends AbstractUpgradeItem {
         migrateBomValidationConfigProperty(connection);
         extendTeamNameColumnMaxLength(connection);
         migrateAuthorToAuthors(connection);
-        dropAuthorColumns(connection);        
-        setInitialIsLatestFlags(connection);
+        dropAuthorColumns(connection);
     }
 
     private static void removeExperimentalBomUploadProcessingV2ConfigProperty(final Connection connection) throws SQLException {
@@ -283,20 +282,6 @@ public class v4120Updater extends AbstractUpgradeItem {
                     """);
             stmt.executeUpdate("""
                     ALTER TABLE "COMPONENT" DROP COLUMN "AUTHOR"
-                    """);
-        }
-    }
-
-
-
-    private void setInitialIsLatestFlags(Connection connection) throws SQLException {
-        LOGGER.info("Setting IS_LATEST flag to false for all Project entries");
-        try (final Statement stmt = connection.createStatement()) {
-            stmt.executeUpdate("""
-                    UPDATE "PROJECT" SET "IS_LATEST" = false
-                    """);
-            stmt.executeUpdate("""
-                    UPDATE "POLICY" SET "ONLY_FOR_LATEST_PROJECT_VERSION" = false
                     """);
         }
     }

--- a/src/test/java/org/dependencytrack/ResourceTest.java
+++ b/src/test/java/org/dependencytrack/ResourceTest.java
@@ -62,6 +62,7 @@ public abstract class ResourceTest {
     protected final String V1_POLICY = "/v1/policy";
     protected final String V1_POLICY_VIOLATION = "/v1/violation";
     protected final String V1_PROJECT = "/v1/project";
+    protected final String V1_PROJECT_LATEST = "/v1/project/latest/";
     protected final String V1_REPOSITORY = "/v1/repository";
     protected final String V1_SCAN = "/v1/scan";
     protected final String V1_SEARCH = "/v1/search";

--- a/src/test/java/org/dependencytrack/ResourceTest.java
+++ b/src/test/java/org/dependencytrack/ResourceTest.java
@@ -24,6 +24,7 @@ import alpine.model.Team;
 import alpine.server.auth.PasswordService;
 import alpine.server.persistence.PersistenceManagerFactory;
 import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.persistence.QueryManager;
 import org.junit.After;
 import org.junit.Before;
@@ -121,6 +122,16 @@ public abstract class ResourceTest {
         }
         team.setPermissions(permissionList);
         qm.persist(team);
+    }
+
+    protected void enablePortfolioAccessControl() {
+        qm.createConfigProperty(
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
+                "true",
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyType(),
+                null
+        );
     }
 
     protected String getPlainTextBody(Response response) {

--- a/src/test/java/org/dependencytrack/event/CloneProjectEventTest.java
+++ b/src/test/java/org/dependencytrack/event/CloneProjectEventTest.java
@@ -29,7 +29,9 @@ public class CloneProjectEventTest {
     @Test
     public void testEvent() {
         UUID uuid = UUID.randomUUID();
-        CloneProjectRequest request = new CloneProjectRequest(uuid.toString(), "1.0", true, true, true, true, true, true, true, true);
+        CloneProjectRequest request = new CloneProjectRequest(uuid.toString(), "1.0", true,
+                true, true, true, true, true,
+                true, true, false);
         CloneProjectEvent event = new CloneProjectEvent(request);
         Assert.assertEquals(request, event.getRequest());
     }

--- a/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
@@ -18,7 +18,6 @@
  */
 package org.dependencytrack.persistence;
 
-import alpine.persistence.PaginatedResult;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.*;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
@@ -27,8 +26,6 @@ import org.junit.Test;
 
 import java.util.Date;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProjectQueryManagerTest extends PersistenceCapableTest {
 
@@ -48,7 +45,8 @@ public class ProjectQueryManagerTest extends PersistenceCapableTest {
         vuln.setSeverity(Severity.HIGH);
         qm.persist(vuln);
         qm.addVulnerability(vuln, comp, AnalyzerIdentity.INTERNAL_ANALYZER, "Vuln1", "http://vuln.com/vuln1", new Date(1708559165229L));
-        Project clonedProject = qm.clone(project.getUuid(), "1.1.0", false, false, true, false, false, false, false);
+        Project clonedProject = qm.clone(project.getUuid(), "1.1.0", false, false,
+                true, false, false, false, false, false);
         List<Finding> findings = qm.getFindings(clonedProject);
         Assert.assertEquals(1, findings.size());
         Finding finding = findings.get(0);

--- a/src/test/java/org/dependencytrack/policy/PolicyEngineTest.java
+++ b/src/test/java/org/dependencytrack/policy/PolicyEngineTest.java
@@ -196,6 +196,52 @@ public class PolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
+    public void policyForLatestTriggersOnLatestVersion() {
+        Policy policy = qm.createPolicy("Test Policy", Operator.ANY, ViolationState.INFO, true);
+        qm.createPolicyCondition(policy, Subject.SEVERITY, PolicyCondition.Operator.IS, Severity.CRITICAL.name());
+        Project project = qm.createProject("My Project", null, "1", null, null,
+                null, true, true, false);
+        Component component = new Component();
+        component.setName("Test Component");
+        component.setVersion("1.0");
+        component.setProject(project);
+        Vulnerability vulnerability = new Vulnerability();
+        vulnerability.setVulnId("12345");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.CRITICAL);
+        qm.persist(project);
+        qm.persist(component);
+        qm.persist(vulnerability);
+        qm.addVulnerability(vulnerability, component, AnalyzerIdentity.INTERNAL_ANALYZER);
+        PolicyEngine policyEngine = new PolicyEngine();
+        List<PolicyViolation> violations = policyEngine.evaluate(List.of(component));
+        Assert.assertEquals(1, violations.size());
+    }
+
+    @Test
+    public void policyForLatestTriggersNotOnNotLatestVersion() {
+        Policy policy = qm.createPolicy("Test Policy", Operator.ANY, ViolationState.INFO, true);
+        qm.createPolicyCondition(policy, Subject.SEVERITY, PolicyCondition.Operator.IS, Severity.CRITICAL.name());
+        Project project = qm.createProject("My Project", null, "1", null, null,
+                null, true, false, false);
+        Component component = new Component();
+        component.setName("Test Component");
+        component.setVersion("1.0");
+        component.setProject(project);
+        Vulnerability vulnerability = new Vulnerability();
+        vulnerability.setVulnId("12345");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.CRITICAL);
+        qm.persist(project);
+        qm.persist(component);
+        qm.persist(vulnerability);
+        qm.addVulnerability(vulnerability, component, AnalyzerIdentity.INTERNAL_ANALYZER);
+        PolicyEngine policyEngine = new PolicyEngine();
+        List<PolicyViolation> violations = policyEngine.evaluate(List.of(component));
+        Assert.assertEquals(0, violations.size());
+    }
+
+    @Test
     public void determineViolationTypeTest() {
         PolicyCondition policyCondition = new PolicyCondition();
         policyCondition.setSubject(null);

--- a/src/test/java/org/dependencytrack/policy/PolicyEngineTest.java
+++ b/src/test/java/org/dependencytrack/policy/PolicyEngineTest.java
@@ -388,13 +388,17 @@ public class PolicyEngineTest extends PersistenceCapableTest {
         // Evaluate policies and ensure that a notification has been sent.
         final var policyEngine = new PolicyEngine();
         assertThat(policyEngine.evaluate(List.of(component))).hasSize(1);
-        assertThat(NOTIFICATIONS).hasSize(1);
+        assertThat(NOTIFICATIONS).hasSize(2);
 
         // Create an additional policy condition that matches on the exact version of the component,
         // and re-evaluate policies. Ensure that only one notification per newly violated condition was sent.
         final var policyConditionB = qm.createPolicyCondition(policy, Subject.VERSION, PolicyCondition.Operator.NUMERIC_EQUAL, "1.2.3");
         assertThat(policyEngine.evaluate(List.of(component))).hasSize(2);
         assertThat(NOTIFICATIONS).satisfiesExactly(
+                notification -> {
+                    assertThat(notification.getScope()).isEqualTo(NotificationScope.PORTFOLIO.name());
+                    assertThat(notification.getGroup()).isEqualTo(NotificationGroup.PROJECT_CREATED.name());
+                },
                 notification -> {
                     assertThat(notification.getScope()).isEqualTo(NotificationScope.PORTFOLIO.name());
                     assertThat(notification.getGroup()).isEqualTo(NotificationGroup.POLICY_VIOLATION.name());
@@ -420,7 +424,7 @@ public class PolicyEngineTest extends PersistenceCapableTest {
         // Delete a policy condition and re-evaluate policies again. No new notifications should be sent.
         qm.deletePolicyCondition(policyConditionA);
         assertThat(policyEngine.evaluate(List.of(component))).hasSize(1);
-        assertThat(NOTIFICATIONS).hasSize(2);
+        assertThat(NOTIFICATIONS).hasSize(3);
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -1397,7 +1397,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
         awaitBomProcessedNotification(bomUploadEvent);
         NOTIFICATIONS.clear();
 
-        final Project clonedProject = qm.clone(project.getUuid(), "3.2.1", true, true, true, true, true, true, true);
+        final Project clonedProject = qm.clone(project.getUuid(), "3.2.1", true, true, true, true, true, true, true, false);
 
         bomBytes = """
                 {

--- a/src/test/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTaskTest.java
@@ -38,6 +38,7 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.notification.NotificationGroup;
+import org.dependencytrack.notification.NotificationScope;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -413,13 +414,19 @@ public class TrivyAnalysisTaskTest extends PersistenceCapableTest {
 
         assertThat(qm.getCount(ComponentAnalysisCache.class)).isZero();
 
-        assertThat(NOTIFICATIONS).satisfiesExactly(notification -> {
-            assertThat(notification.getGroup()).isEqualTo(NotificationGroup.ANALYZER.name());
-            assertThat(notification.getLevel()).isEqualTo(NotificationLevel.ERROR);
-            assertThat(notification.getContent()).isEqualTo("""
-                    An error occurred while communicating with a vulnerability intelligence source. \
-                    Check log for details. Connection reset""");
-        });
+        assertThat(NOTIFICATIONS).satisfiesExactly(
+                notification -> {
+                    assertThat(notification.getScope()).isEqualTo(NotificationScope.PORTFOLIO.name());
+                    assertThat(notification.getGroup()).isEqualTo(NotificationGroup.PROJECT_CREATED.name());
+                },
+                notification -> {
+                    assertThat(notification.getGroup()).isEqualTo(NotificationGroup.ANALYZER.name());
+                    assertThat(notification.getLevel()).isEqualTo(NotificationLevel.ERROR);
+                    assertThat(notification.getContent()).isEqualTo("""
+                            An error occurred while communicating with a vulnerability intelligence source. \
+                            Check log for details. Connection reset""");
+                }
+        );
 
         wireMock.verify(exactly(1), postRequestedFor(urlPathEqualTo("/twirp/trivy.cache.v1.Cache/PutBlob")));
         wireMock.verify(exactly(0), postRequestedFor(urlPathEqualTo("/twirp/trivy.scanner.v1.Scanner/Scan")));

--- a/src/test/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTaskTest.java
@@ -316,8 +316,12 @@ public class TrivyAnalysisTaskTest extends PersistenceCapableTest {
 
         assertThat(qm.getCount(ComponentAnalysisCache.class)).isOne();
 
-        assertThat(NOTIFICATIONS).satisfiesExactly(notification ->
-                assertThat(notification.getGroup()).isEqualTo(NotificationGroup.NEW_VULNERABILITY.name()));
+        assertThat(NOTIFICATIONS).satisfiesExactly(
+                notification ->
+                        assertThat(notification.getGroup()).isEqualTo(NotificationGroup.PROJECT_CREATED.name()),
+                notification ->
+                        assertThat(notification.getGroup()).isEqualTo(NotificationGroup.NEW_VULNERABILITY.name())
+        );
 
         wireMock.verify(postRequestedFor(urlPathEqualTo("/twirp/trivy.cache.v1.Cache/PutBlob"))
                 .withHeader("Trivy-Token", equalTo("token"))
@@ -382,7 +386,10 @@ public class TrivyAnalysisTaskTest extends PersistenceCapableTest {
 
         assertThat(qm.getCount(ComponentAnalysisCache.class)).isZero();
 
-        assertThat(NOTIFICATIONS).isEmpty();
+        assertThat(NOTIFICATIONS).satisfiesExactly(
+                notification ->
+                        assertThat(notification.getGroup()).isEqualTo(NotificationGroup.PROJECT_CREATED.name())
+                );
 
         wireMock.verify(postRequestedFor(urlPathEqualTo("/twirp/trivy.cache.v1.Cache/PutBlob")));
         wireMock.verify(postRequestedFor(urlPathEqualTo("/twirp/trivy.scanner.v1.Scanner/Scan")));


### PR DESCRIPTION
### Description
Frontend PR: https://github.com/DependencyTrack/frontend/pull/1017

Implements #4148 : 
1. Allows projects to be marked as "latest version" via API endpoints allowing creation and updating of projects
2. It is ensured only 1 project version (per project name) is marked as latest, previously marked version is no longer set to latest after a new version is set to latest
3. Allows policies to be limited to project versions marked as latest (e.g. helpful to only apply the version distance policy to the latest development version)
4. Fixed Bug: ProjectQueryManager contains 2 createProject() Methods, but only one triggered a PROJECT_CREATED event. Refactored both methods to use same implementation to avoid such inconsistencies.

### Addressed Issue

closes #4148 

### Additional Details


### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
