### PR TITLE
Backport: Move GHSA notification logic outside recursion

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/GitHubAdvisoryMirrorTask.java
+++ b/src/main/java/org/dependencytrack/tasks/GitHubAdvisoryMirrorTask.java
@@ -112,6 +112,24 @@ public class GitHubAdvisoryMirrorTask implements LoggableSubscriber {
                 final long end = System.currentTimeMillis();
                 LOGGER.info("GitHub Advisory mirroring complete");
                 LOGGER.info("Time spent (total): " + (end - start) + "ms");
+
+                if (mirroredWithoutErrors) {
+                    Notification.dispatch(new Notification()
+                            .scope(NotificationScope.SYSTEM)
+                            .group(NotificationGroup.DATASOURCE_MIRRORING)
+                            .title(NotificationConstants.Title.GITHUB_ADVISORY_MIRROR)
+                            .content("Mirroring of GitHub Advisories completed successfully")
+                            .level(NotificationLevel.INFORMATIONAL)
+                    );
+                } else {
+                    Notification.dispatch(new Notification()
+                            .scope(NotificationScope.SYSTEM)
+                            .group(NotificationGroup.DATASOURCE_MIRRORING)
+                            .title(NotificationConstants.Title.GITHUB_ADVISORY_MIRROR)
+                            .content("An error occurred mirroring the contents of GitHub Advisories. Check log for details.")
+                            .level(NotificationLevel.ERROR)
+                    );
+                }
             } else {
                 LOGGER.warn("GitHub Advisory mirroring is enabled, but no personal access token is configured. Skipping.");
             }
@@ -158,24 +176,6 @@ public class GitHubAdvisoryMirrorTask implements LoggableSubscriber {
                 if (pageableList.isHasNextPage()) {
                     retrieveAdvisories(pageableList.getEndCursor());
                 }
-            }
-
-            if (mirroredWithoutErrors) {
-                Notification.dispatch(new Notification()
-                        .scope(NotificationScope.SYSTEM)
-                        .group(NotificationGroup.DATASOURCE_MIRRORING)
-                        .title(NotificationConstants.Title.GITHUB_ADVISORY_MIRROR)
-                        .content("Mirroring of GitHub Advisories completed successfully")
-                        .level(NotificationLevel.INFORMATIONAL)
-                );
-            } else {
-                Notification.dispatch(new Notification()
-                        .scope(NotificationScope.SYSTEM)
-                        .group(NotificationGroup.DATASOURCE_MIRRORING)
-                        .title(NotificationConstants.Title.GITHUB_ADVISORY_MIRROR)
-                        .content("An error occurred mirroring the contents of GitHub Advisories. Check log for details.")
-                        .level(NotificationLevel.ERROR)
-                );
             }
         }
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Moves GHSA notification logic outside recursion.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #4400 
Backports #4401

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
