### PR TITLE
Backport: Analyze all components of a project at once instead of in batches

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
@@ -154,31 +154,24 @@ public class VulnerabilityAnalysisTask implements Subscriber {
                 return;
             }
 
-            List<Component> components = fetchNextComponentBatch(qm, project, null);
+            // NB: Some analyzers require all components of a project to be analyzed in one go.
+            // Trivy for example checks for the existence of OPERATING_SYSTEM components.
+            // If we were to analyze components in batches, this logic might not work for large projects.
+            final List<Component> components = fetchComponents(qm, project);
             if (components.isEmpty()) {
                 LOGGER.info("Project does not have any components; Nothing to analyze");
                 return;
             }
 
-            while (!components.isEmpty()) {
-                if (Thread.currentThread().isInterrupted()) {
-                    LOGGER.info("Interrupted before all components could be analyzed");
-                    break;
+            analyzeComponents(qm, components, analysisLevel);
+
+            if (analysisLevel == VulnerabilityAnalysisLevel.PERIODIC_ANALYSIS) {
+                try {
+                    performPolicyEvaluation(project, components);
+                } catch (RuntimeException e) {
+                    LOGGER.warn("Policy evaluation against %d components failed".formatted(
+                            components.size()), e);
                 }
-
-                analyzeComponents(qm, components, analysisLevel);
-
-                if (analysisLevel == VulnerabilityAnalysisLevel.PERIODIC_ANALYSIS) {
-                    try {
-                        performPolicyEvaluation(project, components);
-                    } catch (RuntimeException e) {
-                        LOGGER.warn("Policy evaluation against %d components failed".formatted(
-                                components.size()), e);
-                    }
-                }
-
-                qm.getPersistenceManager().evictAll(false, Component.class);
-                components = fetchNextComponentBatch(qm, project, components.getLast().getId());
             }
         } finally {
             projectLock.unlock();
@@ -334,23 +327,10 @@ public class VulnerabilityAnalysisTask implements Subscriber {
         }
     }
 
-    private List<Component> fetchNextComponentBatch(final QueryManager qm, final Project project, final Long lastId) {
-        final var filterParts = new ArrayList<String>(2);
-        filterParts.add("project.id == :projectId");
-
-        final var filterParams = new HashMap<String, Object>();
-        filterParams.put("projectId", project.getId());
-
-        if (lastId != null) {
-            filterParts.add("id > :lastId");
-            filterParams.put("lastId", lastId);
-        }
-
+    private List<Component> fetchComponents(final QueryManager qm, final Project project) {
         final Query<Component> query = qm.getPersistenceManager().newQuery(Component.class);
-        query.setFilter(String.join(" && ", filterParts));
-        query.setNamedParameters(filterParams);
-        query.setOrdering("id asc");
-        query.setRange(0, 1000);
+        query.setFilter("project.id == :projectId");
+        query.setParameters(project.getId());
 
         try (var ignoredPersistenceCustomization = new ScopedCustomization(qm.getPersistenceManager())
                 .withFetchGroup(Component.FetchGroup.COMPONENT_VULN_ANALYSIS.name())) {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Analyzes all components of a project at once instead of in batches.

Unfortunately this is necessary to support Trivy properly, because it checks for the existence of `OPERATING_SYSTEM` components in a project. If we were to analyze components in batches, this logic might not work for large projects.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #4670

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
