### PR TITLE
Backport: Fix component SWID tag ID not being considered in project cloning

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -370,6 +370,7 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
         component.setCpe(sourceComponent.getCpe());
         component.setPurl(sourceComponent.getPurl());
         component.setPurlCoordinates(sourceComponent.getPurlCoordinates());
+        component.setSwidTagId(sourceComponent.getSwidTagId());
         component.setInternal(sourceComponent.isInternal());
         component.setDescription(sourceComponent.getDescription());
         component.setCopyright(sourceComponent.getCopyright());

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -1734,6 +1734,7 @@ public class ProjectResourceTest extends ResourceTest {
         componentA.setProject(project);
         componentA.setName("acme-lib-a");
         componentA.setVersion("2.0.0");
+        componentA.setSwidTagId("swidTagId");
         componentA.setSupplier(componentSupplier);
         qm.persist(componentA);
 
@@ -1803,7 +1804,8 @@ public class ProjectResourceTest extends ResourceTest {
                                         "objectType": "COMPONENT",
                                         "uuid": "${json-unit.matches:notSourceComponentUuid}",
                                         "name": "acme-lib-a",
-                                        "version": "2.0.0"
+                                        "version": "2.0.0",
+                                        "swidTagId":"swidTagId"
                                       }
                                     ]
                                     """);
@@ -1833,6 +1835,7 @@ public class ProjectResourceTest extends ResourceTest {
                                 assertThat(clonedComponent.getUuid()).isNotEqualTo(componentA.getUuid());
                                 assertThat(clonedComponent.getName()).isEqualTo("acme-lib-a");
                                 assertThat(clonedComponent.getVersion()).isEqualTo("2.0.0");
+                                assertThat(clonedComponent.getSwidTagId()).isEqualTo("swidTagId");
                                 assertThat(clonedComponent.getSupplier()).isNotNull();
                                 assertThat(clonedComponent.getSupplier().getName()).isEqualTo("componentSupplier");
                                 assertThatJson(clonedComponent.getDirectDependencies())


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes component SWID tag ID not being considered in project cloning.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #4478
Backports #4480

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
