### PR TITLE
Fix policy evaluation not happening upon creation or update of individual components

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -370,7 +370,7 @@ public class ComponentResource extends AlpineResource {
                 // Wait for RepositoryMetaEvent after VulnerabilityAnalysisEvent,
                 // as both might be needed in policy evaluation
                 .onSuccess(new RepositoryMetaEvent(List.of(component)))
-                .onSuccess(new PolicyEvaluationEvent(component))
+                .onSuccess(new PolicyEvaluationEvent(component).project(component.getProject()))
             );
             return Response.status(Response.Status.CREATED).entity(component).build();
         }
@@ -479,7 +479,7 @@ public class ComponentResource extends AlpineResource {
                     // Wait for RepositoryMetaEvent after VulnerabilityAnalysisEvent,
 // as both might be needed in policy evaluation
                     .onSuccess(new RepositoryMetaEvent(List.of(component)))
-                    .onSuccess(new PolicyEvaluationEvent(component))
+                    .onSuccess(new PolicyEvaluationEvent(component).project(component.getProject()))
                 );
                 return Response.ok(component).build();
             } else {

--- a/src/test/java/org/dependencytrack/tasks/PolicyEvaluationTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/PolicyEvaluationTaskTest.java
@@ -1,0 +1,45 @@
+package org.dependencytrack.tasks;
+
+import alpine.persistence.PaginatedResult;
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.event.PolicyEvaluationEvent;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Policy;
+import org.dependencytrack.model.PolicyCondition;
+import org.dependencytrack.model.Project;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PolicyEvaluationTaskTest extends PersistenceCapableTest {
+
+    @Test
+    public void testPolicyEvaluationForSingleComponent() {
+        Project project = new Project();
+        project.setName("my-project");
+        project.setGroup("com.example");
+        project.setVersion("1.0.0");
+        qm.createProject(project, Collections.emptyList(), false);
+
+        Component component = new Component();
+        component.setGroup("com.example");
+        component.setName("my-component");
+        component.setVersion("1.0.0");
+        component.setPurl("pkg:maven/com.example/my-component@1.0.0");
+        component.setProject(project);
+        qm.createComponent(component, false);
+
+        // a policy that identifies the upper component and thus should be violated
+        Policy policy = qm.createPolicy("my-policy", Policy.Operator.ALL, Policy.ViolationState.FAIL);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.MATCHES, "pkg:maven/com.example/my-component@1.0.0");
+
+        PolicyEvaluationTask task = new PolicyEvaluationTask();
+        task.inform(new PolicyEvaluationEvent(component).project(project));
+
+        PaginatedResult policyViolations = qm.getPolicyViolations(project, false);
+        assertThat(policyViolations.getTotal()).isEqualTo(1);
+    }
+
+}


### PR DESCRIPTION
### Description

Fixes #4373 as suggested in the issue.

### Addressed Issue

#4373 

### Additional Details

The test `PolicyEvaluationTaskTest` does not exactly check the fix.
But I found it valuable since there seems to be no test case yet for `PolicyEvaluationTask`. I used it to study the behavior, it asserts another aspect.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
