### PR TITLE
Prevent application startup when migrations fail

### DIFF
--- a/src/main/java/org/dependencytrack/upgrade/UpgradeInitializer.java
+++ b/src/main/java/org/dependencytrack/upgrade/UpgradeInitializer.java
@@ -81,8 +81,8 @@ public class UpgradeInitializer implements ServletContextListener {
                 final UpgradeExecutor executor = new UpgradeExecutor(qm);
                 try {
                     executor.executeUpgrades(UpgradeItems.getUpgradeItems());
-                } catch (UpgradeException e) {
-                    LOGGER.error("An error occurred performing upgrade processing. " + e.getMessage());
+                } catch (UpgradeException | RuntimeException e) {
+                    throw new IllegalStateException("An error occurred performing upgrade processing", e);
                 }
             }
         }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Prevents application startup when migrations fail.

Previously, failures during migrations were only logged, but application startup was not aborted. This could possibly lead to users never knowing whether migrations failed.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
