### PR TITLE
Fix incorrect CWE schema in OpenAPI spec

### DIFF
--- a/src/main/java/org/dependencytrack/model/Vulnerability.java
+++ b/src/main/java/org/dependencytrack/model/Vulnerability.java
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.dependencytrack.parser.common.resolver.CweResolver;
 import org.dependencytrack.persistence.CollectionIntegerConverter;
 import org.dependencytrack.resources.v1.serializers.CweDeserializer;
@@ -225,6 +227,7 @@ public class Vulnerability implements Serializable {
     @Convert(CollectionIntegerConverter.class)
     @JsonSerialize(using = CweSerializer.class)
     @JsonDeserialize(using = CweDeserializer.class)
+    @ArraySchema(schema = @Schema(implementation = Cwe.class))
     private List<Integer> cwes;
 
     @Persistent


### PR DESCRIPTION
### Description

Added annotation for OpenAPI description.

### Addressed Issue

Fixes #4349 

### Additional Details

Now produces:

```json
"Vulnerability" : {

          "cwes" : {
            "type" : "array",
            "items" : {
              "$ref" : "#/components/schemas/Cwe"
            }
          },
```

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
