### PR TITLE
Remove aws-advanced-jdbc-wrapper again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,6 @@
         <lib.awaitility.version>4.3.0</lib.awaitility.version>
         <lib.brotli-decoder.version>0.1.2</lib.brotli-decoder.version>
         <lib.checkstyle.version>10.22.0</lib.checkstyle.version>
-        <lib.aws-advanced-jdbc-wrapper.version>2.5.5</lib.aws-advanced-jdbc-wrapper.version>
         <lib.cloud-sql-connector-jdbc-sqlserver.version>1.24.1</lib.cloud-sql-connector-jdbc-sqlserver.version>
         <lib.cloud-sql-mysql-socket-factory-connector-j-8.version>1.24.1</lib.cloud-sql-mysql-socket-factory-connector-j-8.version>
         <lib.cloud-sql-postgres-socket-factory.version>1.24.1</lib.cloud-sql-postgres-socket-factory.version>
@@ -357,11 +356,6 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>${lib.jdbc-driver.postgresql.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.jdbc</groupId>
-            <artifactId>aws-advanced-jdbc-wrapper</artifactId>
-            <version>${lib.aws-advanced-jdbc-wrapper.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.sql</groupId>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Removes aws-advanced-jdbc-wrapper again.

The driver is pulling in the entirety of the AWS SDK, increasing our JAR file size by over 20%, and introducing a whole bunch of transitive dependencies that will inevitably cause more noise when users scan our container images for vulnerabilities.

Currently there are vulns being reported for Netty libraries introduced through the AWS SDK. There is no newer SDK version that resolves them, which leaves us the only possibility of overriding transitive dependency versions. Given the many modules of Netty, this is like playing whack-a-mole.

Including AWS libraries is really not justifiable given how absolutely gigantic their dependency tree is. They become technical debt as soon as they're included.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Effectively reverts #4304

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
