### PR TITLE
add endpoint to mass-create tags

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/TagResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/TagResource.java
@@ -53,6 +53,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -144,6 +145,31 @@ public class TagResource extends AlpineResource {
         }
 
         return Response.noContent().build();
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Creates one or more tags.",
+            description = "<p>Requires permission <strong>TAG_MANAGEMENT</strong></p>\n"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "Tags created successfully."
+            )
+    })
+    @PermissionRequired(Permissions.Constants.TAG_MANAGEMENT)
+    public Response createTags(
+            @Parameter(description = "Names of the tags to create")
+            @Size(min = 1, max = 100) final Set<@NotBlank String> tagNames
+    ) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
+            qm.createTags(List.copyOf(tagNames));
+        }
+
+        return Response.noContent().status(Response.Status.CREATED).build();
     }
 
     @GET

--- a/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
@@ -540,6 +540,37 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
+    public void createTagsTest() {
+        initializeWithPermissions(Permissions.TAG_MANAGEMENT);
+
+        final Response response = jersey.target(V1_TAG)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method(HttpMethod.PUT, Entity.json(List.of("foo")));
+        assertThat(response.getStatus()).isEqualTo(201);
+        qm.getPersistenceManager().evictAll();
+        assertThat(qm.getTagByName("foo")).isNotNull();
+    }
+
+    @Test
+    public void createTagsWithExistingTest() {
+        initializeWithPermissions(Permissions.TAG_MANAGEMENT);
+
+        qm.createTag("foo");
+
+        final Response response = jersey.target(V1_TAG)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method(HttpMethod.PUT, Entity.json(List.of("foo", "bar")));
+        assertThat(response.getStatus()).isEqualTo(201);
+        qm.getPersistenceManager().evictAll();
+        assertThat(qm.getTagByName("foo")).isNotNull();
+        assertThat(qm.getTagByName("bar")).isNotNull();
+    }
+
+    @Test
     public void getTaggedProjectsTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 


### PR DESCRIPTION
### Description

Adds an endpoint to create multiple tags.

### Addressed Issue

Closes #4755
Closes #4463

### Additional Details

Don't know whether a POST is the correct method here, but since this ignores already existing tags, it seems to be better than a PUT.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
