### PR TITLE
Add new policy operator for checking if CPE or PURL not present

### DIFF
--- a/src/main/java/org/dependencytrack/model/PolicyCondition.java
+++ b/src/main/java/org/dependencytrack/model/PolicyCondition.java
@@ -52,6 +52,7 @@ public class PolicyCondition implements Serializable {
         IS_NOT,
         MATCHES,
         NO_MATCH,
+        NOT_PRESENT,
         NUMERIC_GREATER_THAN,
         NUMERIC_LESS_THAN,
         NUMERIC_EQUAL,

--- a/src/main/java/org/dependencytrack/policy/CpePolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/CpePolicyEvaluator.java
@@ -55,6 +55,10 @@ public class CpePolicyEvaluator extends AbstractPolicyEvaluator {
                 if (Matcher.matches(component.getCpe(), condition.getValue())) {
                     violations.add(new PolicyConditionViolation(condition, component));
                 }
+            } else if(PolicyCondition.Operator.NOT_PRESENT == condition.getOperator()){
+                if(component.getCpe() == null){
+                    violations.add(new PolicyConditionViolation(condition, component));
+                }
             } else if (PolicyCondition.Operator.NO_MATCH == condition.getOperator()) {
                 if (!Matcher.matches(component.getCpe(), condition.getValue())) {
                     violations.add(new PolicyConditionViolation(condition, component));

--- a/src/main/java/org/dependencytrack/policy/PackageURLPolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/PackageURLPolicyEvaluator.java
@@ -56,6 +56,10 @@ public class PackageURLPolicyEvaluator extends AbstractPolicyEvaluator {
                 if (Matcher.matches(canonicalPurl, condition.getValue())) {
                     violations.add(new PolicyConditionViolation(condition, component));
                 }
+            } else if(PolicyCondition.Operator.NOT_PRESENT == condition.getOperator()){
+                if(component.getPurl() == null){
+                    violations.add(new PolicyConditionViolation(condition, component));
+                }
             } else if (PolicyCondition.Operator.NO_MATCH == condition.getOperator()) {
                 if (!Matcher.matches(canonicalPurl, condition.getValue())) {
                     violations.add(new PolicyConditionViolation(condition, component));

--- a/src/test/java/org/dependencytrack/policy/CpePolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/CpePolicyEvaluatorTest.java
@@ -93,5 +93,13 @@ public class CpePolicyEvaluatorTest extends PersistenceCapableTest {
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
         Assert.assertEquals(0, violations.size());
     }
-
+    
+    @Test
+    public void noCpePresent() {
+        Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.CPE, PolicyCondition.Operator.NOT_PRESENT, "NOT_PRESENT");
+        Component component = new Component();
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        Assert.assertEquals(1, violations.size());
+    }
 }

--- a/src/test/java/org/dependencytrack/policy/PackageURLPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/PackageURLPolicyEvaluatorTest.java
@@ -75,6 +75,15 @@ public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
     }
 
     @Test
+    public void noPurlPresent() throws Exception {
+        Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.NOT_PRESENT, "NOT_PRESENT");
+        Component component = new Component();
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        Assert.assertEquals(1, violations.size());
+    }
+
+    @Test
     public void wrongSubject() throws Exception {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, "pkg:generic/acme/example-component@1.0");


### PR DESCRIPTION
### Description
This change adds a new PolicyCondition operator `NOT_PRESENT` which can be used with PURL or CPE to evaluate wether or not its present.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue
#4218 
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details
Front end PR https://github.com/DependencyTrack/frontend/pull/1053
<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
