### PR TITLE
Add SecObserve to community integrations

### DIFF
--- a/docs/_docs/integrations/community-integrations.md
+++ b/docs/_docs/integrations/community-integrations.md
@@ -30,4 +30,4 @@ to make custom tools and integrations. Many tools that integrate with Dependency
 |[Dependency-Track Backstage plugin](https://github.com/TRIMM/plugin-dependencytrack)| [TRIMM](https://www.trimm.nl/)|
 | [dependency-track-exporter](https://github.com/jetstack/dependency-track-exporter) | [Jetstack](https://jetstack.io) |
 | [Azure DevOps Extension](https://marketplace.visualstudio.com/items?itemName=eshaar-me.vss-dependency-track-integration) | |
-
+| [SecObserve](https://github.com/MaibornWolff/SecObserve) | [MaibornWolff](https://www.maibornwolff.de/en/) |


### PR DESCRIPTION
### Description

The open source vulnerability management system SecObserve has an API integration, to load vulnerabilities from Dependency Track. This is the reason, SecObserve should appear in the documentation for the community integrations.

### Addressed Issue

There is no issue at the moment. Do we need one for this?

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
