### PR TITLE
docs: Clarify OpenAPI endpoint location

### DIFF
--- a/docs/_docs/integrations/rest-api.md
+++ b/docs/_docs/integrations/rest-api.md
@@ -11,8 +11,11 @@ of the platform. Every API is fully documented via OpenAPI v3.
 > http://{hostname}:{port}/api/openapi.json  
 > http://{hostname}:{port}/api/openapi.yaml
 
+**Note:** The OpenAPI endpoints are only available on the backend server, not on the frontend server.
+If you run Dependency Track with the default Docker Compose file, this is port `8081` and *not* port `8080`.
+
 The Swagger UI Console (not included) can be used to visualize and explore the wide range of possibilities. Chrome and
-FireFox extensions can be used to quickly use the Swagger UI Console.
+Firefox extensions can be used to quickly use the Swagger UI Console.
 
 ![Swagger UI Console](/images/screenshots/swagger-ui-console.png)
 


### PR DESCRIPTION
### Description

Clarifies where the OpenAPI endpoint is available because it is not obvious that it is not available from the public endpoint.

### Addressed Issue

Fixes #4555 


### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
