### PR TITLE
Fix OSV severity level calculation

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
+++ b/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
@@ -290,14 +290,13 @@ public class OsvDownloadTask implements LoggableSubscriber {
             }
         }
         // get largest ecosystem_specific severity from its affected packages
-        if (advisory.getAffectedPackages() != null) {
+        if (!advisory.getAffectedPackages().isEmpty()) {
             List<Integer> severityLevels = new ArrayList<>();
             for (OsvAffectedPackage vuln : advisory.getAffectedPackages()) {
                 severityLevels.add(vuln.getSeverity().getLevel());
             }
             Collections.sort(severityLevels);
-            Collections.reverse(severityLevels);
-            return getSeverityByLevel(severityLevels.get(0));
+            return getSeverityByLevel(severityLevels.getLast());
         }
         return Severity.UNASSIGNED;
     }

--- a/src/test/java/org/dependencytrack/tasks/OsvDownloadTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/OsvDownloadTaskTest.java
@@ -428,6 +428,12 @@ public class OsvDownloadTaskTest extends PersistenceCapableTest {
         Assert.assertNotNull(advisory);
         severity = task.calculateOSVSeverity(advisory);
         Assert.assertEquals(Severity.UNASSIGNED, severity);
+
+        prepareJsonObject("src/test/resources/unit/osv.jsons/osv-CURL-CVE-2009-0037.json");
+        advisory = parser.parse(jsonObject);
+        Assert.assertNotNull(advisory);
+        severity = task.calculateOSVSeverity(advisory);
+        Assert.assertEquals(Severity.UNASSIGNED, severity);
     }
 
     @Test

--- a/src/test/resources/unit/osv.jsons/osv-CURL-CVE-2009-0037.json
+++ b/src/test/resources/unit/osv.jsons/osv-CURL-CVE-2009-0037.json
@@ -1,0 +1,145 @@
+{
+  "id": "CURL-CVE-2009-0037",
+  "summary": "Arbitrary File Access",
+  "details": "When told to follow a \"redirect\" automatically, libcurl does not question the\nnew target URL but follows it to any new URL that it understands. As libcurl\nsupports FILE:// URLs, a rogue server can thus \"trick\" a libcurl-using\napplication to read a local file instead of the remote one.\n\nThis is a problem, for example, when the application is running on a server\nand is written to upload or to otherwise provide the transferred data to a\nuser, to another server or to another application etc, as it can be used to\nexpose local files it was not meant to.\n\nThe problem can also be exploited for uploading, if the rogue server\nredirects the client to a local file and thus it would (over)write a local\nfile instead of sending it to the server.\n\nlibcurl compiled to support SCP can get tricked to get a file using embedded\nsemicolons, which can lead to execution of commands on the given\nserver. `Location: scp://name:passwd@host/a;date >/tmp/test;`.\n\nFiles on servers other than the one running libcurl are also accessible when\ncredentials for those servers are stored in the .netrc file of the user\nrunning libcurl. This is most common for FTP servers, but can occur with\nany protocol supported by libcurl. Files on remote SSH servers are also\naccessible when the user has an unencrypted SSH key.",
+  "aliases": [
+    "CVE-2009-0037"
+  ],
+  "modified": "2024-07-02T09:22:24Z",
+  "published": "2009-03-03T08:00:00Z",
+  "database_specific": {
+    "CWE": {
+      "id": "CWE-142",
+      "desc": "Improper Neutralization of Value Delimiters"
+    },
+    "package": "curl",
+    "URL": "https://curl.se/docs/CVE-2009-0037.json",
+    "severity": "Medium",
+    "www": "https://curl.se/docs/CVE-2009-0037.html",
+    "last_affected": "7.19.3"
+  },
+  "affected": [
+    {
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "5.11"
+            },
+            {
+              "fixed": "7.19.4"
+            }
+          ]
+        },
+        {
+          "type": "GIT",
+          "repo": "https://github.com/curl/curl.git",
+          "events": [
+            {
+              "introduced": "ae1912cb0d494b48d514d937826c9fe83ec96c4d"
+            },
+            {
+              "fixed": "042cc1f69ec0878f542667cb684378869f859911"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "7.19.3",
+        "7.19.2",
+        "7.19.1",
+        "7.19.0",
+        "7.18.2",
+        "7.18.1",
+        "7.18.0",
+        "7.17.1",
+        "7.17.0",
+        "7.16.4",
+        "7.16.3",
+        "7.16.2",
+        "7.16.1",
+        "7.16.0",
+        "7.15.5",
+        "7.15.4",
+        "7.15.3",
+        "7.15.2",
+        "7.15.1",
+        "7.15.0",
+        "7.14.1",
+        "7.14.0",
+        "7.13.2",
+        "7.13.1",
+        "7.13.0",
+        "7.12.3",
+        "7.12.2",
+        "7.12.1",
+        "7.12.0",
+        "7.11.2",
+        "7.11.1",
+        "7.11.0",
+        "7.10.8",
+        "7.10.7",
+        "7.10.6",
+        "7.10.5",
+        "7.10.4",
+        "7.10.3",
+        "7.10.2",
+        "7.10.1",
+        "7.10",
+        "7.9.8",
+        "7.9.7",
+        "7.9.6",
+        "7.9.5",
+        "7.9.4",
+        "7.9.3",
+        "7.9.2",
+        "7.9.1",
+        "7.9",
+        "7.8.1",
+        "7.8",
+        "7.7.3",
+        "7.7.2",
+        "7.7.1",
+        "7.7",
+        "7.6.1",
+        "7.6",
+        "7.5.2",
+        "7.5.1",
+        "7.5",
+        "7.4.2",
+        "7.4.1",
+        "7.4",
+        "7.3",
+        "7.2.1",
+        "7.2",
+        "7.1.1",
+        "7.1",
+        "6.5.2",
+        "6.5.1",
+        "6.5",
+        "6.4",
+        "6.3.1",
+        "6.3",
+        "6.2",
+        "6.1",
+        "6.0",
+        "5.11"
+      ],
+      "database_specific": {
+        "source": "https://curl.se/docs/CURL-CVE-2009-0037.json"
+      }
+    }
+  ],
+  "schema_version": "1.6.0",
+  "credits": [
+    {
+      "name": "David Kierznowski",
+      "type": "FINDER"
+    },
+    {
+      "name": "Daniel Stenberg",
+      "type": "REMEDIATION_DEVELOPER"
+    }
+  ]
+}


### PR DESCRIPTION
### Description

When handling OSV advisories that have no CVSS vectors and no explicit severity, calculateOSVSeverity(...) uses the highest severity found in the list of affected packages. In the rare case that this list was empty, this would result in an attempt to access an out-of-bound element. This pull request checks for the empty case before iterating over its contents.

### Addressed Issue

Fixes #3826

### Additional Details

Included in this pull request is an example OSV JSON which causes Issue #3826. The test for this method has been expanded to include parsing this advisory.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [~] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [~] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [~] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
