### PR TITLE
Reduce memory usage of metrics update tasks

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/metrics/ComponentMetricsUpdateTask.java
+++ b/src/main/java/org/dependencytrack/tasks/metrics/ComponentMetricsUpdateTask.java
@@ -21,6 +21,7 @@ package org.dependencytrack.tasks.metrics;
 import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
+import alpine.persistence.ScopedCustomization;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.dependencytrack.event.ComponentMetricsUpdateEvent;
 import org.dependencytrack.metrics.Metrics;
@@ -176,21 +177,26 @@ public class ComponentMetricsUpdateTask implements Subscriber {
     }
 
     @SuppressWarnings("unchecked")
-    private static List<Vulnerability> getVulnerabilities(final PersistenceManager pm, final Component component) throws Exception {
+    private static List<Vulnerability> getVulnerabilities(final PersistenceManager pm, final Component component) {
         // Using the JDO single-string syntax here because we need to pass the parameter
         // of the outer query (the component) to the sub-query. For some reason that does
         // not work with the declarative JDO API.
-        try (final Query<?> query = pm.newQuery(Query.JDOQL, """
+        final Query<?> query = pm.newQuery(Query.JDOQL, """
                 SELECT FROM org.dependencytrack.model.Vulnerability
                 WHERE this.components.contains(:component)
                     && (SELECT FROM org.dependencytrack.model.Analysis a
                         WHERE a.component == :component
                             && a.vulnerability == this
                             && a.suppressed == true).isEmpty()
-                """)) {
-            query.setParameters(component);
-            query.getFetchPlan().setGroup(Vulnerability.FetchGroup.METRICS_UPDATE.name());
+                """);
+        query.setParameters(component);
+
+        // NB: Set fetch group on PM level to avoid fields of the default fetch group from being loaded.
+        try (var ignoredPersistenceCustomization = new ScopedCustomization(pm)
+                .withFetchGroup(Vulnerability.FetchGroup.METRICS_UPDATE.name())) {
             return List.copyOf((List<Vulnerability>) query.executeList());
+        } finally {
+            query.closeAll();
         }
     }
 

--- a/src/main/java/org/dependencytrack/tasks/metrics/PortfolioMetricsUpdateTask.java
+++ b/src/main/java/org/dependencytrack/tasks/metrics/PortfolioMetricsUpdateTask.java
@@ -22,6 +22,7 @@ import alpine.common.logging.Logger;
 import alpine.common.util.SystemUtil;
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
+import alpine.persistence.ScopedCustomization;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.dependencytrack.event.CallbackEvent;
 import org.dependencytrack.event.PortfolioMetricsUpdateEvent;
@@ -68,11 +69,11 @@ public class PortfolioMetricsUpdateTask implements Subscriber {
             final PersistenceManager pm = qm.getPersistenceManager();
 
             LOGGER.debug("Fetching first " + BATCH_SIZE + " projects");
-            List<Project> activeProjects = fetchNextActiveProjectsPage(pm, null);
+            List<Project> activeProjects = fetchNextActiveProjectsBatch(pm, null);
 
             while (!activeProjects.isEmpty()) {
-                final long firstId = activeProjects.get(0).getId();
-                final long lastId = activeProjects.get(activeProjects.size() - 1).getId();
+                final long firstId = activeProjects.getFirst().getId();
+                final long lastId = activeProjects.getLast().getId();
                 final int batchCount = activeProjects.size();
 
                 final var countDownLatch = new CountDownLatch(batchCount);
@@ -113,7 +114,7 @@ public class PortfolioMetricsUpdateTask implements Subscriber {
                     counters.medium += metrics.getMedium();
                     counters.low += metrics.getLow();
                     counters.unassigned += metrics.getUnassigned();
-                    counters.vulnerabilities += metrics.getVulnerabilities();
+                    counters.vulnerabilities += Math.toIntExact(metrics.getVulnerabilities());
 
                     counters.findingsTotal += metrics.getFindingsTotal();
                     counters.findingsAudited += metrics.getFindingsAudited();
@@ -145,8 +146,13 @@ public class PortfolioMetricsUpdateTask implements Subscriber {
                     counters.policyViolationsOperationalUnaudited += metrics.getPolicyViolationsOperationalUnaudited();
                 }
 
+                // Remove projects and project metrics from the L1 cache
+                // to prevent it from growing too large.
+                pm.evictAll(false, Project.class);
+                pm.evictAll(false, ProjectMetrics.class);
+
                 LOGGER.debug("Fetching next " + BATCH_SIZE + " projects");
-                activeProjects = fetchNextActiveProjectsPage(pm, lastId);
+                activeProjects = fetchNextActiveProjectsBatch(pm, lastId);
             }
 
             qm.runInTransaction(() -> {
@@ -166,18 +172,23 @@ public class PortfolioMetricsUpdateTask implements Subscriber {
                 DurationFormatUtils.formatDuration(new Date().getTime() - counters.measuredAt.getTime(), "mm:ss:SS"));
     }
 
-    private List<Project> fetchNextActiveProjectsPage(final PersistenceManager pm, final Long lastId) throws Exception {
-        try (final Query<Project> query = pm.newQuery(Project.class)) {
-            if (lastId == null) {
-                query.setFilter("(active == null || active == true)");
-            } else {
-                query.setFilter("(active == null || active == true) && id < :lastId");
-                query.setParameters(lastId);
-            }
-            query.setOrdering("id DESC");
-            query.range(0, BATCH_SIZE);
-            query.getFetchPlan().setGroup(Project.FetchGroup.METRICS_UPDATE.name());
+    private List<Project> fetchNextActiveProjectsBatch(final PersistenceManager pm, final Long lastId) {
+        final Query<Project> query = pm.newQuery(Project.class);
+        if (lastId == null) {
+            query.setFilter("(active == null || active == true)");
+        } else {
+            query.setFilter("(active == null || active == true) && id < :lastId");
+            query.setParameters(lastId);
+        }
+        query.setOrdering("id DESC");
+        query.range(0, BATCH_SIZE);
+
+        // NB: Set fetch group on PM level to avoid fields of the default fetch group from being loaded.
+        try (var ignoredPersistenceCustomization = new ScopedCustomization(pm)
+                .withFetchGroup(Project.FetchGroup.METRICS_UPDATE.name())) {
             return List.copyOf(query.executeList());
+        } finally {
+            query.closeAll();
         }
     }
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Reduces memory usage of metrics update tasks.

Because the tasks iterated over large datasets (i.e. all projects, or all components of a project), the DataNucleus L1 cache kept growing. Prevent this from happening by evicting objects from the cache after every iteration.

Also, because setting a `FetchGroup` on `Query` level doesn't overwrite the `FetchGroup` on `PersistenceManager` level, too many fields were being loaded. Use `ScopedCustomization` to overwrite the PM's `FetchGroup` when querying objects for metrics calculation.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Based on the fixes for repository meta analysis introduced in #4311.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
