### PR TITLE
Reduce database round-trips during BOM processing

### DIFF
--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -79,6 +79,9 @@ import java.util.UUID;
                 @Persistent(name = "properties"),
                 @Persistent(name = "vulnerabilities"),
         }),
+        @FetchGroup(name = "BOM_UPLOAD_PROCESSING", members = {
+                @Persistent(name = "properties")
+        }),
         @FetchGroup(name = "INTERNAL_IDENTIFICATION", members = {
                 @Persistent(name = "id"),
                 @Persistent(name = "group"),
@@ -107,6 +110,7 @@ public class Component implements Serializable {
      */
     public enum FetchGroup {
         ALL,
+        BOM_UPLOAD_PROCESSING,
         INTERNAL_IDENTIFICATION,
         METRICS_UPDATE,
         REPO_META_ANALYSIS

--- a/src/main/java/org/dependencytrack/model/ComponentIdentity.java
+++ b/src/main/java/org/dependencytrack/model/ComponentIdentity.java
@@ -72,6 +72,13 @@ public class ComponentIdentity {
         this.objectType = ObjectType.COMPONENT;
     }
 
+    public ComponentIdentity(final Component component, final boolean excludeUuid) {
+        this(component);
+        if (excludeUuid) {
+            this.uuid = null;
+        }
+    }
+
     public ComponentIdentity(final org.cyclonedx.model.Component component) {
         try {
             this.purl = new PackageURL(component.getPurl());
@@ -93,6 +100,13 @@ public class ComponentIdentity {
         this.version = service.getVersion();
         this.uuid = service.getUuid();
         this.objectType = ObjectType.SERVICE;
+    }
+
+    public ComponentIdentity(final ServiceComponent service, final boolean excludeUuid) {
+        this(service);
+        if (excludeUuid) {
+            this.uuid = null;
+        }
     }
 
     public ComponentIdentity(final org.cyclonedx.model.Service service) {

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -461,55 +461,6 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
     }
 
     /**
-     * Returns a component by matching its identity information.
-     * <p>
-     * Note that this method employs a stricter matching logic than {@link #matchIdentity(ComponentIdentity)}.
-     * For example, if {@code purl} of the given {@link ComponentIdentity} is {@code null},
-     * this method will use a query that explicitly checks for the {@code purl} column to be {@code null}.
-     * Whereas other methods will simply not include {@code purl} in the query in such cases.
-     *
-     * @param project the Project the component is a dependency of
-     * @param cid     the identity values of the component
-     * @return a Component object, or null if not found
-     * @since 4.11.0
-     */
-    public Component matchSingleIdentityExact(final Project project, final ComponentIdentity cid) {
-        final Pair<String, Map<String, Object>> queryFilterParamsPair = buildExactComponentIdentityQuery(project, cid);
-        final Query<Component> query = pm.newQuery(Component.class, queryFilterParamsPair.getKey());
-        query.setNamedParameters(queryFilterParamsPair.getRight());
-        try {
-            return query.executeUnique();
-        } finally {
-            query.closeAll();
-        }
-    }
-
-    /**
-     * Returns the first component matching a given {@link ComponentIdentity} in a {@link Project}.
-     *
-     * @param project the Project the component is a dependency of
-     * @param cid     the identity values of the component
-     * @return a Component object, or null if not found
-     * @since 4.11.0
-     */
-    public Component matchFirstIdentityExact(final Project project, final ComponentIdentity cid) {
-        final Pair<String, Map<String, Object>> queryFilterParamsPair = buildExactComponentIdentityQuery(project, cid);
-        final Query<Component> query = pm.newQuery(Component.class, queryFilterParamsPair.getKey());
-        query.setNamedParameters(queryFilterParamsPair.getRight());
-        query.setRange(0, 1);
-        try {
-            final List<Component> result = query.executeList();
-            if (result.isEmpty()) {
-                return null;
-            }
-
-            return result.get(0);
-        } finally {
-            query.closeAll();
-        }
-    }
-
-    /**
      * Returns a list of components by matching its identity information.
      * @param project the Project the component is a dependency of
      * @param cid the identity values of the component
@@ -595,87 +546,6 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
         final String filter = "project == :project && (%s)".formatted(String.join(" || ", filterParts));
         params.put("project", project);
         return Pair.of(filter, params);
-    }
-
-    private static Pair<String, Map<String, Object>> buildExactComponentIdentityQuery(final Project project, final ComponentIdentity cid) {
-        var filterParts = new ArrayList<String>();
-        final var params = new HashMap<String, Object>();
-
-        if (cid.getPurl() != null) {
-            filterParts.add("(purl != null && purl == :purl)");
-            params.put("purl", cid.getPurl().canonicalize());
-        } else {
-            filterParts.add("purl == null");
-        }
-
-        if (cid.getCpe() != null) {
-            filterParts.add("(cpe != null && cpe == :cpe)");
-            params.put("cpe", cid.getCpe());
-        } else {
-            filterParts.add("cpe == null");
-        }
-
-        if (cid.getSwidTagId() != null) {
-            filterParts.add("(swidTagId != null && swidTagId == :swidTagId)");
-            params.put("swidTagId", cid.getSwidTagId());
-        } else {
-            filterParts.add("swidTagId == null");
-        }
-
-        var coordinatesFilter = "(";
-        if (cid.getGroup() != null) {
-            coordinatesFilter += "group == :group";
-            params.put("group", cid.getGroup());
-        } else {
-            coordinatesFilter += "group == null";
-        }
-        coordinatesFilter += " && name == :name";
-        params.put("name", cid.getName());
-        if (cid.getVersion() != null) {
-            coordinatesFilter += " && version == :version";
-            params.put("version", cid.getVersion());
-        } else {
-            coordinatesFilter += " && version == null";
-        }
-        coordinatesFilter += ")";
-        filterParts.add(coordinatesFilter);
-
-        final var filter = "project == :project && (" + String.join(" && ", filterParts) + ")";
-        params.put("project", project);
-
-        return Pair.of(filter, params);
-    }
-
-    /**
-     * Intelligently adds dependencies for components that are not already a dependency
-     * of the specified project and removes the dependency relationship for components
-     * that are not in the list of specified components.
-     * @param project the project to bind components to
-     * @param existingProjectComponents the complete list of existing dependent components
-     * @param components the complete list of components that should be dependencies of the project
-     */
-    public void reconcileComponents(Project project, List<Component> existingProjectComponents, List<Component> components) {
-        // Removes components as dependencies to the project for all
-        // components not included in the list provided
-        List<Component> markedForDeletion = new ArrayList<>();
-        for (final Component existingComponent: existingProjectComponents) {
-            boolean keep = false;
-            for (final Component component: components) {
-                if (component.getId() == existingComponent.getId()) {
-                    keep = true;
-                    break;
-                }
-            }
-            if (!keep) {
-                markedForDeletion.add(existingComponent);
-            }
-        }
-        if (!markedForDeletion.isEmpty()) {
-            for (Component c: markedForDeletion) {
-                this.recursivelyDelete(c, false);
-            }
-            //this.delete(markedForDeletion);
-        }
     }
 
     public Map<String, Component> getDependencyGraphForComponents(Project project, List<Component> components) {
@@ -857,7 +727,7 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             //   counter-intuitive to some users, who might expect their manual changes to persist.
             //   If we want to support that, we need a way to track which properties were added and / or
             //   modified manually.
-            if (component.getProperties() != null) {
+            if (component.getProperties() != null && !component.getProperties().isEmpty()) {
                 pm.deletePersistentAll(component.getProperties());
             }
 

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -959,24 +959,12 @@ public class QueryManager extends AlpineQueryManager {
         return getVulnerableSoftwareQueryManager().getAllVulnerableSoftware(cpePart, cpeVendor, cpeProduct, purl);
     }
 
-    public Component matchSingleIdentityExact(final Project project, final ComponentIdentity cid) {
-        return getComponentQueryManager().matchSingleIdentityExact(project, cid);
-    }
-
-    public Component matchFirstIdentityExact(final Project project, final ComponentIdentity cid) {
-        return getComponentQueryManager().matchFirstIdentityExact(project, cid);
-    }
-
     public List<Component> matchIdentity(final Project project, final ComponentIdentity cid) {
         return getComponentQueryManager().matchIdentity(project, cid);
     }
 
     public List<Component> matchIdentity(final ComponentIdentity cid) {
         return getComponentQueryManager().matchIdentity(cid);
-    }
-
-    public void reconcileComponents(Project project, List<Component> existingProjectComponents, List<Component> components) {
-        getComponentQueryManager().reconcileComponents(project, existingProjectComponents, components);
     }
 
     public List<Component> getAllComponents(Project project) {
@@ -997,10 +985,6 @@ public class QueryManager extends AlpineQueryManager {
 
     public ServiceComponent matchServiceIdentity(final Project project, final ComponentIdentity cid) {
         return getServiceComponentQueryManager().matchServiceIdentity(project, cid);
-    }
-
-    public void reconcileServiceComponents(Project project, List<ServiceComponent> existingProjectServices, List<ServiceComponent> services) {
-        getServiceComponentQueryManager().reconcileServiceComponents(project, existingProjectServices, services);
     }
 
     public ServiceComponent createServiceComponent(ServiceComponent service, boolean commitIndex) {

--- a/src/main/java/org/dependencytrack/persistence/ServiceComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ServiceComponentQueryManager.java
@@ -30,7 +30,6 @@ import org.dependencytrack.resources.v1.vo.DependencyGraphResponse;
 import javax.jdo.FetchPlan;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -63,38 +62,6 @@ final class ServiceComponentQueryManager extends QueryManager implements IQueryM
         final Query<ServiceComponent> query = pm.newQuery(ServiceComponent.class, "project == :project && group == :group && name == :name && version == :version");
         query.setRange(0, 1);
         return singleResult(query.executeWithArray(project, cid.getGroup(), cid.getName(), cid.getVersion()));
-    }
-
-    /**
-     * Intelligently adds service components that are not already a dependency
-     * of the specified project and removes the dependency relationship for service components
-     * that are not in the list of specified components.
-     * @param project the project to bind components to
-     * @param existingProjectServices the complete list of existing dependent service components
-     * @param services the complete list of service components that should be dependencies of the project
-     */
-    public void reconcileServiceComponents(Project project, List<ServiceComponent> existingProjectServices, List<ServiceComponent> services) {
-        // Removes components as dependencies to the project for all
-        // components not included in the list provided
-        List<ServiceComponent> markedForDeletion = new ArrayList<>();
-        for (final ServiceComponent existingService: existingProjectServices) {
-            boolean keep = false;
-            for (final ServiceComponent service: services) {
-                if (service.getId() == existingService.getId()) {
-                    keep = true;
-                    break;
-                }
-            }
-            if (!keep) {
-                markedForDeletion.add(existingService);
-            }
-        }
-        if (!markedForDeletion.isEmpty()) {
-            for (ServiceComponent sc: markedForDeletion) {
-                this.recursivelyDelete(sc, false);
-            }
-            //this.delete(markedForDeletion);
-        }
     }
 
     /**

--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -25,12 +25,10 @@ import alpine.notification.Notification;
 import alpine.notification.NotificationLevel;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.parsers.BomParserFactory;
 import org.cyclonedx.parsers.Parser;
 import org.datanucleus.flush.FlushMode;
-import org.datanucleus.store.query.QueryNotUniqueException;
 import org.dependencytrack.event.BomUploadEvent;
 import org.dependencytrack.event.NewVulnerableDependencyAnalysisEvent;
 import org.dependencytrack.event.PolicyEvaluationEvent;
@@ -61,7 +59,6 @@ import org.dependencytrack.util.InternalComponentIdentifier;
 import org.json.JSONArray;
 import org.slf4j.MDC;
 
-import javax.jdo.JDOUserException;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import java.util.ArrayList;
@@ -77,8 +74,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
+import static javax.jdo.FetchPlan.FETCH_SIZE_GREEDY;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.trim;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
@@ -368,10 +368,6 @@ public class BomUploadProcessingTask implements Subscriber {
     ) {
         assertPersistent(project, "Project mut be persistent");
 
-        // Fetch IDs of all components that exist in the project already.
-        // We'll need them later to determine which components to delete.
-        final Set<Long> idsOfComponentsToDelete = getAllComponentIds(qm, project, Component.class);
-
         // Avoid redundant queries by caching resolved licenses.
         // It is likely that if license IDs were present in a BOM,
         // they appear multiple times for different components.
@@ -382,26 +378,34 @@ public class BomUploadProcessingTask implements Subscriber {
         final var customLicenseCache = new HashMap<String, License>();
 
         final var internalComponentIdentifier = new InternalComponentIdentifier();
-        final var persistentComponents = new HashMap<ComponentIdentity, Component>();
+
+        final List<Component> persistentComponents = getAllComponents(qm, project);
+
+        // Group existing components by their identity for easier lookup.
+        // Note that we exclude the UUID from the identity here,
+        // since incoming non-persistent components won't have one yet.
+        final Map<ComponentIdentity, Component> persistentComponentByIdentity = persistentComponents.stream()
+                .collect(Collectors.toMap(
+                        component -> new ComponentIdentity(component, /* excludeUuid */ true),
+                        Function.identity(),
+                        (previous, duplicate) -> {
+                            LOGGER.warn("""
+                                    More than one existing component matches the identity %s; \
+                                    Proceeding with first match, others will be deleted\
+                                    """.formatted(new ComponentIdentity(previous, /* excludeUuid */ true)));
+                            return previous;
+                        }));
+
+        final Set<Long> idsOfComponentsToDelete = persistentComponents.stream()
+                .map(Component::getId)
+                .collect(Collectors.toSet());
+
         for (final Component component : components) {
             component.setInternal(internalComponentIdentifier.isInternal(component));
             resolveAndApplyLicense(qm, component, licenseCache, customLicenseCache);
 
             final var componentIdentity = new ComponentIdentity(component);
-            Component persistentComponent;
-            try {
-                persistentComponent = qm.matchSingleIdentityExact(project, componentIdentity);
-            } catch (JDOUserException e) {
-                if (!(ExceptionUtils.getRootCause(e) instanceof QueryNotUniqueException)) {
-                    throw e;
-                }
-
-                LOGGER.warn("""
-                        More than one existing component match the identity %s; \
-                        Proceeding with first match, others will be deleted\
-                        """.formatted(componentIdentity.toJSON()));
-                persistentComponent = qm.matchFirstIdentityExact(project, componentIdentity);
-            }
+            Component persistentComponent = persistentComponentByIdentity.get(componentIdentity);
             if (persistentComponent == null) {
                 component.setProject(project);
                 persistentComponent = qm.persist(component);
@@ -450,8 +454,20 @@ public class BomUploadProcessingTask implements Subscriber {
                 identitiesByBomRef.put(bomRef, newIdentity);
             }
 
-            persistentComponents.put(newIdentity, persistentComponent);
+            persistentComponentByIdentity.put(newIdentity, persistentComponent);
         }
+
+        persistentComponentByIdentity.entrySet().removeIf(entry -> {
+            // Remove entries for identities without UUID, those were only needed for matching.
+            final ComponentIdentity identity = entry.getKey();
+            if (identity.getUuid() == null) {
+                return true;
+            }
+
+            // Remove entries for components marked for deletion.
+            final Component component = entry.getValue();
+            return idsOfComponentsToDelete.contains(component.getId());
+        });
 
         qm.getPersistenceManager().flush();
 
@@ -460,7 +476,7 @@ public class BomUploadProcessingTask implements Subscriber {
             qm.getPersistenceManager().flush();
         }
 
-        return persistentComponents;
+        return persistentComponentByIdentity;
     }
 
     private Map<ComponentIdentity, ServiceComponent> processServices(
@@ -472,17 +488,30 @@ public class BomUploadProcessingTask implements Subscriber {
     ) {
         assertPersistent(project, "Project must be persistent");
 
-        final PersistenceManager pm = qm.getPersistenceManager();
+        final List<ServiceComponent> persistentServices = getAllServices(qm, project);
 
-        // Fetch IDs of all services that exist in the project already.
-        // We'll need them later to determine which services to delete.
-        final Set<Long> idsOfServicesToDelete = getAllComponentIds(qm, project, ServiceComponent.class);
+        // Group existing services by their identity for easier lookup.
+        // Note that we exclude the UUID from the identity here,
+        // since incoming non-persistent services won't have one yet.
+        final Map<ComponentIdentity, ServiceComponent> persistentServiceByIdentity = persistentServices.stream()
+                .collect(Collectors.toMap(
+                        service -> new ComponentIdentity(service, /* excludeUuid */ true),
+                        Function.identity(),
+                        (previous, duplicate) -> {
+                            LOGGER.warn("""
+                                    More than one existing service matches the identity %s; \
+                                    Proceeding with first match, others will be deleted\
+                                    """.formatted(new ComponentIdentity(previous, /* excludeUuid */ true)));
+                            return previous;
+                        }));
 
-        final var persistentServices = new HashMap<ComponentIdentity, ServiceComponent>();
+        final Set<Long> idsOfServicesToDelete = persistentServices.stream()
+                .map(ServiceComponent::getId)
+                .collect(Collectors.toSet());
 
         for (final ServiceComponent service : services) {
             final var componentIdentity = new ComponentIdentity(service);
-            ServiceComponent persistentService = qm.matchServiceIdentity(project, componentIdentity);
+            ServiceComponent persistentService = persistentServiceByIdentity.get(componentIdentity);
             if (persistentService == null) {
                 service.setProject(project);
                 persistentService = qm.persist(service);
@@ -509,8 +538,20 @@ public class BomUploadProcessingTask implements Subscriber {
                 identitiesByBomRef.put(bomRef, newIdentity);
             }
 
-            persistentServices.put(newIdentity, persistentService);
+            persistentServiceByIdentity.put(newIdentity, persistentService);
         }
+
+        persistentServiceByIdentity.entrySet().removeIf(entry -> {
+            // Remove entries for identities without UUID, those were only needed for matching.
+            final ComponentIdentity identity = entry.getKey();
+            if (identity.getUuid() == null) {
+                return true;
+            }
+
+            // Remove entries for services marked for deletion.
+            final ServiceComponent service = entry.getValue();
+            return idsOfServicesToDelete.contains(service.getId());
+        });
 
         qm.getPersistenceManager().flush();
 
@@ -520,7 +561,7 @@ public class BomUploadProcessingTask implements Subscriber {
         }
 
 
-        return persistentServices;
+        return persistentServiceByIdentity;
     }
 
     private void recordBomImport(final Context ctx, final QueryManager qm, final Project project) {
@@ -728,14 +769,28 @@ public class BomUploadProcessingTask implements Subscriber {
         }
     }
 
-    private static <T> Set<Long> getAllComponentIds(final QueryManager qm, final Project project, final Class<T> clazz) {
-        final Query<T> query = qm.getPersistenceManager().newQuery(clazz);
-        query.setFilter("project == :project");
-        query.setParameters(project);
-        query.setResult("id");
+    private static List<Component> getAllComponents(final QueryManager qm, final Project project) {
+        final Query<Component> query = qm.getPersistenceManager().newQuery(Component.class);
+        query.getFetchPlan().addGroup(Component.FetchGroup.BOM_UPLOAD_PROCESSING.name());
+        query.getFetchPlan().setFetchSize(FETCH_SIZE_GREEDY);
+        query.setFilter("project.id == :projectId");
+        query.setParameters(project.getId());
 
         try {
-            return new HashSet<>(query.executeResultList(Long.class));
+            return List.copyOf(query.executeList());
+        } finally {
+            query.closeAll();
+        }
+    }
+
+    private static List<ServiceComponent> getAllServices(final QueryManager qm, final Project project) {
+        final Query<ServiceComponent> query = qm.getPersistenceManager().newQuery(ServiceComponent.class);
+        query.getFetchPlan().setFetchSize(FETCH_SIZE_GREEDY);
+        query.setFilter("project.id == :projectId");
+        query.setParameters(project.getId());
+
+        try {
+            return List.copyOf(query.executeList());
         } finally {
             query.closeAll();
         }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Reduce database round-trips during BOM processing.

In the previous implementation, a `SELECT` query was issued for every single component and service in a BOM, in order to find existing components that match their identity.

In retrospect, this causes a lot of unnecessary database round-trips and puts the database under unnecessary stress, in particular for new projects where no components and services exist yet.

Now, we query all existing components and services of the project once in bulk. In addition to better performance in most situations, it also allows for more flexibility for component de-duplication in the future (#3861).

A situation where this approach can perform worse, is when a BOM is uploaded to an existing project, and the content differs wildly between BOM and project. We would then load many components into memory, only to delete them shortly after. However, this scenario should be less common. Usually, projects are either empty, or have significant overlap with the uploaded BOM.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports https://github.com/DependencyTrack/hyades-apiserver/pull/1006

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
