### PR TITLE
feat: add property to control Verified flag in DefectDojo integration

### DIFF
--- a/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -40,7 +40,8 @@ public enum ConfigKey implements Config.Key {
     REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_LOCK_BUCKETS("repo.meta.analyzer.cacheStampedeBlocker.lock.buckets", 1000),
     REPO_META_ANALYZER_CACHE_STAMPEDE_BLOCKER_MAX_ATTEMPTS("repo.meta.analyzer.cacheStampedeBlocker.max.attempts", 10),
     SYSTEM_REQUIREMENT_CHECK_ENABLED("system.requirement.check.enabled", true),
-    ALPINE_WORKER_POOL_DRAIN_TIMEOUT_DURATION("alpine.worker.pool.drain.timeout.duration", "PT5S");
+    ALPINE_WORKER_POOL_DRAIN_TIMEOUT_DURATION("alpine.worker.pool.drain.timeout.duration", "PT5S"),
+    DEFECT_DOJO_FINDINGS_AUTO_VERIFY("defectdojo.findings.auto.verify",false);
 
     private final String propertyName;
     private final Object defaultValue;

--- a/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoClient.java
+++ b/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoClient.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.integrations.defectdojo;
 
+import alpine.Config;
 import alpine.common.logging.Logger;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
@@ -32,6 +33,7 @@ import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.InputStreamBody;
 import org.apache.http.entity.mime.content.StringBody;
 import org.apache.http.util.EntityUtils;
+import org.dependencytrack.common.ConfigKey;
 import org.dependencytrack.common.HttpClientPool;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -50,10 +52,12 @@ public class DefectDojoClient {
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
     private final DefectDojoUploader uploader;
     private final URL baseURL;
+    private final boolean autoVerifyFindings;
 
     public DefectDojoClient(final DefectDojoUploader uploader, final URL baseURL) {
         this.uploader = uploader;
         this.baseURL = baseURL;
+        this.autoVerifyFindings = Config.getInstance().getPropertyAsBoolean(ConfigKey.DEFECT_DOJO_FINDINGS_AUTO_VERIFY);
     }
 
     public void uploadDependencyTrackFindings(final String token, final String engagementId, final InputStream findingsJson) {
@@ -66,7 +70,7 @@ public class DefectDojoClient {
                 .addPart("file", inputStreamBody)
                 .addPart("engagement", new StringBody(engagementId, ContentType.MULTIPART_FORM_DATA))
                 .addPart("scan_type", new StringBody("Dependency Track Finding Packaging Format (FPF) Export", ContentType.MULTIPART_FORM_DATA))
-                .addPart("verified", new StringBody("true", ContentType.MULTIPART_FORM_DATA))
+                .addPart("verified", new StringBody(Boolean.toString(autoVerifyFindings), ContentType.MULTIPART_FORM_DATA))
                 .addPart("active", new StringBody("true", ContentType.MULTIPART_FORM_DATA))
                 .addPart("minimum_severity", new StringBody("Info", ContentType.MULTIPART_FORM_DATA))
                 .addPart("close_old_findings", new StringBody("true", ContentType.MULTIPART_FORM_DATA))
@@ -173,7 +177,7 @@ public class DefectDojoClient {
                 .addPart("file", inputStreamBody)
                 .addPart("engagement", new StringBody(engagementId, ContentType.MULTIPART_FORM_DATA))
                 .addPart("scan_type", new StringBody("Dependency Track Finding Packaging Format (FPF) Export", ContentType.MULTIPART_FORM_DATA))
-                .addPart("verified", new StringBody("true", ContentType.MULTIPART_FORM_DATA))
+                .addPart("verified", new StringBody(Boolean.toString(autoVerifyFindings), ContentType.MULTIPART_FORM_DATA))
                 .addPart("active", new StringBody("true", ContentType.MULTIPART_FORM_DATA))
                 .addPart("minimum_severity", new StringBody("Info", ContentType.MULTIPART_FORM_DATA))
                 .addPart("close_old_findings", new StringBody("true", ContentType.MULTIPART_FORM_DATA))

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -474,3 +474,10 @@ repo.meta.analyzer.cacheStampedeBlocker.lock.buckets=1000
 # The default value is 10.
 repo.meta.analyzer.cacheStampedeBlocker.max.attempts=10
 
+# Optional
+# Controls whether findings are automatically marked as verified when uploading to DefectDojo.
+# When set to true, all findings will be marked as verified upon upload.
+# When set to false, the "Verified" flag will not be automatically set, allowing manual verification.
+# Default is false.
+defectdojo.findings.auto.verify=false
+


### PR DESCRIPTION
### Description

Added a new configurable property to manage the "Verified" flag in DefectDojo integration. This allows users to control whether or not the "Verified" flag should be set when submitting data to DefectDojo. 

### Addressed Issue

Addresses issue #3389.

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
