### PR TITLE
Fix unintended manual flushing mode due to DataNucleus `ExecutionContext` pooling

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -147,6 +147,13 @@ alpine.database.pool.max.lifetime=600000
 # alpine.datanucleus.cache.level2.type=
 
 # Required
+# Controls the maximum number of ExecutionContext objects that are pooled by DataNucleus.
+# The default defined by DataNucleus is 20. However, since Dependency-Track occasionally
+# tweaks ExecutionContexts (e.g. to disable auto-flushing for insert-heavy tasks),
+# they are not safe for reuse. We thus disable EC pooling completely.
+alpine.datanucleus.executioncontext.maxidle=0
+
+# Required
 # Specifies the number of bcrypt rounds to use when hashing a users password.
 # The higher the number the more secure the password, at the expense of
 # hardware resources and additional time to generate the hash.


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes unintended manual flushing mode due to DataNucleus `ExecutionContext` pooling.

For BOM upload processing, we customize the `PersistenceManager` for better performance: https://github.com/DependencyTrack/dependency-track/blob/6f7c49c0f2f163895b95e5b80554a49a3ec500f8/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java#L231-L259

It turns out that the custom options are internally delegated to a DataNucleus `ExecutionContext`. Other than `PersistenceManager`s, `ExecutionContext`s are never really closed, but instead reused (https://github.com/datanucleus/datanucleus-core/blob/master/src/main/java/org/datanucleus/ExecutionContextPool.java). Per default, DN pools up to 20 ECs.

The issue with this behavior is that customizing a PM in code location A, can unintentionally impact code location B. An example of this is project cloning, where an EC can get picked that has `FlushMode=MANUAL`, whereas the cloning logic assumes the default `FlushMode=AUTO` (https://github.com/DependencyTrack/dependency-track/issues/4220).

Disable EC pooling to prevent such unintended behavior changes.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #4220

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
