### PR TITLE
Backport: Fix notification limiting to tags not working reliably

### DIFF
--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -34,7 +34,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import org.dependencytrack.parser.cyclonedx.util.ModelConverter;
 import org.dependencytrack.persistence.converter.OrganizationalContactsJsonConverter;
 import org.dependencytrack.persistence.converter.OrganizationalEntityJsonConverter;
@@ -110,6 +109,9 @@ import java.util.UUID;
         @FetchGroup(name = "PARENT", members = {
                 @Persistent(name = "parent")
         }),
+        @FetchGroup(name = "PROJECT_TAGS", members = {
+                @Persistent(name = "tags")
+        }),
         @FetchGroup(name = "PROJECT_VULN_ANALYSIS", members = {
                 @Persistent(name = "id"),
                 @Persistent(name = "name"),
@@ -130,6 +132,7 @@ public class Project implements Serializable {
         METADATA,
         METRICS_UPDATE,
         PARENT,
+        PROJECT_TAGS,
         PROJECT_VULN_ANALYSIS
     }
 

--- a/src/test/java/org/dependencytrack/notification/NotificationRouterTest.java
+++ b/src/test/java/org/dependencytrack/notification/NotificationRouterTest.java
@@ -99,7 +99,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         Project affectedProject = qm.createProject("Test Project", null, "1.0", null, null, null, true, false);
         Component affectedComponent = new Component();
         affectedComponent.setProject(affectedProject);
-        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(new Vulnerability(), affectedComponent, null, null);
+        affectedComponent.setName("acme-lib");
+        qm.persist(affectedComponent);
+        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(
+                new Vulnerability(), qm.detach(affectedComponent), null, null);
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
@@ -130,7 +133,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         affectedProjects.add(project);
         Component affectedComponent = new Component();
         affectedComponent.setProject(project);
-        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(new Vulnerability(), affectedComponent, affectedProjects, null);
+        affectedComponent.setName("acme-lib");
+        qm.persist(affectedComponent);
+        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(
+                new Vulnerability(), qm.detach(affectedComponent), qm.detach(affectedProjects), null);
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
@@ -162,7 +168,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         affectedProjects.add(affectedProject);
         Component affectedComponent = new Component();
         affectedComponent.setProject(affectedProject);
-        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(new Vulnerability(), affectedComponent, affectedProjects, null);
+        affectedComponent.setName("acme-lib");
+        qm.persist(affectedComponent);
+        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(
+                new Vulnerability(), qm.detach(affectedComponent), qm.detach(affectedProjects), null);
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
@@ -188,7 +197,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         Project affectedProject = qm.createProject("Test Project", null, "1.0", null, null, null, true, false);
         Component affectedComponent = new Component();
         affectedComponent.setProject(affectedProject);
-        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(new Vulnerability(), affectedComponent, null, null);
+        affectedComponent.setName("acme-lib");
+        qm.persist(affectedComponent);
+        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(
+                new Vulnerability(), qm.detach(affectedComponent), null, null);
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
@@ -225,7 +237,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         affectedProjects.add(secondProject);
         Component affectedComponent = new Component();
         affectedComponent.setProject(firstProject);
-        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(new Vulnerability(), affectedComponent, affectedProjects, null);
+        affectedComponent.setName("acme-lib");
+        qm.persist(affectedComponent);
+        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(
+                new Vulnerability(), qm.detach(affectedComponent), qm.detach(affectedProjects), null);
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
@@ -257,7 +272,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         Project affectedProject = qm.createProject("Test Project 1", null, "1.0", null, null, null, true, false);
         Component affectedComponent = new Component();
         affectedComponent.setProject(affectedProject);
-        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(new Vulnerability(), affectedComponent, null, null);
+        affectedComponent.setName("acme-lib");
+        qm.persist(affectedComponent);
+        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(
+                new Vulnerability(), qm.detach(affectedComponent), null, null);
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
@@ -352,12 +370,12 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setScope(NotificationScope.PORTFOLIO.name());
         notification.setGroup(NotificationGroup.NEW_VULNERABILITY.name());
         notification.setLevel(NotificationLevel.INFORMATIONAL);
-        notification.setSubject(new NewVulnerabilityIdentified(null, componentB, Set.of(), null));
+        notification.setSubject(new NewVulnerabilityIdentified(null, qm.detach(componentB), Set.of(), null));
 
         final var router = new NotificationRouter();
         assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
 
-        notification.setSubject(new NewVulnerabilityIdentified(null, componentA, Set.of(), null));
+        notification.setSubject(new NewVulnerabilityIdentified(null, qm.detach(componentA), Set.of(), null));
         assertThat(router.resolveRules(PublishContext.from(notification), notification))
                 .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
     }
@@ -386,12 +404,12 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setScope(NotificationScope.PORTFOLIO.name());
         notification.setGroup(NotificationGroup.NEW_VULNERABLE_DEPENDENCY.name());
         notification.setLevel(NotificationLevel.INFORMATIONAL);
-        notification.setSubject(new NewVulnerableDependency(componentB, null));
+        notification.setSubject(new NewVulnerableDependency(qm.detach(componentB), null));
 
         final var router = new NotificationRouter();
         assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
 
-        notification.setSubject(new NewVulnerableDependency(componentA, null));
+        notification.setSubject(new NewVulnerableDependency(qm.detach(componentA), null));
         assertThat(router.resolveRules(PublishContext.from(notification), notification))
                 .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
     }
