### PR TITLE
Fix breaking change in `PUT /api/v1/project` endpoint

### DIFF
--- a/src/main/java/org/dependencytrack/util/PersistenceUtil.java
+++ b/src/main/java/org/dependencytrack/util/PersistenceUtil.java
@@ -233,7 +233,7 @@ public final class PersistenceUtil {
         objects.forEach(object -> assertNonPersistent(object, message));
     }
 
-    private static boolean isPersistent(final Object object) {
+    public static boolean isPersistent(final Object object) {
         final ObjectState objectState = JDOHelper.getObjectState(object);
         return objectState == PERSISTENT_CLEAN
                 || objectState == PERSISTENT_DIRTY


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes breaking change in `PUT /api/v1/project` endpoint.

With #4093, the `accessTeams` field became a required request parameter if portfolio ACL is enabled. While it does make sense to enforce team assignment, it is a breaking change in the REST API and as such cannot be done in a minor version release.

Make `accessTeams` optional. Also:

* Enable `accessTeams` to be specified by `name`, not only by `uuid`
* Document this feature in the OpenAPI spec
* Reduce nesting in the `ProjectResource#createProject` method
* Enhance tests to be more explicit and assert response content

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #4092

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
