### PR TITLE
Notification rule test did not account for teams when using email publisher

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/NotificationPublisherResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/NotificationPublisherResource.java
@@ -340,7 +340,7 @@ public class NotificationPublisherResource extends AlpineResource {
             @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
     @PermissionRequired(Permissions.Constants.SYSTEM_CONFIGURATION)
-    public Response testSlackPublisherConfig(
+    public Response testRuleConfiguration (
             @Parameter(description = "The UUID of the rule to test", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String ruleUuid) throws Exception {
         try(QueryManager qm = new QueryManager()){
@@ -366,7 +366,12 @@ public class NotificationPublisherResource extends AlpineResource {
                     .content("Rule configuration test")
                     .level(rule.getNotificationLevel())
                     .subject(NotificationUtil.generateSubject(group.toString()));
-                publisher.inform(PublishContext.from(notification), notification, config);
+                    if(SendMailPublisher.class.isAssignableFrom(publisherClass) && rule.getTeams() != null && rule.getTeams().size() > 0){
+                        SendMailPublisher sendMailPublisher = (SendMailPublisher) publisherClass.getDeclaredConstructor().newInstance();
+                        sendMailPublisher.inform(PublishContext.from(notification), notification, config, rule.getTeams());
+                    }else  {
+                        publisher.inform(PublishContext.from(notification), notification, config);
+                    }
             }
             return Response.ok().build();
         } catch (InvocationTargetException | InstantiationException | IllegalAccessException | NoSuchMethodException e) {

--- a/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
@@ -18,7 +18,9 @@
  */
 package org.dependencytrack.resources.v1;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -41,6 +43,8 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import alpine.common.util.UuidUtil;
+import alpine.model.ManagedUser;
+import alpine.model.Team;
 import alpine.notification.NotificationLevel;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
@@ -348,10 +352,21 @@ public class NotificationPublisherResourceTest extends ResourceTest {
     public void testNotificationRuleTest() {
         NotificationPublisher publisher = qm.createNotificationPublisher(
                 "Example Publisher", "Publisher description",
-                SlackPublisher.class, "template", "text/html",
+                SendMailPublisher.class, "template", "text/html",
                 false);
         
         NotificationRule rule = qm.createNotificationRule("Example Rule 1", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+
+        List<Team> teams = new ArrayList<>();
+        Team team = new Team();
+        List<ManagedUser> managedUsers = new ArrayList<>();
+        ManagedUser managedUser = new ManagedUser();
+        managedUsers.add(managedUser);
+        team.setManagedUsers(managedUsers);
+        teams.add(team);
+        rule.setTeams(teams);
+
+        qm.updateNotificationRule(rule);
 
         Set<NotificationGroup> groups = new HashSet<>(Set.of(NotificationGroup.BOM_CONSUMED, NotificationGroup.BOM_PROCESSED, NotificationGroup.BOM_PROCESSING_FAILED,
                                 NotificationGroup.BOM_VALIDATION_FAILED, NotificationGroup.NEW_VULNERABILITY, NotificationGroup.NEW_VULNERABLE_DEPENDENCY, 

--- a/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
@@ -361,6 +361,7 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Team team = new Team();
         List<ManagedUser> managedUsers = new ArrayList<>();
         ManagedUser managedUser = new ManagedUser();
+        managedUser.setEmail("test@test.com");
         managedUsers.add(managedUser);
         team.setManagedUsers(managedUsers);
         teams.add(team);


### PR DESCRIPTION

### Description
Added a check before informing if the publisher is of `SendMailPublisher` type. If it is, inform using the teams stored in the rule.
<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue
#4302

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
