### PR TITLE
Add Metrics update trigger after cloning a project

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -913,6 +913,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         if(clonedProject.getParent() != null && clonedProject.getParent().getCollectionLogic() != ProjectCollectionLogic.NONE) {
             Event.dispatch(new ProjectMetricsUpdateEvent(clonedProject.getParent().getUuid()));
         }
+        Event.dispatch(new ProjectMetricsUpdateEvent(clonedProject.getUuid()));
 
         return clonedProject;
     }

--- a/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
@@ -19,15 +19,22 @@
 package org.dependencytrack.persistence;
 
 import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.event.ProjectMetricsUpdateEvent;
 import org.dependencytrack.model.*;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import alpine.event.framework.Event;
 
 import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.times;
 
 class ProjectQueryManagerTest extends PersistenceCapableTest {
 
@@ -93,6 +100,36 @@ class ProjectQueryManagerTest extends PersistenceCapableTest {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> qm.updateProject(detached, false))
                 .withMessage("Project cannot be made a collection project while it has components or services!");
+    }
+    @Test
+    public void testCloneProjectMetricUpdate() throws Exception {
+        Project project = qm.createProject("Example Project 1", "Description 1", "1.0", null, null, null, true, false);
+        Component comp = new Component();
+        comp.setId(111L);
+        comp.setName("name");
+        comp.setProject(project);
+        comp.setVersion("1.0");
+        comp.setCopyright("Copyright Acme");
+        qm.createComponent(comp, true);
+        Vulnerability vuln = new Vulnerability();
+        vuln.setVulnId("INT-123");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        qm.persist(vuln);
+        qm.addVulnerability(vuln, comp, AnalyzerIdentity.INTERNAL_ANALYZER, "Vuln1", "http://vuln.com/vuln1", new Date(1708559165229L));
+
+        try (MockedStatic<Event> mockedEvent = Mockito.mockStatic(Event.class)) {
+            Project clonedProject = qm.clone(project.getUuid(), "1.1.0", false, false,
+                    true, false, false, false, false, false);
+
+            ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+            mockedEvent.verify(() -> Event.dispatch(eventCaptor.capture()), times(4));
+
+            Event updateCloneMetricsEvent = eventCaptor.getAllValues().get(3);
+            Assertions.assertTrue(updateCloneMetricsEvent instanceof ProjectMetricsUpdateEvent);
+            ProjectMetricsUpdateEvent projectMetricsEvent = (ProjectMetricsUpdateEvent) updateCloneMetricsEvent;
+            Assertions.assertEquals(clonedProject.getUuid(), projectMetricsEvent.getUuid());
+        }
     }
 
 }


### PR DESCRIPTION
### Description

Added the trigger, when cloning occurs on a project, the clone project will have metrics its metrics update rather than just empty unless explicitly updated through the UI by refreshing metrics.

```
2025-04-02 11:21:58,857 INFO [CloneProjectTask] Cloning project for version 5.0.1.2 [eventToken=3a8a439d-ce14-45a6-a4b2-ccb59ad614aa, projectUuid=563edfa5-ec55-4858-9e75-56c2a94f905d]
2025-04-02 11:22:03,177 INFO [CloneProjectTask] Cloned project for version 5.0.1.2 into project e66979c3-b8ca-4c72-914e-bce20795197f [eventToken=3a8a439d-ce14-45a6-a4b2-ccb59ad614aa, projectUuid=563edfa5-ec55-4858-9e75-56c2a94f905d]
2025-04-02 11:22:03,178 INFO [ProjectMetricsUpdateTask] Executing metrics update for project e66979c3-b8ca-4c72-914e-bce20795197f
```
![Screenshot 2025-04-02 at 11 24 24](https://github.com/user-attachments/assets/1c765a4e-bcd1-4282-b5f0-0e933f460812)

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

The change fixes [#4579](https://github.com/DependencyTrack/dependency-track/issues/4579) where the metrics update doesn't get triggered on the cloned project when cloning a project. 
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details
N/A

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
