### PR TITLE
update ruby version in gemfile and docs

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -336,12 +336,12 @@ For local development, you may want to run this instead:
 
 This will start a local webserver that listens on `127.0.0.1:4000` and rebuilds the site whenever you make changes.
 
-> To be able to build the docs with Jekyll, you'll need [Ruby 2](https://www.ruby-lang.org/en/),
+> To be able to build the docs with Jekyll, you'll need [Ruby 3](https://www.ruby-lang.org/en/),
 > [RubyGems](https://rubygems.org/pages/download) and [Bundler](https://bundler.io/) installed.
 > If you can't be bothered to install all of this, you can use the 
 > [Jekyll container image](https://hub.docker.com/r/jekyll/jekyll) instead, e.g.:
 > ```
-> docker run --rm -it --name jekyll -p "127.0.0.1:4000:4000" -v "$(pwd)/docs:/srv/jekyll:Z" jekyll/jekyll:3.8 jekyll serve
+> docker run --rm -it --name jekyll -p "127.0.0.1:4000:4000" -v "$(pwd)/docs:/srv/jekyll:Z" jekyll/jekyll:4.2.2 jekyll serve
 > ```
 
 ## Feature Branches

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '~> 2.6'
+ruby '~> 3.1'
 
 gem 'jekyll', '~> 3.9'
 gem 'kramdown-parser-gfm', '1.1.0'


### PR DESCRIPTION
### Description

Updates the ruby version for the doc server in order to fix dependency issue

### Addressed Issue

fixes: https://github.com/DependencyTrack/dependency-track/issues/4247

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
