### PR TITLE
Prevent duplicate policy violations

### DIFF
--- a/src/main/java/org/dependencytrack/policy/PolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/PolicyEngine.java
@@ -27,6 +27,7 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Tag;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.NotificationUtil;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -102,10 +103,10 @@ public class PolicyEngine {
                 }
                 if (Policy.Operator.ANY == policy.getOperator()) {
                     if (policyConditionsViolated > 0) {
-                        policyViolations.addAll(createPolicyViolations(qm, policyConditionViolations));
+                        policyViolations.addAll(createPolicyViolations(policyConditionViolations));
                     }
                 } else if (Policy.Operator.ALL == policy.getOperator() && policyConditionsViolated == policy.getPolicyConditions().size()) {
-                    policyViolations.addAll(createPolicyViolations(qm, policyConditionViolations));
+                    policyViolations.addAll(createPolicyViolations(policyConditionViolations));
                 }
             }
         }
@@ -125,7 +126,7 @@ public class PolicyEngine {
         return (policy.getProjects().stream().anyMatch(p -> p.getId() == project.getId()) || (Boolean.TRUE.equals(policy.isIncludeChildren()) && isPolicyAssignedToParentProject(policy, project)));
     }
 
-    private List<PolicyViolation> createPolicyViolations(final QueryManager qm, final List<PolicyConditionViolation> pcvList) {
+    private List<PolicyViolation> createPolicyViolations(final List<PolicyConditionViolation> pcvList) {
         final List<PolicyViolation> policyViolations = new ArrayList<>();
         for (PolicyConditionViolation pcv : pcvList) {
             final PolicyViolation pv = new PolicyViolation();
@@ -133,7 +134,7 @@ public class PolicyEngine {
             pv.setPolicyCondition(pcv.getPolicyCondition());
             pv.setType(determineViolationType(pcv.getPolicyCondition().getSubject()));
             pv.setTimestamp(new Date());
-            policyViolations.add(qm.addPolicyViolationIfNotExist(pv));
+            policyViolations.add(pv);
         }
         return policyViolations;
     }

--- a/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
@@ -43,12 +43,15 @@ import org.dependencytrack.tasks.scanners.ScanTask;
 import org.dependencytrack.tasks.scanners.SnykAnalysisTask;
 import org.dependencytrack.tasks.scanners.TrivyAnalysisTask;
 import org.dependencytrack.tasks.scanners.VulnDbAnalysisTask;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.dependencytrack.util.LockUtil.getLockForProjectAndNamespace;
 
 public class VulnerabilityAnalysisTask implements Subscriber {
 
@@ -60,33 +63,59 @@ public class VulnerabilityAnalysisTask implements Subscriber {
     @Override
     public void inform(final Event e) {
         if (e instanceof VulnerabilityAnalysisEvent event) {
-            if (event.getComponents() != null && event.getComponents().size() > 0) {
-                final List<Component> components = new ArrayList<>();
-                try (final QueryManager qm = new QueryManager()) {
-                    for (final Component c : event.getComponents()) {
-                        // Ensures the current component (and related objects such as Project) are attached to the
-                        // current persistence manager. This may cause duplicate projects to be created and other
-                        // unexpected behavior.
-                        components.add(qm.getObjectByUuid(Component.class, c.getUuid()));
+            final ReentrantLock projectLock;
+            if (event.getProject() != null) {
+                projectLock = getLockForProjectAndNamespace(event.getProject(), getClass().getSimpleName());
+            } else {
+                projectLock = null;
+            }
+
+            try {
+                if (projectLock != null) {
+                    projectLock.lock();
+                }
+
+                if (event.getComponents() != null && !event.getComponents().isEmpty()) {
+                    final List<Component> components = new ArrayList<>();
+                    try (final QueryManager qm = new QueryManager()) {
+                        for (final Component c : event.getComponents()) {
+                            // Ensures the current component (and related objects such as Project) are attached to the
+                            // current persistence manager. This may cause duplicate projects to be created and other
+                            // unexpected behavior.
+                            components.add(qm.getObjectByUuid(Component.class, c.getUuid()));
+                        }
+                        analyzeComponents(qm, components, e);
                     }
-                    analyzeComponents(qm, components, e);
+                }
+            } finally {
+                if (projectLock != null) {
+                    projectLock.unlock();
                 }
             }
-        } else if (e instanceof PortfolioVulnerabilityAnalysisEvent event) {
+        } else if (e instanceof PortfolioVulnerabilityAnalysisEvent) {
             LOGGER.info("Analyzing portfolio");
             try (final QueryManager qm = new QueryManager()) {
                 final List<UUID> projectUuids = qm.getAllProjects(true)
                         .stream()
                         .map(Project::getUuid)
-                        .collect(Collectors.toList());
+                        .toList();
                 for (final UUID projectUuid : projectUuids) {
                     final Project project = qm.getObjectByUuid(Project.class, projectUuid);
-                    if (project == null) continue;
-                    final List<Component> components = qm.getAllComponents(project);
-                    LOGGER.info("Analyzing " + components.size() + " components in project: " + project.getUuid());
-                    analyzeComponents(qm, components, e);
-                    performPolicyEvaluation(project, components);
-                    LOGGER.info("Completed scheduled analysis of " + components.size() + " components in project: " + project.getUuid());
+                    if (project == null) {
+                        continue;
+                    }
+
+                    final ReentrantLock projectLock = getLockForProjectAndNamespace(project, getClass().getSimpleName());
+                    try {
+                        projectLock.lock();
+                        final List<Component> components = qm.getAllComponents(project);
+                        LOGGER.info("Analyzing " + components.size() + " components in project: " + project.getUuid());
+                        analyzeComponents(qm, components, e);
+                        performPolicyEvaluation(project, components);
+                        LOGGER.info("Completed scheduled analysis of " + components.size() + " components in project: " + project.getUuid());
+                    } finally {
+                        projectLock.unlock();
+                    }
                 }
             }
             LOGGER.info("Portfolio analysis complete");

--- a/src/main/java/org/dependencytrack/util/LockUtil.java
+++ b/src/main/java/org/dependencytrack/util/LockUtil.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.util;
+
+import alpine.Config;
+import alpine.common.metrics.Metrics;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
+import org.dependencytrack.model.Project;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static alpine.Config.AlpineKey.METRICS_ENABLED;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @since 4.13.0
+ */
+public final class LockUtil {
+
+    private static final LoadingCache<String, ReentrantLock> CACHE = buildCache();
+
+    private LockUtil() {
+    }
+
+    public static ReentrantLock getLockForName(final String name) {
+        requireNonNull(name, "name must not be null");
+        return CACHE.get(name);
+    }
+
+    public static ReentrantLock getLockForProjectAndNamespace(final Project project, final String namespace) {
+        requireNonNull(namespace, "namespace must not be null");
+        requireNonNull(project, "project must not be null");
+        requireNonNull(project.getUuid(), "project UUID must not be null");
+        return getLockForName(namespace + ":" + project.getUuid());
+    }
+
+    private static LoadingCache<String, ReentrantLock> buildCache() {
+        final boolean metricsEnabled = Config.getInstance()
+                .getPropertyAsBoolean(METRICS_ENABLED);
+
+        final Caffeine<Object, Object> cacheBuilder = Caffeine.newBuilder()
+                .expireAfterAccess(Duration.ofMinutes(1));
+        if (metricsEnabled) {
+            cacheBuilder.recordStats();
+        }
+
+        final LoadingCache<String, ReentrantLock> cache = cacheBuilder
+                .build(key -> new ReentrantLock());
+
+        if (metricsEnabled) {
+            new CaffeineCacheMetrics<>(cache, "dtrack_locks", Collections.emptyList())
+                    .bindTo(Metrics.getRegistry());
+        }
+
+        return cache;
+    }
+
+}

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
@@ -211,7 +211,6 @@ public class PolicyResourceTest extends ResourceTest {
         violation.setPolicyCondition(condition);
         violation.setType(PolicyViolation.Type.OPERATIONAL);
         violation.setTimestamp(new Date());
-        violation = qm.addPolicyViolationIfNotExist(violation);
 
         qm.reconcilePolicyViolations(component, singletonList(violation));
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Prevents duplicate policy violations.

Introduces project-level locking for BOM upload processing, policy evaluation, and vulnerability analysis. This prevents duplicate records from being created during any of the mentioned activities. The locking happens in-memory.

Refactors policy violation reconciliation to be more deterministic and able to remove duplicates.

In a later release, a `UNIQUE` constraint should be added to the `POLICYVIOLATION` table to prevent duplicate records on the database-level (already done in Hyades).

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #4215

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
