### PR TITLE
Backport: Remove erroneous client-side caching in Trivy analyzer

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTask.java
@@ -91,7 +91,7 @@ import static org.dependencytrack.util.RetryUtil.withTransientErrorCode;
  *
  * @since 4.11.0
  */
-public class TrivyAnalysisTask extends BaseComponentAnalyzerTask implements CacheableScanTask, Subscriber {
+public class TrivyAnalysisTask extends BaseComponentAnalyzerTask implements Subscriber {
 
     private static final Logger LOGGER = Logger.getLogger(TrivyAnalysisTask.class);
     private static final String TOKEN_HEADER = "Trivy-Token";
@@ -332,36 +332,32 @@ public class TrivyAnalysisTask extends BaseComponentAnalyzerTask implements Cach
         }
     }
 
-    @Override
-    public boolean shouldAnalyze(final PackageURL packageUrl) {
-        if (packageUrl == null) {
-            // Components of classifier OPERATING_SYSTEM can "survive"
-            // the #isCapable call, despite not having a package URL.
-            return true;
-        }
-
-        return getApiBaseUrl()
-                .map(baseUrl -> !isCacheCurrent(Vulnerability.Source.TRIVY, apiBaseUrl, packageUrl.getCoordinates()))
-                .orElse(false);
-    }
-
-    @Override
-    public void applyAnalysisFromCache(final Component component) {
-        getApiBaseUrl().ifPresent(baseUrl ->
-                applyAnalysisFromCache(Vulnerability.Source.TRIVY, apiBaseUrl,
-                        component.getPurl().getCoordinates(), component, getAnalyzerIdentity(), vulnerabilityAnalysisLevel));
-    }
-
     private void handleResults(final Map<String, Component> componentByPurl, final ArrayList<Result> input) {
+        final var vulnsByComponent = new HashMap<Component, List<trivy.proto.common.Vulnerability>>();
+
         for (final Result result : input) {
             for (int idx = 0; idx < result.getVulnerabilitiesCount(); idx++) {
                 var vulnerability = result.getVulnerabilities(idx);
                 var key = vulnerability.getPkgIdentifier().getPurl();
-                LOGGER.debug("Searching key %s in map".formatted(key));
                 if (!shouldIgnoreUnfixed || vulnerability.getStatus() == 3) {
-                    handle(componentByPurl.get(key), vulnerability);
+                    final Component component = componentByPurl.get(key);
+                    if (component == null) {
+                        LOGGER.warn("""
+                                Vulnerability %s reported for PURL %s, but no component that was \
+                                submitted for analysis matches it; Skipping""".formatted(
+                                vulnerability.getVulnerabilityId(), key));
+                        continue;
+                    }
+
+                    vulnsByComponent.computeIfAbsent(component, ignored -> new ArrayList<>()).add(vulnerability);
                 }
             }
+        }
+
+        for (final Map.Entry<Component, List<trivy.proto.common.Vulnerability>> entry : vulnsByComponent.entrySet()) {
+            final Component component = entry.getKey();
+            final List<trivy.proto.common.Vulnerability> vulns = entry.getValue();
+            handle(component, vulns);
         }
     }
 
@@ -471,37 +467,35 @@ public class TrivyAnalysisTask extends BaseComponentAnalyzerTask implements Cach
         }
     }
 
