### PR TITLE
Add support for Snyk API version 2024-10-15

### DIFF
--- a/src/test/java/org/dependencytrack/parser/snyk/SnykParserTest.java
+++ b/src/test/java/org/dependencytrack/parser/snyk/SnykParserTest.java
@@ -55,7 +55,23 @@ public class SnykParserTest extends PersistenceCapableTest {
         final JSONObject jsonObject = new JSONObject(jsonString);
         JSONArray ranges = jsonObject.optJSONArray("range0");
         String purl = "pkg:npm/bootstrap-table@1.20.0";
-        List<VulnerableSoftware> vulnerableSoftwares = parser.parseVersionRanges(qm, purl, ranges);
+        List<VulnerableSoftware> vulnerableSoftwares = parser.parseVersionRanges(qm, purl, ranges, false);
+        Assert.assertNotNull(vulnerableSoftwares);
+        Assert.assertEquals(1, vulnerableSoftwares.size());
+
+        VulnerableSoftware vs = vulnerableSoftwares.get(0);
+        Assert.assertEquals("2.13.0", vs.getVersionStartIncluding());
+        Assert.assertEquals("2.13.2.1", vs.getVersionEndExcluding());
+    }
+
+    @Test
+    public void testParseVersionRanges_v3() throws IOException {
+
+        String jsonString = new String(Files.readAllBytes(Paths.get("src/test/resources/unit/snyk.jsons/ranges.json")));
+        final JSONObject jsonObject = new JSONObject(jsonString);
+        JSONArray ranges = jsonObject.optJSONArray("range0_v3");
+        String purl = "pkg:npm/bootstrap-table@1.20.0";
+        List<VulnerableSoftware> vulnerableSoftwares = parser.parseVersionRanges(qm, purl, ranges, true);
         Assert.assertNotNull(vulnerableSoftwares);
         Assert.assertEquals(1, vulnerableSoftwares.size());
 
@@ -71,7 +87,19 @@ public class SnykParserTest extends PersistenceCapableTest {
         final JSONObject jsonObject = new JSONObject(jsonString);
         JSONArray ranges = jsonObject.optJSONArray("range2");
         String purl = "pkg:npm/bootstrap-table@1.20.0";
-        List<VulnerableSoftware> vulnerableSoftwares = parser.parseVersionRanges(qm, purl, ranges);
+        List<VulnerableSoftware> vulnerableSoftwares = parser.parseVersionRanges(qm, purl, ranges, false);
+        Assert.assertNotNull(vulnerableSoftwares);
+        Assert.assertEquals(0, vulnerableSoftwares.size());
+    }
+
+    @Test
+    public void testParseVersionRangesStar_v3() throws IOException {
+
+        String jsonString = new String(Files.readAllBytes(Paths.get("src/test/resources/unit/snyk.jsons/ranges.json")));
+        final JSONObject jsonObject = new JSONObject(jsonString);
+        JSONArray ranges = jsonObject.optJSONArray("range2_v3");
+        String purl = "pkg:npm/bootstrap-table@1.20.0";
+        List<VulnerableSoftware> vulnerableSoftwares = parser.parseVersionRanges(qm, purl, ranges, true);
         Assert.assertNotNull(vulnerableSoftwares);
         Assert.assertEquals(0, vulnerableSoftwares.size());
     }
@@ -83,7 +111,19 @@ public class SnykParserTest extends PersistenceCapableTest {
         final JSONObject jsonObject = new JSONObject(jsonString);
         JSONArray ranges = jsonObject.optJSONArray("range1");
         String purl = "pkg:npm/bootstrap-table@1.20.0";
-        List<VulnerableSoftware> vulnerableSoftwares = parser.parseVersionRanges(qm, purl, ranges);
+        List<VulnerableSoftware> vulnerableSoftwares = parser.parseVersionRanges(qm, purl, ranges, false);
+        Assert.assertNotNull(vulnerableSoftwares);
+        Assert.assertEquals(0, vulnerableSoftwares.size());
+    }
+
+    @Test
+    public void testParseVersionIndefiniteRanges_v3() throws IOException {
+
+        String jsonString = new String(Files.readAllBytes(Paths.get("src/test/resources/unit/snyk.jsons/ranges.json")));
+        final JSONObject jsonObject = new JSONObject(jsonString);
+        JSONArray ranges = jsonObject.optJSONArray("range1_v3");
+        String purl = "pkg:npm/bootstrap-table@1.20.0";
+        List<VulnerableSoftware> vulnerableSoftwares = parser.parseVersionRanges(qm, purl, ranges, true);
         Assert.assertNotNull(vulnerableSoftwares);
         Assert.assertEquals(0, vulnerableSoftwares.size());
     }

--- a/src/test/resources/unit/snyk.jsons/ranges.json
+++ b/src/test/resources/unit/snyk.jsons/ranges.json
@@ -4,11 +4,23 @@
     "[2.13.0, 2.13.2.1)",
     "<1.20.2"
   ],
+  "range0_v3": [
+    { "resource_path": "[, 2.12.6.1)" },
+    { "resource_path": "[2.13.0, 2.13.2.1)" },
+    { "resource_path": "<1.20.2" }
+  ],
   "range1": [
     "[, 2.12.6.1)",
     "<1.20.2"
   ],
+  "range1_v3": [
+    { "resource_path": "[, 2.12.6.1)" },
+    { "resource_path": "<1.20.2" }
+  ],
   "range2": [
     "*"
+  ],
+  "range2_v3": [
+    { "resource_path": "*" }
   ]
 }


### PR DESCRIPTION
### Description

This PR addresses #4714 by adding support for the current version of the Snyk API.

### Additional Details

Attempting to use version `2024-10-15` of the API results in the following error during analysis due to the response from `/orgs/{org_id}/packages/{purl}/issues` having changed shape:
```
2025-02-24 04:29:48,547 ERROR [SnykAnalysisTask] Request failure
java.lang.NullPointerException: Cannot invoke "org.json.JSONArray.length()" because "representation" is null
        at org.dependencytrack.parser.snyk.SnykParser.parse(SnykParser.java:86)
        at org.dependencytrack.tasks.scanners.SnykAnalysisTask.handle(SnykAnalysisTask.java:368)
        at org.dependencytrack.tasks.scanners.SnykAnalysisTask.analyzeComponent(SnykAnalysisTask.java:332)
        at org.dependencytrack.tasks.scanners.SnykAnalysisTask.lambda$analyze$1(SnykAnalysisTask.java:254)
        at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.base/java.lang.Thread.run(Unknown Source)
```

In `2023-06-22` affected version ranges are reported under `data[].attributes.coordinates[].representation` as an array of strings, e.g.:
```json
{
  "representation": [
    ",5.4.0),[6.0.0.pr1,6.4.0)"
  ]
}
```

In `2024-10-15` these same strings are now embedded in an array of objects under the property name `representations`:
```json
{
  "representations": [{
    "resource_path": ",5.4.0),[6.0.0.pr1,6.4.0)"
  }]
}
```

The proposed fix attempts to read both properties and selects different parsing behaviour depending on which one is present. As far as I can tell this is the only breaking change between the two API versions that is relevant to DT's Snyk integration. I've tested the fix against both `2023-06-22` and `2024-10-15` successfully and updated the unit tests to cover the new format. Apologies if the implementation is lacking, I've not written any Java in a while.

This PR does not alter the default Snyk API version used by DT.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