@@ -411,12 +429,12 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setScope(NotificationScope.PORTFOLIO.name());
         notification.setGroup(NotificationGroup.BOM_CONSUMED.name());
         notification.setLevel(NotificationLevel.INFORMATIONAL);
-        notification.setSubject(new BomConsumedOrProcessed(projectB, "", Bom.Format.CYCLONEDX, ""));
+        notification.setSubject(new BomConsumedOrProcessed(qm.detach(projectB), "", Bom.Format.CYCLONEDX, ""));
 
         final var router = new NotificationRouter();
         assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
 
-        notification.setSubject(new BomConsumedOrProcessed(projectA, "", Bom.Format.CYCLONEDX, ""));
+        notification.setSubject(new BomConsumedOrProcessed(qm.detach(projectA), "", Bom.Format.CYCLONEDX, ""));
         assertThat(router.resolveRules(PublishContext.from(notification), notification))
                 .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
     }
@@ -436,12 +454,12 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setScope(NotificationScope.PORTFOLIO.name());
         notification.setGroup(NotificationGroup.BOM_PROCESSING_FAILED.name());
         notification.setLevel(NotificationLevel.INFORMATIONAL);
-        notification.setSubject(new BomProcessingFailed(projectB, "", null, Bom.Format.CYCLONEDX, ""));
+        notification.setSubject(new BomProcessingFailed(qm.detach(projectB), "", null, Bom.Format.CYCLONEDX, ""));
 
         final var router = new NotificationRouter();
         assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
 
-        notification.setSubject(new BomProcessingFailed(projectA, "", null, Bom.Format.CYCLONEDX, ""));
+        notification.setSubject(new BomProcessingFailed(qm.detach(projectA), "", null, Bom.Format.CYCLONEDX, ""));
         assertThat(router.resolveRules(PublishContext.from(notification), notification))
                 .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
     }
@@ -461,12 +479,12 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setScope(NotificationScope.PORTFOLIO.name());
         notification.setGroup(NotificationGroup.BOM_VALIDATION_FAILED.name());
         notification.setLevel(NotificationLevel.ERROR);
-        notification.setSubject(new BomValidationFailed(projectB, "", null, Bom.Format.CYCLONEDX));
+        notification.setSubject(new BomValidationFailed(qm.detach(projectB), "", null, Bom.Format.CYCLONEDX));
 
         final var router = new NotificationRouter();
         assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
 
-        notification.setSubject(new BomValidationFailed(projectA, "", null, Bom.Format.CYCLONEDX));
+        notification.setSubject(new BomValidationFailed(qm.detach(projectA), "", null, Bom.Format.CYCLONEDX));
         assertThat(router.resolveRules(PublishContext.from(notification), notification))
                 .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
     }
@@ -486,12 +504,12 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setScope(NotificationScope.PORTFOLIO.name());
         notification.setGroup(NotificationGroup.VEX_CONSUMED.name());
         notification.setLevel(NotificationLevel.INFORMATIONAL);
-        notification.setSubject(new VexConsumedOrProcessed(projectB, "", Vex.Format.CYCLONEDX, ""));
+        notification.setSubject(new VexConsumedOrProcessed(qm.detach(projectB), "", Vex.Format.CYCLONEDX, ""));
 
         final var router = new NotificationRouter();
         assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
 
-        notification.setSubject(new VexConsumedOrProcessed(projectA, "", Vex.Format.CYCLONEDX, ""));
+        notification.setSubject(new VexConsumedOrProcessed(qm.detach(projectA), "", Vex.Format.CYCLONEDX, ""));
         assertThat(router.resolveRules(PublishContext.from(notification), notification))
                 .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
     }
@@ -525,7 +543,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         final var router = new NotificationRouter();
         assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
 
-        notification.setSubject(new PolicyViolationIdentified(null, componentA, projectA));
+        notification.setSubject(new PolicyViolationIdentified(null, qm.detach(componentA), projectA));
         assertThat(router.resolveRules(PublishContext.from(notification), notification))
                 .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
     }