-    private void handle(final Component component, final trivy.proto.common.Vulnerability data) {
-        if (component == null) {
-            LOGGER.error("Unable to handle null component");
-            return;
-        } else if (data == null) {
-            addNoVulnerabilityToCache(component);
-            return;
-        }
-
+    private void handle(final Component component, final Collection<trivy.proto.common.Vulnerability> trivyVulns) {
         try (final var qm = new QueryManager()) {
             final var trivyParser = new TrivyParser();
+            final var persistentComponent = qm.getObjectByUuid(Component.class, component.getUuid());
+            if (persistentComponent == null) {
+                LOGGER.warn("""
+                        %s vulnerabilities were reported for component %s, \
+                        but it no longer exists; Skipping""".formatted(trivyVulns.size(), component.getUuid()));
+                return;
+            }
 
-            final Vulnerability parsedVulnerability = trivyParser.parse(data);
-            final Component componentPersisted = qm.getObjectByUuid(Component.class, component.getUuid());
+            boolean didCreateVulns = false;
+            for (final trivy.proto.common.Vulnerability trivyVuln : trivyVulns) {
+                final Vulnerability parsedVulnerability = trivyParser.parse(trivyVuln);
 
-            if (componentPersisted != null && parsedVulnerability.getVulnId() != null) {
                 Vulnerability vulnerability = qm.getVulnerabilityByVulnId(parsedVulnerability.getSource(), parsedVulnerability.getVulnId());
-
                 if (vulnerability == null) {
                     LOGGER.debug("Creating unavailable vulnerability:" + parsedVulnerability.getSource() + " - " + parsedVulnerability.getVulnId());
                     vulnerability = qm.createVulnerability(parsedVulnerability, false);
-                    addVulnerabilityToCache(componentPersisted, vulnerability);
+                    didCreateVulns = true;
                 }
 
-                LOGGER.debug("Trivy vulnerability added: " + vulnerability.getVulnId() + " to component " + componentPersisted.getName());
+                LOGGER.debug("Trivy vulnerability added: " + vulnerability.getVulnId() + " to component " + persistentComponent.getName());
+                NotificationUtil.analyzeNotificationCriteria(qm, vulnerability, persistentComponent, vulnerabilityAnalysisLevel);
+                qm.addVulnerability(vulnerability, persistentComponent, this.getAnalyzerIdentity());
+            }
 
-                NotificationUtil.analyzeNotificationCriteria(qm, vulnerability, componentPersisted, vulnerabilityAnalysisLevel);
-                qm.addVulnerability(vulnerability, componentPersisted, this.getAnalyzerIdentity());
-
+            if (didCreateVulns) {
                 Event.dispatch(new IndexEvent(IndexEvent.Action.COMMIT, Vulnerability.class));
-                updateAnalysisCacheStats(qm, Vulnerability.Source.TRIVY, apiBaseUrl, componentPersisted.getPurl().getCoordinates(), componentPersisted.getCacheResult());
             }
         }
     }

--- a/src/test/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTaskTest.java
@@ -24,7 +24,6 @@ import alpine.notification.NotificationService;
 import alpine.notification.Subscriber;
 import alpine.notification.Subscription;
 import alpine.security.crypto.DataEncryption;
-import com.github.packageurl.PackageURL;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.protobuf.util.Timestamps;
@@ -52,9 +51,7 @@ import trivy.proto.common.PkgIdentifier;
 import trivy.proto.scanner.v1.Result;
 import trivy.proto.scanner.v1.ScanResponse;
 
-import jakarta.json.Json;
 import java.text.ParseException;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -150,22 +147,6 @@ public class TrivyAnalysisTaskTest extends PersistenceCapableTest {
         }
 
         asserts.assertAll();
-    }
-
-    @Test
-    public void testShouldAnalyzeWhenCacheIsCurrent() throws Exception {
-        qm.updateComponentAnalysisCache(ComponentAnalysisCache.CacheType.VULNERABILITY, wireMock.baseUrl(),
-                Vulnerability.Source.TRIVY.name(), "pkg:maven/com.fasterxml.woodstox/woodstox-core@5.0.0", new Date(),
-                Json.createObjectBuilder()
-                        .add("vulnIds", Json.createArrayBuilder().add(123))
-                        .build());
-
-        assertThat(new TrivyAnalysisTask().shouldAnalyze(new PackageURL("pkg:maven/com.fasterxml.woodstox/woodstox-core@5.0.0?foo=bar#baz"))).isFalse();
-    }
-
-    @Test
-    public void testShouldAnalyzeWhenCacheIsNotCurrent() throws Exception {
-        assertThat(new TrivyAnalysisTask().shouldAnalyze(new PackageURL("pkg:maven/com.fasterxml.woodstox/woodstox-core@5.0.0?foo=bar#baz"))).isTrue();
     }
 
     @Test
@@ -316,7 +297,7 @@ public class TrivyAnalysisTaskTest extends PersistenceCapableTest {
             assertThat(vuln.getVulnerableSoftware()).isEmpty();
         });
 
-        assertThat(qm.getCount(ComponentAnalysisCache.class)).isOne();
+        assertThat(qm.getCount(ComponentAnalysisCache.class)).isZero();
 
         assertThat(NOTIFICATIONS).satisfiesExactly(
                 notification ->


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Removes erroneous client-side caching in Trivy analyzer.

Trivy already acts as a cache, there is no rate limiting we need to be careful with, and our cache wasn't ever used prior to 4.12.4 anyway.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #4704
Fixes #4727
Backports #4735 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
