### PR TITLE
Move GHAM notification logic outside recursion

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/GitHubAdvisoryMirrorTask.java
+++ b/src/main/java/org/dependencytrack/tasks/GitHubAdvisoryMirrorTask.java
@@ -113,6 +113,24 @@ public class GitHubAdvisoryMirrorTask implements LoggableSubscriber {
                 final long end = System.currentTimeMillis();
                 LOGGER.info("GitHub Advisory mirroring complete");
                 LOGGER.info("Time spent (total): " + (end - start) + "ms");
+
+                if (mirroredWithoutErrors) {
+                    Notification.dispatch(new Notification()
+                            .scope(NotificationScope.SYSTEM)
+                            .group(NotificationGroup.DATASOURCE_MIRRORING)
+                            .title(NotificationConstants.Title.GITHUB_ADVISORY_MIRROR)
+                            .content("Mirroring of GitHub Advisories completed successfully")
+                            .level(NotificationLevel.INFORMATIONAL)
+                    );
+                } else {
+                    Notification.dispatch(new Notification()
+                            .scope(NotificationScope.SYSTEM)
+                            .group(NotificationGroup.DATASOURCE_MIRRORING)
+                            .title(NotificationConstants.Title.GITHUB_ADVISORY_MIRROR)
+                            .content("An error occurred mirroring the contents of GitHub Advisories. Check log for details.")
+                            .level(NotificationLevel.ERROR)
+                    );
+                }
             } else {
                 LOGGER.warn("GitHub Advisory mirroring is enabled, but no personal access token is configured. Skipping.");
             }
@@ -159,24 +177,6 @@ public class GitHubAdvisoryMirrorTask implements LoggableSubscriber {
                 if (pageableList.isHasNextPage()) {
                     retrieveAdvisories(pageableList.getEndCursor());
                 }
-            }
-
-            if (mirroredWithoutErrors) {
-                Notification.dispatch(new Notification()
-                        .scope(NotificationScope.SYSTEM)
-                        .group(NotificationGroup.DATASOURCE_MIRRORING)
-                        .title(NotificationConstants.Title.GITHUB_ADVISORY_MIRROR)
-                        .content("Mirroring of GitHub Advisories completed successfully")
-                        .level(NotificationLevel.INFORMATIONAL)
-                );
-            } else {
-                Notification.dispatch(new Notification()
-                        .scope(NotificationScope.SYSTEM)
-                        .group(NotificationGroup.DATASOURCE_MIRRORING)
-                        .title(NotificationConstants.Title.GITHUB_ADVISORY_MIRROR)
-                        .content("An error occurred mirroring the contents of GitHub Advisories. Check log for details.")
-                        .level(NotificationLevel.ERROR)
-                );
             }
         }
     }


### PR DESCRIPTION
### Description

Fix GitHub Advisory Mirroring task triggering too many notifications.

### Addressed Issue

#4400

### Additional Details

N/A

### Checklist

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
