### PR TITLE
Use Caffeine as DataNucleus L2 cache

### DIFF
--- a/dev/monitoring/grafana/dashboards/apiserver.json
+++ b/dev/monitoring/grafana/dashboards/apiserver.json
@@ -2403,6 +2403,197 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Number of events per second in the L2 cache of the object relational mapper (ORM).\n\nNote that these metrics are only available when \"alpine.metrics.enabled\" is \"true\", \"alpine.datanucleus.cache.level2.type\" is \"caffeine\", and \"alpine.datanucleus.cache.level2.statisticsenabled\" is \"true\".",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Hits"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Misses"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Puts"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Evictions"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 58
+      },
+      "id": 81,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(cache_gets_total{instance=\"$instance\", cache=\"datanucleus_second_level\", result=\"hit\"}[1m]))",
+          "legendFormat": "Hits",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(cache_gets_total{instance=\"$instance\", cache=\"datanucleus_second_level\", result=\"miss\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Misses",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(cache_puts_total{instance=\"$instance\", cache=\"datanucleus_second_level\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Puts",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(cache_evictions_total{instance=\"$instance\", cache=\"datanucleus_second_level\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Evictions",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "ORM L2 Cache Events",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -3292,8 +3483,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3405,8 +3595,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3503,8 +3692,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3601,8 +3789,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3699,8 +3886,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3797,8 +3983,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
         <lib.cvss-calculator.version>1.4.2</lib.cvss-calculator.version>
         <lib.owasp-rr-calculator.version>1.0.1</lib.owasp-rr-calculator.version>
         <lib.cyclonedx-java.version>9.1.0</lib.cyclonedx-java.version>
+        <lib.datanucleus-cache-caffeine.version>0.4.0</lib.datanucleus-cache-caffeine.version>
         <lib.greenmail.version>2.1.0</lib.greenmail.version>
         <lib.jackson.version>2.18.0</lib.jackson.version>
         <lib.jackson-databind.version>2.18.0</lib.jackson-databind.version>
@@ -197,6 +198,12 @@
             <groupId>org.cyclonedx</groupId>
             <artifactId>cyclonedx-core-java</artifactId>
             <version>${lib.cyclonedx-java.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.nscuro</groupId>
+            <artifactId>datanucleus-cache-caffeine</artifactId>
+            <version>${lib.datanucleus-cache-caffeine.version}</version>
         </dependency>
 
         <!-- org.json
@@ -616,6 +623,7 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <configuration>
                     <excludes>
+                        <exclude>org/dependencytrack/observability/MeterRegistryCustomizer.class</exclude>
                         <exclude>org/dependencytrack/upgrade/**/*</exclude>
                         <exclude>trivy/proto/**/*</exclude>
                     </excludes>

--- a/src/main/java/org/dependencytrack/observability/MeterRegistryCustomizer.java
+++ b/src/main/java/org/dependencytrack/observability/MeterRegistryCustomizer.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.observability;
+
+import alpine.Config;
+import alpine.common.logging.Logger;
+import alpine.server.persistence.PersistenceManagerFactory;
+import io.github.nscuro.datanucleus.cache.caffeine.CaffeineLevel2Cache;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
+import org.datanucleus.api.jdo.JDODataStoreCache;
+import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+import org.datanucleus.cache.Level2Cache;
+
+import javax.jdo.PersistenceManager;
+import java.util.concurrent.TimeUnit;
+
+import static org.datanucleus.PropertyNames.PROPERTY_CACHE_L2_STATISTICS_ENABLED;
+import static org.datanucleus.PropertyNames.PROPERTY_CACHE_L2_TYPE;
+
+public class MeterRegistryCustomizer implements alpine.common.metrics.MeterRegistryCustomizer {
+
+    private static final Logger LOGGER = Logger.getLogger(MeterRegistryCustomizer.class);
+
+    @Override
+    public void accept(final MeterRegistry meterRegistry) {
+        if (!Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.METRICS_ENABLED)) {
+            return;
+        }
+
+        maybeRegisterCaffeineLevel2CacheMetrics(meterRegistry);
+    }
+
+    /**
+     * Register Caffeine-specific metrics for the DataNucleus L2 cache, if and only if
+     * Caffeine is configured as L2 cache via {@code datanucleus.cache.level2.type}.
+     * <p>
+     * DataNucleus' {@link Level2Cache} doesn't expose any more statistics than the size,
+     * but we would like to monitor hit, miss, and invalidation metrics.
+     */
+    @SuppressWarnings("BusyWait")
+    private void maybeRegisterCaffeineLevel2CacheMetrics(final MeterRegistry meterRegistry) {
+        // The customizer executes before the persistence context is created.
+        // Use a separate thread to wait for the persistence context to become available,
+        // and register cache metrics once it is.
+        //
+        // To prevent the thread from waiting forever (should not happen),
+        // cap the max wait duration at 15 seconds.
+        final long timeoutMs = TimeUnit.SECONDS.toMillis(15);
+
+        final var thread = new Thread(() -> {
+            final long startTimeMs = System.currentTimeMillis();
+
+            while ((System.currentTimeMillis() - startTimeMs) < timeoutMs) {
+                try (final PersistenceManager pm = PersistenceManagerFactory.createPersistenceManager()) {
+                    final var pmf = (JDOPersistenceManagerFactory) pm.getPersistenceManagerFactory();
+                    if (!"caffeine".equals(pmf.getProperties().get(PROPERTY_CACHE_L2_TYPE))) {
+                        LOGGER.debug("Not registering Caffeine L2 cache metrics, because %s is not \"caffeine\""
+                                .formatted(PROPERTY_CACHE_L2_TYPE));
+                        return;
+                    }
+                    if (!Boolean.TRUE.equals(pmf.getProperties().get(PROPERTY_CACHE_L2_STATISTICS_ENABLED))) {
+                        LOGGER.debug("Not registering Caffeine L2 cache metrics, because %s is not enabled"
+                                .formatted(PROPERTY_CACHE_L2_STATISTICS_ENABLED));
+                        return;
+                    }
+
+                    final var dataStoreCache = (JDODataStoreCache) pmf.getDataStoreCache();
+                    if (dataStoreCache.getLevel2Cache() instanceof final CaffeineLevel2Cache level2Cache) {
+                        new CaffeineCacheMetrics<>(
+                                level2Cache.getCaffeineCache(),
+                                /* cacheName */ "datanucleus_second_level",
+                                /* tags */ null)
+                                .bindTo(meterRegistry);
+                        LOGGER.debug("Registered Caffeine L2 cache metrics");
+                    }
+
+                    break;
+                } catch (IllegalStateException e) {
+                    // Persistence context not created yet.
+                }
+
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Thread was interrupted while sleeping", e);
+                }
+            }
+        });
+        thread.start();
+    }
+
+}

--- a/src/main/resources/META-INF/services/alpine.common.metrics.MeterRegistryCustomizer
+++ b/src/main/resources/META-INF/services/alpine.common.metrics.MeterRegistryCustomizer
@@ -1,0 +1,1 @@
+org.dependencytrack.observability.MeterRegistryCustomizer

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -136,7 +136,7 @@ alpine.database.pool.max.lifetime=600000
 # Optional
 # Controls the 2nd level cache type used by DataNucleus, the Object Relational Mapper (ORM).
 # See https://www.datanucleus.org/products/accessplatform_6_0/jdo/persistence.html#cache_level2
-# Values supported by Dependency-Track are "soft" (default), "weak", and "none".
+# Values supported by Dependency-Track are "caffeine" (default), "soft", "weak", and "none".
 #
 # Setting this property to "none" may help in reducing the memory footprint of Dependency-Track,
 # but has the potential to slow down database operations.
@@ -144,7 +144,49 @@ alpine.database.pool.max.lifetime=600000
 # refer to https://docs.dependencytrack.org/getting-started/monitoring/#metrics for details.
 #
 # DO NOT CHANGE UNLESS THERE IS A GOOD REASON TO.
-# alpine.datanucleus.cache.level2.type=
+alpine.datanucleus.cache.level2.type=caffeine
+
+# Optional
+# Defines the time in milliseconds, after which entries in the L2 cache expire.
+# Expiration is timed according to alpine.datanucleus.cache.level2.caffeine.expirymode.
+#
+# Can help in reducing the memory footprint of Dependency-Track,
+# when disabling the L2 cache altogether is not an option.
+#
+# Has no effect unless alpine.datanucleus.cache.level2.type is set to "caffeine".
+# alpine.datanucleus.cache.level2.expirymillis=
+
+# Optional
+# Defines whether entries of the L2 cache should expire after they've been written (after-write),
+# or after they've been last accessed (after-access).
+# Note that after-access includes read AND write operations, and is usually a better choice
+# because it keeps frequently accessed entries.
+#
+# Has no effect unless alpine.datanucleus.cache.level2.type is set to "caffeine",
+# and alpine.datanucleus.cache.level2.expirymillis is configured.
+alpine.datanucleus.cache.level2.caffeine.expirymode=after-access
+
+# Optional
+# Defines the maximum number of entries in the L2 cache.
+#
+# Can help in reducing the memory footprint of Dependency-Track,
+# when disabling the L2 cache altogether is not an option.
+#
+# Has no effect unless alpine.datanucleus.cache.level2.type is set to "caffeine".
+# alpine.datanucleus.cache.level2.maxsize=
+
+# Optional
+# Defines whether additional statistics (e.g. hit/miss rates) should be collected for the DataNucleus L2 cache.
+#
+# Important metrics made available are the following:
+#   cache_gets_total{cache="datanucleus_second_level", result="hit"}
+#   cache_gets_total{cache="datanucleus_second_level", result="miss"}
+#   cache_puts_total{cache="datanucleus_second_level"}
+#   cache_evictions_total{cache="datanucleus_second_level"}
+#
+# Has no effect unless alpine.metrics.enabled is true,
+# and alpine.datanucleus.cache.level2.type is set to "caffeine".
+# alpine.datanucleus.cache.level2.statisticsenabled=false
 
 # Required
 # Controls the maximum number of ExecutionContext objects that are pooled by DataNucleus.


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Uses Caffeine as DataNucleus L2 cache per default.

Users continue to run into situations where the DataNucleus L2 cache grows to excessive sizes, eventually causing the application to become unresponsive, or crash due to OOM.

The default, `Map`-based L2 cache of DataNucleus does not support time- or size-based expiration of entries. Users are thus unable to limit the impact of L2 caching in their environment.

Disabling the L2 cache entirely is possible, but because the default L2 caches don't expose hit/miss metrics, we've been blind to the impact of disabling it so far.

This change switches the default L2 cache implementation to one backed by Caffeine (https://github.com/ben-manes/caffeine). This cache supports time and size expiry policies, and is capable of exposing more detailed metrics.

The example Grafana dashboard was updated to include a widget for the newly available metrics. This should make it easier for users to determine whether they can safely disable L2 caching altogether (i.e. high miss-rates, low hit-rates), and monitor the effectiveness or their configured expiry policies.

It should also help us to determine if we can safely turn off L2 caching per default, to avoid such problematic situations for users entirely.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

![Screenshot 2024-10-24 211038](https://github.com/user-attachments/assets/849196ce-3f14-4ad0-9cad-87e3da4bc458)

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