@@ -545,7 +563,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setScope(NotificationScope.PORTFOLIO.name());
         notification.setGroup(NotificationGroup.PROJECT_AUDIT_CHANGE.name());
         notification.setLevel(NotificationLevel.INFORMATIONAL);
-        notification.setSubject(new AnalysisDecisionChange(null, null, projectB, null));
+        notification.setSubject(new AnalysisDecisionChange(null, null, qm.detach(projectB), null));
 
         final var router = new NotificationRouter();
         assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
@@ -579,7 +597,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         notification.setScope(NotificationScope.PORTFOLIO.name());
         notification.setGroup(NotificationGroup.PROJECT_AUDIT_CHANGE.name());
         notification.setLevel(NotificationLevel.INFORMATIONAL);
-        notification.setSubject(new ViolationAnalysisDecisionChange(null, componentB, null));
+        notification.setSubject(new ViolationAnalysisDecisionChange(null, qm.detach(componentB), null));
 
         final var router = new NotificationRouter();
         assertThat(router.resolveRules(PublishContext.from(notification), notification)).isEmpty();
@@ -608,6 +626,8 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         // Creates a new component
         Component component = new Component();
         component.setProject(grandChild);
+        component.setName("acme-lib");
+        qm.persist(component);
         // Creates a new notification
         Notification notification = new Notification();
         notification.setScope(NotificationScope.PORTFOLIO.name());
@@ -616,7 +636,8 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         // Notification should be limited to only specific projects - Set the projects which are affected by the notification event
         Set<Project> affectedProjects = new HashSet<>();
         affectedProjects.add(grandChild);
-        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(new Vulnerability(), component, affectedProjects, null);
+        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(
+                new Vulnerability(), qm.detach(component), qm.detach(affectedProjects), null);
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
@@ -645,6 +666,8 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         // Creates a new component
         Component component = new Component();
         component.setProject(grandChild);
+        component.setName("acme-lib");
+        qm.persist(component);
         // Creates a new notification
         Notification notification = new Notification();
         notification.setScope(NotificationScope.PORTFOLIO.name());
@@ -653,7 +676,8 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         // Notification should be limited to only specific projects - Set the projects which are affected by the notification event
         Set<Project> affectedProjects = new HashSet<>();
         affectedProjects.add(grandChild);
-        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(new Vulnerability(), component, affectedProjects, null);
+        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(
+                new Vulnerability(), qm.detach(component), qm.detach(affectedProjects), null);
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
@@ -681,6 +705,8 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         // Creates a new component
         Component component = new Component();
         component.setProject(grandChild);
+        component.setName("acme-lib");
+        qm.persist(component);
         // Creates a new notification
         Notification notification = new Notification();
         notification.setScope(NotificationScope.PORTFOLIO.name());
@@ -689,7 +715,8 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         // Notification should be limited to only specific projects - Set the projects which are affected by the notification event
         Set<Project> affectedProjects = new HashSet<>();
         affectedProjects.add(grandChild);
-        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(new Vulnerability(), component, affectedProjects, null);
+        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(
+                new Vulnerability(), qm.detach(component), qm.detach(affectedProjects), null);
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
@@ -721,7 +748,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         affectedProjects.add(project);
         Component affectedComponent = new Component();
         affectedComponent.setProject(project);
-        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(new Vulnerability(), affectedComponent, affectedProjects, null);
+        affectedComponent.setName("acme-lib");
+        qm.persist(affectedComponent);
+        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(
+                new Vulnerability(), qm.detach(affectedComponent), qm.detach(affectedProjects), null);
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
@@ -754,7 +784,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         affectedProjects.add(affectedProject);
         Component affectedComponent = new Component();
         affectedComponent.setProject(affectedProject);
-        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(new Vulnerability(), affectedComponent, affectedProjects, null);
+        affectedComponent.setName("acme-lib");
+        qm.persist(affectedComponent);
+        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(
+                new Vulnerability(), qm.detach(affectedComponent), qm.detach(affectedProjects), null);
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
@@ -791,7 +824,10 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         affectedProjects.add(otherAffectedProject);
         Component affectedComponent = new Component();
         affectedComponent.setProject(taggedProject);
-        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(new Vulnerability(), affectedComponent, affectedProjects, null);
+        affectedComponent.setName("acme-lib");
+        qm.persist(affectedComponent);
+        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(
+                new Vulnerability(), qm.detach(affectedComponent), qm.detach(affectedProjects), null);
         notification.setSubject(subject);
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes notification limiting to tags not working reliably.

The code assumed inspected projects to be in persistent state, which they were in unit tests, but not at application runtime.

Notification subjects are always in detached state. `NotificationRouterTest` was updated to reflect this fact.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #4661

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
