### PR TITLE
Fix onlyOutdated ungrouped component filtering

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -166,7 +166,7 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
                 " && !("+
                 " SELECT FROM org.dependencytrack.model.RepositoryMetaComponent m " +
                 " WHERE m.name == this.name " +
-                " && m.namespace == this.group " +
+                " && (m.namespace == this.group || (m.namespace == null && this.group == null)) " +
                 " && m.latestVersion != this.version " +
                 " && this.purl.matches('pkg:' + m.repositoryType.toString().toLowerCase() + '/%') " +
                 " ).isEmpty()";

--- a/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
@@ -121,6 +121,50 @@ public class ComponentResourceTest extends ResourceTest {
         return project;
     }
 
+    /**
+     * Generate a project with ungrouped dependencies
+     * @return A project with 10 dependencies: <ul>
+     * <li>7 outdated dependencies</li>
+     * <li>3 recent dependencies</li></ul>
+     * @throws MalformedPackageURLException
+     */
+    private Project prepareProjectUngroupedComponents() throws MalformedPackageURLException {
+        final Project project = qm.createProject("Ungrouped Application", null, null, null, null, null, true, false);
+        final List<String> directDepencencies = new ArrayList<>();
+        // Generate 10 dependencies
+        for (int i = 0; i < 10; i++) {
+            Component component = new Component();
+            component.setProject(project);
+            component.setName("component-name-"+i);
+            component.setVersion(String.valueOf(i)+".0");
+            component.setPurl(new PackageURL(RepositoryType.PYPI.toString(), null, "component-name-"+i , String.valueOf(i)+".0", null, null));
+            component = qm.createComponent(component, false);
+            // direct depencencies
+            if (i < 4) {
+                // 4 direct depencencies, 6 transitive depencencies
+                directDepencencies.add("{\"uuid\":\"" + component.getUuid() + "\"}");
+            }
+            // Recent & Outdated
+            if ((i < 7)) {
+                final var metaComponent = new RepositoryMetaComponent();
+                metaComponent.setRepositoryType(RepositoryType.PYPI);
+                metaComponent.setName("component-name-"+i);
+                metaComponent.setLatestVersion(String.valueOf(i+1)+".0");
+                metaComponent.setLastCheck(new Date());
+                qm.persist(metaComponent);
+            } else {
+                final var metaComponent = new RepositoryMetaComponent();
+                metaComponent.setRepositoryType(RepositoryType.PYPI);
+                metaComponent.setName("component-name-"+i);
+                metaComponent.setLatestVersion(String.valueOf(i)+".0");
+                metaComponent.setLastCheck(new Date());
+                qm.persist(metaComponent);
+            }
+        }
+        project.setDirectDependencies("[" + String.join(",", directDepencencies.toArray(new String[0])) + "]");
+        return project;
+    }
+
     @Test
     public void getOutdatedComponentsTest() throws MalformedPackageURLException {
         final Project project = prepareProject();
@@ -139,6 +183,23 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
+    public void getUngroupedOutdatedComponentsTest() throws MalformedPackageURLException {
+        final Project project = prepareProjectUngroupedComponents();
+
+        final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
+                .queryParam("onlyOutdated", true)
+                .queryParam("onlyDirect", false)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("7"); // 7 outdated dependencies, direct and transitive
+
+        final JsonArray json = parseJsonArray(response);
+        assertThat(json).hasSize(7);
+    }
+
+    @Test
     public void getOutdatedDirectComponentsTest() throws MalformedPackageURLException {
         final Project project = prepareProject();
 
@@ -153,6 +214,23 @@ public class ComponentResourceTest extends ResourceTest {
 
         final JsonArray json = parseJsonArray(response);
         assertThat(json).hasSize(75);
+    }
+
+    @Test
+    public void getUngroupedOutdatedDirectComponentsTest() throws MalformedPackageURLException {
+        final Project project = prepareProjectUngroupedComponents();
+
+        final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
+                .queryParam("onlyOutdated", true)
+                .queryParam("onlyDirect", true)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("4"); // 4 outdated direct dependencies
+
+        final JsonArray json = parseJsonArray(response);
+        assertThat(json).hasSize(4);
     }
 
     @Test


### PR DESCRIPTION
### Description

Fixes onlyOutdated filter when listing a project's components missing any ungrouped (outdated) components, such as Python packages.

### Addressed Issue

Fixes #4510

### Additional Details

N/A

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
