### PR TITLE
Extend CycloneDX metadata by custom properties

### DIFF
--- a/src/main/java/org/dependencytrack/model/MetadataProperty.java
+++ b/src/main/java/org/dependencytrack/model/MetadataProperty.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import alpine.server.json.TrimmedStringDeserializer;
+
+/**
+ * Model class for tracking metadata properties.
+ *
+ * @author Eric Klatzer
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MetadataProperty implements Serializable {
+
+    @JsonDeserialize(using = TrimmedStringDeserializer.class)
+    private String name;
+
+    @JsonDeserialize(using = TrimmedStringDeserializer.class)
+    private String value;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final MetadataProperty that = (MetadataProperty) o;
+        return Objects.equals(name, that.name) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, value);
+    }
+}

--- a/src/main/java/org/dependencytrack/model/ProjectMetadata.java
+++ b/src/main/java/org/dependencytrack/model/ProjectMetadata.java
@@ -18,11 +18,7 @@
  */
 package org.dependencytrack.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import org.dependencytrack.persistence.converter.OrganizationalContactsJsonConverter;
-import org.dependencytrack.persistence.converter.OrganizationalEntityJsonConverter;
+import java.util.List;
 
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Convert;
@@ -31,7 +27,14 @@ import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
 import javax.jdo.annotations.PrimaryKey;
 import javax.jdo.annotations.Unique;
-import java.util.List;
+
+import org.dependencytrack.persistence.converter.MetadataPropertyJsonConverter;
+import org.dependencytrack.persistence.converter.OrganizationalContactsJsonConverter;
+import org.dependencytrack.persistence.converter.OrganizationalEntityJsonConverter;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
  * Metadata that relates to, but does not directly describe, a {@link Project}.
@@ -66,6 +69,11 @@ public class ProjectMetadata {
     @Column(name = "AUTHORS", jdbcType = "CLOB", allowsNull = "true")
     private List<OrganizationalContact> authors;
 
+    @Persistent(defaultFetchGroup = "true")
+    @Convert(MetadataPropertyJsonConverter.class)
+    @Column(name = "PROPERTIES", jdbcType = "CLOB", allowsNull = "true")
+    private List<MetadataProperty> properties;
+
     public long getId() {
         return id;
     }
@@ -98,4 +106,11 @@ public class ProjectMetadata {
         this.authors = authors;
     }
 
+    public List<MetadataProperty> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(final List<MetadataProperty> properties) {
+        this.properties = properties;
+    }
 }

--- a/src/main/java/org/dependencytrack/persistence/converter/MetadataPropertyJsonConverter.java
+++ b/src/main/java/org/dependencytrack/persistence/converter/MetadataPropertyJsonConverter.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.converter;
+
+import java.util.List;
+
+import org.dependencytrack.model.MetadataProperty;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+public class MetadataPropertyJsonConverter extends AbstractJsonConverter<List<MetadataProperty>> {
+
+    public MetadataPropertyJsonConverter() {
+        super(new TypeReference<>() {});
+    }
+
+    @Override
+    public String convertToDatastore(final List<MetadataProperty> attributeValue) {
+        // Overriding is required for DataNucleus to correctly detect the return type.
+        return super.convertToDatastore(attributeValue);
+    }
+
+    @Override
+    public List<MetadataProperty> convertToAttribute(final String datastoreValue) {
+        // Overriding is required for DataNucleus to correctly detect the return type.
+        return super.convertToAttribute(datastoreValue);
+    }
+
+}

