### PR TITLE
Fix notification webhook sending blank headers

### DIFF
--- a/src/main/java/org/dependencytrack/notification/publisher/AbstractWebhookPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/AbstractWebhookPublisher.java
@@ -76,7 +76,7 @@ public abstract class AbstractWebhookPublisher implements Publisher {
             } else {
                 request.addHeader("Authorization", "Bearer " + credentials.password);
             }
-        } else if (getToken(config) != null) {
+        } else if (getToken(config) != null && !getToken(config).isEmpty() && getTokenHeader(config) != null && !getTokenHeader(config).isEmpty()) {
             request.addHeader(getTokenHeader(config), getToken(config));
         }
 


### PR DESCRIPTION
### Description

When the API token header and/or API token has not been set when configuring an Outbound Webhook notification endpoint, the HTTP request will include an empty http header.

This does not conform with [RFC 2616](https://datatracker.ietf.org/doc/html/rfc2616#section-4.2)

### Addressed Issue

Fixes issue #4344. 

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
