### PR TITLE
Create pr-detect-merge-conflicts GitHub workflow

### DIFF
--- a/.github/workflows/pr-detect-merge-conflicts
+++ b/.github/workflows/pr-detect-merge-conflicts
@@ -1,0 +1,22 @@
+name: "Detect Merge Conflicts"
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - 4*
+      
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check if prs are conflicted
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: "conflicts-detected"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "This pull request has conflicts, please resolve those before we can evaluate the pull request."
+          commentOnClean: "Conflicts have been resolved. A maintainer will review the pull request shortly."


### PR DESCRIPTION
### Description
I've seen in other projects that it might be helpful to inform PR authors and reviewers of when a PR has conflicts (or when these have been resolved).