--- a/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -147,6 +147,7 @@ public class BomResource extends AlpineResource {
             if (project == null) {
                 return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();
             }
+
             if (! qm.hasAccess(super.getPrincipal(), project)) {
                 return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
             }

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -18,12 +18,20 @@
  */
 package org.dependencytrack.resources.v1;
 
-import alpine.common.util.UuidUtil;
-import alpine.model.IConfigProperty;
-import alpine.server.filters.ApiFilter;
-import alpine.server.filters.AuthenticationFilter;
-import com.fasterxml.jackson.core.StreamReadConstraints;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.commons.io.IOUtils.resourceToByteArray;
+import static org.apache.commons.io.IOUtils.resourceToString;
 import org.apache.http.HttpStatus;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
@@ -33,6 +41,10 @@ import org.dependencytrack.model.BomValidationMode;
 import org.dependencytrack.model.Classifier;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentProperty;
+import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_MODE;
+import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE;
+import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE;
+import org.dependencytrack.model.MetadataProperty;
 import org.dependencytrack.model.OrganizationalContact;
 import org.dependencytrack.model.OrganizationalEntity;
 import org.dependencytrack.model.Project;
@@ -50,34 +62,24 @@ import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
+import static org.hamcrest.CoreMatchers.equalTo;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
+
+import alpine.common.util.UuidUtil;
+import alpine.model.IConfigProperty;
+import alpine.server.filters.ApiFilter;
+import alpine.server.filters.AuthenticationFilter;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
-import static org.apache.commons.io.IOUtils.resourceToByteArray;
-import static org.apache.commons.io.IOUtils.resourceToString;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_MODE;
-import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE;
-import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE;
-import static org.hamcrest.CoreMatchers.equalTo;
 
 public class BomResourceTest extends ResourceTest {
 
@@ -158,6 +160,10 @@ public class BomResourceTest extends ResourceTest {
         projectMetadata.setProject(project);
         projectMetadata.setAuthors(List.of(bomAuthor));
         projectMetadata.setSupplier(bomSupplier);
+        final var metadataProperty = new MetadataProperty();
+        metadataProperty.setName("foo");
+        metadataProperty.setValue("bar");
+        projectMetadata.setProperties(List.of(metadataProperty));
         qm.persist(projectMetadata);
 
         final var componentSupplier = new OrganizationalEntity();
@@ -240,87 +246,93 @@ public class BomResourceTest extends ResourceTest {
                     "metadata": {
                         "timestamp": "${json-unit.any-string}",
                         "authors": [
-                          {
+                        {
                             "name": "bomAuthor"
-                          }
+                        }
                         ],
                         "component": {
-                            "type": "application",
-                            "bom-ref": "${json-unit.matches:projectUuid}",
-                            "author": "SampleAuthor",
-                            "supplier": {
-                              "name": "projectSupplier"
-                            },
-                            "name": "acme-app",
-                            "version": ""
+                        "type": "application",
+                        "bom-ref": "${json-unit.matches:projectUuid}",
+                        "author": "SampleAuthor",
+                        "supplier": {
+                            "name": "projectSupplier"
+                        },
+                        "name": "acme-app",
+                        "version": ""
                         },
                         "manufacture": {
-                          "name": "projectManufacturer"
+                        "name": "projectManufacturer"
                         },
+                        "properties": [
+                        {
+                            "name": "foo",
+                            "value": "bar"
+                        }
+                        ],
                         "supplier": {
-                          "name": "bomSupplier"
+                        "name": "bomSupplier"
                         },
                         "tools": [
-                            {
-                                "vendor": "OWASP",
-                                "name": "Dependency-Track",
-                                "version": "${json-unit.any-string}"
-                            }
+                        {
+                            "vendor": "OWASP",
+                            "name": "Dependency-Track",
+                            "version": "${json-unit.any-string}"
+                        }
                         ]
                     },
                     "components": [
                         {
-                            "type": "library",
-                            "bom-ref": "${json-unit.matches:componentWithoutVulnUuid}",
-                            "supplier": {
-                              "name": "componentSupplier"
-                            },
-                            "name": "acme-lib-a",
-                            "version": "1.0.0",
-                            "properties": [
-                              {
-                                "name": "foo:bar",
-                                "value": "baz"
-                              }
-                            ]
+                        "type": "library",
+                        "bom-ref": "${json-unit.matches:componentWithoutVulnUuid}",
+                        "supplier": {
+                            "name": "componentSupplier"
+                        },
+                        "name": "acme-lib-a",
+                        "version": "1.0.0",
+                        "properties": [
+                            {
+                            "name": "foo:bar",
+                            "value": "baz"
+                            }
+                        ]
                         },
                         {
-                            "type": "library",
-                            "bom-ref": "${json-unit.matches:componentWithVulnUuid}",
-                            "name": "acme-lib-b",
-                            "version": "1.0.0"
+                        "type": "library",
+                        "bom-ref": "${json-unit.matches:componentWithVulnUuid}",
+                        "name": "acme-lib-b",
+                        "version": "1.0.0"
                         },
                         {
-                            "type": "library",
-                            "bom-ref": "${json-unit.matches:componentWithVulnAndAnalysisUuid}",
-                            "name": "acme-lib-c",
-                            "version": "1.0.0"
+                        "type": "library",
+                        "bom-ref": "${json-unit.matches:componentWithVulnAndAnalysisUuid}",
+                        "name": "acme-lib-c",
+                        "version": "1.0.0"
                         }
                     ],
                     "dependencies": [
                         {
-                            "ref": "${json-unit.matches:projectUuid}",
-                            "dependsOn": [
-                                "${json-unit.matches:componentWithoutVulnUuid}",
-                                "${json-unit.matches:componentWithVulnAndAnalysisUuid}"
-                            ]
+                        "ref": "${json-unit.matches:projectUuid}",
+                        "dependsOn": [
+                            "${json-unit.matches:componentWithoutVulnUuid}",
+                            "${json-unit.matches:componentWithVulnAndAnalysisUuid}"
+                        ]
                         },
                         {
-                            "ref": "${json-unit.matches:componentWithoutVulnUuid}",
-                            "dependsOn": [
-                                "${json-unit.matches:componentWithVulnUuid}"
-                            ]
+                        "ref": "${json-unit.matches:componentWithoutVulnUuid}",
+                        "dependsOn": [
+                            "${json-unit.matches:componentWithVulnUuid}"
+                        ]
                         },
                         {
-                            "ref": "${json-unit.matches:componentWithVulnUuid}",
-                            "dependsOn": []
+                        "ref": "${json-unit.matches:componentWithVulnUuid}",
+                        "dependsOn": []
                         },
                         {
-                            "ref": "${json-unit.matches:componentWithVulnAndAnalysisUuid}",
-                            "dependsOn": []
+                        "ref": "${json-unit.matches:componentWithVulnAndAnalysisUuid}",
+                        "dependsOn": []
                         }
                     ]
-                }
+                    }
                 """));
 
         // Ensure the dependency graph did not get deleted during export.

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -207,6 +207,12 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
                 assertThat(contact.getPhone()).isEqualTo("123-456-7890");
             });
         });
+        assertThat(project.getMetadata().getProperties()).isNotNull();
+        assertThat(project.getMetadata().getProperties()).hasSize(2);
+        assertThat(project.getMetadata().getProperties().get(0).getName()).isEqualTo("BUILD_SYSTEM");
+        assertThat(project.getMetadata().getProperties().get(0).getValue()).isEqualTo("Maven");
+        assertThat(project.getMetadata().getProperties().get(1).getName()).isEqualTo("LANGUAGE");
+        assertThat(project.getMetadata().getProperties().get(1).getValue()).isEqualTo("Java");
 
         final List<Component> components = qm.getAllComponents(project);
         assertThat(components).hasSize(1);

--- a/src/test/resources/unit/bom-1.xml
+++ b/src/test/resources/unit/bom-1.xml
@@ -58,6 +58,16 @@
                 <phone>123-456-7890</phone>
             </contact>
         </supplier>
+        <properties>
+            <property>
+                <name>BUILD_SYSTEM</name>
+                <value>Maven</value>
+            </property>
+            <property>
+                <name>LANGUAGE</name>
+                <value>Java</value>
+            </property>
+        </properties>
     </metadata>
     <components>
         <component type="application">


### PR DESCRIPTION
### Description

Extend CycloneDX metadata by custom properties, to keep the information when uploading an re-downloading an SBOM file

### Addressed Issue

closes https://github.com/DependencyTrack/dependency-track/issues/4321

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
