### PR TITLE
Convert tests to JUnit 5

### DIFF
--- a/.idea/runConfigurations/Tests.xml
+++ b/.idea/runConfigurations/Tests.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Tests" type="JUnit" factoryName="JUnit">
+    <module name="dependency-track" />
+    <shortenClasspath name="MANIFEST" />
+    <option name="PACKAGE_NAME" value="org.dependencytrack" />
+    <option name="MAIN_CLASS_NAME" value="" />
+    <option name="METHOD_NAME" value="" />
+    <option name="TEST_OBJECT" value="package" />
+    <option name="TEST_SEARCH_SCOPE">
+      <value defaultName="wholeProject" />
+    </option>
+    <fork_mode value="class" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <lib.jackson-databind.version>2.18.3</lib.jackson-databind.version>
         <lib.json-java.version>20250107</lib.json-java.version>
         <lib.json-unit.version>4.1.0</lib.json-unit.version>
-        <lib.junit.version>4.13.2</lib.junit.version>
+        <lib.junit.version>5.11.4</lib.junit.version>
         <lib.lucene.version>8.11.4</lib.lucene.version>
         <lib.maven-artifact.version>3.9.9</lib.maven-artifact.version>
         <lib.mockserver-netty.version>5.15.0</lib.mockserver-netty.version>
@@ -115,11 +115,10 @@
         <lib.protobuf-java.version>4.30.2</lib.protobuf-java.version>
         <lib.resilience4j.version>2.2.0</lib.resilience4j.version>
         <lib.swagger-parser.version>2.1.25</lib.swagger-parser.version>
-        <lib.system-rules.version>1.19.0</lib.system-rules.version>
+        <lib.junit-pioneer.version>2.3.0</lib.junit-pioneer.version>
         <lib.testcontainers.version>1.21.0</lib.testcontainers.version>
         <lib.wiremock.version>2.35.2</lib.wiremock.version>
         <lib.woodstox.version>7.0.0</lib.woodstox.version>
-        <lib.junit-params.version>1.1.1</lib.junit-params.version>
         <lib.signpost-core.version>2.1.1</lib.signpost-core.version>
         <lib.httpclient.version>4.5.14</lib.httpclient.version>
         <lib.httpclient5.version>5.4.4</lib.httpclient5.version>
@@ -421,15 +420,21 @@
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <version>${lib.junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>pl.pragmatists</groupId>
-            <artifactId>JUnitParams</artifactId>
-            <version>${lib.junit-params.version}</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${lib.junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${lib.junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -437,6 +442,12 @@
             <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
             <version>${lib.jersey.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.connectors</groupId>
@@ -458,9 +469,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>${lib.system-rules.version}</version>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <version>${lib.junit-pioneer.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -489,7 +500,7 @@
         </dependency>
         <dependency>
             <groupId>com.icegreen</groupId>
-            <artifactId>greenmail-junit4</artifactId>
+            <artifactId>greenmail-junit5</artifactId>
             <version>${lib.greenmail.version}</version>
             <scope>test</scope>
         </dependency>
@@ -617,13 +628,6 @@
                         </property>
                     </systemProperties>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit4</artifactId>
-                        <version>${maven.surefire.plugin.version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/src/test/java/org/dependencytrack/DTGrizzlyWebTestContainerFactory.java
+++ b/src/test/java/org/dependencytrack/DTGrizzlyWebTestContainerFactory.java
@@ -10,12 +10,10 @@ import org.glassfish.jersey.test.spi.TestContainerFactory;
 
 import java.net.URI;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Custom factory needed to instantiate a TestContainer allowing body payload for DELETE method.
- *
- * @See org.dependencytrack.DTGrizzlyWebTestContainer
  */
 public class DTGrizzlyWebTestContainerFactory implements TestContainerFactory {
     @Override

--- a/src/test/java/org/dependencytrack/JerseyTestExtension.java
+++ b/src/test/java/org/dependencytrack/JerseyTestExtension.java
@@ -28,8 +28,8 @@ import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.function.Supplier;
@@ -37,7 +37,7 @@ import java.util.function.Supplier;
 /**
  * @since 4.11.0
  */
-public class JerseyTestExtension implements BeforeEachCallback, AfterEachCallback {
+public class JerseyTestExtension implements BeforeAllCallback, AfterAllCallback {
 
     private final Supplier<ResourceConfig> resourceConfigSupplier;
     private JerseyTest jerseyTest;
@@ -47,7 +47,7 @@ public class JerseyTestExtension implements BeforeEachCallback, AfterEachCallbac
     }
 
     @Override
-    public void beforeEach(ExtensionContext context) throws Exception {
+    public void beforeAll(ExtensionContext context) throws Exception {
         this.jerseyTest = new JerseyTest() {
 
             @Override
@@ -74,12 +74,14 @@ public class JerseyTestExtension implements BeforeEachCallback, AfterEachCallbac
     }
 
     @Override
-    public void afterEach(ExtensionContext context) {
+    public void afterAll(ExtensionContext context) {
         if (jerseyTest != null) {
             try {
                 jerseyTest.tearDown();
             } catch (Exception e) {
                 throw new RuntimeException(e);
+            } finally {
+                jerseyTest = null;
             }
         }
     }

--- a/src/test/java/org/dependencytrack/JerseyTestExtension.java
+++ b/src/test/java/org/dependencytrack/JerseyTestExtension.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack;
 
+import jakarta.ws.rs.client.WebTarget;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.grizzly.connector.GrizzlyConnectorProvider;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -27,18 +28,26 @@ import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
-import org.junit.rules.ExternalResource;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
-import jakarta.ws.rs.client.WebTarget;
+import java.util.function.Supplier;
 
 /**
  * @since 4.11.0
  */
-public class JerseyTestRule extends ExternalResource {
+public class JerseyTestExtension implements BeforeEachCallback, AfterEachCallback {
 
-    private final JerseyTest jerseyTest;
+    private final Supplier<ResourceConfig> resourceConfigSupplier;
+    private JerseyTest jerseyTest;
 
-    public JerseyTestRule(final ResourceConfig resourceConfig) {
+    public JerseyTestExtension(final Supplier<ResourceConfig> resourceConfigSupplier) {
+        this.resourceConfigSupplier = resourceConfigSupplier;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
         this.jerseyTest = new JerseyTest() {
 
             @Override
@@ -56,25 +65,22 @@ public class JerseyTestRule extends ExternalResource {
 
             @Override
             protected DeploymentContext configureDeployment() {
-                return ServletDeploymentContext.forServlet(new ServletContainer(
-                        // Ensure exception mappers are registered.
-                        resourceConfig.packages("org.dependencytrack.resources.v1.exception"))).build();
+                return ServletDeploymentContext.forServlet(new ServletContainer(resourceConfigSupplier.get()
+                        .packages("org.dependencytrack.resources.v1.exception"))).build();
             }
 
         };
-    }
-
-    @Override
-    protected void before() throws Throwable {
         jerseyTest.setUp();
     }
 
     @Override
-    protected void after() {
-        try {
-            jerseyTest.tearDown();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+    public void afterEach(ExtensionContext context) {
+        if (jerseyTest != null) {
+            try {
+                jerseyTest.tearDown();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/src/test/java/org/dependencytrack/PersistenceCapableTest.java
+++ b/src/test/java/org/dependencytrack/PersistenceCapableTest.java
@@ -21,26 +21,32 @@ package org.dependencytrack;
 import alpine.Config;
 import alpine.server.persistence.PersistenceManagerFactory;
 import org.dependencytrack.persistence.QueryManager;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class PersistenceCapableTest {
 
     protected QueryManager qm;
 
-    @BeforeClass
-    public static void init() {
+    @BeforeAll
+    static void init() {
         Config.enableUnitTests();
+
+        // ensure nothing is left open so the database is properly cleaned up between tests
+        System.setProperty(Config.AlpineKey.DATABASE_POOL_TX_MAX_LIFETIME.getPropertyName(), "0");
+        System.setProperty(Config.AlpineKey.DATABASE_POOL_NONTX_MAX_LIFETIME.getPropertyName(), "0");
+        System.setProperty(Config.AlpineKey.DATABASE_POOL_TX_IDLE_TIMEOUT.getPropertyName(), "0");
+        System.setProperty(Config.AlpineKey.DATABASE_POOL_NONTX_IDLE_TIMEOUT.getPropertyName(), "0");
     }
 
-    @Before
-    public void before() throws Exception {
+    @BeforeEach
+    final void initQueryManager() {
         this.qm = new QueryManager();
     }
 
-    @After
-    public void after() {
+    @AfterEach
+    final void tearDownQueryManager() {
         // PersistenceManager will refuse to close when there's an active transaction
         // that was neither committed nor rolled back. Unfortunately some areas of the
         // code base can leave such a broken state behind if they run into unexpected

--- a/src/test/java/org/dependencytrack/assertion/AssertionsTest.java
+++ b/src/test/java/org/dependencytrack/assertion/AssertionsTest.java
@@ -1,6 +1,6 @@
 package org.dependencytrack.assertion;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.function.Supplier;
@@ -9,10 +9,10 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.dependencytrack.assertion.Assertions.assertConditionWithTimeout;
 
-public class AssertionsTest {
+class AssertionsTest {
 
     @Test
-    public void testAssertConditionWithTimeout() {
+    void testAssertConditionWithTimeout() {
         assertThatNoException()
                 .isThrownBy(() -> assertConditionWithTimeout(new TestSupplier(), Duration.ofMillis(500)));
 

--- a/src/test/java/org/dependencytrack/auth/PermissionsTest.java
+++ b/src/test/java/org/dependencytrack/auth/PermissionsTest.java
@@ -18,8 +18,8 @@
  */
 package org.dependencytrack.auth;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.dependencytrack.auth.Permissions.Constants.ACCESS_MANAGEMENT;
 import static org.dependencytrack.auth.Permissions.Constants.BOM_UPLOAD;
@@ -35,42 +35,42 @@ import static org.dependencytrack.auth.Permissions.Constants.VIEW_VULNERABILITY;
 import static org.dependencytrack.auth.Permissions.Constants.VULNERABILITY_ANALYSIS;
 import static org.dependencytrack.auth.Permissions.Constants.VULNERABILITY_MANAGEMENT;
 import static org.dependencytrack.auth.Permissions.Constants.VIEW_BADGES;
-public class PermissionsTest {
+class PermissionsTest {
 
     @Test
-    public void testPermissionEnums() {
-        Assert.assertEquals(14, Permissions.values().length);
-        Assert.assertEquals("BOM_UPLOAD", Permissions.BOM_UPLOAD.name());
-        Assert.assertEquals("VIEW_PORTFOLIO", Permissions.VIEW_PORTFOLIO.name());
-        Assert.assertEquals("PORTFOLIO_MANAGEMENT", Permissions.PORTFOLIO_MANAGEMENT.name());
-        Assert.assertEquals("VIEW_VULNERABILITY", Permissions.VIEW_VULNERABILITY.name());
-        Assert.assertEquals("VULNERABILITY_ANALYSIS", Permissions.VULNERABILITY_ANALYSIS.name());
-        Assert.assertEquals("VIEW_POLICY_VIOLATION", Permissions.VIEW_POLICY_VIOLATION.name());
-        Assert.assertEquals("VULNERABILITY_MANAGEMENT", Permissions.VULNERABILITY_MANAGEMENT.name());
-        Assert.assertEquals("POLICY_VIOLATION_ANALYSIS", Permissions.POLICY_VIOLATION_ANALYSIS.name());
-        Assert.assertEquals("ACCESS_MANAGEMENT", Permissions.ACCESS_MANAGEMENT.name());
-        Assert.assertEquals("SYSTEM_CONFIGURATION", Permissions.SYSTEM_CONFIGURATION.name());
-        Assert.assertEquals("PROJECT_CREATION_UPLOAD", Permissions.PROJECT_CREATION_UPLOAD.name());
-        Assert.assertEquals("POLICY_MANAGEMENT", Permissions.POLICY_MANAGEMENT.name());
-        Assert.assertEquals("TAG_MANAGEMENT", Permissions.TAG_MANAGEMENT.name());
-        Assert.assertEquals("VIEW_BADGES", Permissions.VIEW_BADGES.name());
+    void testPermissionEnums() {
+        Assertions.assertEquals(14, Permissions.values().length);
+        Assertions.assertEquals("BOM_UPLOAD", Permissions.BOM_UPLOAD.name());
+        Assertions.assertEquals("VIEW_PORTFOLIO", Permissions.VIEW_PORTFOLIO.name());
+        Assertions.assertEquals("PORTFOLIO_MANAGEMENT", Permissions.PORTFOLIO_MANAGEMENT.name());
+        Assertions.assertEquals("VIEW_VULNERABILITY", Permissions.VIEW_VULNERABILITY.name());
+        Assertions.assertEquals("VULNERABILITY_ANALYSIS", Permissions.VULNERABILITY_ANALYSIS.name());
+        Assertions.assertEquals("VIEW_POLICY_VIOLATION", Permissions.VIEW_POLICY_VIOLATION.name());
+        Assertions.assertEquals("VULNERABILITY_MANAGEMENT", Permissions.VULNERABILITY_MANAGEMENT.name());
+        Assertions.assertEquals("POLICY_VIOLATION_ANALYSIS", Permissions.POLICY_VIOLATION_ANALYSIS.name());
+        Assertions.assertEquals("ACCESS_MANAGEMENT", Permissions.ACCESS_MANAGEMENT.name());
+        Assertions.assertEquals("SYSTEM_CONFIGURATION", Permissions.SYSTEM_CONFIGURATION.name());
+        Assertions.assertEquals("PROJECT_CREATION_UPLOAD", Permissions.PROJECT_CREATION_UPLOAD.name());
+        Assertions.assertEquals("POLICY_MANAGEMENT", Permissions.POLICY_MANAGEMENT.name());
+        Assertions.assertEquals("TAG_MANAGEMENT", Permissions.TAG_MANAGEMENT.name());
+        Assertions.assertEquals("VIEW_BADGES", Permissions.VIEW_BADGES.name());
     }
 
     @Test
-    public void testPermissionConstants() {
-        Assert.assertEquals("BOM_UPLOAD", BOM_UPLOAD);
-        Assert.assertEquals("VIEW_PORTFOLIO", VIEW_PORTFOLIO);
-        Assert.assertEquals("PORTFOLIO_MANAGEMENT", PORTFOLIO_MANAGEMENT);
-        Assert.assertEquals("VIEW_VULNERABILITY", VIEW_VULNERABILITY);
-        Assert.assertEquals("VULNERABILITY_ANALYSIS", VULNERABILITY_ANALYSIS);
-        Assert.assertEquals("VIEW_POLICY_VIOLATION", VIEW_POLICY_VIOLATION);
-        Assert.assertEquals("VULNERABILITY_MANAGEMENT", VULNERABILITY_MANAGEMENT);
-        Assert.assertEquals("POLICY_VIOLATION_ANALYSIS", POLICY_VIOLATION_ANALYSIS);
-        Assert.assertEquals("ACCESS_MANAGEMENT", ACCESS_MANAGEMENT);
-        Assert.assertEquals("SYSTEM_CONFIGURATION", SYSTEM_CONFIGURATION);
-        Assert.assertEquals("PROJECT_CREATION_UPLOAD", PROJECT_CREATION_UPLOAD);
-        Assert.assertEquals("POLICY_MANAGEMENT", POLICY_MANAGEMENT);
-        Assert.assertEquals("TAG_MANAGEMENT", TAG_MANAGEMENT);
-        Assert.assertEquals("VIEW_BADGES", VIEW_BADGES);
+    void testPermissionConstants() {
+        Assertions.assertEquals("BOM_UPLOAD", BOM_UPLOAD);
+        Assertions.assertEquals("VIEW_PORTFOLIO", VIEW_PORTFOLIO);
+        Assertions.assertEquals("PORTFOLIO_MANAGEMENT", PORTFOLIO_MANAGEMENT);
+        Assertions.assertEquals("VIEW_VULNERABILITY", VIEW_VULNERABILITY);
+        Assertions.assertEquals("VULNERABILITY_ANALYSIS", VULNERABILITY_ANALYSIS);
+        Assertions.assertEquals("VIEW_POLICY_VIOLATION", VIEW_POLICY_VIOLATION);
+        Assertions.assertEquals("VULNERABILITY_MANAGEMENT", VULNERABILITY_MANAGEMENT);
+        Assertions.assertEquals("POLICY_VIOLATION_ANALYSIS", POLICY_VIOLATION_ANALYSIS);
+        Assertions.assertEquals("ACCESS_MANAGEMENT", ACCESS_MANAGEMENT);
+        Assertions.assertEquals("SYSTEM_CONFIGURATION", SYSTEM_CONFIGURATION);
+        Assertions.assertEquals("PROJECT_CREATION_UPLOAD", PROJECT_CREATION_UPLOAD);
+        Assertions.assertEquals("POLICY_MANAGEMENT", POLICY_MANAGEMENT);
+        Assertions.assertEquals("TAG_MANAGEMENT", TAG_MANAGEMENT);
+        Assertions.assertEquals("VIEW_BADGES", VIEW_BADGES);
     }
 }

--- a/src/test/java/org/dependencytrack/common/AlpineHttpProxySelectorTest.java
+++ b/src/test/java/org/dependencytrack/common/AlpineHttpProxySelectorTest.java
@@ -19,7 +19,7 @@
 package org.dependencytrack.common;
 
 import alpine.common.util.ProxyConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.Proxy;
 import java.net.URI;
@@ -27,10 +27,10 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AlpineHttpProxySelectorTest {
+class AlpineHttpProxySelectorTest {
 
     @Test
-    public void testSelect() {
+    void testSelect() {
         final var proxyConfig = new ProxyConfig();
         proxyConfig.setHost("example.com");
         proxyConfig.setPort(6666);

--- a/src/test/java/org/dependencytrack/common/HttpClientPoolTest.java
+++ b/src/test/java/org/dependencytrack/common/HttpClientPoolTest.java
@@ -18,16 +18,16 @@
  */
 package org.dependencytrack.common;
 
-import io.jsonwebtoken.lang.Assert;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class HttpClientPoolTest {
+class HttpClientPoolTest {
 
     @Test
-    public void getClientTest() {
+    void getClientTest() {
         CloseableHttpClient client = HttpClientPool.getClient();
-        Assert.notNull(client);
+        Assertions.assertNotNull(client);
     }
 
 }

--- a/src/test/java/org/dependencytrack/common/ManagedHttpClientFactoryTest.java
+++ b/src/test/java/org/dependencytrack/common/ManagedHttpClientFactoryTest.java
@@ -23,60 +23,50 @@ import alpine.common.util.SystemUtil;
 import org.apache.http.HttpHost;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
-public class ManagedHttpClientFactoryTest {
-
-    @Rule
-    public EnvironmentVariables environmentVariables = new EnvironmentVariables();
-
-    @Before
-    public void before() {
-        environmentVariables.set("http_proxy", "http://acme%5Cusername:password@127.0.0.1:1080");
-        environmentVariables.set("no_proxy", "localhost:443,127.0.0.1:8080,example.com,www.example.net");
-    }
-
+@SetEnvironmentVariable(key = "http_proxy", value = "http://acme%5Cusername:password@127.0.0.1:1080")
+@SetEnvironmentVariable(key = "no_proxy", value = "localhost:443,127.0.0.1:8080,example.com,www.example.net")
+class ManagedHttpClientFactoryTest {
     @Test
-    public void instanceTest() {
+    void instanceTest() {
         HttpClient c1 = ManagedHttpClientFactory.newManagedHttpClient().getHttpClient();
         HttpClient c2 = ManagedHttpClientFactory.newManagedHttpClient().getHttpClient();
-        Assert.assertNotSame(c1, c2);
-        Assert.assertTrue(c1 instanceof CloseableHttpClient);
+        Assertions.assertNotSame(c1, c2);
+        Assertions.assertInstanceOf(CloseableHttpClient.class, c1);
     }
 
     @Test
-    public void proxyInfoTest() {
+    void proxyInfoTest() {
         ManagedHttpClientFactory.ProxyInfo proxyInfo = ManagedHttpClientFactory.createProxyInfo();
-        Assert.assertEquals("127.0.0.1", proxyInfo.getHost());
-        Assert.assertEquals(1080, proxyInfo.getPort());
-        Assert.assertEquals("acme", proxyInfo.getDomain());
-        Assert.assertEquals("username", proxyInfo.getUsername());
-        Assert.assertEquals("password", proxyInfo.getPassword());
-        Assert.assertArrayEquals(new String[]{"localhost:443", "127.0.0.1:8080", "example.com", "www.example.net"}, proxyInfo.getNoProxy());
+        Assertions.assertEquals("127.0.0.1", proxyInfo.getHost());
+        Assertions.assertEquals(1080, proxyInfo.getPort());
+        Assertions.assertEquals("acme", proxyInfo.getDomain());
+        Assertions.assertEquals("username", proxyInfo.getUsername());
+        Assertions.assertEquals("password", proxyInfo.getPassword());
+        Assertions.assertArrayEquals(new String[]{"localhost:443", "127.0.0.1:8080", "example.com", "www.example.net"}, proxyInfo.getNoProxy());
     }
 
     @Test
-    public void isProxyTest() {
+    void isProxyTest() {
         ManagedHttpClientFactory.ProxyInfo proxyInfo = ManagedHttpClientFactory.createProxyInfo();
-        Assert.assertFalse(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("example.com",443)));
-        Assert.assertFalse(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("example.com",8080)));
-        Assert.assertFalse(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("www.example.com",443)));
-        Assert.assertFalse(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("foo.example.com",80)));
-        Assert.assertTrue(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("fooexample.com",80)));
-        Assert.assertFalse(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("foo.bar.example.com",8000)));
-        Assert.assertFalse(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("www.example.net",80)));
-        Assert.assertTrue(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("foo.example.net",80)));
-        Assert.assertTrue(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("example.org",443)));
-        Assert.assertFalse(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("127.0.0.1",8080)));
-        Assert.assertTrue(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("127.0.0.1",8000)));
+        Assertions.assertFalse(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("example.com",443)));
+        Assertions.assertFalse(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("example.com",8080)));
+        Assertions.assertFalse(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("www.example.com",443)));
+        Assertions.assertFalse(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("foo.example.com",80)));
+        Assertions.assertTrue(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("fooexample.com",80)));
+        Assertions.assertFalse(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("foo.bar.example.com",8000)));
+        Assertions.assertFalse(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("www.example.net",80)));
+        Assertions.assertTrue(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("foo.example.net",80)));
+        Assertions.assertTrue(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("example.org",443)));
+        Assertions.assertFalse(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("127.0.0.1",8080)));
+        Assertions.assertTrue(ManagedHttpClientFactory.isProxy(proxyInfo.getNoProxy(), new HttpHost("127.0.0.1",8000)));
     }
 
     @Test
-    public void userAgentTest() {
+    void userAgentTest() {
         String expected = Config.getInstance().getApplicationName()
                 + " v" + Config.getInstance().getApplicationVersion()
                 + " ("
@@ -84,6 +74,6 @@ public class ManagedHttpClientFactoryTest {
                 + SystemUtil.getOsName() + "; "
                 + SystemUtil.getOsVersion()
                 + ") ManagedHttpClient/";
-        Assert.assertTrue(ManagedHttpClientFactory.getUserAgent().startsWith(expected));
+        Assertions.assertTrue(ManagedHttpClientFactory.getUserAgent().startsWith(expected));
     }
 }

--- a/src/test/java/org/dependencytrack/common/ManagedHttpClientTest.java
+++ b/src/test/java/org/dependencytrack/common/ManagedHttpClientTest.java
@@ -22,19 +22,19 @@ package org.dependencytrack.common;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class ManagedHttpClientTest {
+class ManagedHttpClientTest {
 
     @Test
-    public void objectTest() {
+    void objectTest() {
         PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
         HttpClientBuilder clientBuilder = HttpClientBuilder.create();
         clientBuilder.setConnectionManager(connectionManager);
         CloseableHttpClient client = clientBuilder.build();
         ManagedHttpClient managedHttpClient = new ManagedHttpClient(client, connectionManager);
-        Assert.assertSame(client, managedHttpClient.getHttpClient());
-        Assert.assertSame(connectionManager, managedHttpClient.getConnectionManager());
+        Assertions.assertSame(client, managedHttpClient.getHttpClient());
+        Assertions.assertSame(connectionManager, managedHttpClient.getConnectionManager());
     }
 }

--- a/src/test/java/org/dependencytrack/event/BomUploadEventTest.java
+++ b/src/test/java/org/dependencytrack/event/BomUploadEventTest.java
@@ -19,19 +19,19 @@
 package org.dependencytrack.event;
 
 import org.dependencytrack.model.Project;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class BomUploadEventTest {
+class BomUploadEventTest {
 
     @Test
-    public void testByteArrayConstructor() {
+    void testByteArrayConstructor() {
         var project = new Project();
         byte[] bom = "testing".getBytes();
         BomUploadEvent event = new BomUploadEvent(project, bom);
-        Assert.assertEquals(project, event.getProject());
-        Assert.assertNotEquals(bom, event.getBom()); // should be a cloned byte array - not the same reference
-        Assert.assertTrue(event.getBom().length > 0);
+        Assertions.assertEquals(project, event.getProject());
+        Assertions.assertNotEquals(bom, event.getBom()); // should be a cloned byte array - not the same reference
+        Assertions.assertTrue(event.getBom().length > 0);
     }
 
 }

--- a/src/test/java/org/dependencytrack/event/CloneProjectEventTest.java
+++ b/src/test/java/org/dependencytrack/event/CloneProjectEventTest.java
@@ -19,20 +19,20 @@
 package org.dependencytrack.event;
 
 import org.dependencytrack.resources.v1.vo.CloneProjectRequest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-public class CloneProjectEventTest {
+class CloneProjectEventTest {
 
     @Test
-    public void testEvent() {
+    void testEvent() {
         UUID uuid = UUID.randomUUID();
         CloneProjectRequest request = new CloneProjectRequest(uuid.toString(), "1.0", true,
                 true, true, true, true, true,
                 true, true, false);
         CloneProjectEvent event = new CloneProjectEvent(request);
-        Assert.assertEquals(request, event.getRequest());
+        Assertions.assertEquals(request, event.getRequest());
     }
 }

--- a/src/test/java/org/dependencytrack/event/FortifySscUploadEventTest.java
+++ b/src/test/java/org/dependencytrack/event/FortifySscUploadEventTest.java
@@ -18,23 +18,23 @@
  */
 package org.dependencytrack.event;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-public class FortifySscUploadEventTest {
+class FortifySscUploadEventTest {
 
     @Test
-    public void testDefaultConstructor() {
+    void testDefaultConstructor() {
         FortifySscUploadEventAbstract event = new FortifySscUploadEventAbstract();
-        Assert.assertNull(event.getProjectUuid());
+        Assertions.assertNull(event.getProjectUuid());
     }
 
     @Test
-    public void testProjectConstructor() {
+    void testProjectConstructor() {
         UUID uuid = UUID.randomUUID();
         FortifySscUploadEventAbstract event = new FortifySscUploadEventAbstract(uuid);
-        Assert.assertEquals(uuid, event.getProjectUuid());
+        Assertions.assertEquals(uuid, event.getProjectUuid());
     }
 }

--- a/src/test/java/org/dependencytrack/event/IndexEventTest.java
+++ b/src/test/java/org/dependencytrack/event/IndexEventTest.java
@@ -28,73 +28,73 @@ import org.dependencytrack.search.document.LicenseDocument;
 import org.dependencytrack.search.document.ProjectDocument;
 import org.dependencytrack.search.document.VulnerabilityDocument;
 import org.dependencytrack.search.document.VulnerableSoftwareDocument;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class IndexEventTest {
+class IndexEventTest {
 
     @Test
-    public void testProjectEvent() {
+    void testProjectEvent() {
         Project project = new Project();
         IndexEvent event = new IndexEvent(IndexEvent.Action.CREATE, project);
-        Assert.assertEquals(IndexEvent.Action.CREATE, event.getAction());
-        Assert.assertEquals(new ProjectDocument(project), event.getDocument());
-        Assert.assertEquals(Project.class,event.getIndexableClass());
+        Assertions.assertEquals(IndexEvent.Action.CREATE, event.getAction());
+        Assertions.assertEquals(new ProjectDocument(project), event.getDocument());
+        Assertions.assertEquals(Project.class, event.getIndexableClass());
     }
 
     @Test
-    public void testComponentEvent() {
+    void testComponentEvent() {
         Component component = new Component();
         IndexEvent event = new IndexEvent(IndexEvent.Action.UPDATE, component);
-        Assert.assertEquals(IndexEvent.Action.UPDATE, event.getAction());
-        Assert.assertEquals(new ComponentDocument(component), event.getDocument());
-        Assert.assertEquals(Component.class,event.getIndexableClass());
+        Assertions.assertEquals(IndexEvent.Action.UPDATE, event.getAction());
+        Assertions.assertEquals(new ComponentDocument(component), event.getDocument());
+        Assertions.assertEquals(Component.class, event.getIndexableClass());
     }
 
     @Test
-    public void testVulnerabilityEvent() {
+    void testVulnerabilityEvent() {
         Vulnerability vulnerability = new Vulnerability();
         IndexEvent event = new IndexEvent(IndexEvent.Action.DELETE, vulnerability);
-        Assert.assertEquals(IndexEvent.Action.DELETE, event.getAction());
-        Assert.assertEquals(new VulnerabilityDocument(vulnerability), event.getDocument());
-        Assert.assertEquals(Vulnerability.class, event.getIndexableClass());
+        Assertions.assertEquals(IndexEvent.Action.DELETE, event.getAction());
+        Assertions.assertEquals(new VulnerabilityDocument(vulnerability), event.getDocument());
+        Assertions.assertEquals(Vulnerability.class, event.getIndexableClass());
     }
 
     @Test
-    public void testLicenseEvent() {
+    void testLicenseEvent() {
         License license = new License();
         IndexEvent event = new IndexEvent(IndexEvent.Action.COMMIT, license);
-        Assert.assertEquals(IndexEvent.Action.COMMIT, event.getAction());
-        Assert.assertEquals(new LicenseDocument(license), event.getDocument());
-        Assert.assertEquals(License.class, event.getIndexableClass());
+        Assertions.assertEquals(IndexEvent.Action.COMMIT, event.getAction());
+        Assertions.assertEquals(new LicenseDocument(license), event.getDocument());
+        Assertions.assertEquals(License.class, event.getIndexableClass());
     }
 
     @Test
-    public void testVulnerableSoftwareEvent() {
+    void testVulnerableSoftwareEvent() {
         VulnerableSoftware vulnerableSoftware = new VulnerableSoftware();
         IndexEvent event = new IndexEvent(IndexEvent.Action.COMMIT, vulnerableSoftware);
-        Assert.assertEquals(IndexEvent.Action.COMMIT, event.getAction());
-        Assert.assertEquals(new VulnerableSoftwareDocument(vulnerableSoftware), event.getDocument());
-        Assert.assertEquals(VulnerableSoftware.class, event.getIndexableClass());
+        Assertions.assertEquals(IndexEvent.Action.COMMIT, event.getAction());
+        Assertions.assertEquals(new VulnerableSoftwareDocument(vulnerableSoftware), event.getDocument());
+        Assertions.assertEquals(VulnerableSoftware.class, event.getIndexableClass());
     }
 
     @Test
-    public void testClassEvent() {
+    void testClassEvent() {
         Class clazz = License.class;
         IndexEvent event = new IndexEvent(IndexEvent.Action.REINDEX, clazz);
-        Assert.assertEquals(IndexEvent.Action.REINDEX, event.getAction());
-        Assert.assertNull(event.getDocument());
-        Assert.assertEquals(clazz, event.getIndexableClass());
+        Assertions.assertEquals(IndexEvent.Action.REINDEX, event.getAction());
+        Assertions.assertNull(event.getDocument());
+        Assertions.assertEquals(clazz, event.getIndexableClass());
     }
 
     @Test
-    public void testActions() {
-        Assert.assertEquals(6, IndexEvent.Action.values().length);
-        Assert.assertEquals("CREATE", IndexEvent.Action.CREATE.name());
-        Assert.assertEquals("UPDATE", IndexEvent.Action.UPDATE.name());
-        Assert.assertEquals("DELETE", IndexEvent.Action.DELETE.name());
-        Assert.assertEquals("COMMIT", IndexEvent.Action.COMMIT.name());
-        Assert.assertEquals("REINDEX", IndexEvent.Action.REINDEX.name());
-        Assert.assertEquals("CHECK", IndexEvent.Action.CHECK.name());
+    void testActions() {
+        Assertions.assertEquals(6, IndexEvent.Action.values().length);
+        Assertions.assertEquals("CREATE", IndexEvent.Action.CREATE.name());
+        Assertions.assertEquals("UPDATE", IndexEvent.Action.UPDATE.name());
+        Assertions.assertEquals("DELETE", IndexEvent.Action.DELETE.name());
+        Assertions.assertEquals("COMMIT", IndexEvent.Action.COMMIT.name());
+        Assertions.assertEquals("REINDEX", IndexEvent.Action.REINDEX.name());
+        Assertions.assertEquals("CHECK", IndexEvent.Action.CHECK.name());
     }
 }

--- a/src/test/java/org/dependencytrack/event/KennaSecurityUploadEventTest.java
+++ b/src/test/java/org/dependencytrack/event/KennaSecurityUploadEventTest.java
@@ -18,23 +18,23 @@
  */
 package org.dependencytrack.event;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-public class KennaSecurityUploadEventTest {
+class KennaSecurityUploadEventTest {
 
     @Test
-    public void testDefaultConstructor() {
+    void testDefaultConstructor() {
         KennaSecurityUploadEventAbstract event = new KennaSecurityUploadEventAbstract();
-        Assert.assertNull(event.getProjectUuid());
+        Assertions.assertNull(event.getProjectUuid());
     }
 
     @Test
-    public void testProjectConstructor() {
+    void testProjectConstructor() {
         UUID uuid = UUID.randomUUID();
         KennaSecurityUploadEventAbstract event = new KennaSecurityUploadEventAbstract(uuid);
-        Assert.assertEquals(uuid, event.getProjectUuid());
+        Assertions.assertEquals(uuid, event.getProjectUuid());
     }
 }

--- a/src/test/java/org/dependencytrack/event/NistMirrorEventTest.java
+++ b/src/test/java/org/dependencytrack/event/NistMirrorEventTest.java
@@ -18,14 +18,14 @@
  */
 package org.dependencytrack.event;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class NistMirrorEventTest {
+class NistMirrorEventTest {
 
     @Test
-    public void testDefaultConstructor() {
+    void testDefaultConstructor() {
         NistMirrorEvent event = new NistMirrorEvent();
-        Assert.assertNotNull(event);
+        Assertions.assertNotNull(event);
     }
 }

--- a/src/test/java/org/dependencytrack/event/PolicyEvaluationEventTest.java
+++ b/src/test/java/org/dependencytrack/event/PolicyEvaluationEventTest.java
@@ -22,39 +22,39 @@ import java.util.ArrayList;
 import java.util.List;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class PolicyEvaluationEventTest {
+class PolicyEvaluationEventTest {
 
     @Test
-    public void testDefaultConstructor() {
+    void testDefaultConstructor() {
         PolicyEvaluationEvent event = new PolicyEvaluationEvent();
-        Assert.assertNull(event.getProject());
-        Assert.assertEquals(0, event.getComponents().size());
+        Assertions.assertNull(event.getProject());
+        Assertions.assertEquals(0, event.getComponents().size());
     }
 
     @Test
-    public void testComponentConstructor() {
+    void testComponentConstructor() {
         Component component = new Component();
         PolicyEvaluationEvent event = new PolicyEvaluationEvent(component);
-        Assert.assertEquals(1, event.getComponents().size());
+        Assertions.assertEquals(1, event.getComponents().size());
     }
 
     @Test
-    public void testComponentsConstructor() {
+    void testComponentsConstructor() {
         Component component = new Component();
         List<Component> components = new ArrayList<>();
         components.add(component);
         PolicyEvaluationEvent event = new PolicyEvaluationEvent(components);
-        Assert.assertEquals(1, event.getComponents().size());
+        Assertions.assertEquals(1, event.getComponents().size());
     }
 
     @Test
-    public void testProjectCriteria() {
+    void testProjectCriteria() {
         Project project = new Project();
         PolicyEvaluationEvent event = new PolicyEvaluationEvent().project(project);
-        Assert.assertEquals(project, event.getProject());
-        Assert.assertEquals(0, event.getComponents().size());
+        Assertions.assertEquals(project, event.getProject());
+        Assertions.assertEquals(0, event.getComponents().size());
     }
 }

--- a/src/test/java/org/dependencytrack/event/RepositoryMetaEventTest.java
+++ b/src/test/java/org/dependencytrack/event/RepositoryMetaEventTest.java
@@ -19,26 +19,26 @@
 package org.dependencytrack.event;
 
 import org.dependencytrack.model.Component;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
-public class RepositoryMetaEventTest {
+class RepositoryMetaEventTest {
 
     @Test
-    public void testDefaultConstructor() {
+    void testDefaultConstructor() {
         RepositoryMetaEvent event = new RepositoryMetaEvent();
-        Assert.assertEquals(Optional.empty(), event.getComponents());
+        Assertions.assertEquals(Optional.empty(), event.getComponents());
     }
 
     @Test
-    public void testComponentConstructor() {
+    void testComponentConstructor() {
         List<Component> components = new LinkedList<>();
         Component component = new Component();
         components.add(component);
         RepositoryMetaEvent event = new RepositoryMetaEvent(components);
-        Assert.assertEquals(components, event.getComponents().get());
+        Assertions.assertEquals(components, event.getComponents().get());
     }
 }

--- a/src/test/java/org/dependencytrack/event/VulnDbSyncEventTest.java
+++ b/src/test/java/org/dependencytrack/event/VulnDbSyncEventTest.java
@@ -18,14 +18,14 @@
  */
 package org.dependencytrack.event;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class VulnDbSyncEventTest {
+class VulnDbSyncEventTest {
 
     @Test
-    public void testDefaultConstructor() {
+    void testDefaultConstructor() {
         VulnDbSyncEvent event = new VulnDbSyncEvent();
-        Assert.assertNotNull(event);
+        Assertions.assertNotNull(event);
     }
 }

--- a/src/test/java/org/dependencytrack/exception/ParseExceptionTest.java
+++ b/src/test/java/org/dependencytrack/exception/ParseExceptionTest.java
@@ -18,32 +18,32 @@
  */
 package org.dependencytrack.exception;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-public class ParseExceptionTest {
+class ParseExceptionTest {
 
     @Test
-    public void testMessageConstructor() {
+    void testMessageConstructor() {
         ParseException ex = new ParseException("An error occurred");
-        Assert.assertEquals("An error occurred", ex.getMessage());
+        Assertions.assertEquals("An error occurred", ex.getMessage());
     }
 
     @Test
-    public void testThrowableConstructor() {
+    void testThrowableConstructor() {
         IOException e = new IOException("Filed to open file");
         ParseException ex = new ParseException(e);
-        Assert.assertNotNull(ex.getMessage());
-        Assert.assertEquals(e, ex.getCause());
+        Assertions.assertNotNull(ex.getMessage());
+        Assertions.assertEquals(e, ex.getCause());
     }
 
     @Test
-    public void testMessageThrowableConstructor() {
+    void testMessageThrowableConstructor() {
         IOException e = new IOException("Filed to open file");
         ParseException ex = new ParseException("Oops", e);
-        Assert.assertEquals("Oops", ex.getMessage());
-        Assert.assertEquals(e, ex.getCause());
+        Assertions.assertEquals("Oops", ex.getMessage());
+        Assertions.assertEquals(e, ex.getCause());
     }
 }

--- a/src/test/java/org/dependencytrack/integrations/AbstractIntegrationPointTest.java
+++ b/src/test/java/org/dependencytrack/integrations/AbstractIntegrationPointTest.java
@@ -20,13 +20,13 @@ package org.dependencytrack.integrations;
 
 import alpine.common.logging.Logger;
 import org.dependencytrack.PersistenceCapableTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class AbstractIntegrationPointTest extends PersistenceCapableTest {
+class AbstractIntegrationPointTest extends PersistenceCapableTest {
 
     @Test
-    public void testAbstractMethods() {
+    void testAbstractMethods() {
         AbstractIntegrationPoint extension = Mockito.mock(
                 AbstractIntegrationPoint.class,
                 Mockito.CALLS_REAL_METHODS

--- a/src/test/java/org/dependencytrack/integrations/FindingPackagingFormatTest.java
+++ b/src/test/java/org/dependencytrack/integrations/FindingPackagingFormatTest.java
@@ -29,19 +29,19 @@ import org.dependencytrack.model.VulnerabilityAlias;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-public class FindingPackagingFormatTest extends PersistenceCapableTest {
+class FindingPackagingFormatTest extends PersistenceCapableTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void wrapperTest() {
+    void wrapperTest() {
         Project project = qm.createProject(
                 "Test", "Sample project", "1.0", null, null, null, true, false);
         FindingPackagingFormat fpf = new FindingPackagingFormat(
@@ -51,20 +51,20 @@ public class FindingPackagingFormatTest extends PersistenceCapableTest {
         JSONObject root = fpf.getDocument();
 
         JSONObject meta = root.getJSONObject("meta");
-        Assert.assertEquals(Config.getInstance().getApplicationName(), meta.getString("application"));
-        Assert.assertEquals(Config.getInstance().getApplicationVersion(), meta.getString("version"));
-        Assert.assertNotNull(meta.getString("timestamp"));
+        Assertions.assertEquals(Config.getInstance().getApplicationName(), meta.getString("application"));
+        Assertions.assertEquals(Config.getInstance().getApplicationVersion(), meta.getString("version"));
+        Assertions.assertNotNull(meta.getString("timestamp"));
 
         JSONObject pjson = root.getJSONObject("project");
-        Assert.assertEquals(project.getName(), pjson.getString("name"));
-        Assert.assertEquals(project.getDescription(), pjson.getString("description"));
-        Assert.assertEquals(project.getVersion(), pjson.getString("version"));
+        Assertions.assertEquals(project.getName(), pjson.getString("name"));
+        Assertions.assertEquals(project.getDescription(), pjson.getString("description"));
+        Assertions.assertEquals(project.getVersion(), pjson.getString("version"));
 
-        Assert.assertEquals("1.2", root.getString("version"));
+        Assertions.assertEquals("1.2", root.getString("version"));
     }
 
     @Test
-    public void testFindingsVulnerabilityAndAliases() {
+    void testFindingsVulnerabilityAndAliases() {
         Project project = qm.createProject(
                 "Test", "Sample project", "1.0", null, null, null, true, false);
 
@@ -110,30 +110,30 @@ public class FindingPackagingFormatTest extends PersistenceCapableTest {
 
         JSONArray findings = root.getJSONArray("findings");
 
-        Assert.assertEquals("component-name-1", findings.getJSONObject(0).getJSONObject("component").getString("name"));
-        Assert.assertEquals("component-name-2", findings.getJSONObject(1).getJSONObject("component").getString("name"));
+        Assertions.assertEquals("component-name-1", findings.getJSONObject(0).getJSONObject("component").getString("name"));
+        Assertions.assertEquals("component-name-2", findings.getJSONObject(1).getJSONObject("component").getString("name"));
 
-        Assert.assertEquals(AnalyzerIdentity.OSSINDEX_ANALYZER, findings.getJSONObject(0).getJSONObject("attribution").get("analyzerIdentity"));
-        Assert.assertEquals(AnalyzerIdentity.INTERNAL_ANALYZER, findings.getJSONObject(1).getJSONObject("attribution").get("analyzerIdentity"));
+        Assertions.assertEquals(AnalyzerIdentity.OSSINDEX_ANALYZER, findings.getJSONObject(0).getJSONObject("attribution").get("analyzerIdentity"));
+        Assertions.assertEquals(AnalyzerIdentity.INTERNAL_ANALYZER, findings.getJSONObject(1).getJSONObject("attribution").get("analyzerIdentity"));
 
-        Assert.assertEquals(Severity.CRITICAL.toString(), findings.getJSONObject(0).getJSONObject("vulnerability").get("severity"));
-        Assert.assertEquals(Severity.HIGH.toString(), findings.getJSONObject(1).getJSONObject("vulnerability").get("severity"));
+        Assertions.assertEquals(Severity.CRITICAL.toString(), findings.getJSONObject(0).getJSONObject("vulnerability").get("severity"));
+        Assertions.assertEquals(Severity.HIGH.toString(), findings.getJSONObject(1).getJSONObject("vulnerability").get("severity"));
 
         JSONArray aliases_1 =  findings.getJSONObject(0).getJSONObject("vulnerability").getJSONArray("aliases");
-        Assert.assertTrue(aliases_1.isEmpty());
+        Assertions.assertTrue(aliases_1.isEmpty());
         JSONArray aliases_2 =  findings.getJSONObject(1).getJSONObject("vulnerability").getJSONArray("aliases");
-        Assert.assertFalse(aliases_2.isEmpty());
-        Assert.assertEquals(2, aliases_2.length());
-        Assert.assertEquals("anotherCveId", aliases_2.getJSONObject(0).getString("cveId"));
-        Assert.assertEquals("anotherGhsaId", aliases_2.getJSONObject(0).getString("ghsaId"));
-        Assert.assertEquals("someCveId", aliases_2.getJSONObject(1).getString("cveId"));
-        Assert.assertEquals("someOsvId", aliases_2.getJSONObject(1).getString("osvId"));
+        Assertions.assertFalse(aliases_2.isEmpty());
+        Assertions.assertEquals(2, aliases_2.length());
+        Assertions.assertEquals("anotherCveId", aliases_2.getJSONObject(0).getString("cveId"));
+        Assertions.assertEquals("anotherGhsaId", aliases_2.getJSONObject(0).getString("ghsaId"));
+        Assertions.assertEquals("someCveId", aliases_2.getJSONObject(1).getString("cveId"));
+        Assertions.assertEquals("someOsvId", aliases_2.getJSONObject(1).getString("osvId"));
 
         // negative test to see if technical id is not included
-        Assert.assertFalse(aliases_2.getJSONObject(0).has("id"));
+        Assertions.assertFalse(aliases_2.getJSONObject(0).has("id"));
 
         //final negative test to make sure the allBySource element is not included
         String finalJsonOutput = root.toString();
-        Assert.assertFalse(finalJsonOutput.contains("allBySource"));
+        Assertions.assertFalse(finalJsonOutput.contains("allBySource"));
     }
 }

--- a/src/test/java/org/dependencytrack/integrations/FindingUploaderTest.java
+++ b/src/test/java/org/dependencytrack/integrations/FindingUploaderTest.java
@@ -18,25 +18,25 @@
  */
 package org.dependencytrack.integrations;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class FindingUploaderTest {
+class FindingUploaderTest {
 
     @Test
-    public final void testIsEnabled_True() {
+    final void testIsEnabled_True() {
         FindingUploader findingUploader = mock(FindingUploader.class);
         when(findingUploader.isEnabled()).thenReturn(true);
-        Assert.assertTrue(findingUploader.isEnabled());
+        Assertions.assertTrue(findingUploader.isEnabled());
     }
 
     @Test
-    public final void testIsEnabled_False() {
+    final void testIsEnabled_False() {
         FindingUploader findingUploader = mock(FindingUploader.class);
         when(findingUploader.isEnabled()).thenReturn(false);
-        Assert.assertFalse(findingUploader.isEnabled());
+        Assertions.assertFalse(findingUploader.isEnabled());
     }
 }

--- a/src/test/java/org/dependencytrack/integrations/IntegrationPointTest.java
+++ b/src/test/java/org/dependencytrack/integrations/IntegrationPointTest.java
@@ -18,20 +18,20 @@
  */
 package org.dependencytrack.integrations;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class IntegrationPointTest {
+class IntegrationPointTest {
 
     @Test
-    public final void integrationPointMetadataTest() {
+    final void integrationPointMetadataTest() {
         IntegrationPoint integrationPoint = mock(IntegrationPoint.class);
         when(integrationPoint.name()).thenReturn("Acme Endpoint");
         when(integrationPoint.description()).thenReturn("An example endpoint");
-        Assert.assertEquals("Acme Endpoint", integrationPoint.name());
-        Assert.assertEquals("An example endpoint", integrationPoint.description());
+        Assertions.assertEquals("Acme Endpoint", integrationPoint.name());
+        Assertions.assertEquals("An example endpoint", integrationPoint.description());
     }
 }

--- a/src/test/java/org/dependencytrack/integrations/PortfolioFindingUploaderTest.java
+++ b/src/test/java/org/dependencytrack/integrations/PortfolioFindingUploaderTest.java
@@ -18,8 +18,8 @@
  */
 package org.dependencytrack.integrations;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,10 +27,10 @@ import java.io.InputStream;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class PortfolioFindingUploaderTest {
+class PortfolioFindingUploaderTest {
 
     @Test
-    public final void portfolioFindingMethodsTest() throws IOException {
+    final void portfolioFindingMethodsTest() throws IOException {
         PortfolioFindingUploader uploader = mock(PortfolioFindingUploader.class);
         when(uploader.process()).thenReturn(new InputStream() {
             @Override
@@ -43,7 +43,7 @@ public class PortfolioFindingUploaderTest {
             }
         });
         InputStream in = uploader.process();
-        Assert.assertTrue(in != null && in.available() == 1);
+        Assertions.assertTrue(in != null && in.available() == 1);
         uploader.upload(in);
     }
 }

--- a/src/test/java/org/dependencytrack/integrations/ProjectFindingUploaderTest.java
+++ b/src/test/java/org/dependencytrack/integrations/ProjectFindingUploaderTest.java
@@ -20,8 +20,8 @@ package org.dependencytrack.integrations;
 
 import org.dependencytrack.model.Finding;
 import org.dependencytrack.model.Project;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,11 +31,11 @@ import java.util.List;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ProjectFindingUploaderTest {
+class ProjectFindingUploaderTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public final void projectFindingMethodsTest() throws IOException {
+    final void projectFindingMethodsTest() throws IOException {
         Project project = new Project();
         List<Finding> findings = Collections.EMPTY_LIST;
         ProjectFindingUploader uploader = mock(ProjectFindingUploader.class);
@@ -50,11 +50,11 @@ public class ProjectFindingUploaderTest {
             }
         });
         InputStream in = uploader.process(project, findings);
-        Assert.assertTrue(in != null && in.available() == 1);
+        Assertions.assertTrue(in != null && in.available() == 1);
         uploader.upload(project, in);
         when(uploader.isProjectConfigured(project)).thenReturn(true);
-        Assert.assertTrue(uploader.isProjectConfigured(project));
+        Assertions.assertTrue(uploader.isProjectConfigured(project));
         when(uploader.isProjectConfigured(project)).thenReturn(false);
-        Assert.assertFalse(uploader.isProjectConfigured(project));
+        Assertions.assertFalse(uploader.isProjectConfigured(project));
     }
 }

--- a/src/test/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploaderTest.java
+++ b/src/test/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploaderTest.java
@@ -21,22 +21,22 @@ package org.dependencytrack.integrations.defectdojo;
 import alpine.model.IConfigProperty;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Project;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.dependencytrack.model.ConfigPropertyConstants.DEFECTDOJO_ENABLED;
 
-public class DefectDojoUploaderTest extends PersistenceCapableTest {
+class DefectDojoUploaderTest extends PersistenceCapableTest {
 
     @Test
-    public void testIntegrationMetadata() {
+    void testIntegrationMetadata() {
         DefectDojoUploader extension = new DefectDojoUploader();
-        Assert.assertEquals("DefectDojo", extension.name());
-        Assert.assertEquals("Pushes Dependency-Track findings to DefectDojo", extension.description());
+        Assertions.assertEquals("DefectDojo", extension.name());
+        Assertions.assertEquals("Pushes Dependency-Track findings to DefectDojo", extension.description());
     }
 
     @Test
-    public void testIntegrationEnabledCases() {
+    void testIntegrationEnabledCases() {
         qm.createConfigProperty(
                 DEFECTDOJO_ENABLED.getGroupName(),
                 DEFECTDOJO_ENABLED.getPropertyName(),
@@ -55,17 +55,17 @@ public class DefectDojoUploaderTest extends PersistenceCapableTest {
         );
         DefectDojoUploader extension = new DefectDojoUploader();
         extension.setQueryManager(qm);
-        Assert.assertTrue(extension.isEnabled());
-        Assert.assertTrue(extension.isProjectConfigured(project));
+        Assertions.assertTrue(extension.isEnabled());
+        Assertions.assertTrue(extension.isProjectConfigured(project));
     }
 
     @Test
-    public void testIntegrationDisabledCases() {
+    void testIntegrationDisabledCases() {
         Project project = qm.createProject("ACME Example", null, "1.0", null, null, null, true, false);
         DefectDojoUploader extension = new DefectDojoUploader();
         extension.setQueryManager(qm);
-        Assert.assertFalse(extension.isEnabled());
-        Assert.assertFalse(extension.isProjectConfigured(project));
+        Assertions.assertFalse(extension.isEnabled());
+        Assertions.assertFalse(extension.isProjectConfigured(project));
     }
 
 }

--- a/src/test/java/org/dependencytrack/integrations/fortifyssc/FortifySscUploaderTest.java
+++ b/src/test/java/org/dependencytrack/integrations/fortifyssc/FortifySscUploaderTest.java
@@ -21,25 +21,24 @@ package org.dependencytrack.integrations.fortifyssc;
 import alpine.model.IConfigProperty;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Project;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.util.ArrayList;
 
 import static org.dependencytrack.model.ConfigPropertyConstants.FORTIFY_SSC_ENABLED;
 
-public class FortifySscUploaderTest extends PersistenceCapableTest {
-
+class FortifySscUploaderTest extends PersistenceCapableTest {
     @Test
-    public void testIntegrationMetadata() {
+    void testIntegrationMetadata() {
         FortifySscUploader extension = new FortifySscUploader();
-        Assert.assertEquals("Fortify SSC", extension.name());
-        Assert.assertEquals("Pushes Dependency-Track findings to Software Security Center", extension.description());
+        Assertions.assertEquals("Fortify SSC", extension.name());
+        Assertions.assertEquals("Pushes Dependency-Track findings to Software Security Center", extension.description());
     }
 
     @Test
-    public void testIntegrationEnabledCases() {
+    void testIntegrationEnabledCases() {
         qm.createConfigProperty(
                 FORTIFY_SSC_ENABLED.getGroupName(),
                 FORTIFY_SSC_ENABLED.getPropertyName(),
@@ -58,25 +57,25 @@ public class FortifySscUploaderTest extends PersistenceCapableTest {
         );
         FortifySscUploader extension = new FortifySscUploader();
         extension.setQueryManager(qm);
-        Assert.assertTrue(extension.isEnabled());
-        Assert.assertTrue(extension.isProjectConfigured(project));
+        Assertions.assertTrue(extension.isEnabled());
+        Assertions.assertTrue(extension.isProjectConfigured(project));
     }
 
     @Test
-    public void testIntegrationDisabledCases() {
+    void testIntegrationDisabledCases() {
         Project project = qm.createProject("ACME Example", null, "1.0", null, null, null, true, false);
         FortifySscUploader extension = new FortifySscUploader();
         extension.setQueryManager(qm);
-        Assert.assertFalse(extension.isEnabled());
-        Assert.assertFalse(extension.isProjectConfigured(project));
+        Assertions.assertFalse(extension.isEnabled());
+        Assertions.assertFalse(extension.isProjectConfigured(project));
     }
 
     @Test
-    public void testIntegrationFindings() throws Exception {
+    void testIntegrationFindings() throws Exception {
         Project project = qm.createProject("ACME Example", null, "1.0", null, null, null, true, false);
         FortifySscUploader extension = new FortifySscUploader();
         extension.setQueryManager(qm);
         InputStream in = extension.process(project, new ArrayList<>());
-        Assert.assertTrue(in != null && in.available() > 0);
+        Assertions.assertTrue(in != null && in.available() > 0);
     }
 }

--- a/src/test/java/org/dependencytrack/integrations/kenna/KennaSecurityUploaderTest.java
+++ b/src/test/java/org/dependencytrack/integrations/kenna/KennaSecurityUploaderTest.java
@@ -20,25 +20,24 @@ package org.dependencytrack.integrations.kenna;
 
 import alpine.model.IConfigProperty;
 import org.dependencytrack.PersistenceCapableTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 
 import static org.dependencytrack.model.ConfigPropertyConstants.KENNA_CONNECTOR_ID;
 import static org.dependencytrack.model.ConfigPropertyConstants.KENNA_ENABLED;
 
-public class KennaSecurityUploaderTest extends PersistenceCapableTest {
-
+class KennaSecurityUploaderTest extends PersistenceCapableTest {
     @Test
-    public void testIntegrationMetadata() {
+    void testIntegrationMetadata() {
         KennaSecurityUploader extension = new KennaSecurityUploader();
-        Assert.assertEquals("Kenna Security", extension.name());
-        Assert.assertEquals("Pushes Dependency-Track findings to Kenna Security", extension.description());
+        Assertions.assertEquals("Kenna Security", extension.name());
+        Assertions.assertEquals("Pushes Dependency-Track findings to Kenna Security", extension.description());
     }
 
     @Test
-    public void testIntegrationEnabledCases() {
+    void testIntegrationEnabledCases() {
         qm.createConfigProperty(
                 KENNA_ENABLED.getGroupName(),
                 KENNA_ENABLED.getPropertyName(),
@@ -55,21 +54,21 @@ public class KennaSecurityUploaderTest extends PersistenceCapableTest {
         );
         KennaSecurityUploader extension = new KennaSecurityUploader();
         extension.setQueryManager(qm);
-        Assert.assertTrue(extension.isEnabled());
+        Assertions.assertTrue(extension.isEnabled());
     }
 
     @Test
-    public void testIntegrationDisabledCases() {
+    void testIntegrationDisabledCases() {
         KennaSecurityUploader extension = new KennaSecurityUploader();
         extension.setQueryManager(qm);
-        Assert.assertFalse(extension.isEnabled());
+        Assertions.assertFalse(extension.isEnabled());
     }
 
     @Test
-    public void testIntegrationFindings() throws Exception {
+    void testIntegrationFindings() throws Exception {
         KennaSecurityUploader extension = new KennaSecurityUploader();
         extension.setQueryManager(qm);
         InputStream in = extension.process();
-        Assert.assertTrue(in != null && in.available() > 0);
+        Assertions.assertTrue(in != null && in.available() > 0);
     }
 }

--- a/src/test/java/org/dependencytrack/metrics/MetricsTest.java
+++ b/src/test/java/org/dependencytrack/metrics/MetricsTest.java
@@ -18,17 +18,17 @@
  */
 package org.dependencytrack.metrics;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class MetricsTest {
+class MetricsTest {
 
     @Test
-    public void testMetricCalculations() {
+    void testMetricCalculations() {
         double chml = Metrics.inheritedRiskScore(20, 10, 5, 1, 3);
-        Assert.assertEquals(281, chml, 0);
+        Assertions.assertEquals(281, chml, 0);
 
         double ratio = Metrics.vulnerableComponentRatio(5, 100);
-        Assert.assertEquals(0.05, ratio, 0);
+        Assertions.assertEquals(0.05, ratio, 0);
     }
 }

--- a/src/test/java/org/dependencytrack/model/AnalysisCommentTest.java
+++ b/src/test/java/org/dependencytrack/model/AnalysisCommentTest.java
@@ -18,49 +18,49 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 
-public class AnalysisCommentTest {
+class AnalysisCommentTest {
 
     @Test
-    public void testId() {
+    void testId() {
         AnalysisComment comment = new AnalysisComment();
         comment.setId(111L);
-        Assert.assertEquals(111L, comment.getId());
+        Assertions.assertEquals(111L, comment.getId());
     }
 
     @Test
-    public void testAnalysis() {
+    void testAnalysis() {
         Analysis analysis = new Analysis();
         AnalysisComment comment = new AnalysisComment();
         comment.setAnalysis(analysis);
-        Assert.assertEquals(analysis, comment.getAnalysis());
+        Assertions.assertEquals(analysis, comment.getAnalysis());
     }
 
     @Test
-    public void testTimestamp() {
+    void testTimestamp() {
         Date date = new Date();
         AnalysisComment comment = new AnalysisComment();
         comment.setTimestamp(date);
-        Assert.assertEquals(date, comment.getTimestamp());
+        Assertions.assertEquals(date, comment.getTimestamp());
     }
 
     @Test
-    public void testComment() {
+    void testComment() {
         String commentString = "This is a test comment";
         AnalysisComment comment = new AnalysisComment();
         comment.setComment(commentString);
-        Assert.assertEquals(commentString, comment.getComment());
+        Assertions.assertEquals(commentString, comment.getComment());
     }
 
     @Test
-    public void testCommenter() {
+    void testCommenter() {
         String commenter = "John Doe";
         AnalysisComment comment = new AnalysisComment();
         comment.setCommenter(commenter);
-        Assert.assertEquals(commenter, comment.getCommenter());
+        Assertions.assertEquals(commenter, comment.getCommenter());
     }
 } 

--- a/src/test/java/org/dependencytrack/model/AnalysisStateTest.java
+++ b/src/test/java/org/dependencytrack/model/AnalysisStateTest.java
@@ -18,18 +18,18 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class AnalysisStateTest { 
+class AnalysisStateTest {
 
     @Test
-    public void testEnums() {
-        Assert.assertEquals("NOT_SET", AnalysisState.NOT_SET.name());
-        Assert.assertEquals("IN_TRIAGE", AnalysisState.IN_TRIAGE.name());
-        Assert.assertEquals("NOT_AFFECTED", AnalysisState.NOT_AFFECTED.name());
-        Assert.assertEquals("FALSE_POSITIVE", AnalysisState.FALSE_POSITIVE.name());
-        Assert.assertEquals("NOT_AFFECTED", AnalysisState.NOT_AFFECTED.name());
+    void testEnums() {
+        Assertions.assertEquals("NOT_SET", AnalysisState.NOT_SET.name());
+        Assertions.assertEquals("IN_TRIAGE", AnalysisState.IN_TRIAGE.name());
+        Assertions.assertEquals("NOT_AFFECTED", AnalysisState.NOT_AFFECTED.name());
+        Assertions.assertEquals("FALSE_POSITIVE", AnalysisState.FALSE_POSITIVE.name());
+        Assertions.assertEquals("NOT_AFFECTED", AnalysisState.NOT_AFFECTED.name());
     }
 
 } 

--- a/src/test/java/org/dependencytrack/model/AnalysisTest.java
+++ b/src/test/java/org/dependencytrack/model/AnalysisTest.java
@@ -18,65 +18,65 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class AnalysisTest {
+class AnalysisTest {
 
     @Test
-    public void testId() {
+    void testId() {
         Analysis analysis = new Analysis();
         analysis.setId(111L);
-        Assert.assertEquals(111L, analysis.getId());
+        Assertions.assertEquals(111L, analysis.getId());
     }
 
     @Test
-    public void testComponent() {
+    void testComponent() {
         Project project = new Project();
         Component component = new Component();
         component.setProject(project);
         Analysis analysis = new Analysis();
         analysis.setComponent(component);
-        Assert.assertEquals(component, analysis.getComponent());
-        Assert.assertEquals(project, analysis.getProject());
-        Assert.assertEquals(project, analysis.getComponent().getProject());
+        Assertions.assertEquals(component, analysis.getComponent());
+        Assertions.assertEquals(project, analysis.getProject());
+        Assertions.assertEquals(project, analysis.getComponent().getProject());
     }
 
     @Test
-    public void testVulnerability() {
+    void testVulnerability() {
         Vulnerability vuln = new Vulnerability();
         Analysis analysis = new Analysis();
         analysis.setVulnerability(vuln);
-        Assert.assertEquals(vuln, analysis.getVulnerability());
+        Assertions.assertEquals(vuln, analysis.getVulnerability());
     }
 
     @Test
-    public void testAnalysisState() {
+    void testAnalysisState() {
         Analysis analysis = new Analysis();
         analysis.setAnalysisState(AnalysisState.EXPLOITABLE);
-        Assert.assertEquals(AnalysisState.EXPLOITABLE, analysis.getAnalysisState());
+        Assertions.assertEquals(AnalysisState.EXPLOITABLE, analysis.getAnalysisState());
     }
 
     @Test
-    public void testGetAnalysisComments() {
+    void testGetAnalysisComments() {
         List<AnalysisComment> comments = new ArrayList<>();
         AnalysisComment comment = new AnalysisComment();
         comments.add(comment);
         Analysis analysis = new Analysis();
         analysis.setAnalysisComments(comments);
-        Assert.assertEquals(1, analysis.getAnalysisComments().size());
-        Assert.assertEquals(comment, analysis.getAnalysisComments().get(0));
+        Assertions.assertEquals(1, analysis.getAnalysisComments().size());
+        Assertions.assertEquals(comment, analysis.getAnalysisComments().get(0));
     }
 
     @Test
-    public void testSuppressed() {
+    void testSuppressed() {
         Analysis analysis = new Analysis();
         analysis.setSuppressed(true);
-        Assert.assertTrue(analysis.isSuppressed());
+        Assertions.assertTrue(analysis.isSuppressed());
         analysis.setSuppressed(false);
-        Assert.assertFalse(analysis.isSuppressed());
+        Assertions.assertFalse(analysis.isSuppressed());
     }
 }

--- a/src/test/java/org/dependencytrack/model/BomTest.java
+++ b/src/test/java/org/dependencytrack/model/BomTest.java
@@ -18,56 +18,56 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 import java.util.UUID;
 
-public class BomTest {
+class BomTest {
 
     @Test
-    public void testId() {
+    void testId() {
         Bom bom = new Bom();
         bom.setId(111L);
-        Assert.assertEquals(111L, bom.getId());
+        Assertions.assertEquals(111L, bom.getId());
     }
 
     @Test
-    public void testImported() {
+    void testImported() {
         Date date = new Date();
         Bom bom = new Bom();
         bom.setImported(date);
-        Assert.assertEquals(date, bom.getImported());
+        Assertions.assertEquals(date, bom.getImported());
     }
 
     @Test
-    public void testProject() {
+    void testProject() {
         Project project = new Project();
         Bom bom = new Bom();
         bom.setProject(project);
-        Assert.assertEquals(project, bom.getProject());
+        Assertions.assertEquals(project, bom.getProject());
     }
 
     @Test
-    public void testUuid() {
+    void testUuid() {
         UUID uuid = UUID.randomUUID();
         Bom bom = new Bom();
         bom.setUuid(uuid);
-        Assert.assertEquals(uuid.toString(), bom.getUuid().toString());
+        Assertions.assertEquals(uuid.toString(), bom.getUuid().toString());
     }
 
     @Test
-    public void testBomFormat() {
+    void testBomFormat() {
         Bom bom = new Bom();
         bom.setBomFormat(Bom.Format.CYCLONEDX);
-        Assert.assertEquals(Bom.Format.CYCLONEDX.getFormatShortName(), bom.getBomFormat());
+        Assertions.assertEquals(Bom.Format.CYCLONEDX.getFormatShortName(), bom.getBomFormat());
     }
 
     @Test
-    public void testBomSpecVersion() {
+    void testBomSpecVersion() {
         Bom bom = new Bom();
         bom.setSpecVersion("1.1");
-        Assert.assertEquals("1.1", bom.getSpecVersion());
+        Assertions.assertEquals("1.1", bom.getSpecVersion());
     }
 }

--- a/src/test/java/org/dependencytrack/model/ClassifierTest.java
+++ b/src/test/java/org/dependencytrack/model/ClassifierTest.java
@@ -18,20 +18,20 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class ClassifierTest {
+class ClassifierTest {
 
     @Test
-    public void testEnums() {
-        Assert.assertEquals("APPLICATION", Classifier.APPLICATION.name());
-        Assert.assertEquals("FRAMEWORK", Classifier.FRAMEWORK.name());
-        Assert.assertEquals("LIBRARY", Classifier.LIBRARY.name());
-        Assert.assertEquals("CONTAINER", Classifier.CONTAINER.name());
-        Assert.assertEquals("OPERATING_SYSTEM", Classifier.OPERATING_SYSTEM.name());
-        Assert.assertEquals("DEVICE", Classifier.DEVICE.name());
-        Assert.assertEquals("FIRMWARE", Classifier.FIRMWARE.name());
-        Assert.assertEquals("FILE", Classifier.FILE.name());
+    void testEnums() {
+        Assertions.assertEquals("APPLICATION", Classifier.APPLICATION.name());
+        Assertions.assertEquals("FRAMEWORK", Classifier.FRAMEWORK.name());
+        Assertions.assertEquals("LIBRARY", Classifier.LIBRARY.name());
+        Assertions.assertEquals("CONTAINER", Classifier.CONTAINER.name());
+        Assertions.assertEquals("OPERATING_SYSTEM", Classifier.OPERATING_SYSTEM.name());
+        Assertions.assertEquals("DEVICE", Classifier.DEVICE.name());
+        Assertions.assertEquals("FIRMWARE", Classifier.FIRMWARE.name());
+        Assertions.assertEquals("FILE", Classifier.FILE.name());
     }
 }

--- a/src/test/java/org/dependencytrack/model/ComponentIdentityTest.java
+++ b/src/test/java/org/dependencytrack/model/ComponentIdentityTest.java
@@ -19,18 +19,15 @@
 package org.dependencytrack.model;
 
 import com.github.packageurl.PackageURL;
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(JUnitParamsRunner.class)
-public class ComponentIdentityTest {
+class ComponentIdentityTest {
 
     @SuppressWarnings("unused")
-    private Object[] testEqualsAndHashCodeParams() throws Exception {
+    private static Object[] testEqualsAndHashCodeParams() throws Exception {
         return new Object[]{
                 // Equal
                 new Object[]{
@@ -155,9 +152,9 @@ public class ComponentIdentityTest {
         };
     }
 
-    @Test
-    @Parameters(method = "testEqualsAndHashCodeParams")
-    public void testEqualsAndHashCode(final ComponentIdentity left, final ComponentIdentity right, final boolean expectEqual) {
+    @ParameterizedTest
+    @MethodSource("testEqualsAndHashCodeParams")
+    void testEqualsAndHashCode(final ComponentIdentity left, final ComponentIdentity right, final boolean expectEqual) {
         if (expectEqual) {
             assertThat(left).isEqualTo(right);
             assertThat(right).isEqualTo(left);

--- a/src/test/java/org/dependencytrack/model/ComponentPropertyTest.java
+++ b/src/test/java/org/dependencytrack/model/ComponentPropertyTest.java
@@ -19,59 +19,59 @@
 package org.dependencytrack.model;
 
 import alpine.model.IConfigProperty;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class ComponentPropertyTest {
+class ComponentPropertyTest {
 
     @Test
-    public void testId() {
+    void testId() {
         ComponentProperty property = new ComponentProperty();
         property.setId(111L);
-        Assert.assertEquals(111L, property.getId());
+        Assertions.assertEquals(111L, property.getId());
     }
 
     @Test
-    public void testProject() {
+    void testProject() {
         Component component = new Component();
         ComponentProperty property = new ComponentProperty();
         property.setComponent(component);
-        Assert.assertEquals(component, property.getComponent());
+        Assertions.assertEquals(component, property.getComponent());
     }
 
     @Test
-    public void testGroupName() {
+    void testGroupName() {
         ComponentProperty property = new ComponentProperty();
         property.setGroupName("Group Name");
-        Assert.assertEquals("Group Name", property.getGroupName());
+        Assertions.assertEquals("Group Name", property.getGroupName());
     }
 
     @Test
-    public void testPropertyName() {
+    void testPropertyName() {
         ComponentProperty property = new ComponentProperty();
         property.setPropertyName("Property Name");
-        Assert.assertEquals("Property Name", property.getPropertyName());
+        Assertions.assertEquals("Property Name", property.getPropertyName());
     }
 
     @Test
-    public void testPropertyValue() {
+    void testPropertyValue() {
         ComponentProperty property = new ComponentProperty();
         property.setPropertyValue("Property Value");
-        Assert.assertEquals("Property Value", property.getPropertyValue());
+        Assertions.assertEquals("Property Value", property.getPropertyValue());
     }
 
     @Test
-    public void testPropertyType() {
+    void testPropertyType() {
         ComponentProperty property = new ComponentProperty();
         property.setPropertyType(IConfigProperty.PropertyType.STRING);
-        Assert.assertEquals(IConfigProperty.PropertyType.STRING, property.getPropertyType());
+        Assertions.assertEquals(IConfigProperty.PropertyType.STRING, property.getPropertyType());
     }
 
     @Test
-    public void testDescription() {
+    void testDescription() {
         ComponentProperty property = new ComponentProperty();
         property.setDescription("Property Description");
-        Assert.assertEquals("Property Description", property.getDescription());
+        Assertions.assertEquals("Property Description", property.getDescription());
     }
 
 } 

--- a/src/test/java/org/dependencytrack/model/ComponentTest.java
+++ b/src/test/java/org/dependencytrack/model/ComponentTest.java
@@ -30,223 +30,220 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 
 import org.dependencytrack.util.JsonUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.CpeParser;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-public class ComponentTest {
+class ComponentTest {
     private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
     
     @Test
-    public void testId() {
+    void testId() {
         Component component = new Component();
         component.setId(111L);
-        Assert.assertEquals(111L, component.getId());
+        Assertions.assertEquals(111L, component.getId());
     }
 
     @Test
-    public void testGroup() {
+    void testGroup() {
         Component component = new Component();
         component.setGroup("group");
-        Assert.assertEquals("group", component.getGroup());
+        Assertions.assertEquals("group", component.getGroup());
     }
 
     @Test
-    public void testName() {
+    void testName() {
         Component component = new Component();
         component.setName("name");
-        Assert.assertEquals("name", component.getName());
+        Assertions.assertEquals("name", component.getName());
     }
 
     @Test
-    public void testVersion() {
+    void testVersion() {
         Component component = new Component();
         component.setVersion("1.0");
-        Assert.assertEquals("1.0", component.getVersion());
+        Assertions.assertEquals("1.0", component.getVersion());
     }
 
     @Test
-    public void testClassifier() {
+    void testClassifier() {
         Component component = new Component();
         component.setClassifier(Classifier.LIBRARY);
-        Assert.assertEquals(Classifier.LIBRARY, component.getClassifier());
+        Assertions.assertEquals(Classifier.LIBRARY, component.getClassifier());
     }
 
     @Test
-    public void testFilename() {
+    void testFilename() {
         Component component = new Component();
         component.setFilename("foo.bar");
-        Assert.assertEquals("foo.bar", component.getFilename());
+        Assertions.assertEquals("foo.bar", component.getFilename());
     }
 
     @Test
-    public void testExtension() {
+    void testExtension() {
         Component component = new Component();
         component.setExtension("bar");
-        Assert.assertEquals("bar", component.getExtension());
+        Assertions.assertEquals("bar", component.getExtension());
     }
 
     @Test
-    public void testMd5() {
+    void testMd5() {
         Component component = new Component();
         String hash = "299189766eddf8b5fea4954f0a63d4b1";
         component.setMd5(hash);
-        Assert.assertEquals(hash, component.getMd5());
+        Assertions.assertEquals(hash, component.getMd5());
     }
 
     @Test
-    public void testSha1() {
+    void testSha1() {
         Component component = new Component();
         String hash = "74f7fcc24e02e61b0eb367e273139b6b24c6587f";
         component.setSha1(hash);
-        Assert.assertEquals(hash, component.getSha1());
+        Assertions.assertEquals(hash, component.getSha1());
     }
 
     @Test
-    public void testSha256()  {
+    void testSha256()  {
         Component component = new Component();
         String hash = "cfb16d5a50169bac7699d6fc1ad4f8f2559d09e3fa580003b149ae0134e16d05";
         component.setSha256(hash);
-        Assert.assertEquals(hash, component.getSha256());
+        Assertions.assertEquals(hash, component.getSha256());
     }
 
     @Test
-    public void testSha512() {
+    void testSha512() {
         Component component = new Component();
         String hash = "d52e762d8e1b8a33c7f7b4b2ab356a02d43e6bf51d273a5809a3478dc47f17b6df350890d06bb0240a7d3f51f49dde564a32f569952c8b02f54242cc3f92d277";
         component.setSha512(hash);
-        Assert.assertEquals(hash, component.getSha512());
+        Assertions.assertEquals(hash, component.getSha512());
     }
 
     @Test
-    public void testSha3_256() {
+    void testSha3_256() {
         Component component = new Component();
         String hash = "b59bf7eba413502f563528a9719c38cd471ca59b4fb50c1d94db0504101ea780";
         component.setSha3_256(hash);
-        Assert.assertEquals(hash, component.getSha3_256());
+        Assertions.assertEquals(hash, component.getSha3_256());
     }
 
     @Test
-    public void testSha3_512() {
+    void testSha3_512() {
         Component component = new Component();
         String hash = "40c72266a83cb97e6c5dbe628d3efb7fe564739e7d4c016d282c59ae14054ccd74142defa2d5d0295c7bdff0d1ea045364a595438263dd8ffd13623a685034e1";
         component.setSha3_512(hash);
-        Assert.assertEquals(hash, component.getSha3_512());
+        Assertions.assertEquals(hash, component.getSha3_512());
     }
 
     @Test
-    public void testCpe() throws Exception {
+    void testCpe() throws Exception {
         Component component = new Component();
         Cpe cpe = CpeParser.parse("cpe:2.3:a:acme:product:1.0:*:*:*:*:*:*:*");
         component.setCpe(cpe.toCpe23FS());
-        Assert.assertEquals("cpe:2.3:a:acme:product:1.0:*:*:*:*:*:*:*", component.getCpe());
+        Assertions.assertEquals("cpe:2.3:a:acme:product:1.0:*:*:*:*:*:*:*", component.getCpe());
     }
 
     @Test
-    public void testPurl() throws Exception {
+    void testPurl() throws Exception {
         Component component = new Component();
         PackageURL purl = PackageURLBuilder.aPackageURL()
                 .withType("maven").withNamespace("acme").withName("product").withVersion("1.0").build();
         component.setPurl(purl);
-        Assert.assertEquals(purl.toString(), component.getPurl().toString());
+        Assertions.assertEquals(purl.toString(), component.getPurl().toString());
     }
 
     @Test
-    public void testDescription() {
+    void testDescription() {
         Component component = new Component();
         component.setDescription("Component description");
-        Assert.assertEquals("Component description", component.getDescription());
+        Assertions.assertEquals("Component description", component.getDescription());
     }
 
     @Test
-    public void testCopyright() {
+    void testCopyright() {
         Component component = new Component();
         component.setCopyright("Copyright Acme");
-        Assert.assertEquals("Copyright Acme", component.getCopyright());
+        Assertions.assertEquals("Copyright Acme", component.getCopyright());
     }
 
     @Test
-    public void testLicense() {
+    void testLicense() {
         Component component = new Component();
         component.setLicense("Apache 2.0");
-        Assert.assertEquals("Apache 2.0", component.getLicense());
+        Assertions.assertEquals("Apache 2.0", component.getLicense());
     }
 
     @Test
-    public void testResolvedLicense() {
+    void testResolvedLicense() {
         License license = new License();
         Component component = new Component();
         component.setResolvedLicense(license);
-        Assert.assertEquals(license, component.getResolvedLicense());
+        Assertions.assertEquals(license, component.getResolvedLicense());
     }
 
     @Test
-    public void testParent() {
+    void testParent() {
         Component parent = new Component();
         Component component = new Component();
         component.setParent(parent);
-        Assert.assertEquals(parent, component.getParent());
+        Assertions.assertEquals(parent, component.getParent());
     }
 
     @Test
-    public void testChildren() {
+    void testChildren() {
         List<Component> children = new ArrayList<>();
         Component child = new Component();
         children.add(child);
         Component component = new Component();
         component.setChildren(children);
-        Assert.assertEquals(1, component.getChildren().size());
-        Assert.assertEquals(child, component.getChildren().iterator().next());
+        Assertions.assertEquals(1, component.getChildren().size());
+        Assertions.assertEquals(child, component.getChildren().iterator().next());
     }
 
     @Test
-    public void testVulnerabilities() {
+    void testVulnerabilities() {
         List<Vulnerability> vulns = new ArrayList<>();
         Vulnerability vuln = new Vulnerability();
         vulns.add(vuln);
         Component component = new Component();
         component.setVulnerabilities(vulns);
-        Assert.assertEquals(1, component.getVulnerabilities().size());
-        Assert.assertEquals(vuln, component.getVulnerabilities().iterator().next());
+        Assertions.assertEquals(1, component.getVulnerabilities().size());
+        Assertions.assertEquals(vuln, component.getVulnerabilities().iterator().next());
     }
 
     @Test
-    public void testUuid() {
+    void testUuid() {
         UUID uuid = UUID.randomUUID();
         Component component = new Component();
         component.setUuid(uuid);
-        Assert.assertEquals(uuid.toString(), component.getUuid().toString());
+        Assertions.assertEquals(uuid.toString(), component.getUuid().toString());
     }
 
     @Test
-    public void testToStringWithPurl() throws Exception {
+    void testToStringWithPurl() throws Exception {
         Component component = new Component();
         PackageURL purl = PackageURLBuilder.aPackageURL()
                 .withType("maven").withNamespace("acme").withName("product").withVersion("1.0").build();
         component.setPurl(purl);
-        Assert.assertEquals(component.getPurl().toString(), component.toString());
+        Assertions.assertEquals(component.getPurl().toString(), component.toString());
     }
 
     @Test
-    public void testToStringWithoutPurl() {
+    void testToStringWithoutPurl() {
         Component component = new Component();
         component.setGroup("acme");
         component.setName("product");
         component.setVersion("1.0");
-        Assert.assertEquals("acme : product : 1.0", component.toString());
+        Assertions.assertEquals("acme : product : 1.0", component.toString());
     }
 
     @Test
-    public void testValidEmptyValues() throws JsonProcessingException {
+    void testValidEmptyValues() throws JsonProcessingException {
         // test for all the String fields validated during update component
         String[] fields = { "version", "group", "description", "license", "licenseExpression", "licenseUrl", "filename",
                 "cpe", "swidTagId", "copyright", "md5", "sha1", "sha256", "sha512", "sha3_256", "sha3_512" };
@@ -263,12 +260,12 @@ public class ComponentTest {
         Set<ConstraintViolation<Component>> violations = null;
         for (String field : fields) {
             violations = validator.validateProperty(component, field);
-            assertTrue(violations.isEmpty());
+            Assertions.assertTrue(violations.isEmpty());
         }
     }
 
     @Test
-    public void testInvalidEmptyName() throws JsonProcessingException {
+    void testInvalidEmptyName() throws JsonProcessingException {
         JsonObjectBuilder componentBuilder = Json.createObjectBuilder();
         componentBuilder.add("name", "");
         String json = componentBuilder.build().toString();
@@ -277,6 +274,6 @@ public class ComponentTest {
         Component component = mapper.readValue(json, Component.class);
 
         Set<ConstraintViolation<Component>> violations = validator.validateProperty(component, "name");
-        assertFalse(violations.isEmpty());
+        Assertions.assertFalse(violations.isEmpty());
     }
 }

--- a/src/test/java/org/dependencytrack/model/CweTest.java
+++ b/src/test/java/org/dependencytrack/model/CweTest.java
@@ -18,22 +18,22 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class CweTest {
+class CweTest {
 
     @Test
-    public void testCweId() {
+    void testCweId() {
         Cwe cwe = new Cwe();
         cwe.setCweId(79);
-        Assert.assertEquals(79, cwe.getCweId());
+        Assertions.assertEquals(79, cwe.getCweId());
     }
 
     @Test
-    public void testName() {
+    void testName() {
         Cwe cwe = new Cwe();
         cwe.setName("Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')");
-        Assert.assertEquals("Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')", cwe.getName());
+        Assertions.assertEquals("Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')", cwe.getName());
     }
 } 

--- a/src/test/java/org/dependencytrack/model/DependencyMetricsTest.java
+++ b/src/test/java/org/dependencytrack/model/DependencyMetricsTest.java
@@ -18,126 +18,126 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 
-public class DependencyMetricsTest {
+class DependencyMetricsTest {
 
     @Test
-    public void testId() {
+    void testId() {
         DependencyMetrics metric = new DependencyMetrics();
         metric.setId(111L);
-        Assert.assertEquals(111L, metric.getId());
+        Assertions.assertEquals(111L, metric.getId());
     }
 
     @Test
-    public void testProject() {
+    void testProject() {
         Project project = new Project();
         DependencyMetrics metric = new DependencyMetrics();
         metric.setProject(project);
-        Assert.assertEquals(project, metric.getProject());
+        Assertions.assertEquals(project, metric.getProject());
     }
 
     @Test
-    public void testComponent() {
+    void testComponent() {
         Component component = new Component();
         DependencyMetrics metric = new DependencyMetrics();
         metric.setComponent(component);
-        Assert.assertEquals(component, metric.getComponent());
+        Assertions.assertEquals(component, metric.getComponent());
     }
 
     @Test
-    public void testCritical() {
+    void testCritical() {
         DependencyMetrics metric = new DependencyMetrics();
         metric.setCritical(10);
-        Assert.assertEquals(10, metric.getCritical());
+        Assertions.assertEquals(10, metric.getCritical());
     }
 
     @Test
-    public void testHigh() {
+    void testHigh() {
         DependencyMetrics metric = new DependencyMetrics();
         metric.setHigh(9);
-        Assert.assertEquals(9, metric.getHigh());
+        Assertions.assertEquals(9, metric.getHigh());
     }
 
     @Test
-    public void testMedium() {
+    void testMedium() {
         DependencyMetrics metric = new DependencyMetrics();
         metric.setMedium(8);
-        Assert.assertEquals(8, metric.getMedium());
+        Assertions.assertEquals(8, metric.getMedium());
     }
 
     @Test
-    public void testLow() {
+    void testLow() {
         DependencyMetrics metric = new DependencyMetrics();
         metric.setLow(7);
-        Assert.assertEquals(7, metric.getLow());
+        Assertions.assertEquals(7, metric.getLow());
     }
 
     @Test
-    public void testUnassigned() {
+    void testUnassigned() {
         DependencyMetrics metric = new DependencyMetrics();
         metric.setUnassigned(9191);
-        Assert.assertEquals(9191, metric.getUnassigned());
+        Assertions.assertEquals(9191, metric.getUnassigned());
     }
 
     @Test
-    public void testVulnerabilities() {
+    void testVulnerabilities() {
         DependencyMetrics metric = new DependencyMetrics();
         metric.setVulnerabilities(6);
-        Assert.assertEquals(6, metric.getVulnerabilities());
+        Assertions.assertEquals(6, metric.getVulnerabilities());
     }
 
     @Test
-    public void testSuppressed() {
+    void testSuppressed() {
         DependencyMetrics metric = new DependencyMetrics();
         metric.setSuppressed(5);
-        Assert.assertEquals(5, metric.getSuppressed());
+        Assertions.assertEquals(5, metric.getSuppressed());
     }
 
     @Test
-    public void testFindingsTotal() {
+    void testFindingsTotal() {
         DependencyMetrics metric = new DependencyMetrics();
         metric.setFindingsTotal(4);
-        Assert.assertEquals(4, metric.getFindingsTotal());
+        Assertions.assertEquals(4, metric.getFindingsTotal());
     }
 
     @Test
-    public void testFindingsAudited() {
+    void testFindingsAudited() {
         DependencyMetrics metric = new DependencyMetrics();
         metric.setFindingsAudited(3);
-        Assert.assertEquals(3, metric.getFindingsAudited());
+        Assertions.assertEquals(3, metric.getFindingsAudited());
     }
 
     @Test
-    public void testFindingsUnaudited() {
+    void testFindingsUnaudited() {
         DependencyMetrics metric = new DependencyMetrics();
         metric.setFindingsUnaudited(2);
-        Assert.assertEquals(2, metric.getFindingsUnaudited());
+        Assertions.assertEquals(2, metric.getFindingsUnaudited());
     }
 
     @Test
-    public void testInheritedRiskScore() {
+    void testInheritedRiskScore() {
         DependencyMetrics metric = new DependencyMetrics();
         metric.setInheritedRiskScore(1000);
-        Assert.assertEquals(1000, metric.getInheritedRiskScore(), 0);
+        Assertions.assertEquals(1000, metric.getInheritedRiskScore(), 0);
     }
 
     @Test
-    public void testFirstOccurrence() {
+    void testFirstOccurrence() {
         Date date = new Date();
         DependencyMetrics metric = new DependencyMetrics();
         metric.setFirstOccurrence(date);
-        Assert.assertEquals(date, metric.getFirstOccurrence());
+        Assertions.assertEquals(date, metric.getFirstOccurrence());
     }
 
     @Test
-    public void testLastOccurrence() {
+    void testLastOccurrence() {
         Date date = new Date();
         DependencyMetrics metric = new DependencyMetrics();
         metric.setLastOccurrence(date);
-        Assert.assertEquals(date, metric.getLastOccurrence());
+        Assertions.assertEquals(date, metric.getLastOccurrence());
     }
 } 

--- a/src/test/java/org/dependencytrack/model/FindingAttributionTest.java
+++ b/src/test/java/org/dependencytrack/model/FindingAttributionTest.java
@@ -20,14 +20,14 @@ package org.dependencytrack.model;
 
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FindingAttributionTest extends PersistenceCapableTest {
+class FindingAttributionTest extends PersistenceCapableTest {
 
     @Test
-    public void testReferenceUrlTrimQueryParams() {
+    void testReferenceUrlTrimQueryParams() {
         final var vuln = new Vulnerability();
         vuln.setVulnId("INT-001");
         vuln.setSource(Vulnerability.Source.INTERNAL);
@@ -58,7 +58,7 @@ public class FindingAttributionTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testReferenceUrlTrim() {
+    void testReferenceUrlTrim() {
         final var vuln = new Vulnerability();
         vuln.setVulnId("INT-001");
         vuln.setSource(Vulnerability.Source.INTERNAL);

--- a/src/test/java/org/dependencytrack/model/FindingTest.java
+++ b/src/test/java/org/dependencytrack/model/FindingTest.java
@@ -20,8 +20,8 @@ package org.dependencytrack.model;
 
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.Date;
@@ -30,7 +30,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FindingTest extends PersistenceCapableTest {
+class FindingTest extends PersistenceCapableTest {
 
     private final UUID projectUuid = UUID.randomUUID();
     private final Date attributedOn = new Date();
@@ -40,48 +40,48 @@ public class FindingTest extends PersistenceCapableTest {
             "0.5", "0.9", null, AnalyzerIdentity.INTERNAL_ANALYZER, attributedOn, null, null, AnalysisState.NOT_AFFECTED, true);
 
     @Test
-    public void testComponent() {
+    void testComponent() {
         Map<String, Object> map = finding.getComponent();
-        Assert.assertEquals("component-uuid", map.get("uuid"));
-        Assert.assertEquals("component-name", map.get("name"));
-        Assert.assertEquals("component-group", map.get("group"));
-        Assert.assertEquals("component-version", map.get("version"));
-        Assert.assertEquals("component-purl", map.get("purl"));
+        Assertions.assertEquals("component-uuid", map.get("uuid"));
+        Assertions.assertEquals("component-name", map.get("name"));
+        Assertions.assertEquals("component-group", map.get("group"));
+        Assertions.assertEquals("component-version", map.get("version"));
+        Assertions.assertEquals("component-purl", map.get("purl"));
     }
 
     @Test
-    public void testVulnerability() {
+    void testVulnerability() {
         Map<String, Object> map = finding.getVulnerability();
-        Assert.assertEquals("vuln-uuid", map.get("uuid"));
-        Assert.assertEquals("vuln-source", map.get("source"));
-        Assert.assertEquals("vuln-vulnId", map.get("vulnId"));
-        Assert.assertEquals("vuln-title", map.get("title"));
-        Assert.assertEquals("vuln-subtitle", map.get("subtitle"));
-        //Assert.assertEquals("vuln-description", map.get("description"));
-        //Assert.assertEquals("vuln-recommendation", map.get("recommendation"));
-        Assert.assertEquals(BigDecimal.valueOf(7.2), map.get("cvssV2BaseScore"));
-        Assert.assertEquals(BigDecimal.valueOf(8.4), map.get("cvssV3BaseScore"));
-        Assert.assertEquals(BigDecimal.valueOf(1.25), map.get("owaspLikelihoodScore"));
-        Assert.assertEquals(BigDecimal.valueOf(1.75), map.get("owaspTechnicalImpactScore"));
-        Assert.assertEquals(BigDecimal.valueOf(1.3), map.get("owaspBusinessImpactScore"));
-        Assert.assertEquals(Severity.HIGH.name(), map.get("severity"));
-        Assert.assertEquals(1, map.get("severityRank"));
+        Assertions.assertEquals("vuln-uuid", map.get("uuid"));
+        Assertions.assertEquals("vuln-source", map.get("source"));
+        Assertions.assertEquals("vuln-vulnId", map.get("vulnId"));
+        Assertions.assertEquals("vuln-title", map.get("title"));
+        Assertions.assertEquals("vuln-subtitle", map.get("subtitle"));
+        //Assertions.assertEquals("vuln-description", map.get("description"));
+        //Assertions.assertEquals("vuln-recommendation", map.get("recommendation"));
+        Assertions.assertEquals(BigDecimal.valueOf(7.2), map.get("cvssV2BaseScore"));
+        Assertions.assertEquals(BigDecimal.valueOf(8.4), map.get("cvssV3BaseScore"));
+        Assertions.assertEquals(BigDecimal.valueOf(1.25), map.get("owaspLikelihoodScore"));
+        Assertions.assertEquals(BigDecimal.valueOf(1.75), map.get("owaspTechnicalImpactScore"));
+        Assertions.assertEquals(BigDecimal.valueOf(1.3), map.get("owaspBusinessImpactScore"));
+        Assertions.assertEquals(Severity.HIGH.name(), map.get("severity"));
+        Assertions.assertEquals(1, map.get("severityRank"));
     }
 
     @Test
-    public void testAnalysis() {
+    void testAnalysis() {
         Map<String, Object> map = finding.getAnalysis();
-        Assert.assertEquals(AnalysisState.NOT_AFFECTED, map.get("state"));
-        Assert.assertEquals(true, map.get("isSuppressed"));
+        Assertions.assertEquals(AnalysisState.NOT_AFFECTED, map.get("state"));
+        Assertions.assertEquals(true, map.get("isSuppressed"));
     }
 
     @Test
-    public void testMatrix() {
-        Assert.assertEquals(projectUuid + ":component-uuid" + ":vuln-uuid", finding.getMatrix());
+    void testMatrix() {
+        Assertions.assertEquals(projectUuid + ":component-uuid" + ":vuln-uuid", finding.getMatrix());
     }
 
     @Test
-    public void testGetCwes() {
+    void testGetCwes() {
         assertThat(Finding.getCwes("787,79,,89,"))
                 .hasSize(3)
                 .satisfiesExactly(
@@ -92,13 +92,13 @@ public class FindingTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testGetCwesWhenInputIsEmpty() {
+    void testGetCwesWhenInputIsEmpty() {
         assertThat(Finding.getCwes("")).isNull();
         assertThat(Finding.getCwes(",")).isNull();
     }
 
     @Test
-    public void testGetCwesWhenInputIsNull() {
+    void testGetCwesWhenInputIsNull() {
         assertThat(Finding.getCwes(null)).isNull();
     }
 

--- a/src/test/java/org/dependencytrack/model/GroupedFindingTest.java
+++ b/src/test/java/org/dependencytrack/model/GroupedFindingTest.java
@@ -20,14 +20,14 @@ package org.dependencytrack.model;
 
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.Map;
 
-public class GroupedFindingTest extends PersistenceCapableTest {
+class GroupedFindingTest extends PersistenceCapableTest {
 
     private final Date published = new Date();
     private final GroupedFinding groupedFinding = new GroupedFinding("vuln-source", "vuln-vulnId", "vuln-title",
@@ -35,21 +35,21 @@ public class GroupedFindingTest extends PersistenceCapableTest {
 
 
     @Test
-    public void testVulnerability() {
+    void testVulnerability() {
         Map<String, Object> map = groupedFinding.getVulnerability();
-        Assert.assertEquals("vuln-source", map.get("source"));
-        Assert.assertEquals("vuln-vulnId", map.get("vulnId"));
-        Assert.assertEquals("vuln-title", map.get("title"));
-        Assert.assertEquals(Severity.HIGH, map.get("severity"));
-        Assert.assertEquals(published, map.get("published"));
-        Assert.assertEquals(BigDecimal.valueOf(8.5), map.get("cvssV2BaseScore"));
-        Assert.assertEquals(BigDecimal.valueOf(8.4), map.get("cvssV3BaseScore"));
-        Assert.assertEquals(3, map.get("affectedProjectCount"));
+        Assertions.assertEquals("vuln-source", map.get("source"));
+        Assertions.assertEquals("vuln-vulnId", map.get("vulnId"));
+        Assertions.assertEquals("vuln-title", map.get("title"));
+        Assertions.assertEquals(Severity.HIGH, map.get("severity"));
+        Assertions.assertEquals(published, map.get("published"));
+        Assertions.assertEquals(BigDecimal.valueOf(8.5), map.get("cvssV2BaseScore"));
+        Assertions.assertEquals(BigDecimal.valueOf(8.4), map.get("cvssV3BaseScore"));
+        Assertions.assertEquals(3, map.get("affectedProjectCount"));
     }
 
     @Test
-    public void testAttribution() {
+    void testAttribution() {
         Map<String, Object> map = groupedFinding.getAttribution();
-        Assert.assertEquals(AnalyzerIdentity.INTERNAL_ANALYZER, map.get("analyzerIdentity"));
+        Assertions.assertEquals(AnalyzerIdentity.INTERNAL_ANALYZER, map.get("analyzerIdentity"));
     }
 }

--- a/src/test/java/org/dependencytrack/model/LicenseGroupTest.java
+++ b/src/test/java/org/dependencytrack/model/LicenseGroupTest.java
@@ -18,43 +18,43 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class LicenseGroupTest {
+class LicenseGroupTest {
 
     @Test
-    public void testId() {
+    void testId() {
         LicenseGroup lg = new LicenseGroup();
         lg.setId(111L);
-        Assert.assertEquals(111L, lg.getId());
+        Assertions.assertEquals(111L, lg.getId());
     }
 
     @Test
-    public void testName() {
+    void testName() {
         LicenseGroup lg = new LicenseGroup();
         lg.setName("Copyleft");
-        Assert.assertEquals("Copyleft", lg.getName());
+        Assertions.assertEquals("Copyleft", lg.getName());
     }
 
     @Test
-    public void testLicenses() {
+    void testLicenses() {
         List<License> licenses = new ArrayList<>();
         License license = new License();
         licenses.add(license);
         LicenseGroup lg = new LicenseGroup();
         lg.setLicenses(licenses);
-        Assert.assertEquals(1, lg.getLicenses().size());
-        Assert.assertEquals(license, lg.getLicenses().get(0));
+        Assertions.assertEquals(1, lg.getLicenses().size());
+        Assertions.assertEquals(license, lg.getLicenses().get(0));
     }
 
     @Test
-    public void testRiskWeight() {
+    void testRiskWeight() {
         LicenseGroup lg = new LicenseGroup();
         lg.setRiskWeight(9);
-        Assert.assertEquals(9, lg.getRiskWeight());
+        Assertions.assertEquals(9, lg.getRiskWeight());
     }
 }

--- a/src/test/java/org/dependencytrack/model/LicenseTest.java
+++ b/src/test/java/org/dependencytrack/model/LicenseTest.java
@@ -18,115 +18,115 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.UUID;
 
-public class LicenseTest {
+class LicenseTest {
 
     @Test
-    public void testId() {
+    void testId() {
         License license = new License();
         license.setId(111L);
-        Assert.assertEquals(111L, license.getId());
+        Assertions.assertEquals(111L, license.getId());
     }
 
     @Test
-    public void testName() {
+    void testName() {
         License license = new License();
         license.setName("Apache License 2.0");
-        Assert.assertEquals("Apache License 2.0", license.getName());
+        Assertions.assertEquals("Apache License 2.0", license.getName());
     }
 
     @Test
-    public void testText() {
+    void testText() {
         License license = new License();
         license.setText("License text");
-        Assert.assertEquals("License text", license.getText());
+        Assertions.assertEquals("License text", license.getText());
     }
 
     @Test
-    public void testTemplate() {
+    void testTemplate() {
         License license = new License();
         license.setTemplate("License template");
-        Assert.assertEquals("License template", license.getTemplate());
+        Assertions.assertEquals("License template", license.getTemplate());
     }
 
     @Test
-    public void testHeader() {
+    void testHeader() {
         License license = new License();
         license.setHeader("License header");
-        Assert.assertEquals("License header", license.getHeader());
+        Assertions.assertEquals("License header", license.getHeader());
     }
 
     @Test
-    public void testComment() {
+    void testComment() {
         License license = new License();
         license.setComment("License comment");
-        Assert.assertEquals("License comment", license.getComment());
+        Assertions.assertEquals("License comment", license.getComment());
     }
 
     @Test
-    public void testLicenseId() {
+    void testLicenseId() {
         License license = new License();
         license.setLicenseId("Apache-2.0");
-        Assert.assertEquals("Apache-2.0", license.getLicenseId());
+        Assertions.assertEquals("Apache-2.0", license.getLicenseId());
     }
 
     @Test
-    public void tesOsiApproved() {
+    void tesOsiApproved() {
         License license = new License();
         license.setOsiApproved(true);
-        Assert.assertTrue(license.isOsiApproved());
+        Assertions.assertTrue(license.isOsiApproved());
     }
 
     @Test
-    public void tesFsfLibre() {
+    void tesFsfLibre() {
         License license = new License();
         license.setFsfLibre(true);
-        Assert.assertTrue(license.isFsfLibre());
+        Assertions.assertTrue(license.isFsfLibre());
     }
 
     @Test
-    public void testDeprecatedLicenseId() {
+    void testDeprecatedLicenseId() {
         License license = new License();
         license.setDeprecatedLicenseId(true);
-        Assert.assertTrue(license.isDeprecatedLicenseId());
+        Assertions.assertTrue(license.isDeprecatedLicenseId());
     }
 
     @Test
-    public void testCustomLicense() {
+    void testCustomLicense() {
         License license = new License();
         license.setCustomLicense(true);
-        Assert.assertTrue(license.isCustomLicense());
+        Assertions.assertTrue(license.isCustomLicense());
     }
 
     @Test
-    public void testSeeAlso() {
+    void testSeeAlso() {
         License license = new License();
         license.setSeeAlso("url #1", "url #2");
-        Assert.assertEquals(2, license.getSeeAlso().length);
-        Assert.assertEquals("url #1", license.getSeeAlso()[0]);
-        Assert.assertEquals("url #2", license.getSeeAlso()[1]);
+        Assertions.assertEquals(2, license.getSeeAlso().length);
+        Assertions.assertEquals("url #1", license.getSeeAlso()[0]);
+        Assertions.assertEquals("url #2", license.getSeeAlso()[1]);
     }
 
     @Test
-    public void testLicenseGroups() {
+    void testLicenseGroups() {
         License license = new License();
         LicenseGroup lg = new LicenseGroup();
         lg.setName("Copyleft");
         license.setLicenseGroups(Collections.singletonList(lg));
-        Assert.assertEquals(1, license.getLicenseGroups().size());
-        Assert.assertEquals("Copyleft", license.getLicenseGroups().get(0).getName());
+        Assertions.assertEquals(1, license.getLicenseGroups().size());
+        Assertions.assertEquals("Copyleft", license.getLicenseGroups().get(0).getName());
     }
 
     @Test
-    public void testUuid() {
+    void testUuid() {
         UUID uuid = UUID.randomUUID();
         License license = new License();
         license.setUuid(uuid);
-        Assert.assertEquals(uuid.toString(), license.getUuid().toString());
+        Assertions.assertEquals(uuid.toString(), license.getUuid().toString());
     }
 }

--- a/src/test/java/org/dependencytrack/model/NotificationPublisherTest.java
+++ b/src/test/java/org/dependencytrack/model/NotificationPublisherTest.java
@@ -18,67 +18,67 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-public class NotificationPublisherTest { 
+class NotificationPublisherTest {
 
     @Test
-    public void testId() {
+    void testId() {
         NotificationPublisher publisher = new NotificationPublisher();
         publisher.setId(111L);
-        Assert.assertEquals(111L, publisher.getId());
+        Assertions.assertEquals(111L, publisher.getId());
     } 
 
     @Test
-    public void testName() {
+    void testName() {
         NotificationPublisher publisher = new NotificationPublisher();
         publisher.setName("My Publisher");
-        Assert.assertEquals("My Publisher", publisher.getName());
+        Assertions.assertEquals("My Publisher", publisher.getName());
     } 
 
     @Test
-    public void testDescription() {
+    void testDescription() {
         NotificationPublisher publisher = new NotificationPublisher();
         publisher.setDescription("My description");
-        Assert.assertEquals("My description", publisher.getDescription());
+        Assertions.assertEquals("My description", publisher.getDescription());
     } 
 
     @Test
-    public void testPublisherClass() {
+    void testPublisherClass() {
         NotificationPublisher publisher = new NotificationPublisher();
         publisher.setPublisherClass("org.acme.publisher");
-        Assert.assertEquals("org.acme.publisher", publisher.getPublisherClass());
+        Assertions.assertEquals("org.acme.publisher", publisher.getPublisherClass());
     } 
 
     @Test
-    public void testTemplate() {
+    void testTemplate() {
         NotificationPublisher publisher = new NotificationPublisher();
         publisher.setTemplate("{ \"config\": \"configured\" }");
-        Assert.assertEquals("{ \"config\": \"configured\" }", publisher.getTemplate());
+        Assertions.assertEquals("{ \"config\": \"configured\" }", publisher.getTemplate());
     } 
 
     @Test
-    public void testTemplateMimeType() {
+    void testTemplateMimeType() {
         NotificationPublisher publisher = new NotificationPublisher();
         publisher.setTemplateMimeType("application/json");
-        Assert.assertEquals("application/json", publisher.getTemplateMimeType());
+        Assertions.assertEquals("application/json", publisher.getTemplateMimeType());
     } 
 
     @Test
-    public void testDefaultPublisher() {
+    void testDefaultPublisher() {
         NotificationPublisher publisher = new NotificationPublisher();
         publisher.setDefaultPublisher(true);
-        Assert.assertTrue(publisher.isDefaultPublisher());
+        Assertions.assertTrue(publisher.isDefaultPublisher());
     } 
 
     @Test
-    public void testUuid() {
+    void testUuid() {
         UUID uuid = UUID.randomUUID();
         NotificationPublisher publisher = new NotificationPublisher();
         publisher.setUuid(uuid);
-        Assert.assertEquals(uuid.toString(), publisher.getUuid().toString());
+        Assertions.assertEquals(uuid.toString(), publisher.getUuid().toString());
     } 
 }

--- a/src/test/java/org/dependencytrack/model/NotificationRuleTest.java
+++ b/src/test/java/org/dependencytrack/model/NotificationRuleTest.java
@@ -25,8 +25,8 @@ import alpine.model.Team;
 import alpine.notification.NotificationLevel;
 import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationScope;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -34,107 +34,107 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-public class NotificationRuleTest {
+class NotificationRuleTest {
 
     @Test
-    public void testId() {
+    void testId() {
         NotificationRule rule = new NotificationRule();
         rule.setId(111L);
-        Assert.assertEquals(111L, rule.getId());
+        Assertions.assertEquals(111L, rule.getId());
     }
 
     @Test
-    public void testName() {
+    void testName() {
         NotificationRule rule = new NotificationRule();
         rule.setName("Test Name");
-        Assert.assertEquals("Test Name", rule.getName());
+        Assertions.assertEquals("Test Name", rule.getName());
     }
 
     @Test
-    public void testEnabled() {
+    void testEnabled() {
         NotificationRule rule = new NotificationRule();
         rule.setEnabled(true);
-        Assert.assertTrue(rule.isEnabled());
+        Assertions.assertTrue(rule.isEnabled());
     }
 
     @Test
-    public void testScope() {
+    void testScope() {
         NotificationRule rule = new NotificationRule();
         rule.setScope(NotificationScope.PORTFOLIO);
-        Assert.assertEquals(NotificationScope.PORTFOLIO, rule.getScope());
+        Assertions.assertEquals(NotificationScope.PORTFOLIO, rule.getScope());
     }
 
     @Test
-    public void testNotificationLevel() {
+    void testNotificationLevel() {
         NotificationRule rule = new NotificationRule();
         rule.setNotificationLevel(NotificationLevel.INFORMATIONAL);
-        Assert.assertEquals(NotificationLevel.INFORMATIONAL, rule.getNotificationLevel());
+        Assertions.assertEquals(NotificationLevel.INFORMATIONAL, rule.getNotificationLevel());
     }
 
     @Test
-    public void testProjects() {
+    void testProjects() {
         List<Project> projects = new ArrayList<>();
         Project project = new Project();
         projects.add(project);
         NotificationRule rule = new NotificationRule();
         rule.setProjects(projects);
-        Assert.assertEquals(1, rule.getProjects().size());
-        Assert.assertEquals(project, rule.getProjects().get(0));
+        Assertions.assertEquals(1, rule.getProjects().size());
+        Assertions.assertEquals(project, rule.getProjects().get(0));
     }
 
     @Test
-    public void testMessage() {
+    void testMessage() {
         NotificationRule rule = new NotificationRule();
         rule.setMessage("Test Message");
-        Assert.assertEquals("Test Message", rule.getMessage());
+        Assertions.assertEquals("Test Message", rule.getMessage());
     }
 
     @Test
-    public void testNotifyOn() {
+    void testNotifyOn() {
         Set<NotificationGroup> groups = new HashSet<>();
         groups.add(NotificationGroup.NEW_VULNERABLE_DEPENDENCY);
         groups.add(NotificationGroup.NEW_VULNERABILITY);
         NotificationRule rule = new NotificationRule();
         rule.setNotifyOn(groups);
-        Assert.assertEquals(2, rule.getNotifyOn().size());
+        Assertions.assertEquals(2, rule.getNotifyOn().size());
     }
 
     @Test
-    public void testPublisher() {
+    void testPublisher() {
         NotificationPublisher publisher = new NotificationPublisher();
         NotificationRule rule = new NotificationRule();
         rule.setPublisher(publisher);
-        Assert.assertEquals(publisher, rule.getPublisher());
+        Assertions.assertEquals(publisher, rule.getPublisher());
     }
 
     @Test
-    public void testPublisherConfig() {
+    void testPublisherConfig() {
         NotificationRule rule = new NotificationRule();
         rule.setPublisherConfig("{ \"config\": \"configured\" }");
-        Assert.assertEquals("{ \"config\": \"configured\" }", rule.getPublisherConfig());
+        Assertions.assertEquals("{ \"config\": \"configured\" }", rule.getPublisherConfig());
     }
 
     @Test
-    public void testUuid() {
+    void testUuid() {
         UUID uuid = UUID.randomUUID();
         NotificationRule rule = new NotificationRule();
         rule.setUuid(uuid);
-        Assert.assertEquals(uuid.toString(), rule.getUuid().toString());
+        Assertions.assertEquals(uuid.toString(), rule.getUuid().toString());
     }
 
     @Test
-    public void testTeams(){
+    void testTeams(){
         List<Team> teams = new ArrayList<>();
         Team team = new Team();
         teams.add(team);
         NotificationRule rule = new NotificationRule();
         rule.setTeams(teams);
-        Assert.assertEquals(1, rule.getTeams().size());
-        Assert.assertEquals(team, rule.getTeams().get(0));
+        Assertions.assertEquals(1, rule.getTeams().size());
+        Assertions.assertEquals(team, rule.getTeams().get(0));
     }
 
     @Test
-    public void testManagedUsers(){
+    void testManagedUsers(){
         List<Team> teams = new ArrayList<>();
         Team team = new Team();
         List<ManagedUser> managedUsers = new ArrayList<>();
@@ -144,13 +144,13 @@ public class NotificationRuleTest {
         teams.add(team);
         NotificationRule rule = new NotificationRule();
         rule.setTeams(teams);
-        Assert.assertEquals(1, rule.getTeams().size());
-        Assert.assertEquals(team, rule.getTeams().get(0));
-        Assert.assertEquals(managedUser, rule.getTeams().get(0).getManagedUsers().get(0));
+        Assertions.assertEquals(1, rule.getTeams().size());
+        Assertions.assertEquals(team, rule.getTeams().get(0));
+        Assertions.assertEquals(managedUser, rule.getTeams().get(0).getManagedUsers().get(0));
     }
 
     @Test
-    public void testLdapUsers(){
+    void testLdapUsers(){
         List<Team> teams = new ArrayList<>();
         Team team = new Team();
         List<LdapUser> ldapUsers = new ArrayList<>();
@@ -160,13 +160,13 @@ public class NotificationRuleTest {
         teams.add(team);
         NotificationRule rule = new NotificationRule();
         rule.setTeams(teams);
-        Assert.assertEquals(1, rule.getTeams().size());
-        Assert.assertEquals(team, rule.getTeams().get(0));
-        Assert.assertEquals(ldapUser, rule.getTeams().get(0).getLdapUsers().get(0));
+        Assertions.assertEquals(1, rule.getTeams().size());
+        Assertions.assertEquals(team, rule.getTeams().get(0));
+        Assertions.assertEquals(ldapUser, rule.getTeams().get(0).getLdapUsers().get(0));
     }
 
     @Test
-    public void testOidcUsers(){
+    void testOidcUsers(){
         List<Team> teams = new ArrayList<>();
         Team team = new Team();
         List<OidcUser> oidcUsers = new ArrayList<>();
@@ -176,8 +176,8 @@ public class NotificationRuleTest {
         teams.add(team);
         NotificationRule rule = new NotificationRule();
         rule.setTeams(teams);
-        Assert.assertEquals(1, rule.getTeams().size());
-        Assert.assertEquals(team, rule.getTeams().get(0));
-        Assert.assertEquals(oidcUser, rule.getTeams().get(0).getOidcUsers().get(0));
+        Assertions.assertEquals(1, rule.getTeams().size());
+        Assertions.assertEquals(team, rule.getTeams().get(0));
+        Assertions.assertEquals(oidcUser, rule.getTeams().get(0).getOidcUsers().get(0));
     }
 }

--- a/src/test/java/org/dependencytrack/model/PolicyConditionTest.java
+++ b/src/test/java/org/dependencytrack/model/PolicyConditionTest.java
@@ -18,44 +18,44 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class PolicyConditionTest {
+class PolicyConditionTest {
 
     @Test
-    public void testId() {
+    void testId() {
         PolicyCondition pc = new PolicyCondition();
         pc.setId(111L);
-        Assert.assertEquals(111L, pc.getId());
+        Assertions.assertEquals(111L, pc.getId());
     }
 
     @Test
-    public void testPolicy() {
+    void testPolicy() {
         Policy policy = new Policy();
         PolicyCondition pc = new PolicyCondition();
         pc.setPolicy(policy);
-        Assert.assertEquals(policy, pc.getPolicy());
+        Assertions.assertEquals(policy, pc.getPolicy());
     }
 
     @Test
-    public void testOperator() {
+    void testOperator() {
         PolicyCondition pc = new PolicyCondition();
         pc.setOperator(PolicyCondition.Operator.NUMERIC_EQUAL);
-        Assert.assertEquals("NUMERIC_EQUAL", pc.getOperator().name());
+        Assertions.assertEquals("NUMERIC_EQUAL", pc.getOperator().name());
     }
 
     @Test
-    public void testSubject() {
+    void testSubject() {
         PolicyCondition pc = new PolicyCondition();
         pc.setSubject(PolicyCondition.Subject.LICENSE_GROUP);
-        Assert.assertEquals("LICENSE_GROUP", pc.getSubject().name());
+        Assertions.assertEquals("LICENSE_GROUP", pc.getSubject().name());
     }
 
     @Test
-    public void testValue() {
+    void testValue() {
         PolicyCondition pc = new PolicyCondition();
         pc.setValue("Test Value");
-        Assert.assertEquals("Test Value", pc.getValue());
+        Assertions.assertEquals("Test Value", pc.getValue());
     }
 }

--- a/src/test/java/org/dependencytrack/model/PolicyTest.java
+++ b/src/test/java/org/dependencytrack/model/PolicyTest.java
@@ -18,82 +18,82 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-public class PolicyTest {
+class PolicyTest {
 
     @Test
-    public void testId() {
+    void testId() {
         Policy policy = new Policy();
         policy.setId(111L);
-        Assert.assertEquals(111L, policy.getId());
+        Assertions.assertEquals(111L, policy.getId());
     }
 
     @Test
-    public void testName() {
+    void testName() {
         Policy policy = new Policy();
         policy.setName("Banned Components");
-        Assert.assertEquals("Banned Components", policy.getName());
+        Assertions.assertEquals("Banned Components", policy.getName());
     }
 
     @Test
-    public void testOperator() {
+    void testOperator() {
         Policy policy = new Policy();
         policy.setOperator(Policy.Operator.ALL);
-        Assert.assertEquals("ALL", policy.getOperator().name());
+        Assertions.assertEquals("ALL", policy.getOperator().name());
     }
 
     @Test
-    public void testViolationState() {
+    void testViolationState() {
         Policy policy = new Policy();
         policy.setViolationState(Policy.ViolationState.WARN);
-        Assert.assertEquals("WARN", policy.getViolationState().name());
+        Assertions.assertEquals("WARN", policy.getViolationState().name());
     }
 
     @Test
-    public void testPolicyConditions() {
+    void testPolicyConditions() {
         List<PolicyCondition> conditions = new ArrayList<>();
         PolicyCondition condition = new PolicyCondition();
         conditions.add(condition);
         Policy policy = new Policy();
         policy.setPolicyConditions(conditions);
-        Assert.assertEquals(1, policy.getPolicyConditions().size());
-        Assert.assertEquals(condition, policy.getPolicyConditions().get(0));
+        Assertions.assertEquals(1, policy.getPolicyConditions().size());
+        Assertions.assertEquals(condition, policy.getPolicyConditions().get(0));
     }
 
     @Test
-    public void testProjects() {
+    void testProjects() {
         List<Project> projects = new ArrayList<>();
         Project project = new Project();
         projects.add(project);
         Policy policy = new Policy();
         policy.setProjects(projects);
-        Assert.assertEquals(1, policy.getProjects().size());
-        Assert.assertEquals(project, policy.getProjects().get(0));
+        Assertions.assertEquals(1, policy.getProjects().size());
+        Assertions.assertEquals(project, policy.getProjects().get(0));
     }
 
     @Test
-    public void testTags() {
+    void testTags() {
         Set<Tag> tags = new HashSet<>();
         Tag tag = new Tag();
         tags.add(tag);
         Policy policy = new Policy();
         policy.setTags(tags);
-        Assert.assertEquals(1, policy.getTags().size());
-        Assert.assertEquals(tag, policy.getTags().iterator().next());
+        Assertions.assertEquals(1, policy.getTags().size());
+        Assertions.assertEquals(tag, policy.getTags().iterator().next());
     }
 
     @Test
-    public void testIncludeChildren() {
+    void testIncludeChildren() {
         Policy policy = new Policy();
-        Assert.assertFalse(policy.isIncludeChildren());
+        Assertions.assertFalse(policy.isIncludeChildren());
         policy.setIncludeChildren(true);
-        Assert.assertTrue(policy.isIncludeChildren());
+        Assertions.assertTrue(policy.isIncludeChildren());
     }
 }

--- a/src/test/java/org/dependencytrack/model/PortfolioMetricsTest.java
+++ b/src/test/java/org/dependencytrack/model/PortfolioMetricsTest.java
@@ -18,138 +18,138 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 
-public class PortfolioMetricsTest {
+class PortfolioMetricsTest {
 
     @Test
-    public void testId() {
+    void testId() {
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setId(111L);
-        Assert.assertEquals(111L, metric.getId());
+        Assertions.assertEquals(111L, metric.getId());
     }
 
     @Test
-    public void testCritical() {
+    void testCritical() {
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setCritical(10);
-        Assert.assertEquals(10, metric.getCritical());
+        Assertions.assertEquals(10, metric.getCritical());
     }
 
     @Test
-    public void testHigh() {
+    void testHigh() {
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setHigh(9);
-        Assert.assertEquals(9, metric.getHigh());
+        Assertions.assertEquals(9, metric.getHigh());
     }
 
     @Test
-    public void testMedium() {
+    void testMedium() {
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setMedium(8);
-        Assert.assertEquals(8, metric.getMedium());
+        Assertions.assertEquals(8, metric.getMedium());
     }
 
     @Test
-    public void testLow() {
+    void testLow() {
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setLow(7);
-        Assert.assertEquals(7, metric.getLow());
+        Assertions.assertEquals(7, metric.getLow());
     }
 
     @Test
-    public void testUnassigned() {
+    void testUnassigned() {
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setUnassigned(9191);
-        Assert.assertEquals(9191, metric.getUnassigned());
+        Assertions.assertEquals(9191, metric.getUnassigned());
     }
 
     @Test
-    public void testVulnerabilities() {
+    void testVulnerabilities() {
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setVulnerabilities(6);
-        Assert.assertEquals(6, metric.getVulnerabilities());
+        Assertions.assertEquals(6, metric.getVulnerabilities());
     }
 
     @Test
-    public void testProjects() {
+    void testProjects() {
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setProjects(99);
-        Assert.assertEquals(99, metric.getProjects());
+        Assertions.assertEquals(99, metric.getProjects());
     }
 
     @Test
-    public void testVulnerableProjects() {
+    void testVulnerableProjects() {
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setVulnerableProjects(98);
-        Assert.assertEquals(98, metric.getVulnerableProjects());
+        Assertions.assertEquals(98, metric.getVulnerableProjects());
     }
 
     @Test
-    public void testComponents() {
+    void testComponents() {
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setComponents(97);
-        Assert.assertEquals(97, metric.getComponents());
+        Assertions.assertEquals(97, metric.getComponents());
     }
 
     @Test
-    public void testVulnerableComponents() {
+    void testVulnerableComponents() {
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setVulnerableComponents(96);
-        Assert.assertEquals(96, metric.getVulnerableComponents());
+        Assertions.assertEquals(96, metric.getVulnerableComponents());
     }
 
     @Test
-    public void testSuppressed() {
+    void testSuppressed() {
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setSuppressed(5);
-        Assert.assertEquals(5, metric.getSuppressed());
+        Assertions.assertEquals(5, metric.getSuppressed());
     }
 
     @Test
-    public void testFindingsTotal() {
+    void testFindingsTotal() {
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setFindingsTotal(4);
-        Assert.assertEquals(4, metric.getFindingsTotal());
+        Assertions.assertEquals(4, metric.getFindingsTotal());
     }
 
     @Test
-    public void testFindingsAudited() {
+    void testFindingsAudited() {
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setFindingsAudited(3);
-        Assert.assertEquals(3, metric.getFindingsAudited());
+        Assertions.assertEquals(3, metric.getFindingsAudited());
     }
 
     @Test
-    public void testFindingsUnaudited() {
+    void testFindingsUnaudited() {
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setFindingsUnaudited(2);
-        Assert.assertEquals(2, metric.getFindingsUnaudited());
+        Assertions.assertEquals(2, metric.getFindingsUnaudited());
     }
 
     @Test
-    public void testInheritedRiskScore() {
+    void testInheritedRiskScore() {
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setInheritedRiskScore(1000);
-        Assert.assertEquals(1000, metric.getInheritedRiskScore(), 0);
+        Assertions.assertEquals(1000, metric.getInheritedRiskScore(), 0);
     }
 
     @Test
-    public void testFirstOccurrence() {
+    void testFirstOccurrence() {
         Date date = new Date();
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setFirstOccurrence(date);
-        Assert.assertEquals(date, metric.getFirstOccurrence());
+        Assertions.assertEquals(date, metric.getFirstOccurrence());
     }
 
     @Test
-    public void testLastOccurrence() {
+    void testLastOccurrence() {
         Date date = new Date();
         PortfolioMetrics metric = new PortfolioMetrics();
         metric.setLastOccurrence(date);
-        Assert.assertEquals(date, metric.getLastOccurrence());
+        Assertions.assertEquals(date, metric.getLastOccurrence());
     }
 }

--- a/src/test/java/org/dependencytrack/model/ProjectMetricsTest.java
+++ b/src/test/java/org/dependencytrack/model/ProjectMetricsTest.java
@@ -18,124 +18,124 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 
-public class ProjectMetricsTest {
+class ProjectMetricsTest {
 
     @Test
-    public void testId() {
+    void testId() {
         ProjectMetrics metric = new ProjectMetrics();
         metric.setId(111L);
-        Assert.assertEquals(111L, metric.getId());
+        Assertions.assertEquals(111L, metric.getId());
     }
 
     @Test
-    public void testCritical() {
+    void testCritical() {
         ProjectMetrics metric = new ProjectMetrics();
         metric.setCritical(10);
-        Assert.assertEquals(10, metric.getCritical());
+        Assertions.assertEquals(10, metric.getCritical());
     }
 
     @Test
-    public void testHigh() {
+    void testHigh() {
         ProjectMetrics metric = new ProjectMetrics();
         metric.setHigh(9);
-        Assert.assertEquals(9, metric.getHigh());
+        Assertions.assertEquals(9, metric.getHigh());
     }
 
     @Test
-    public void testMedium() {
+    void testMedium() {
         ProjectMetrics metric = new ProjectMetrics();
         metric.setMedium(8);
-        Assert.assertEquals(8, metric.getMedium());
+        Assertions.assertEquals(8, metric.getMedium());
     }
 
     @Test
-    public void testLow() {
+    void testLow() {
         ProjectMetrics metric = new ProjectMetrics();
         metric.setLow(7);
-        Assert.assertEquals(7, metric.getLow());
+        Assertions.assertEquals(7, metric.getLow());
     }
 
     @Test
-    public void testUnassigned() {
+    void testUnassigned() {
         ProjectMetrics metric = new ProjectMetrics();
         metric.setUnassigned(9191);
-        Assert.assertEquals(9191, metric.getUnassigned());
+        Assertions.assertEquals(9191, metric.getUnassigned());
     }
 
     @Test
-    public void testVulnerabilities() {
+    void testVulnerabilities() {
         ProjectMetrics metric = new ProjectMetrics();
         metric.setVulnerabilities(6);
-        Assert.assertEquals(6, metric.getVulnerabilities());
+        Assertions.assertEquals(6, metric.getVulnerabilities());
     }
 
     @Test
-    public void testComponents() {
+    void testComponents() {
         ProjectMetrics metric = new ProjectMetrics();
         metric.setComponents(97);
-        Assert.assertEquals(97, metric.getComponents());
+        Assertions.assertEquals(97, metric.getComponents());
     }
 
     @Test
-    public void testVulnerableComponents() {
+    void testVulnerableComponents() {
         ProjectMetrics metric = new ProjectMetrics();
         metric.setVulnerableComponents(96);
-        Assert.assertEquals(96, metric.getVulnerableComponents());
+        Assertions.assertEquals(96, metric.getVulnerableComponents());
     }
 
     @Test
-    public void testSuppressed() {
+    void testSuppressed() {
         ProjectMetrics metric = new ProjectMetrics();
         metric.setSuppressed(5);
-        Assert.assertEquals(5, metric.getSuppressed());
+        Assertions.assertEquals(5, metric.getSuppressed());
     }
 
     @Test
-    public void testFindingsTotal() {
+    void testFindingsTotal() {
         ProjectMetrics metric = new ProjectMetrics();
         metric.setFindingsTotal(4);
-        Assert.assertEquals(4, metric.getFindingsTotal());
+        Assertions.assertEquals(4, metric.getFindingsTotal());
     }
 
     @Test
-    public void testFindingsAudited() {
+    void testFindingsAudited() {
         ProjectMetrics metric = new ProjectMetrics();
         metric.setFindingsAudited(3);
-        Assert.assertEquals(3, metric.getFindingsAudited());
+        Assertions.assertEquals(3, metric.getFindingsAudited());
     }
 
     @Test
-    public void testFindingsUnaudited() {
+    void testFindingsUnaudited() {
         ProjectMetrics metric = new ProjectMetrics();
         metric.setFindingsUnaudited(2);
-        Assert.assertEquals(2, metric.getFindingsUnaudited());
+        Assertions.assertEquals(2, metric.getFindingsUnaudited());
     }
 
     @Test
-    public void testInheritedRiskScore() {
+    void testInheritedRiskScore() {
         ProjectMetrics metric = new ProjectMetrics();
         metric.setInheritedRiskScore(1000);
-        Assert.assertEquals(1000, metric.getInheritedRiskScore(), 0);
+        Assertions.assertEquals(1000, metric.getInheritedRiskScore(), 0);
     }
 
     @Test
-    public void testFirstOccurrence() {
+    void testFirstOccurrence() {
         Date date = new Date();
         ProjectMetrics metric = new ProjectMetrics();
         metric.setFirstOccurrence(date);
-        Assert.assertEquals(date, metric.getFirstOccurrence());
+        Assertions.assertEquals(date, metric.getFirstOccurrence());
     }
 
     @Test
-    public void testLastOccurrence() {
+    void testLastOccurrence() {
         Date date = new Date();
         ProjectMetrics metric = new ProjectMetrics();
         metric.setLastOccurrence(date);
-        Assert.assertEquals(date, metric.getLastOccurrence());
+        Assertions.assertEquals(date, metric.getLastOccurrence());
     }
 } 

--- a/src/test/java/org/dependencytrack/model/ProjectPropertyTest.java
+++ b/src/test/java/org/dependencytrack/model/ProjectPropertyTest.java
@@ -19,58 +19,58 @@
 package org.dependencytrack.model;
 
 import alpine.model.IConfigProperty;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class ProjectPropertyTest {
+class ProjectPropertyTest {
 
     @Test
-    public void testId() {
+    void testId() {
         ProjectProperty property = new ProjectProperty();
         property.setId(111L);
-        Assert.assertEquals(111L, property.getId());
+        Assertions.assertEquals(111L, property.getId());
     } 
 
     @Test
-    public void testProject() {
+    void testProject() {
         Project project = new Project();
         ProjectProperty property = new ProjectProperty();
         property.setProject(project);
-        Assert.assertEquals(project, property.getProject());
+        Assertions.assertEquals(project, property.getProject());
     }
 
     @Test
-    public void testGroupName() {
+    void testGroupName() {
         ProjectProperty property = new ProjectProperty();
         property.setGroupName("Group Name");
-        Assert.assertEquals("Group Name", property.getGroupName());
+        Assertions.assertEquals("Group Name", property.getGroupName());
     } 
 
     @Test
-    public void testPropertyName() {
+    void testPropertyName() {
         ProjectProperty property = new ProjectProperty();
         property.setPropertyName("Property Name");
-        Assert.assertEquals("Property Name", property.getPropertyName());
+        Assertions.assertEquals("Property Name", property.getPropertyName());
     }
 
     @Test
-    public void testPropertyValue() {
+    void testPropertyValue() {
         ProjectProperty property = new ProjectProperty();
         property.setPropertyValue("Property Value");
-        Assert.assertEquals("Property Value", property.getPropertyValue());
+        Assertions.assertEquals("Property Value", property.getPropertyValue());
     }
 
     @Test
-    public void testPropertyType() {
+    void testPropertyType() {
         ProjectProperty property = new ProjectProperty();
         property.setPropertyType(IConfigProperty.PropertyType.STRING);
-        Assert.assertEquals(IConfigProperty.PropertyType.STRING, property.getPropertyType());
+        Assertions.assertEquals(IConfigProperty.PropertyType.STRING, property.getPropertyType());
     } 
 
     @Test
-    public void testDescription() {
+    void testDescription() {
         ProjectProperty property = new ProjectProperty();
         property.setDescription("Property Description");
-        Assert.assertEquals("Property Description", property.getDescription());
+        Assertions.assertEquals("Property Description", property.getDescription());
     }
 } 

--- a/src/test/java/org/dependencytrack/model/ProjectTest.java
+++ b/src/test/java/org/dependencytrack/model/ProjectTest.java
@@ -19,37 +19,37 @@
 package org.dependencytrack.model;
 
 import org.dependencytrack.PersistenceCapableTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 import java.util.UUID;
 
-public class ProjectTest extends PersistenceCapableTest {
+class ProjectTest extends PersistenceCapableTest {
 
     @Test
-    public void testProjectPersistence() {
+    void testProjectPersistence() {
         Project p1 = qm.createProject("Example Project 1", "Description 1", "1.0", null, null, null, true, false);
         Project p2 = qm.createProject("Example Project 2", "Description 2", "1.1", null, null, null, true, false);
         Bom bom = qm.createBom(p1, new Date(), Bom.Format.CYCLONEDX, "1.1", 1, UUID.randomUUID().toString());
 
-        Assert.assertEquals("Example Project 1", p1.getName());
-        Assert.assertEquals("Example Project 2", p2.getName());
+        Assertions.assertEquals("Example Project 1", p1.getName());
+        Assertions.assertEquals("Example Project 2", p2.getName());
 
-        Assert.assertNotNull(p1.getUuid());
-        Assert.assertNotNull(p2.getUuid());
+        Assertions.assertNotNull(p1.getUuid());
+        Assertions.assertNotNull(p2.getUuid());
 
-        Assert.assertNotNull(bom.getProject());
-        Assert.assertEquals("Example Project 1", bom.getProject().getName());
-        Assert.assertEquals("Description 1", bom.getProject().getDescription());
-        Assert.assertEquals("1.0", bom.getProject().getVersion());
+        Assertions.assertNotNull(bom.getProject());
+        Assertions.assertEquals("Example Project 1", bom.getProject().getName());
+        Assertions.assertEquals("Description 1", bom.getProject().getDescription());
+        Assertions.assertEquals("1.0", bom.getProject().getVersion());
 
-        Assert.assertNotNull(bom.getUuid());
-        Assert.assertNotNull(bom.getImported());
+        Assertions.assertNotNull(bom.getUuid());
+        Assertions.assertNotNull(bom.getImported());
     }
 
     @Test
-    public void testProjectPersistActiveFieldDefaultsToTrue() {
+    void testProjectPersistActiveFieldDefaultsToTrue() {
 
         Project project = new Project();
         project.setName("Example Project 1");
@@ -58,6 +58,6 @@ public class ProjectTest extends PersistenceCapableTest {
 
         Project persistedProject = qm.createProject(project, null, false);
 
-        Assert.assertTrue(persistedProject.isActive());
+        Assertions.assertTrue(persistedProject.isActive());
     }
 }

--- a/src/test/java/org/dependencytrack/model/RepositoryMetaComponentTest.java
+++ b/src/test/java/org/dependencytrack/model/RepositoryMetaComponentTest.java
@@ -18,61 +18,61 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 
-public class RepositoryMetaComponentTest {
+class RepositoryMetaComponentTest {
 
     @Test
-    public void testId() {
+    void testId() {
         RepositoryMetaComponent rmc = new RepositoryMetaComponent();
         rmc.setId(111L);
-        Assert.assertEquals(111L, rmc.getId());
+        Assertions.assertEquals(111L, rmc.getId());
     }
 
     @Test
-    public void testRepositoryType() {
+    void testRepositoryType() {
         RepositoryMetaComponent rmc = new RepositoryMetaComponent();
         rmc.setRepositoryType(RepositoryType.MAVEN);
-        Assert.assertEquals(RepositoryType.MAVEN, rmc.getRepositoryType());
+        Assertions.assertEquals(RepositoryType.MAVEN, rmc.getRepositoryType());
     }
 
     @Test
-    public void testNamespace() {
+    void testNamespace() {
         RepositoryMetaComponent rmc = new RepositoryMetaComponent();
         rmc.setNamespace("My Namespace");
-        Assert.assertEquals("My Namespace", rmc.getNamespace());
+        Assertions.assertEquals("My Namespace", rmc.getNamespace());
     } 
 
     @Test
-    public void testName() {
+    void testName() {
         RepositoryMetaComponent rmc = new RepositoryMetaComponent();
         rmc.setName("My Name");
-        Assert.assertEquals("My Name", rmc.getName());
+        Assertions.assertEquals("My Name", rmc.getName());
     } 
     
     @Test
-    public void testLatestVersion() {
+    void testLatestVersion() {
         RepositoryMetaComponent rmc = new RepositoryMetaComponent();
         rmc.setLatestVersion("2.0.0");
-        Assert.assertEquals("2.0.0", rmc.getLatestVersion());
+        Assertions.assertEquals("2.0.0", rmc.getLatestVersion());
     } 
 
     @Test
-    public void testPublished() {
+    void testPublished() {
         Date date = new Date();
         RepositoryMetaComponent rmc = new RepositoryMetaComponent();
         rmc.setPublished(date);
-        Assert.assertEquals(date, rmc.getPublished());
+        Assertions.assertEquals(date, rmc.getPublished());
     }
 
     @Test
-    public void testLastCheck() {
+    void testLastCheck() {
         Date date = new Date();
         RepositoryMetaComponent rmc = new RepositoryMetaComponent();
         rmc.setLastCheck(date);
-        Assert.assertEquals(date, rmc.getLastCheck());
+        Assertions.assertEquals(date, rmc.getLastCheck());
     }
 } 

--- a/src/test/java/org/dependencytrack/model/RepositoryTest.java
+++ b/src/test/java/org/dependencytrack/model/RepositoryTest.java
@@ -18,64 +18,64 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class RepositoryTest {
+class RepositoryTest {
 
     @Test
-    public void testId() {
+    void testId() {
         Repository repo = new Repository();
         repo.setId(111L);
-        Assert.assertEquals(111L, repo.getId());
+        Assertions.assertEquals(111L, repo.getId());
     }
 
     @Test
-    public void testType() {
+    void testType() {
         Repository repo = new Repository();
         repo.setType(RepositoryType.MAVEN);
-        Assert.assertEquals(RepositoryType.MAVEN, repo.getType());
+        Assertions.assertEquals(RepositoryType.MAVEN, repo.getType());
     }
 
     @Test
-    public void testIdentifier() {
+    void testIdentifier() {
         Repository repo = new Repository();
         repo.setIdentifier("maven-central");
-        Assert.assertEquals("maven-central", repo.getIdentifier());
+        Assertions.assertEquals("maven-central", repo.getIdentifier());
     }
 
     @Test
-    public void testUrl() {
+    void testUrl() {
         Repository repo = new Repository();
         repo.setUrl("https://repo.maven.apache.org/maven2");
-        Assert.assertEquals("https://repo.maven.apache.org/maven2", repo.getUrl());
+        Assertions.assertEquals("https://repo.maven.apache.org/maven2", repo.getUrl());
     }
 
     @Test
-    public void testResolutionOrder() {
+    void testResolutionOrder() {
         Repository repo = new Repository();
         repo.setResolutionOrder(5);
-        Assert.assertEquals(5, repo.getResolutionOrder());
+        Assertions.assertEquals(5, repo.getResolutionOrder());
     }
 
     @Test
-    public void testEnabled() {
+    void testEnabled() {
         Repository repo = new Repository();
         repo.setEnabled(true);
-        Assert.assertTrue(repo.isEnabled());
+        Assertions.assertTrue(repo.isEnabled());
     }
 
     @Test
-    public void testAuthenticationRequiredTrue() {
+    void testAuthenticationRequiredTrue() {
         Repository repo = new Repository();
         repo.setAuthenticationRequired(true);
-        Assert.assertTrue(repo.isAuthenticationRequired());
+        Assertions.assertTrue(repo.isAuthenticationRequired());
     }
 
     @Test
-    public void testAuthenticationRequiredFalse() {
+    void testAuthenticationRequiredFalse() {
         Repository repo = new Repository();
         repo.setAuthenticationRequired(false);
-        Assert.assertFalse(repo.isAuthenticationRequired());
+        Assertions.assertFalse(repo.isAuthenticationRequired());
     }
 } 

--- a/src/test/java/org/dependencytrack/model/RepositoryTypeTest.java
+++ b/src/test/java/org/dependencytrack/model/RepositoryTypeTest.java
@@ -18,69 +18,69 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import com.github.packageurl.PackageURL;
 
-public class RepositoryTypeTest {
+class RepositoryTypeTest {
 
     @Test
-    public void testEnums() {
-        Assert.assertEquals("CPAN", RepositoryType.CPAN.name());
-        Assert.assertEquals("MAVEN", RepositoryType.MAVEN.name());
-        Assert.assertEquals("NPM", RepositoryType.NPM.name());
-        Assert.assertEquals("GEM", RepositoryType.GEM.name());
-        Assert.assertEquals("PYPI", RepositoryType.PYPI.name());
-        Assert.assertEquals("NUGET", RepositoryType.NUGET.name());
-        Assert.assertEquals("HEX", RepositoryType.HEX.name());
-        Assert.assertEquals("UNSUPPORTED", RepositoryType.UNSUPPORTED.name());
+    void testEnums() {
+        Assertions.assertEquals("CPAN", RepositoryType.CPAN.name());
+        Assertions.assertEquals("MAVEN", RepositoryType.MAVEN.name());
+        Assertions.assertEquals("NPM", RepositoryType.NPM.name());
+        Assertions.assertEquals("GEM", RepositoryType.GEM.name());
+        Assertions.assertEquals("PYPI", RepositoryType.PYPI.name());
+        Assertions.assertEquals("NUGET", RepositoryType.NUGET.name());
+        Assertions.assertEquals("HEX", RepositoryType.HEX.name());
+        Assertions.assertEquals("UNSUPPORTED", RepositoryType.UNSUPPORTED.name());
     }
 
     @Test
-    public void testResolveMaven() throws Exception {
+    void testResolveMaven() throws Exception {
         PackageURL purl = new PackageURL("pkg:maven/groupId/artifactId@1.0.0");
-        Assert.assertEquals(RepositoryType.MAVEN, RepositoryType.resolve(purl));
+        Assertions.assertEquals(RepositoryType.MAVEN, RepositoryType.resolve(purl));
     }
 
     @Test
-    public void testResolveCpan() throws Exception {
+    void testResolveCpan() throws Exception {
         PackageURL purl = new PackageURL("pkg:cpan/artifact@1.0.0");
-        Assert.assertEquals(RepositoryType.CPAN, RepositoryType.resolve(purl));
+        Assertions.assertEquals(RepositoryType.CPAN, RepositoryType.resolve(purl));
     }
 
     @Test
-    public void testResolveNpm() throws Exception {
+    void testResolveNpm() throws Exception {
         PackageURL purl = new PackageURL("pkg:npm/artifact@1.0.0");
-        Assert.assertEquals(RepositoryType.NPM, RepositoryType.resolve(purl));
+        Assertions.assertEquals(RepositoryType.NPM, RepositoryType.resolve(purl));
     }
 
     @Test
-    public void testResolveGem() throws Exception {
+    void testResolveGem() throws Exception {
         PackageURL purl = new PackageURL("pkg:gem/artifact@1.0.0");
-        Assert.assertEquals(RepositoryType.GEM, RepositoryType.resolve(purl));
+        Assertions.assertEquals(RepositoryType.GEM, RepositoryType.resolve(purl));
     }
 
     @Test
-    public void testResolvePypi() throws Exception {
+    void testResolvePypi() throws Exception {
         PackageURL purl = new PackageURL("pkg:pypi/artifact@1.0.0");
-        Assert.assertEquals(RepositoryType.PYPI, RepositoryType.resolve(purl));
+        Assertions.assertEquals(RepositoryType.PYPI, RepositoryType.resolve(purl));
     }
 
     @Test
-    public void testResolveNuget() throws Exception {
+    void testResolveNuget() throws Exception {
         PackageURL purl = new PackageURL("pkg:nuget/artifact@1.0.0");
-        Assert.assertEquals(RepositoryType.NUGET, RepositoryType.resolve(purl));
+        Assertions.assertEquals(RepositoryType.NUGET, RepositoryType.resolve(purl));
     }
 
     @Test
-    public void testResolveHex() throws Exception {
+    void testResolveHex() throws Exception {
         PackageURL purl = new PackageURL("pkg:hex/phoenix@1.14.10");
-        Assert.assertEquals(RepositoryType.HEX, RepositoryType.resolve(purl));
+        Assertions.assertEquals(RepositoryType.HEX, RepositoryType.resolve(purl));
     }
 
     @Test
-    public void testResolveUnsupported() throws Exception {
+    void testResolveUnsupported() throws Exception {
         PackageURL purl = new PackageURL("pkg:generic/artifact@1.0.0");
-        Assert.assertEquals(RepositoryType.UNSUPPORTED, RepositoryType.resolve(purl));
+        Assertions.assertEquals(RepositoryType.UNSUPPORTED, RepositoryType.resolve(purl));
     }
 }

--- a/src/test/java/org/dependencytrack/model/SeverityTest.java
+++ b/src/test/java/org/dependencytrack/model/SeverityTest.java
@@ -18,18 +18,18 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class SeverityTest {
+class SeverityTest {
 
     @Test
-    public void testEnums() {
-        Assert.assertEquals("CRITICAL", Severity.CRITICAL.name());
-        Assert.assertEquals("HIGH", Severity.HIGH.name());
-        Assert.assertEquals("MEDIUM", Severity.MEDIUM.name());
-        Assert.assertEquals("LOW", Severity.LOW.name());
-        Assert.assertEquals("INFO", Severity.INFO.name());
-        Assert.assertEquals("UNASSIGNED", Severity.UNASSIGNED.name());
+    void testEnums() {
+        Assertions.assertEquals("CRITICAL", Severity.CRITICAL.name());
+        Assertions.assertEquals("HIGH", Severity.HIGH.name());
+        Assertions.assertEquals("MEDIUM", Severity.MEDIUM.name());
+        Assertions.assertEquals("LOW", Severity.LOW.name());
+        Assertions.assertEquals("INFO", Severity.INFO.name());
+        Assertions.assertEquals("UNASSIGNED", Severity.UNASSIGNED.name());
     }
 }

--- a/src/test/java/org/dependencytrack/model/TagTest.java
+++ b/src/test/java/org/dependencytrack/model/TagTest.java
@@ -18,48 +18,48 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
 
-public class TagTest { 
+class TagTest {
 
     @Test
-    public void testId() { 
+    void testId() {
         Tag tag = new Tag();
         tag.setId(111L);
-        Assert.assertEquals(111L, tag.getId());
+        Assertions.assertEquals(111L, tag.getId());
     } 
 
     @Test
-    public void testName() {
+    void testName() {
         Tag tag = new Tag();
         tag.setName("java");
-        Assert.assertEquals("java", tag.getName());
+        Assertions.assertEquals("java", tag.getName());
     } 
 
     @Test
-    public void testProjects() {
+    void testProjects() {
         Set<Project> projects = new HashSet<>();
         Project project = new Project();
         projects.add(project);
         Tag tag = new Tag();
         tag.setProjects(projects);
-        Assert.assertEquals(1, tag.getProjects().size());
-        Assert.assertEquals(project, tag.getProjects().iterator().next());
+        Assertions.assertEquals(1, tag.getProjects().size());
+        Assertions.assertEquals(project, tag.getProjects().iterator().next());
     } 
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         Tag t1 = new Tag();
         t1.setName("foo");
         Tag t2 = new Tag();
         t2.setName("bar");
         Tag t3 = new Tag();
         t3.setName("foo");
-        Assert.assertFalse(t1.equals(t2));
-        Assert.assertTrue(t1.equals(t3));
+        Assertions.assertFalse(t1.equals(t2));
+        Assertions.assertTrue(t1.equals(t3));
     }
 } 

--- a/src/test/java/org/dependencytrack/model/VulnerabilityAliasTest.java
+++ b/src/test/java/org/dependencytrack/model/VulnerabilityAliasTest.java
@@ -1,12 +1,12 @@
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class VulnerabilityAliasTest {
+class VulnerabilityAliasTest {
 
     @Test
-    public void testCopyFieldsFrom() {
+    void testCopyFieldsFrom() {
         var alias = new VulnerabilityAlias();
         alias.setCveId("someCveId");
         alias.setSonatypeId("someSonatypeId");
@@ -29,15 +29,15 @@ public class VulnerabilityAliasTest {
 
         alias.copyFieldsFrom(other);
 
-        Assert.assertEquals(other.getCveId(), alias.getCveId());
-        Assert.assertEquals(other.getSonatypeId(), alias.getSonatypeId());
-        Assert.assertEquals(other.getGhsaId(), alias.getGhsaId());
-        Assert.assertEquals(other.getOsvId(), alias.getOsvId());
-        Assert.assertEquals(other.getSnykId(), alias.getSnykId());
-        Assert.assertEquals(other.getGsdId(), alias.getGsdId());
-        Assert.assertEquals(other.getInternalId(), alias.getInternalId());
+        Assertions.assertEquals(other.getCveId(), alias.getCveId());
+        Assertions.assertEquals(other.getSonatypeId(), alias.getSonatypeId());
+        Assertions.assertEquals(other.getGhsaId(), alias.getGhsaId());
+        Assertions.assertEquals(other.getOsvId(), alias.getOsvId());
+        Assertions.assertEquals(other.getSnykId(), alias.getSnykId());
+        Assertions.assertEquals(other.getGsdId(), alias.getGsdId());
+        Assertions.assertEquals(other.getInternalId(), alias.getInternalId());
 
         // null does not overwrite existing value
-        Assert.assertEquals(alias.getVulnDbId(), alias.getVulnDbId());
+        Assertions.assertEquals(alias.getVulnDbId(), alias.getVulnDbId());
     }
 }

--- a/src/test/java/org/dependencytrack/model/VulnerabilityMetricsTest.java
+++ b/src/test/java/org/dependencytrack/model/VulnerabilityMetricsTest.java
@@ -18,46 +18,46 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 
-public class VulnerabilityMetricsTest { 
+class VulnerabilityMetricsTest {
     
     @Test
-    public void testId() {
+    void testId() {
         VulnerabilityMetrics metric = new VulnerabilityMetrics();
         metric.setId(111L);
-        Assert.assertEquals(111L, metric.getId());
+        Assertions.assertEquals(111L, metric.getId());
     } 
 
     @Test
-    public void testYear() {
+    void testYear() {
         VulnerabilityMetrics metric = new VulnerabilityMetrics();
         metric.setYear(10);
-        Assert.assertEquals(10, metric.getYear());
+        Assertions.assertEquals(10, metric.getYear());
     } 
 
     @Test
-    public void testMonth() {
+    void testMonth() {
         VulnerabilityMetrics metric = new VulnerabilityMetrics();
         metric.setMonth(9);
-        Assert.assertEquals((Integer) 9, metric.getMonth());
+        Assertions.assertEquals((Integer) 9, metric.getMonth());
     } 
 
     @Test
-    public void testCount() {
+    void testCount() {
         VulnerabilityMetrics metric = new VulnerabilityMetrics();
         metric.setCount(8);
-        Assert.assertEquals(8, metric.getCount());
+        Assertions.assertEquals(8, metric.getCount());
     } 
 
     @Test
-    public void testMeasuredAt() {
+    void testMeasuredAt() {
         Date date = new Date();
         VulnerabilityMetrics metric = new VulnerabilityMetrics();
         metric.setMeasuredAt(date);
-        Assert.assertEquals(date, metric.getMeasuredAt());
+        Assertions.assertEquals(date, metric.getMeasuredAt());
     }
 } 

--- a/src/test/java/org/dependencytrack/model/VulnerabilityTest.java
+++ b/src/test/java/org/dependencytrack/model/VulnerabilityTest.java
@@ -18,8 +18,8 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -27,17 +27,17 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
-public class VulnerabilityTest { 
+class VulnerabilityTest {
 
     @Test
-    public void testId() {
+    void testId() {
         Vulnerability vuln = new Vulnerability();
         vuln.setId(111L);
-        Assert.assertEquals(111L, vuln.getId());
+        Assertions.assertEquals(111L, vuln.getId());
     } 
 
     @Test
-    public void testSeverity() {
+    void testSeverity() {
         // NB: Before https://github.com/DependencyTrack/dependency-track/issues/2474,
         // severity was computed in the getter based on the provided scores.
         Vulnerability vuln = new Vulnerability();
@@ -49,198 +49,198 @@ public class VulnerabilityTest {
         vuln.setCvssV3BaseScore(new BigDecimal(6.0));
         vuln.setCvssV3ImpactSubScore(new BigDecimal(6.1));
         vuln.setCvssV3ExploitabilitySubScore(new BigDecimal(6.2));
-        Assert.assertNull(vuln.getSeverity());
+        Assertions.assertNull(vuln.getSeverity());
 
         // NB: Before https://github.com/DependencyTrack/dependency-track/issues/2474,
         // calling setSeverity cleared all score and vector fields.
         vuln.setSeverity(Severity.HIGH);
-        Assert.assertNotNull(vuln.getCvssV2Vector());
-        Assert.assertNotNull(vuln.getCvssV2BaseScore());
-        Assert.assertNotNull(vuln.getCvssV2ImpactSubScore());
-        Assert.assertNotNull(vuln.getCvssV2ExploitabilitySubScore());
-        Assert.assertNotNull(vuln.getCvssV3Vector());
-        Assert.assertNotNull(vuln.getCvssV3BaseScore());
-        Assert.assertNotNull(vuln.getCvssV3ImpactSubScore());
-        Assert.assertNotNull(vuln.getCvssV3ExploitabilitySubScore());
-        Assert.assertEquals(Severity.HIGH, vuln.getSeverity());
+        Assertions.assertNotNull(vuln.getCvssV2Vector());
+        Assertions.assertNotNull(vuln.getCvssV2BaseScore());
+        Assertions.assertNotNull(vuln.getCvssV2ImpactSubScore());
+        Assertions.assertNotNull(vuln.getCvssV2ExploitabilitySubScore());
+        Assertions.assertNotNull(vuln.getCvssV3Vector());
+        Assertions.assertNotNull(vuln.getCvssV3BaseScore());
+        Assertions.assertNotNull(vuln.getCvssV3ImpactSubScore());
+        Assertions.assertNotNull(vuln.getCvssV3ExploitabilitySubScore());
+        Assertions.assertEquals(Severity.HIGH, vuln.getSeverity());
     } 
 
     @Test
-    public void testVulnId() {
+    void testVulnId() {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("CVE-2019-0000");
-        Assert.assertEquals("CVE-2019-0000", vuln.getVulnId());
+        Assertions.assertEquals("CVE-2019-0000", vuln.getVulnId());
     } 
 
     @Test
-    public void testDescription() {
+    void testDescription() {
         Vulnerability vuln = new Vulnerability();
         vuln.setDescription("My description");
-        Assert.assertEquals("My description", vuln.getDescription());
+        Assertions.assertEquals("My description", vuln.getDescription());
     }
 
     @Test
-    public void testRecommendation() {
+    void testRecommendation() {
         Vulnerability vuln = new Vulnerability();
         vuln.setRecommendation("My recommendation");
-        Assert.assertEquals("My recommendation", vuln.getRecommendation());
+        Assertions.assertEquals("My recommendation", vuln.getRecommendation());
     } 
 
     @Test
-    public void testReferences() {
+    void testReferences() {
         Vulnerability vuln = new Vulnerability();
         vuln.setReferences("My references");
-        Assert.assertEquals("My references", vuln.getReferences());
+        Assertions.assertEquals("My references", vuln.getReferences());
     } 
 
     @Test
-    public void testCredits() {
+    void testCredits() {
         Vulnerability vuln = new Vulnerability();
         vuln.setCredits("My credits");
-        Assert.assertEquals("My credits", vuln.getCredits());
+        Assertions.assertEquals("My credits", vuln.getCredits());
     } 
 
     @Test
-    public void testCreated() {
+    void testCreated() {
         Date date = new Date();
         Vulnerability vuln = new Vulnerability();
         vuln.setCreated(date);
-        Assert.assertEquals(date, vuln.getCreated());
+        Assertions.assertEquals(date, vuln.getCreated());
     } 
 
     @Test
-    public void testPublished() {
+    void testPublished() {
         Date date = new Date();
         Vulnerability vuln = new Vulnerability();
         vuln.setPublished(date);
-        Assert.assertEquals(date, vuln.getPublished());
+        Assertions.assertEquals(date, vuln.getPublished());
     }
 
     @Test
-    public void testUpdated() {
+    void testUpdated() {
         Date date = new Date();
         Vulnerability vuln = new Vulnerability();
         vuln.setUpdated(date);
-        Assert.assertEquals(date, vuln.getUpdated());
+        Assertions.assertEquals(date, vuln.getUpdated());
     } 
 
     @Test
-    public void testVulnerableVersions() {
+    void testVulnerableVersions() {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnerableVersions("Vulnerable versions");
-        Assert.assertEquals("Vulnerable versions", vuln.getVulnerableVersions());
+        Assertions.assertEquals("Vulnerable versions", vuln.getVulnerableVersions());
     } 
 
     @Test
-    public void testPatchedVersions() {
+    void testPatchedVersions() {
         Vulnerability vuln = new Vulnerability();
         vuln.setPatchedVersions("Patched versions");
-        Assert.assertEquals("Patched versions", vuln.getPatchedVersions());
+        Assertions.assertEquals("Patched versions", vuln.getPatchedVersions());
     } 
 
     @Test
-    public void testSource() {
+    void testSource() {
         Vulnerability vuln = new Vulnerability();
         vuln.setSource("My source");
-        Assert.assertEquals("My source", vuln.getSource());
+        Assertions.assertEquals("My source", vuln.getSource());
         vuln.setSource(Vulnerability.Source.NPM);
-        Assert.assertEquals("NPM", vuln.getSource());
+        Assertions.assertEquals("NPM", vuln.getSource());
     } 
 
     @Test
-    public void testTitle() {
+    void testTitle() {
         Vulnerability vuln = new Vulnerability();
         vuln.setTitle("My title");
-        Assert.assertEquals("My title", vuln.getTitle());
+        Assertions.assertEquals("My title", vuln.getTitle());
     } 
 
     @Test
-    public void testSubTitle() {
+    void testSubTitle() {
         Vulnerability vuln = new Vulnerability();
         vuln.setSubTitle("My subtitle");
-        Assert.assertEquals("My subtitle", vuln.getSubTitle());
+        Assertions.assertEquals("My subtitle", vuln.getSubTitle());
     } 
 
     @Test
-    public void testCwe() {
+    void testCwe() {
         Vulnerability vuln = new Vulnerability();
         List<Integer> cwes = List.of(80);
         vuln.setCwes(cwes);
-        Assert.assertEquals(cwes.get(0), vuln.getCwes().get(0));
+        Assertions.assertEquals(cwes.get(0), vuln.getCwes().get(0));
     } 
 
     @Test
-    public void testCvssV2BaseScore() {
+    void testCvssV2BaseScore() {
         Vulnerability vuln = new Vulnerability();
         vuln.setCvssV2BaseScore(new BigDecimal(5.0));
-        Assert.assertEquals(new BigDecimal(5.0), vuln.getCvssV2BaseScore());
+        Assertions.assertEquals(new BigDecimal(5.0), vuln.getCvssV2BaseScore());
     } 
 
     @Test
-    public void testCvssV2ImpactSubScore() {
+    void testCvssV2ImpactSubScore() {
         Vulnerability vuln = new Vulnerability();
         vuln.setCvssV2ImpactSubScore(new BigDecimal(5.1));
-        Assert.assertEquals(new BigDecimal(5.1), vuln.getCvssV2ImpactSubScore());
+        Assertions.assertEquals(new BigDecimal(5.1), vuln.getCvssV2ImpactSubScore());
     } 
 
     @Test
-    public void testCvssV2ExploitabilitySubScore() {
+    void testCvssV2ExploitabilitySubScore() {
         Vulnerability vuln = new Vulnerability();
         vuln.setCvssV2ExploitabilitySubScore(new BigDecimal(5.2));
-        Assert.assertEquals(new BigDecimal(5.2), vuln.getCvssV2ExploitabilitySubScore());
+        Assertions.assertEquals(new BigDecimal(5.2), vuln.getCvssV2ExploitabilitySubScore());
     }
 
     @Test
-    public void testCvssV2Vector() {
+    void testCvssV2Vector() {
         Vulnerability vuln = new Vulnerability();
         vuln.setCvssV2Vector("CVSS vector");
-        Assert.assertEquals("CVSS vector", vuln.getCvssV2Vector());
+        Assertions.assertEquals("CVSS vector", vuln.getCvssV2Vector());
     }
 
     @Test
-    public void testCvssV3BaseScore() {
+    void testCvssV3BaseScore() {
         Vulnerability vuln = new Vulnerability();
         vuln.setCvssV3BaseScore(new BigDecimal(6.0));
-        Assert.assertEquals(new BigDecimal(6.0), vuln.getCvssV3BaseScore());
+        Assertions.assertEquals(new BigDecimal(6.0), vuln.getCvssV3BaseScore());
     } 
 
     @Test
-    public void testCvssV3ImpactSubScore() {
+    void testCvssV3ImpactSubScore() {
         Vulnerability vuln = new Vulnerability();
         vuln.setCvssV3ImpactSubScore(new BigDecimal(6.1));
-        Assert.assertEquals(new BigDecimal(6.1), vuln.getCvssV3ImpactSubScore());
+        Assertions.assertEquals(new BigDecimal(6.1), vuln.getCvssV3ImpactSubScore());
     } 
 
     @Test
-    public void testCvssV3ExploitabilitySubScore() {
+    void testCvssV3ExploitabilitySubScore() {
         Vulnerability vuln = new Vulnerability();
         vuln.setCvssV3ExploitabilitySubScore(new BigDecimal(6.2));
-        Assert.assertEquals(new BigDecimal(6.2), vuln.getCvssV3ExploitabilitySubScore());
+        Assertions.assertEquals(new BigDecimal(6.2), vuln.getCvssV3ExploitabilitySubScore());
     } 
 
     @Test
-    public void testCvssV3Vector() {
+    void testCvssV3Vector() {
         Vulnerability vuln = new Vulnerability();
         vuln.setCvssV3Vector("CVSS vector");
-        Assert.assertEquals("CVSS vector", vuln.getCvssV3Vector());
+        Assertions.assertEquals("CVSS vector", vuln.getCvssV3Vector());
     }
 
     @Test
-    public void testComponents() {
+    void testComponents() {
         List<Component> components = new ArrayList<>();
         Component component = new Component();
         components.add(component);
         Vulnerability vuln = new Vulnerability();
         vuln.setComponents(components);
-        Assert.assertEquals(1, vuln.getComponents().size());
-        Assert.assertEquals(component, vuln.getComponents().get(0));
+        Assertions.assertEquals(1, vuln.getComponents().size());
+        Assertions.assertEquals(component, vuln.getComponents().get(0));
     } 
 
     @Test
-    public void testUuid() {
+    void testUuid() {
         UUID uuid = UUID.randomUUID();
         Vulnerability vuln = new Vulnerability();
         vuln.setUuid(uuid);
-        Assert.assertEquals(uuid.toString(), vuln.getUuid().toString());
+        Assertions.assertEquals(uuid.toString(), vuln.getUuid().toString());
     }
 } 

--- a/src/test/java/org/dependencytrack/model/VulnerableSoftwareTest.java
+++ b/src/test/java/org/dependencytrack/model/VulnerableSoftwareTest.java
@@ -18,36 +18,36 @@
  */
 package org.dependencytrack.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-public class VulnerableSoftwareTest {
+class VulnerableSoftwareTest {
 
     @Test
-    public void testId() {
+    void testId() {
         VulnerableSoftware vs = new VulnerableSoftware();
         vs.setId(111L);
-        Assert.assertEquals(111L, vs.getId());
+        Assertions.assertEquals(111L, vs.getId());
     }
 
     @Test
-    public void testCpe22() {
+    void testCpe22() {
         VulnerableSoftware vs = new VulnerableSoftware();
         vs.setCpe22("cpe:/a:gimp:gimp:2.10.0");
-        Assert.assertEquals("cpe:/a:gimp:gimp:2.10.0", vs.getCpe22());
+        Assertions.assertEquals("cpe:/a:gimp:gimp:2.10.0", vs.getCpe22());
     }
 
     @Test
-    public void testCpe23() {
+    void testCpe23() {
         VulnerableSoftware vs = new VulnerableSoftware();
         vs.setCpe23("cpe:2.3:a:gimp:gimp:2.10.0:*:*:*:*:*:*:*");
-        Assert.assertEquals("cpe:2.3:a:gimp:gimp:2.10.0:*:*:*:*:*:*:*", vs.getCpe23());
+        Assertions.assertEquals("cpe:2.3:a:gimp:gimp:2.10.0:*:*:*:*:*:*:*", vs.getCpe23());
     }
 
     @Test
-    public void testVulnerableSoftwareFields() {
+    void testVulnerableSoftwareFields() {
         VulnerableSoftware vs = new VulnerableSoftware();
         vs.setPart("a");
         vs.setVendor("acme");
@@ -65,29 +65,29 @@ public class VulnerableSoftwareTest {
         vs.setVersionStartExcluding("333");
         vs.setVersionStartIncluding("444");
         vs.setVulnerable(true);
-        Assert.assertEquals("a", vs.getPart());
-        Assert.assertEquals("acme", vs.getVendor());
-        Assert.assertEquals("cool-product", vs.getProduct());
-        Assert.assertEquals("1.1.0", vs.getVersion());
-        Assert.assertEquals("*", vs.getUpdate());
-        Assert.assertEquals("*", vs.getEdition());
-        Assert.assertEquals("*", vs.getLanguage());
-        Assert.assertEquals("*", vs.getSwEdition());
-        Assert.assertEquals("*", vs.getTargetSw());
-        Assert.assertEquals("*", vs.getTargetHw());
-        Assert.assertEquals("*", vs.getOther());
-        Assert.assertEquals("111", vs.getVersionEndExcluding());
-        Assert.assertEquals("222", vs.getVersionEndIncluding());
-        Assert.assertEquals("333", vs.getVersionStartExcluding());
-        Assert.assertEquals("444", vs.getVersionStartIncluding());
-        Assert.assertTrue(vs.isVulnerable());
+        Assertions.assertEquals("a", vs.getPart());
+        Assertions.assertEquals("acme", vs.getVendor());
+        Assertions.assertEquals("cool-product", vs.getProduct());
+        Assertions.assertEquals("1.1.0", vs.getVersion());
+        Assertions.assertEquals("*", vs.getUpdate());
+        Assertions.assertEquals("*", vs.getEdition());
+        Assertions.assertEquals("*", vs.getLanguage());
+        Assertions.assertEquals("*", vs.getSwEdition());
+        Assertions.assertEquals("*", vs.getTargetSw());
+        Assertions.assertEquals("*", vs.getTargetHw());
+        Assertions.assertEquals("*", vs.getOther());
+        Assertions.assertEquals("111", vs.getVersionEndExcluding());
+        Assertions.assertEquals("222", vs.getVersionEndIncluding());
+        Assertions.assertEquals("333", vs.getVersionStartExcluding());
+        Assertions.assertEquals("444", vs.getVersionStartIncluding());
+        Assertions.assertTrue(vs.isVulnerable());
     }
 
     @Test
-    public void testUuid() {
+    void testUuid() {
         UUID uuid = UUID.randomUUID();
         VulnerableSoftware vs = new VulnerableSoftware();
         vs.setUuid(uuid);
-        Assert.assertEquals(uuid.toString(), vs.getUuid().toString());
+        Assertions.assertEquals(uuid.toString(), vs.getUuid().toString());
     }
 }

--- a/src/test/java/org/dependencytrack/model/validation/SpdxExpressionValidatorTest.java
+++ b/src/test/java/org/dependencytrack/model/validation/SpdxExpressionValidatorTest.java
@@ -18,44 +18,45 @@
  */
 package org.dependencytrack.model.validation;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
+
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SpdxExpressionValidatorTest {
+class SpdxExpressionValidatorTest {
 
     private Validator validator;
 
     private record TestRecord(@ValidSpdxExpression String expression) {
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
         validator = validatorFactory.getValidator();
     }
 
     @Test
-    public void testWithValidExpression() {
+    void testWithValidExpression() {
         final Set<ConstraintViolation<TestRecord>> violations = validator.validate(new TestRecord("Apache-2.0 OR MIT"));
         assertThat(violations).isEmpty();
     }
 
     @Test
-    public void testWithInvalidExpression() {
+    void testWithInvalidExpression() {
         final Set<ConstraintViolation<TestRecord>> violations = validator.validate(new TestRecord("(Apache-2.0"));
         assertThat(violations).isNotEmpty();
     }
 
     @Test
-    public void testWithNullExpression() {
+    void testWithNullExpression() {
         final Set<ConstraintViolation<TestRecord>> violations = validator.validate(new TestRecord(null));
         assertThat(violations).isEmpty();
     }

--- a/src/test/java/org/dependencytrack/notification/NotificationConstantsTest.java
+++ b/src/test/java/org/dependencytrack/notification/NotificationConstantsTest.java
@@ -18,34 +18,34 @@
  */
 package org.dependencytrack.notification;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class NotificationConstantsTest {
+class NotificationConstantsTest {
 
     @Test
-    public void testConstants() {
-        Assert.assertEquals("Notification Test", NotificationConstants.Title.NOTIFICATION_TEST);
-        Assert.assertEquals("NVD Mirroring", NotificationConstants.Title.NVD_MIRROR);
-        Assert.assertEquals("NPM Advisory Mirroring", NotificationConstants.Title.NPM_ADVISORY_MIRROR);
-        Assert.assertEquals("VulnDB Mirroring", NotificationConstants.Title.VULNDB_MIRROR);
-        Assert.assertEquals("Component Indexing Service", NotificationConstants.Title.COMPONENT_INDEXER);
-        Assert.assertEquals("License Indexing Service", NotificationConstants.Title.LICENSE_INDEXER);
-        Assert.assertEquals("Project Indexing Service", NotificationConstants.Title.PROJECT_INDEXER);
-        Assert.assertEquals("Vulnerability Indexing Service", NotificationConstants.Title.VULNERABILITY_INDEXER);
-        Assert.assertEquals("Core Indexing Services", NotificationConstants.Title.CORE_INDEXING_SERVICES);
-        Assert.assertEquals("File System Error", NotificationConstants.Title.FILE_SYSTEM_ERROR);
-        Assert.assertEquals("Repository Error", NotificationConstants.Title.REPO_ERROR);
-        Assert.assertEquals("Integration Error", NotificationConstants.Title.INTEGRATION_ERROR);
-        Assert.assertEquals("New Vulnerability Identified", NotificationConstants.Title.NEW_VULNERABILITY);
-        Assert.assertEquals("Vulnerable Dependency Introduced", NotificationConstants.Title.NEW_VULNERABLE_DEPENDENCY);
-        Assert.assertEquals("Analysis Decision: Exploitable", NotificationConstants.Title.ANALYSIS_DECISION_EXPLOITABLE);
-        Assert.assertEquals("Analysis Decision: In Triage", NotificationConstants.Title.ANALYSIS_DECISION_IN_TRIAGE);
-        Assert.assertEquals("Analysis Decision: False Positive", NotificationConstants.Title.ANALYSIS_DECISION_FALSE_POSITIVE);
-        Assert.assertEquals("Analysis Decision: Not Affected", NotificationConstants.Title.ANALYSIS_DECISION_NOT_AFFECTED);
-        Assert.assertEquals("Analysis Decision: Marking Finding as NOT SET", NotificationConstants.Title.ANALYSIS_DECISION_NOT_SET);
-        Assert.assertEquals("Analysis Decision: Finding Suppressed", NotificationConstants.Title.ANALYSIS_DECISION_SUPPRESSED);
-        Assert.assertEquals("Analysis Decision: Finding UnSuppressed", NotificationConstants.Title.ANALYSIS_DECISION_UNSUPPRESSED);
-        Assert.assertEquals("Analysis Decision: Finding Resolved", NotificationConstants.Title.ANALYSIS_DECISION_RESOLVED);
+    void testConstants() {
+        Assertions.assertEquals("Notification Test", NotificationConstants.Title.NOTIFICATION_TEST);
+        Assertions.assertEquals("NVD Mirroring", NotificationConstants.Title.NVD_MIRROR);
+        Assertions.assertEquals("NPM Advisory Mirroring", NotificationConstants.Title.NPM_ADVISORY_MIRROR);
+        Assertions.assertEquals("VulnDB Mirroring", NotificationConstants.Title.VULNDB_MIRROR);
+        Assertions.assertEquals("Component Indexing Service", NotificationConstants.Title.COMPONENT_INDEXER);
+        Assertions.assertEquals("License Indexing Service", NotificationConstants.Title.LICENSE_INDEXER);
+        Assertions.assertEquals("Project Indexing Service", NotificationConstants.Title.PROJECT_INDEXER);
+        Assertions.assertEquals("Vulnerability Indexing Service", NotificationConstants.Title.VULNERABILITY_INDEXER);
+        Assertions.assertEquals("Core Indexing Services", NotificationConstants.Title.CORE_INDEXING_SERVICES);
+        Assertions.assertEquals("File System Error", NotificationConstants.Title.FILE_SYSTEM_ERROR);
+        Assertions.assertEquals("Repository Error", NotificationConstants.Title.REPO_ERROR);
+        Assertions.assertEquals("Integration Error", NotificationConstants.Title.INTEGRATION_ERROR);
+        Assertions.assertEquals("New Vulnerability Identified", NotificationConstants.Title.NEW_VULNERABILITY);
+        Assertions.assertEquals("Vulnerable Dependency Introduced", NotificationConstants.Title.NEW_VULNERABLE_DEPENDENCY);
+        Assertions.assertEquals("Analysis Decision: Exploitable", NotificationConstants.Title.ANALYSIS_DECISION_EXPLOITABLE);
+        Assertions.assertEquals("Analysis Decision: In Triage", NotificationConstants.Title.ANALYSIS_DECISION_IN_TRIAGE);
+        Assertions.assertEquals("Analysis Decision: False Positive", NotificationConstants.Title.ANALYSIS_DECISION_FALSE_POSITIVE);
+        Assertions.assertEquals("Analysis Decision: Not Affected", NotificationConstants.Title.ANALYSIS_DECISION_NOT_AFFECTED);
+        Assertions.assertEquals("Analysis Decision: Marking Finding as NOT SET", NotificationConstants.Title.ANALYSIS_DECISION_NOT_SET);
+        Assertions.assertEquals("Analysis Decision: Finding Suppressed", NotificationConstants.Title.ANALYSIS_DECISION_SUPPRESSED);
+        Assertions.assertEquals("Analysis Decision: Finding UnSuppressed", NotificationConstants.Title.ANALYSIS_DECISION_UNSUPPRESSED);
+        Assertions.assertEquals("Analysis Decision: Finding Resolved", NotificationConstants.Title.ANALYSIS_DECISION_RESOLVED);
     }
 }

--- a/src/test/java/org/dependencytrack/notification/NotificationGroupTest.java
+++ b/src/test/java/org/dependencytrack/notification/NotificationGroupTest.java
@@ -18,27 +18,27 @@
  */
 package org.dependencytrack.notification;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class NotificationGroupTest {
+class NotificationGroupTest {
 
     @Test
-    public void testEnums() {
+    void testEnums() {
         // System Groups
-        Assert.assertEquals("CONFIGURATION", NotificationGroup.CONFIGURATION.name());
-        Assert.assertEquals("DATASOURCE_MIRRORING", NotificationGroup.DATASOURCE_MIRRORING.name());
-        Assert.assertEquals("REPOSITORY", NotificationGroup.REPOSITORY.name());
-        Assert.assertEquals("ANALYZER", NotificationGroup.ANALYZER.name());
-        Assert.assertEquals("INTEGRATION", NotificationGroup.INTEGRATION.name());
-        Assert.assertEquals("INDEXING_SERVICE", NotificationGroup.INDEXING_SERVICE.name());
+        Assertions.assertEquals("CONFIGURATION", NotificationGroup.CONFIGURATION.name());
+        Assertions.assertEquals("DATASOURCE_MIRRORING", NotificationGroup.DATASOURCE_MIRRORING.name());
+        Assertions.assertEquals("REPOSITORY", NotificationGroup.REPOSITORY.name());
+        Assertions.assertEquals("ANALYZER", NotificationGroup.ANALYZER.name());
+        Assertions.assertEquals("INTEGRATION", NotificationGroup.INTEGRATION.name());
+        Assertions.assertEquals("INDEXING_SERVICE", NotificationGroup.INDEXING_SERVICE.name());
         // Portfolio Groups
-        Assert.assertEquals("NEW_VULNERABILITY", NotificationGroup.NEW_VULNERABILITY.name());
-        Assert.assertEquals("NEW_VULNERABLE_DEPENDENCY", NotificationGroup.NEW_VULNERABLE_DEPENDENCY.name());
-        //Assert.assertEquals("NEW_OUTDATED_COMPONENT", NotificationGroup.NEW_OUTDATED_COMPONENT.name());
-        //Assert.assertEquals("FIXED_VULNERABILITY", NotificationGroup.FIXED_VULNERABILITY.name());
-        //Assert.assertEquals("FIXED_OUTDATED", NotificationGroup.FIXED_OUTDATED.name());
-        //Assert.assertEquals("GLOBAL_AUDIT_CHANGE", NotificationGroup.GLOBAL_AUDIT_CHANGE.name());
-        Assert.assertEquals("PROJECT_AUDIT_CHANGE", NotificationGroup.PROJECT_AUDIT_CHANGE.name());
+        Assertions.assertEquals("NEW_VULNERABILITY", NotificationGroup.NEW_VULNERABILITY.name());
+        Assertions.assertEquals("NEW_VULNERABLE_DEPENDENCY", NotificationGroup.NEW_VULNERABLE_DEPENDENCY.name());
+        //Assertions.assertEquals("NEW_OUTDATED_COMPONENT", NotificationGroup.NEW_OUTDATED_COMPONENT.name());
+        //Assertions.assertEquals("FIXED_VULNERABILITY", NotificationGroup.FIXED_VULNERABILITY.name());
+        //Assertions.assertEquals("FIXED_OUTDATED", NotificationGroup.FIXED_OUTDATED.name());
+        //Assertions.assertEquals("GLOBAL_AUDIT_CHANGE", NotificationGroup.GLOBAL_AUDIT_CHANGE.name());
+        Assertions.assertEquals("PROJECT_AUDIT_CHANGE", NotificationGroup.PROJECT_AUDIT_CHANGE.name());
     }
 }

--- a/src/test/java/org/dependencytrack/notification/NotificationRouterTest.java
+++ b/src/test/java/org/dependencytrack/notification/NotificationRouterTest.java
@@ -42,8 +42,8 @@ import org.dependencytrack.notification.vo.NewVulnerableDependency;
 import org.dependencytrack.notification.vo.PolicyViolationIdentified;
 import org.dependencytrack.notification.vo.VexConsumedOrProcessed;
 import org.dependencytrack.notification.vo.ViolationAnalysisDecisionChange;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import jakarta.json.JsonObject;
 import java.util.ArrayList;
@@ -53,37 +53,37 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class NotificationRouterTest extends PersistenceCapableTest {
+class NotificationRouterTest extends PersistenceCapableTest {
 
     @Test
-    public void testNullNotification() {
+    void testNullNotification() {
         Notification notification = null;
         NotificationRouter router = new NotificationRouter();
         List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
-        Assert.assertEquals(0, rules.size());
+        Assertions.assertEquals(0, rules.size());
     }
 
     @Test
-    public void testInvalidNotification() {
+    void testInvalidNotification() {
         Notification notification = new Notification();
         NotificationRouter router = new NotificationRouter();
         List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
-        Assert.assertEquals(0, rules.size());
+        Assertions.assertEquals(0, rules.size());
     }
 
     @Test
-    public void testNoRules() {
+    void testNoRules() {
         Notification notification = new Notification();
         notification.setScope(NotificationScope.PORTFOLIO.name());
         notification.setGroup(NotificationGroup.NEW_VULNERABILITY.name());
         notification.setLevel(NotificationLevel.INFORMATIONAL);
         NotificationRouter router = new NotificationRouter();
         List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
-        Assert.assertEquals(0, rules.size());
+        Assertions.assertEquals(0, rules.size());
     }
 
     @Test
-    public void testValidMatchingRule() {
+    void testValidMatchingRule() {
         NotificationPublisher publisher = createSlackPublisher();
         // Creates a new rule and defines when the rule should be triggered (notifyOn)
         NotificationRule rule = qm.createNotificationRule("Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -107,11 +107,11 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
         List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
-        Assert.assertEquals(1, rules.size());
+        Assertions.assertEquals(1, rules.size());
     }
 
     @Test
-    public void testValidMatchingProjectLimitingRule() {
+    void testValidMatchingProjectLimitingRule() {
         NotificationPublisher publisher = createSlackPublisher();
         // Creates a new rule and defines when the rule should be triggered (notifyOn)
         NotificationRule rule = qm.createNotificationRule("Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -141,11 +141,11 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
         List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
-        Assert.assertEquals(1, rules.size());
+        Assertions.assertEquals(1, rules.size());
     }
 
     @Test
-    public void testValidNonMatchingProjectLimitingRule() {
+    void testValidNonMatchingProjectLimitingRule() {
         NotificationPublisher publisher = createSlackPublisher();
         // Creates a new rule and defines when the rule should be triggered (notifyOn)
         NotificationRule rule = qm.createNotificationRule("Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -176,11 +176,11 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
         List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
-        Assert.assertEquals(0, rules.size());
+        Assertions.assertEquals(0, rules.size());
     }
 
     @Test
-    public void testValidMatchingRuleAndPublisherInform()  {
+    void testValidMatchingRuleAndPublisherInform()  {
         NotificationPublisher publisher = createMockPublisher();
         // Creates a new rule and defines when the rule should be triggered (notifyOn)
         NotificationRule rule = qm.createNotificationRule("Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -206,13 +206,13 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         NotificationRouter router = new NotificationRouter();
         router.inform(notification);
         JsonObject providedConfig = MockPublisher.getConfig();
-        Assert.assertEquals(MockPublisher.MOCK_PUBLISHER_TEMPLATE_CONTENT, providedConfig.getString(Publisher.CONFIG_TEMPLATE_KEY));
-        Assert.assertEquals(MockPublisher.MOCK_PUBLISHER_TEMPLATE_MIME_TYPE, providedConfig.getString(Publisher.CONFIG_TEMPLATE_MIME_TYPE_KEY));
-        Assert.assertEquals("testDestination", providedConfig.getString(Publisher.CONFIG_DESTINATION));
+        Assertions.assertEquals(MockPublisher.MOCK_PUBLISHER_TEMPLATE_CONTENT, providedConfig.getString(Publisher.CONFIG_TEMPLATE_KEY));
+        Assertions.assertEquals(MockPublisher.MOCK_PUBLISHER_TEMPLATE_MIME_TYPE, providedConfig.getString(Publisher.CONFIG_TEMPLATE_MIME_TYPE_KEY));
+        Assertions.assertEquals("testDestination", providedConfig.getString(Publisher.CONFIG_DESTINATION));
     }
 
     @Test
-    public void testValidMatchingProjectLimitingRuleAndPublisherInform()  {
+    void testValidMatchingProjectLimitingRuleAndPublisherInform()  {
         NotificationPublisher publisher = createMockPublisher();
         // Creates a new rule and defines when the rule should be triggered (notifyOn)
         NotificationRule rule = qm.createNotificationRule("Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -246,17 +246,17 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         NotificationRouter router = new NotificationRouter();
         router.inform(notification);
         JsonObject providedConfig = MockPublisher.getConfig();
-        Assert.assertEquals(MockPublisher.MOCK_PUBLISHER_TEMPLATE_CONTENT, providedConfig.getString(Publisher.CONFIG_TEMPLATE_KEY));
-        Assert.assertEquals(MockPublisher.MOCK_PUBLISHER_TEMPLATE_MIME_TYPE, providedConfig.getString(Publisher.CONFIG_TEMPLATE_MIME_TYPE_KEY));
-        Assert.assertEquals("testDestination", providedConfig.getString(Publisher.CONFIG_DESTINATION));
+        Assertions.assertEquals(MockPublisher.MOCK_PUBLISHER_TEMPLATE_CONTENT, providedConfig.getString(Publisher.CONFIG_TEMPLATE_KEY));
+        Assertions.assertEquals(MockPublisher.MOCK_PUBLISHER_TEMPLATE_MIME_TYPE, providedConfig.getString(Publisher.CONFIG_TEMPLATE_MIME_TYPE_KEY));
+        Assertions.assertEquals("testDestination", providedConfig.getString(Publisher.CONFIG_DESTINATION));
         Notification providedNotification = MockPublisher.getNotification();
         NewVulnerabilityIdentified providedSubject = (NewVulnerabilityIdentified) providedNotification.getSubject();
-        Assert.assertEquals(1, providedSubject.getAffectedProjects().size());
-        Assert.assertEquals(firstProject.getName(), providedSubject.getAffectedProjects().toArray(new Project[1])[0].getName());
+        Assertions.assertEquals(1, providedSubject.getAffectedProjects().size());
+        Assertions.assertEquals(firstProject.getName(), providedSubject.getAffectedProjects().toArray(new Project[1])[0].getName());
     }
 
     @Test
-    public void testValidNonMatchingRule() {
+    void testValidNonMatchingRule() {
         NotificationPublisher publisher = createSlackPublisher();
         // Creates a new rule and defines when the rule should be triggered (notifyOn)
         NotificationRule rule = qm.createNotificationRule("Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -280,11 +280,11 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
         List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
-        Assert.assertEquals(0, rules.size());
+        Assertions.assertEquals(0, rules.size());
     }
 
     @Test
-    public void testRuleLevelEqual() {
+    void testRuleLevelEqual() {
         final NotificationPublisher publisher = createSlackPublisher();
         final NotificationRule rule = qm.createNotificationRule("Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.WARNING, publisher);
         rule.setNotifyOn(Set.of(NotificationGroup.NEW_VULNERABILITY));
@@ -299,7 +299,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testRuleLevelBelow() {
+    void testRuleLevelBelow() {
         final NotificationPublisher publisher = createSlackPublisher();
         final NotificationRule rule = qm.createNotificationRule("Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.WARNING, publisher);
         rule.setNotifyOn(Set.of(NotificationGroup.NEW_VULNERABILITY));
@@ -314,7 +314,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testRuleLevelAbove() {
+    void testRuleLevelAbove() {
         final NotificationPublisher publisher = createSlackPublisher();
 
         final NotificationRule rule = qm.createNotificationRule("Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.WARNING, publisher);
@@ -330,7 +330,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testDisabledRule() {
+    void testDisabledRule() {
         final NotificationPublisher publisher = createSlackPublisher();
 
         final NotificationRule rule = qm.createNotificationRule("Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -347,7 +347,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testNewVulnerabilityIdentifiedLimitedToProject() {
+    void testNewVulnerabilityIdentifiedLimitedToProject() {
         final Project projectA = qm.createProject("Project A", null, "1.0", null, null, null, true, false);
         var componentA = new Component();
         componentA.setProject(projectA);
@@ -381,7 +381,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testNewVulnerableDependencyLimitedToProject() {
+    void testNewVulnerableDependencyLimitedToProject() {
         final Project projectA = qm.createProject("Project A", null, "1.0", null, null, null, true, false);
         var componentA = new Component();
         componentA.setProject(projectA);
@@ -415,7 +415,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testBomConsumedOrProcessedLimitedToProject() {
+    void testBomConsumedOrProcessedLimitedToProject() {
         final Project projectA = qm.createProject("Project A", null, "1.0", null, null, null, true, false);
         final Project projectB = qm.createProject("Project B", null, "1.0", null, null, null, true, false);
 
@@ -440,7 +440,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testBomProcessingFailedLimitedToProject() {
+    void testBomProcessingFailedLimitedToProject() {
         final Project projectA = qm.createProject("Project A", null, "1.0", null, null, null, true, false);
         final Project projectB = qm.createProject("Project B", null, "1.0", null, null, null, true, false);
 
@@ -465,7 +465,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testBomValidationFailedLimitedToProject() {
+    void testBomValidationFailedLimitedToProject() {
         final Project projectA = qm.createProject("Project A", null, "1.0", null, null, null, true, false);
         final Project projectB = qm.createProject("Project B", null, "1.0", null, null, null, true, false);
 
@@ -490,7 +490,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testVexConsumedOrProcessedLimitedToProject() {
+    void testVexConsumedOrProcessedLimitedToProject() {
         final Project projectA = qm.createProject("Project A", null, "1.0", null, null, null, true, false);
         final Project projectB = qm.createProject("Project B", null, "1.0", null, null, null, true, false);
 
@@ -515,7 +515,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testPolicyViolationIdentifiedLimitedToProject() {
+    void testPolicyViolationIdentifiedLimitedToProject() {
         final Project projectA = qm.createProject("Project A", null, "1.0", null, null, null, true, false);
         var componentA = new Component();
         componentA.setProject(projectA);
@@ -549,7 +549,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAnalysisDecisionChangeLimitedToProject() {
+    void testAnalysisDecisionChangeLimitedToProject() {
         final Project projectA = qm.createProject("Project A", null, "1.0", null, null, null, true, false);
         final Project projectB = qm.createProject("Project B", null, "1.0", null, null, null, true, false);
 
@@ -574,7 +574,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testViolationAnalysisDecisionChangeLimitedToProject() {
+    void testViolationAnalysisDecisionChangeLimitedToProject() {
         final Project projectA = qm.createProject("Project A", null, "1.0", null, null, null, true, false);
         var componentA = new Component();
         componentA.setProject(projectA);
@@ -608,7 +608,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAffectedChild() {
+    void testAffectedChild() {
         NotificationPublisher publisher = createSlackPublisher();
         // Creates a new rule and defines when the rule should be triggered (notifyOn)
         NotificationRule rule = qm.createNotificationRule("Matching Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -642,12 +642,12 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
         List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
-        Assert.assertTrue(rule.isNotifyChildren());
-        Assert.assertEquals(1, rules.size());
+        Assertions.assertTrue(rule.isNotifyChildren());
+        Assertions.assertEquals(1, rules.size());
     }
 
     @Test
-    public void testAffectedChildNotifyChildrenDisabled() {
+    void testAffectedChildNotifyChildrenDisabled() {
         NotificationPublisher publisher = createSlackPublisher();
         // Creates a new rule and defines when the rule should be triggered (notifyOn)
         NotificationRule rule = qm.createNotificationRule("Matching Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -682,12 +682,12 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
         List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
-        Assert.assertFalse(rule.isNotifyChildren());
-        Assert.assertEquals(0, rules.size());
+        Assertions.assertFalse(rule.isNotifyChildren());
+        Assertions.assertEquals(0, rules.size());
     }
 
     @Test
-    public void testAffectedInactiveChild() {
+    void testAffectedInactiveChild() {
         NotificationPublisher publisher = createSlackPublisher();
         // Creates a new rule and defines when the rule should be triggered (notifyOn)
         NotificationRule rule = qm.createNotificationRule("Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -721,12 +721,12 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
         List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
-        Assert.assertTrue(rule.isNotifyChildren());
-        Assert.assertEquals(0, rules.size());
+        Assertions.assertTrue(rule.isNotifyChildren());
+        Assertions.assertEquals(0, rules.size());
     }
 
     @Test
-    public void testValidMatchingTagLimitingRule() {
+    void testValidMatchingTagLimitingRule() {
         NotificationPublisher publisher = createSlackPublisher();
         // Creates a new rule and defines when the rule should be triggered (notifyOn)
         NotificationRule rule = qm.createNotificationRule("Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -756,11 +756,11 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         // Ok, let's test this
         NotificationRouter router = new NotificationRouter();
         List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
-        Assert.assertEquals(1, rules.size());
+        Assertions.assertEquals(1, rules.size());
     }
 
     @Test
-    public void testValidNonMatchingTagLimitingRule() {
+    void testValidNonMatchingTagLimitingRule() {
         NotificationPublisher publisher = createSlackPublisher();
         // Creates a new rule and defines when the rule should be triggered (notifyOn)
         NotificationRule rule = qm.createNotificationRule("Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -793,11 +793,11 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         NotificationRouter router = new NotificationRouter();
         List<NotificationRule> rules = router.resolveRules(PublishContext.from(notification), notification);
         // Affected project is not tagged, rule should be empty
-        Assert.assertEquals(0, rules.size());
+        Assertions.assertEquals(0, rules.size());
     }
 
     @Test
-    public void testValidMatchingProjectAndTagLimitingRule() {
+    void testValidMatchingProjectAndTagLimitingRule() {
         NotificationPublisher publisher = createMockPublisher();
         // Creates a new rule and defines when the rule should be triggered (notifyOn)
         NotificationRule rule = qm.createNotificationRule("Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -835,7 +835,7 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         // Affected project is not tagged, rules should be empty
         Notification providedNotification = MockPublisher.getNotification();
         NewVulnerabilityIdentified providedSubject = (NewVulnerabilityIdentified) providedNotification.getSubject();
-        Assert.assertEquals(2, providedSubject.getAffectedProjects().size());
+        Assertions.assertEquals(2, providedSubject.getAffectedProjects().size());
     }
 
     private NotificationPublisher createSlackPublisher() {

--- a/src/test/java/org/dependencytrack/notification/NotificationScopeTest.java
+++ b/src/test/java/org/dependencytrack/notification/NotificationScopeTest.java
@@ -18,14 +18,14 @@
  */
 package org.dependencytrack.notification;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class NotificationScopeTest {
+class NotificationScopeTest {
 
     @Test
-    public void testEnums() {
-        Assert.assertEquals("SYSTEM", NotificationScope.SYSTEM.name());
-        Assert.assertEquals("PORTFOLIO", NotificationScope.PORTFOLIO.name());
+    void testEnums() {
+        Assertions.assertEquals("SYSTEM", NotificationScope.SYSTEM.name());
+        Assertions.assertEquals("PORTFOLIO", NotificationScope.PORTFOLIO.name());
     }
 }

--- a/src/test/java/org/dependencytrack/notification/NotificationSubsystemInitializerTest.java
+++ b/src/test/java/org/dependencytrack/notification/NotificationSubsystemInitializerTest.java
@@ -20,20 +20,20 @@ package org.dependencytrack.notification;
 
 import alpine.notification.Notification;
 import alpine.notification.NotificationService;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletContextEvent;
 
 import static org.mockito.Mockito.mock;
 
-public class NotificationSubsystemInitializerTest {
+class NotificationSubsystemInitializerTest {
 
     @Test
-    public void testInitialization() {
+    void testInitialization() {
         NotificationSubsystemInitializer listener = new NotificationSubsystemInitializer();
         listener.contextInitialized(new ServletContextEvent(mock(ServletContext.class)));
-        Assert.assertTrue(NotificationService.getInstance().hasSubscriptions(new Notification()));
+        Assertions.assertTrue(NotificationService.getInstance().hasSubscriptions(new Notification()));
     }
 }

--- a/src/test/java/org/dependencytrack/notification/publisher/AbstractWebhookPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/AbstractWebhookPublisherTest.java
@@ -18,30 +18,23 @@
  */
 package org.dependencytrack.notification.publisher;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import org.junit.Before;
-import org.junit.Rule;
-
 import jakarta.json.JsonObjectBuilder;
+import org.junit.jupiter.api.BeforeEach;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.dependencytrack.model.ConfigPropertyConstants.GENERAL_BASE_URL;
 
 public abstract class AbstractWebhookPublisherTest<T extends AbstractWebhookPublisher> extends AbstractPublisherTest<T> {
-
-    @Rule
-    public WireMockRule wireMock = new WireMockRule(options().dynamicPort());
 
     AbstractWebhookPublisherTest(final DefaultNotificationPublishers publisher, final T publisherInstance) {
         super(publisher, publisherInstance);
     }
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    final void initAbstractWebhookPublisherTest() {
         qm.createConfigProperty(
                 GENERAL_BASE_URL.getGroupName(),
                 GENERAL_BASE_URL.getPropertyName(),
@@ -58,7 +51,7 @@ public abstract class AbstractWebhookPublisherTest<T extends AbstractWebhookPubl
     @Override
     JsonObjectBuilder extraConfig() {
         return super.extraConfig()
-                .add(Publisher.CONFIG_DESTINATION, wireMock.baseUrl());
+                .add(Publisher.CONFIG_DESTINATION, wmRuntimeInfo.getHttpBaseUrl());
     }
 
 }

--- a/src/test/java/org/dependencytrack/notification/publisher/ConsolePublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/ConsolePublisherTest.java
@@ -23,36 +23,36 @@ import alpine.notification.NotificationLevel;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationScope;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 
-public class ConsolePublisherTest extends PersistenceCapableTest implements NotificationTestConfigProvider {
+class ConsolePublisherTest extends PersistenceCapableTest implements NotificationTestConfigProvider {
 
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
     private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
     private final PrintStream originalOut = System.out;
     private final PrintStream originalErr = System.err;
 
-    @Before
+    @BeforeEach
     public void setUpStreams() {
         System.setOut(new PrintStream(outContent));
         System.setErr(new PrintStream(errContent));
     }
 
-    @After
+    @AfterEach
     public void restoreStreams() {
         System.setOut(originalOut);
         System.setErr(originalErr);
     }
 
     @Test
-    public void testOutputStream() throws IOException {
+    void testOutputStream() throws IOException {
         Notification notification = new Notification();
         notification.setScope(NotificationScope.PORTFOLIO.name());
         notification.setGroup(NotificationGroup.NEW_VULNERABILITY.name());
@@ -61,11 +61,11 @@ public class ConsolePublisherTest extends PersistenceCapableTest implements Noti
         notification.setContent("This is only a test");
         ConsolePublisher publisher = new ConsolePublisher();
         publisher.inform(PublishContext.from(notification), notification, getConfig(DefaultNotificationPublishers.CONSOLE, ""));
-        Assert.assertTrue(outContent.toString().contains(expectedResult(notification)));
+        Assertions.assertTrue(outContent.toString().contains(expectedResult(notification)));
     }
 
     @Test
-    public void testErrorStream() throws IOException {
+    void testErrorStream() throws IOException {
         Notification notification = new Notification();
         notification.setScope(NotificationScope.SYSTEM.name());
         notification.setGroup(NotificationGroup.FILE_SYSTEM.name());
@@ -74,7 +74,7 @@ public class ConsolePublisherTest extends PersistenceCapableTest implements Noti
         notification.setContent("This is only a test");
         ConsolePublisher publisher = new ConsolePublisher();
         publisher.inform(PublishContext.from(notification), notification, getConfig(DefaultNotificationPublishers.CONSOLE, ""));
-        Assert.assertTrue(errContent.toString().contains(expectedResult(notification)));
+        Assertions.assertTrue(errContent.toString().contains(expectedResult(notification)));
     }
 
     private String expectedResult(Notification notification) {

--- a/src/test/java/org/dependencytrack/notification/publisher/CsWebexPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/CsWebexPublisherTest.java
@@ -24,9 +24,9 @@ import org.apache.http.HttpHeaders;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationScope;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 
@@ -37,22 +37,22 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
-public class CsWebexPublisherTest extends PersistenceCapableTest implements NotificationTestConfigProvider {
+class CsWebexPublisherTest extends PersistenceCapableTest implements NotificationTestConfigProvider {
 
     private static ClientAndServer mockServer;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         mockServer = startClientAndServer(1080);
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         mockServer.stop();
     }
 
     @Test
-    public void testPublish() throws IOException {
+    void testPublish() throws IOException {
         new MockServerClient("localhost", 1080)
                 .when(
                         request()

--- a/src/test/java/org/dependencytrack/notification/publisher/DefaultNotificationPublishersTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/DefaultNotificationPublishersTest.java
@@ -18,91 +18,91 @@
  */
 package org.dependencytrack.notification.publisher;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import jakarta.ws.rs.core.MediaType;
 
-public class DefaultNotificationPublishersTest {
+class DefaultNotificationPublishersTest {
 
     @Test
-    public void testEnums() {
-        Assert.assertEquals("SLACK", DefaultNotificationPublishers.SLACK.name());
-        Assert.assertEquals("MS_TEAMS", DefaultNotificationPublishers.MS_TEAMS.name());
-        Assert.assertEquals("MATTERMOST", DefaultNotificationPublishers.MATTERMOST.name());
-        Assert.assertEquals("EMAIL", DefaultNotificationPublishers.EMAIL.name());
-        Assert.assertEquals("CONSOLE", DefaultNotificationPublishers.CONSOLE.name());
-        Assert.assertEquals("WEBHOOK", DefaultNotificationPublishers.WEBHOOK.name());
-        Assert.assertEquals("JIRA", DefaultNotificationPublishers.JIRA.name());
+    void testEnums() {
+        Assertions.assertEquals("SLACK", DefaultNotificationPublishers.SLACK.name());
+        Assertions.assertEquals("MS_TEAMS", DefaultNotificationPublishers.MS_TEAMS.name());
+        Assertions.assertEquals("MATTERMOST", DefaultNotificationPublishers.MATTERMOST.name());
+        Assertions.assertEquals("EMAIL", DefaultNotificationPublishers.EMAIL.name());
+        Assertions.assertEquals("CONSOLE", DefaultNotificationPublishers.CONSOLE.name());
+        Assertions.assertEquals("WEBHOOK", DefaultNotificationPublishers.WEBHOOK.name());
+        Assertions.assertEquals("JIRA", DefaultNotificationPublishers.JIRA.name());
     }
 
     @Test
-    public void testSlack() {
-        Assert.assertEquals("Slack", DefaultNotificationPublishers.SLACK.getPublisherName());
-        Assert.assertEquals("Publishes notifications to a Slack channel", DefaultNotificationPublishers.SLACK.getPublisherDescription());
-        Assert.assertEquals(SlackPublisher.class, DefaultNotificationPublishers.SLACK.getPublisherClass());
-        Assert.assertEquals("/templates/notification/publisher/slack.peb", DefaultNotificationPublishers.SLACK.getPublisherTemplateFile());
-        Assert.assertEquals(MediaType.APPLICATION_JSON, DefaultNotificationPublishers.SLACK.getTemplateMimeType());
-        Assert.assertTrue(DefaultNotificationPublishers.SLACK.isDefaultPublisher());
+    void testSlack() {
+        Assertions.assertEquals("Slack", DefaultNotificationPublishers.SLACK.getPublisherName());
+        Assertions.assertEquals("Publishes notifications to a Slack channel", DefaultNotificationPublishers.SLACK.getPublisherDescription());
+        Assertions.assertEquals(SlackPublisher.class, DefaultNotificationPublishers.SLACK.getPublisherClass());
+        Assertions.assertEquals("/templates/notification/publisher/slack.peb", DefaultNotificationPublishers.SLACK.getPublisherTemplateFile());
+        Assertions.assertEquals(MediaType.APPLICATION_JSON, DefaultNotificationPublishers.SLACK.getTemplateMimeType());
+        Assertions.assertTrue(DefaultNotificationPublishers.SLACK.isDefaultPublisher());
     }
 
     @Test
-    public void testMsTeams() {
-        Assert.assertEquals("Microsoft Teams", DefaultNotificationPublishers.MS_TEAMS.getPublisherName());
-        Assert.assertEquals("Publishes notifications to a Microsoft Teams channel", DefaultNotificationPublishers.MS_TEAMS.getPublisherDescription());
-        Assert.assertEquals(MsTeamsPublisher.class, DefaultNotificationPublishers.MS_TEAMS.getPublisherClass());
-        Assert.assertEquals("/templates/notification/publisher/msteams.peb", DefaultNotificationPublishers.MS_TEAMS.getPublisherTemplateFile());
-        Assert.assertEquals(MediaType.APPLICATION_JSON, DefaultNotificationPublishers.MS_TEAMS.getTemplateMimeType());
-        Assert.assertTrue(DefaultNotificationPublishers.MS_TEAMS.isDefaultPublisher());
+    void testMsTeams() {
+        Assertions.assertEquals("Microsoft Teams", DefaultNotificationPublishers.MS_TEAMS.getPublisherName());
+        Assertions.assertEquals("Publishes notifications to a Microsoft Teams channel", DefaultNotificationPublishers.MS_TEAMS.getPublisherDescription());
+        Assertions.assertEquals(MsTeamsPublisher.class, DefaultNotificationPublishers.MS_TEAMS.getPublisherClass());
+        Assertions.assertEquals("/templates/notification/publisher/msteams.peb", DefaultNotificationPublishers.MS_TEAMS.getPublisherTemplateFile());
+        Assertions.assertEquals(MediaType.APPLICATION_JSON, DefaultNotificationPublishers.MS_TEAMS.getTemplateMimeType());
+        Assertions.assertTrue(DefaultNotificationPublishers.MS_TEAMS.isDefaultPublisher());
     }
 
     @Test
-    public void testMattermost() {
-        Assert.assertEquals("Mattermost", DefaultNotificationPublishers.MATTERMOST.getPublisherName());
-        Assert.assertEquals("Publishes notifications to a Mattermost channel", DefaultNotificationPublishers.MATTERMOST.getPublisherDescription());
-        Assert.assertEquals(MattermostPublisher.class, DefaultNotificationPublishers.MATTERMOST.getPublisherClass());
-        Assert.assertEquals("/templates/notification/publisher/mattermost.peb", DefaultNotificationPublishers.MATTERMOST.getPublisherTemplateFile());
-        Assert.assertEquals(MediaType.APPLICATION_JSON, DefaultNotificationPublishers.MATTERMOST.getTemplateMimeType());
-        Assert.assertTrue(DefaultNotificationPublishers.MATTERMOST.isDefaultPublisher());
+    void testMattermost() {
+        Assertions.assertEquals("Mattermost", DefaultNotificationPublishers.MATTERMOST.getPublisherName());
+        Assertions.assertEquals("Publishes notifications to a Mattermost channel", DefaultNotificationPublishers.MATTERMOST.getPublisherDescription());
+        Assertions.assertEquals(MattermostPublisher.class, DefaultNotificationPublishers.MATTERMOST.getPublisherClass());
+        Assertions.assertEquals("/templates/notification/publisher/mattermost.peb", DefaultNotificationPublishers.MATTERMOST.getPublisherTemplateFile());
+        Assertions.assertEquals(MediaType.APPLICATION_JSON, DefaultNotificationPublishers.MATTERMOST.getTemplateMimeType());
+        Assertions.assertTrue(DefaultNotificationPublishers.MATTERMOST.isDefaultPublisher());
     }
 
     @Test
-    public void testEmail() {
-        Assert.assertEquals("Email", DefaultNotificationPublishers.EMAIL.getPublisherName());
-        Assert.assertEquals("Sends notifications to an email address", DefaultNotificationPublishers.EMAIL.getPublisherDescription());
-        Assert.assertEquals(SendMailPublisher.class, DefaultNotificationPublishers.EMAIL.getPublisherClass());
-        Assert.assertEquals("/templates/notification/publisher/email.peb", DefaultNotificationPublishers.EMAIL.getPublisherTemplateFile());
-        Assert.assertEquals("text/plain; charset=utf-8", DefaultNotificationPublishers.EMAIL.getTemplateMimeType());
-        Assert.assertTrue(DefaultNotificationPublishers.EMAIL.isDefaultPublisher());
+    void testEmail() {
+        Assertions.assertEquals("Email", DefaultNotificationPublishers.EMAIL.getPublisherName());
+        Assertions.assertEquals("Sends notifications to an email address", DefaultNotificationPublishers.EMAIL.getPublisherDescription());
+        Assertions.assertEquals(SendMailPublisher.class, DefaultNotificationPublishers.EMAIL.getPublisherClass());
+        Assertions.assertEquals("/templates/notification/publisher/email.peb", DefaultNotificationPublishers.EMAIL.getPublisherTemplateFile());
+        Assertions.assertEquals("text/plain; charset=utf-8", DefaultNotificationPublishers.EMAIL.getTemplateMimeType());
+        Assertions.assertTrue(DefaultNotificationPublishers.EMAIL.isDefaultPublisher());
     }
 
     @Test
-    public void testConsole() {
-        Assert.assertEquals("Console", DefaultNotificationPublishers.CONSOLE.getPublisherName());
-        Assert.assertEquals("Displays notifications on the system console", DefaultNotificationPublishers.CONSOLE.getPublisherDescription());
-        Assert.assertEquals(ConsolePublisher.class, DefaultNotificationPublishers.CONSOLE.getPublisherClass());
-        Assert.assertEquals("/templates/notification/publisher/console.peb", DefaultNotificationPublishers.CONSOLE.getPublisherTemplateFile());
-        Assert.assertEquals(MediaType.TEXT_PLAIN, DefaultNotificationPublishers.CONSOLE.getTemplateMimeType());
-        Assert.assertTrue(DefaultNotificationPublishers.CONSOLE.isDefaultPublisher());
+    void testConsole() {
+        Assertions.assertEquals("Console", DefaultNotificationPublishers.CONSOLE.getPublisherName());
+        Assertions.assertEquals("Displays notifications on the system console", DefaultNotificationPublishers.CONSOLE.getPublisherDescription());
+        Assertions.assertEquals(ConsolePublisher.class, DefaultNotificationPublishers.CONSOLE.getPublisherClass());
+        Assertions.assertEquals("/templates/notification/publisher/console.peb", DefaultNotificationPublishers.CONSOLE.getPublisherTemplateFile());
+        Assertions.assertEquals(MediaType.TEXT_PLAIN, DefaultNotificationPublishers.CONSOLE.getTemplateMimeType());
+        Assertions.assertTrue(DefaultNotificationPublishers.CONSOLE.isDefaultPublisher());
     }
 
     @Test
-    public void testWebhook() {
-        Assert.assertEquals("Outbound Webhook", DefaultNotificationPublishers.WEBHOOK.getPublisherName());
-        Assert.assertEquals("Publishes notifications to a configurable endpoint", DefaultNotificationPublishers.WEBHOOK.getPublisherDescription());
-        Assert.assertEquals(WebhookPublisher.class, DefaultNotificationPublishers.WEBHOOK.getPublisherClass());
-        Assert.assertEquals("/templates/notification/publisher/webhook.peb", DefaultNotificationPublishers.WEBHOOK.getPublisherTemplateFile());
-        Assert.assertEquals(MediaType.APPLICATION_JSON, DefaultNotificationPublishers.WEBHOOK.getTemplateMimeType());
-        Assert.assertTrue(DefaultNotificationPublishers.WEBHOOK.isDefaultPublisher());
+    void testWebhook() {
+        Assertions.assertEquals("Outbound Webhook", DefaultNotificationPublishers.WEBHOOK.getPublisherName());
+        Assertions.assertEquals("Publishes notifications to a configurable endpoint", DefaultNotificationPublishers.WEBHOOK.getPublisherDescription());
+        Assertions.assertEquals(WebhookPublisher.class, DefaultNotificationPublishers.WEBHOOK.getPublisherClass());
+        Assertions.assertEquals("/templates/notification/publisher/webhook.peb", DefaultNotificationPublishers.WEBHOOK.getPublisherTemplateFile());
+        Assertions.assertEquals(MediaType.APPLICATION_JSON, DefaultNotificationPublishers.WEBHOOK.getTemplateMimeType());
+        Assertions.assertTrue(DefaultNotificationPublishers.WEBHOOK.isDefaultPublisher());
     }
 
     @Test
-    public void testJira() {
-        Assert.assertEquals("Jira", DefaultNotificationPublishers.JIRA.getPublisherName());
-        Assert.assertEquals("Creates a Jira issue in a configurable Jira instance and queue", DefaultNotificationPublishers.JIRA.getPublisherDescription());
-        Assert.assertEquals(JiraPublisher.class, DefaultNotificationPublishers.JIRA.getPublisherClass());
-        Assert.assertEquals("/templates/notification/publisher/jira.peb", DefaultNotificationPublishers.JIRA.getPublisherTemplateFile());
-        Assert.assertEquals(MediaType.APPLICATION_JSON, DefaultNotificationPublishers.JIRA.getTemplateMimeType());
-        Assert.assertTrue(DefaultNotificationPublishers.JIRA.isDefaultPublisher());
+    void testJira() {
+        Assertions.assertEquals("Jira", DefaultNotificationPublishers.JIRA.getPublisherName());
+        Assertions.assertEquals("Creates a Jira issue in a configurable Jira instance and queue", DefaultNotificationPublishers.JIRA.getPublisherDescription());
+        Assertions.assertEquals(JiraPublisher.class, DefaultNotificationPublishers.JIRA.getPublisherClass());
+        Assertions.assertEquals("/templates/notification/publisher/jira.peb", DefaultNotificationPublishers.JIRA.getPublisherTemplateFile());
+        Assertions.assertEquals(MediaType.APPLICATION_JSON, DefaultNotificationPublishers.JIRA.getTemplateMimeType());
+        Assertions.assertTrue(DefaultNotificationPublishers.JIRA.isDefaultPublisher());
     }
 }

--- a/src/test/java/org/dependencytrack/notification/publisher/JiraPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/JiraPublisherTest.java
@@ -20,10 +20,9 @@ package org.dependencytrack.notification.publisher;
 
 import alpine.model.ConfigProperty;
 import alpine.security.crypto.DataEncryption;
-import org.junit.Before;
-import org.junit.Test;
-
 import jakarta.json.JsonObjectBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
@@ -34,20 +33,17 @@ import static org.dependencytrack.model.ConfigPropertyConstants.JIRA_PASSWORD;
 import static org.dependencytrack.model.ConfigPropertyConstants.JIRA_URL;
 import static org.dependencytrack.model.ConfigPropertyConstants.JIRA_USERNAME;
 
-public class JiraPublisherTest extends AbstractWebhookPublisherTest<JiraPublisher> {
-
+class JiraPublisherTest extends AbstractWebhookPublisherTest<JiraPublisher> {
     public JiraPublisherTest() {
         super(DefaultNotificationPublishers.JIRA, new JiraPublisher());
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
-
         qm.createConfigProperty(
                 JIRA_URL.getGroupName(),
                 JIRA_URL.getPropertyName(),
-                wireMock.baseUrl(),
+                wmRuntimeInfo.getHttpBaseUrl(),
                 JIRA_URL.getPropertyType(),
                 JIRA_URL.getDescription()
         );
@@ -67,9 +63,9 @@ public class JiraPublisherTest extends AbstractWebhookPublisherTest<JiraPublishe
         );
     }
 
-    @Override
+    @Test
     public void testInformWithBomConsumedNotification() {
-        super.testInformWithBomConsumedNotification();
+        super.baseTestInformWithBomConsumedNotification();
 
         verify(postRequestedFor(urlPathEqualTo("/rest/api/2/issue"))
                 .withHeader("Authorization", equalTo("Basic amlyYVVzZXI6amlyYVBhc3N3b3Jk"))
@@ -90,9 +86,9 @@ public class JiraPublisherTest extends AbstractWebhookPublisherTest<JiraPublishe
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithBomProcessingFailedNotification() {
-        super.testInformWithBomProcessingFailedNotification();
+        super.baseTestInformWithBomProcessingFailedNotification();
 
         verify(postRequestedFor(urlPathEqualTo("/rest/api/2/issue"))
                 .withHeader("Authorization", equalTo("Basic amlyYVVzZXI6amlyYVBhc3N3b3Jk"))
@@ -113,9 +109,9 @@ public class JiraPublisherTest extends AbstractWebhookPublisherTest<JiraPublishe
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithBomValidationFailedNotification() {
-        super.testInformWithBomValidationFailedNotification();
+        super.baseTestInformWithBomValidationFailedNotification();
 
         verify(postRequestedFor(urlPathEqualTo("/rest/api/2/issue"))
                 .withHeader("Authorization", equalTo("Basic amlyYVVzZXI6amlyYVBhc3N3b3Jk"))
@@ -136,9 +132,9 @@ public class JiraPublisherTest extends AbstractWebhookPublisherTest<JiraPublishe
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject() {
-        super.testInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject();
+        super.baseTestInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject();
 
         verify(postRequestedFor(urlPathEqualTo("/rest/api/2/issue"))
                 .withHeader("Authorization", equalTo("Basic amlyYVVzZXI6amlyYVBhc3N3b3Jk"))
@@ -159,9 +155,9 @@ public class JiraPublisherTest extends AbstractWebhookPublisherTest<JiraPublishe
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithDataSourceMirroringNotification() {
-        super.testInformWithDataSourceMirroringNotification();
+        super.baseTestInformWithDataSourceMirroringNotification();
 
         verify(postRequestedFor(urlPathEqualTo("/rest/api/2/issue"))
                 .withHeader("Authorization", equalTo("Basic amlyYVVzZXI6amlyYVBhc3N3b3Jk"))
@@ -182,9 +178,9 @@ public class JiraPublisherTest extends AbstractWebhookPublisherTest<JiraPublishe
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithNewVulnerabilityNotification() {
-        super.testInformWithNewVulnerabilityNotification();
+        super.baseTestInformWithNewVulnerabilityNotification();
 
         verify(postRequestedFor(urlPathEqualTo("/rest/api/2/issue"))
                 .withHeader("Authorization", equalTo("Basic amlyYVVzZXI6amlyYVBhc3N3b3Jk"))
@@ -205,9 +201,9 @@ public class JiraPublisherTest extends AbstractWebhookPublisherTest<JiraPublishe
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithNewVulnerableDependencyNotification() {
-        super.testInformWithNewVulnerableDependencyNotification();
+        super.baseTestInformWithNewVulnerableDependencyNotification();
 
         verify(postRequestedFor(urlPathEqualTo("/rest/api/2/issue"))
                 .withHeader("Authorization", equalTo("Basic amlyYVVzZXI6amlyYVBhc3N3b3Jk"))
@@ -228,9 +224,9 @@ public class JiraPublisherTest extends AbstractWebhookPublisherTest<JiraPublishe
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithProjectAuditChangeNotification() {
-        super.testInformWithProjectAuditChangeNotification();
+        super.baseTestInformWithProjectAuditChangeNotification();
 
         verify(postRequestedFor(urlPathEqualTo("/rest/api/2/issue"))
                 .withHeader("Authorization", equalTo("Basic amlyYVVzZXI6amlyYVBhc3N3b3Jk"))
@@ -252,7 +248,7 @@ public class JiraPublisherTest extends AbstractWebhookPublisherTest<JiraPublishe
     }
 
     @Test
-    public void testPublishWithBearerToken() throws Exception {
+    void testPublishWithBearerToken() throws Exception {
         final ConfigProperty usernameProperty = qm.getConfigProperty(JIRA_USERNAME.getGroupName(), JIRA_USERNAME.getPropertyName());
         usernameProperty.setPropertyValue(null);
         qm.persist(usernameProperty);
@@ -261,7 +257,7 @@ public class JiraPublisherTest extends AbstractWebhookPublisherTest<JiraPublishe
         passwordProperty.setPropertyValue(DataEncryption.encryptAsString("jiraToken"));
         qm.persist(passwordProperty);
 
-        super.testInformWithBomConsumedNotification();
+        super.baseTestInformWithBomConsumedNotification();
 
         verify(postRequestedFor(urlPathEqualTo("/rest/api/2/issue"))
                 .withHeader("Authorization", equalTo("Bearer jiraToken"))

--- a/src/test/java/org/dependencytrack/notification/publisher/MattermostPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/MattermostPublisherTest.java
@@ -18,6 +18,8 @@
  */
 package org.dependencytrack.notification.publisher;
 
+import org.junit.jupiter.api.Test;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
@@ -30,9 +32,9 @@ public class MattermostPublisherTest extends AbstractWebhookPublisherTest<Matter
         super(DefaultNotificationPublishers.MATTERMOST, new MattermostPublisher());
     }
 
-    @Override
+    @Test
     public void testInformWithBomConsumedNotification() {
-        super.testInformWithBomConsumedNotification();
+        super.baseTestInformWithBomConsumedNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -45,9 +47,9 @@ public class MattermostPublisherTest extends AbstractWebhookPublisherTest<Matter
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithBomProcessingFailedNotification() {
-        super.testInformWithBomProcessingFailedNotification();
+        super.baseTestInformWithBomProcessingFailedNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -60,9 +62,9 @@ public class MattermostPublisherTest extends AbstractWebhookPublisherTest<Matter
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithBomValidationFailedNotification() {
-        super.testInformWithBomValidationFailedNotification();
+        super.baseTestInformWithBomValidationFailedNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -75,9 +77,9 @@ public class MattermostPublisherTest extends AbstractWebhookPublisherTest<Matter
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject() {
-        super.testInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject();
+        super.baseTestInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -90,9 +92,9 @@ public class MattermostPublisherTest extends AbstractWebhookPublisherTest<Matter
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithDataSourceMirroringNotification() {
-        super.testInformWithDataSourceMirroringNotification();
+        super.baseTestInformWithDataSourceMirroringNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -105,9 +107,9 @@ public class MattermostPublisherTest extends AbstractWebhookPublisherTest<Matter
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithNewVulnerabilityNotification() {
-        super.testInformWithNewVulnerabilityNotification();
+        super.baseTestInformWithNewVulnerabilityNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -120,9 +122,9 @@ public class MattermostPublisherTest extends AbstractWebhookPublisherTest<Matter
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithNewVulnerableDependencyNotification() {
-        super.testInformWithNewVulnerableDependencyNotification();
+        super.baseTestInformWithNewVulnerableDependencyNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -135,9 +137,9 @@ public class MattermostPublisherTest extends AbstractWebhookPublisherTest<Matter
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithProjectAuditChangeNotification() {
-        super.testInformWithProjectAuditChangeNotification();
+        super.baseTestInformWithProjectAuditChangeNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))

--- a/src/test/java/org/dependencytrack/notification/publisher/MsTeamsPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/MsTeamsPublisherTest.java
@@ -18,6 +18,8 @@
  */
 package org.dependencytrack.notification.publisher;
 
+import org.junit.jupiter.api.Test;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
@@ -30,9 +32,9 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
         super(DefaultNotificationPublishers.MS_TEAMS, new MsTeamsPublisher());
     }
 
-    @Override
+    @Test
     public void testInformWithBomConsumedNotification() {
-        super.testInformWithBomConsumedNotification();
+        super.baseTestInformWithBomConsumedNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -68,9 +70,9 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithBomProcessingFailedNotification() {
-        super.testInformWithBomProcessingFailedNotification();
+        super.baseTestInformWithBomProcessingFailedNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -114,9 +116,9 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithBomValidationFailedNotification() {
-        super.testInformWithBomValidationFailedNotification();
+        super.baseTestInformWithBomValidationFailedNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -164,9 +166,9 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject() {
-        super.testInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject();
+        super.baseTestInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -210,9 +212,9 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithDataSourceMirroringNotification() {
-        super.testInformWithDataSourceMirroringNotification();
+        super.baseTestInformWithDataSourceMirroringNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -248,9 +250,9 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithNewVulnerabilityNotification() {
-        super.testInformWithNewVulnerabilityNotification();
+        super.baseTestInformWithNewVulnerabilityNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -290,9 +292,9 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithNewVulnerableDependencyNotification() {
-        super.testInformWithNewVulnerableDependencyNotification();
+        super.baseTestInformWithNewVulnerableDependencyNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -324,9 +326,9 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithProjectAuditChangeNotification() {
-        super.testInformWithProjectAuditChangeNotification();
+        super.baseTestInformWithProjectAuditChangeNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -382,9 +384,9 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testPublishWithScheduledNewVulnerabilitiesNotification() {
-        super.testPublishWithScheduledNewVulnerabilitiesNotification();
+        super.baseTestPublishWithScheduledNewVulnerabilitiesNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -420,9 +422,9 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testPublishWithScheduledNewPolicyViolationsNotification() {
-        super.testPublishWithScheduledNewPolicyViolationsNotification();
+        super.baseTestPublishWithScheduledNewPolicyViolationsNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))

--- a/src/test/java/org/dependencytrack/notification/publisher/SendMailPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/SendMailPublisherTest.java
@@ -8,22 +8,22 @@ import alpine.notification.Notification;
 import alpine.notification.NotificationLevel;
 import alpine.security.crypto.DataEncryption;
 import alpine.server.auth.PasswordService;
-import com.icegreen.greenmail.junit4.GreenMailRule;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.util.ServerSetup;
-import org.dependencytrack.model.NotificationPublisher;
-import org.dependencytrack.model.NotificationRule;
-import org.dependencytrack.notification.NotificationConstants;
-import org.dependencytrack.notification.NotificationGroup;
-import org.dependencytrack.notification.NotificationScope;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMultipart;
+import org.dependencytrack.model.NotificationPublisher;
+import org.dependencytrack.model.NotificationRule;
+import org.dependencytrack.notification.NotificationConstants;
+import org.dependencytrack.notification.NotificationGroup;
+import org.dependencytrack.notification.NotificationScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -42,13 +42,13 @@ import static org.dependencytrack.model.ConfigPropertyConstants.EMAIL_SMTP_SSLTL
 import static org.dependencytrack.model.ConfigPropertyConstants.EMAIL_SMTP_TRUSTCERT;
 import static org.dependencytrack.model.ConfigPropertyConstants.EMAIL_SMTP_USERNAME;
 
-public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
+class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
 
     // Hashing is expensive. Do it once and re-use across tests as much as possible.
     protected static final String TEST_USER_PASSWORD_HASH = new String(PasswordService.createHash("testuser".toCharArray()));
 
-    @Rule
-    public final GreenMailRule greenMail = new GreenMailRule(ServerSetup.SMTP.dynamicPort())
+    @RegisterExtension
+    public static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetup.SMTP.dynamicPort())
             .withConfiguration(aConfig().
                     withUser("username", "password"));
 
@@ -56,7 +56,7 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
         super(DefaultNotificationPublishers.EMAIL, new SendMailPublisher());
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         qm.createConfigProperty(
                 EMAIL_SMTP_ENABLED.getGroupName(),
@@ -123,9 +123,9 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
         );
     }
 
-    @Override
+    @Test
     public void testInformWithBomConsumedNotification() {
-        super.testInformWithBomConsumedNotification();
+        super.baseTestInformWithBomConsumedNotification();
 
         assertThat(greenMail.getReceivedMessages()).satisfiesExactly(message -> {
             assertThat(message.getSubject()).isEqualTo("[Dependency-Track] Bill of Materials Consumed");
@@ -154,9 +154,9 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
         });
     }
 
-    @Override
+    @Test
     public void testInformWithBomProcessingFailedNotification() {
-        super.testInformWithBomProcessingFailedNotification();
+        super.baseTestInformWithBomProcessingFailedNotification();
 
         assertThat(greenMail.getReceivedMessages()).satisfiesExactly(message -> {
             assertThat(message.getSubject()).isEqualTo("[Dependency-Track] Bill of Materials Processing Failed");
@@ -190,9 +190,9 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
         });
     }
 
-    @Override
+    @Test
     public void testInformWithBomValidationFailedNotification() {
-        super.testInformWithBomValidationFailedNotification();
+        super.baseTestInformWithBomValidationFailedNotification();
 
         assertThat(greenMail.getReceivedMessages()).satisfiesExactly(message -> {
             assertThat(message.getSubject()).isEqualTo("[Dependency-Track] Bill of Materials Validation Failed");
@@ -222,9 +222,9 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
         });
     }
 
-    @Override
+    @Test
     public void testInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject() {
-        super.testInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject();
+        super.baseTestInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject();
 
         assertThat(greenMail.getReceivedMessages()).satisfiesExactly(message -> {
             assertThat(message.getSubject()).isEqualTo("[Dependency-Track] Bill of Materials Processing Failed");
@@ -258,9 +258,9 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
         });
     }
 
-    @Override
+    @Test
     public void testInformWithDataSourceMirroringNotification() {
-        super.testInformWithDataSourceMirroringNotification();
+        super.baseTestInformWithDataSourceMirroringNotification();
 
         assertThat(greenMail.getReceivedMessages()).satisfiesExactly(message -> {
             assertThat(message.getSubject()).isEqualTo("[Dependency-Track] GitHub Advisory Mirroring");
@@ -288,9 +288,9 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
         });
     }
 
-    @Override
+    @Test
     public void testInformWithNewVulnerabilityNotification() {
-        super.testInformWithNewVulnerabilityNotification();
+        super.baseTestInformWithNewVulnerabilityNotification();
 
         assertThat(greenMail.getReceivedMessages()).satisfiesExactly(message -> {
             assertThat(message.getSubject()).isEqualTo("[Dependency-Track] New Vulnerability Identified");
@@ -325,9 +325,9 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
         });
     }
 
-    @Override
+    @Test
     public void testPublishWithScheduledNewVulnerabilitiesNotification() {
-        super.testPublishWithScheduledNewVulnerabilitiesNotification();
+        super.baseTestPublishWithScheduledNewVulnerabilitiesNotification();
 
         assertThat(greenMail.getReceivedMessages()).satisfiesExactly(message -> {
             assertThat(message.getSubject()).isEqualTo("[Dependency-Track] New Vulnerabilities Summary");
@@ -383,9 +383,9 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
         });
     }
 
-    @Override
+    @Test
     public void testPublishWithScheduledNewPolicyViolationsNotification() {
-        super.testPublishWithScheduledNewPolicyViolationsNotification();
+        super.baseTestPublishWithScheduledNewPolicyViolationsNotification();
 
         assertThat(greenMail.getReceivedMessages()).satisfiesExactly(message -> {
             assertThat(message.getSubject()).isEqualTo("[Dependency-Track] New Policy Violations Summary");
@@ -442,9 +442,9 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
         });
     }
 
-    @Override
+    @Test
     public void testInformWithNewVulnerableDependencyNotification() {
-        super.testInformWithNewVulnerableDependencyNotification();
+        super.baseTestInformWithNewVulnerableDependencyNotification();
 
         assertThat(greenMail.getReceivedMessages()).satisfiesExactly(message -> {
             assertThat(message.getSubject()).isEqualTo("[Dependency-Track] Vulnerable Dependency Introduced");
@@ -484,9 +484,9 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
         });
     }
 
-    @Override
+    @Test
     public void testInformWithProjectAuditChangeNotification() {
-        super.testInformWithProjectAuditChangeNotification();
+        super.baseTestInformWithProjectAuditChangeNotification();
 
         assertThat(greenMail.getReceivedMessages()).satisfiesExactly(message -> {
             assertThat(message.getSubject()).isEqualTo("[Dependency-Track] Analysis Decision: Finding Suppressed");
@@ -525,9 +525,9 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
         });
     }
 
-    @Override
+    @Test
     public void testInformWithEscapedData() {
-        super.testInformWithEscapedData();
+        super.baseTestInformWithEscapedData();
 
         assertThat(greenMail.getReceivedMessages()).satisfiesExactly(message -> {
             assertThat(message.getSubject()).isEqualTo("[Dependency-Track] Notification Test");
@@ -556,6 +556,7 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
         
     }
 
+    @Test
     @Override
     public void testInformWithTemplateInclude() throws Exception {
         final var notification = new Notification()
@@ -589,14 +590,14 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
     }
 
     @Test
-    public void testSingleDestination() {
+    void testSingleDestination() {
         JsonObject config = configWithDestination("john@doe.com");
         assertThat(SendMailPublisher.getDestinations(config, -1L)).containsOnly("john@doe.com");
     }
 
 
     @Test
-    public void testMultipleDestinations() {
+    void testMultipleDestinations() {
         JsonObject config = configWithDestination("john@doe.com,steve@jobs.org");
         assertThat(SendMailPublisher.getDestinations(config, -1L))
                 .containsExactlyInAnyOrder("john@doe.com", "steve@jobs.org");
@@ -608,13 +609,13 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
     }
 
     @Test
-    public void testEmptyDestinations() {
+    void testEmptyDestinations() {
         JsonObject config = configWithDestination("");
         assertThat(SendMailPublisher.getDestinations(config, -1L)).isNull();
     }
 
     @Test
-    public void testSingleTeamAsDestination() {
+    void testSingleTeamAsDestination() {
         JsonObject config = configWithDestination("");
 
         ManagedUser managedUser = qm.createManagedUser("ManagedUserTest", TEST_USER_PASSWORD_HASH);
@@ -641,7 +642,7 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
     }
 
     @Test
-    public void testMultipleTeamsAsDestination() {
+    void testMultipleTeamsAsDestination() {
         JsonObject config = configWithDestination("");
 
         ManagedUser managedUser1 = qm.createManagedUser("ManagedUserTest1", TEST_USER_PASSWORD_HASH);
@@ -689,7 +690,7 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
     }
 
     @Test
-    public void testDuplicateTeamAsDestination() {
+    void testDuplicateTeamAsDestination() {
         JsonObject config = configWithDestination("");
 
         ManagedUser managedUser1 = qm.createManagedUser("ManagedUserTest1", TEST_USER_PASSWORD_HASH);
@@ -738,7 +739,7 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
     }
 
     @Test
-    public void testDuplicateUserAsDestination() {
+    void testDuplicateUserAsDestination() {
         JsonObject config = configWithDestination("");
 
         ManagedUser managedUser = qm.createManagedUser("ManagedUserTest", TEST_USER_PASSWORD_HASH);
@@ -766,7 +767,7 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
     }
 
     @Test
-    public void testEmptyTeamAsDestination() {
+    void testEmptyTeamAsDestination() {
         JsonObject config = configWithDestination("");
         List<Team> teams = new ArrayList<>();
         Team team = qm.createTeam("testTeam");
@@ -777,7 +778,7 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
     }
 
     @Test
-    public void testEmptyTeamsAsDestination() {
+    void testEmptyTeamsAsDestination() {
         JsonObject config = configWithDestination("");
         List<Team> teams = new ArrayList<>();
         NotificationRule rule = createNotificationRule();
@@ -786,7 +787,7 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
     }
 
     @Test
-    public void testEmptyUserEmailsAsDestination() {
+    void testEmptyUserEmailsAsDestination() {
         JsonObject config = configWithDestination("");
         ManagedUser managedUser = qm.createManagedUser("ManagedUserTest", TEST_USER_PASSWORD_HASH);
 
@@ -808,7 +809,7 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
     }
 
     @Test
-    public void testConfigDestinationAndTeamAsDestination() {
+    void testConfigDestinationAndTeamAsDestination() {
         JsonObject config = configWithDestination("john@doe.com,steve@jobs.org");
         ManagedUser managedUser = qm.createManagedUser("ManagedUserTest", TEST_USER_PASSWORD_HASH);
         managedUser.setEmail("managedUser@Test.com");
@@ -838,7 +839,7 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
     }
 
     @Test
-    public void testNullConfigDestinationAndTeamsDestination() {
+    void testNullConfigDestinationAndTeamsDestination() {
         JsonObject config = Json.createObjectBuilder().build();
         ManagedUser managedUser = qm.createManagedUser("ManagedUserTest", TEST_USER_PASSWORD_HASH);
         managedUser.setEmail("managedUser@Test.com");
@@ -864,7 +865,7 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
     }
 
     @Test
-    public void testEmptyManagedUsersAsDestination() {
+    void testEmptyManagedUsersAsDestination() {
         JsonObject config = configWithDestination("john@doe.com,steve@jobs.org");
 
         LdapUser ldapUser = qm.createLdapUser("ldapUserTest");
@@ -891,7 +892,7 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
     }
 
     @Test
-    public void testEmptyLdapUsersAsDestination() {
+    void testEmptyLdapUsersAsDestination() {
         JsonObject config = configWithDestination("john@doe.com,steve@jobs.org");
         ManagedUser managedUser = qm.createManagedUser("ManagedUserTest", TEST_USER_PASSWORD_HASH);
         managedUser.setEmail("managedUser@Test.com");
@@ -917,7 +918,7 @@ public class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublish
     }
 
     @Test
-    public void testEmptyOidcUsersAsDestination() {
+    void testEmptyOidcUsersAsDestination() {
         JsonObject config = configWithDestination("john@doe.com,steve@jobs.org");
         ManagedUser managedUser = qm.createManagedUser("ManagedUserTest", TEST_USER_PASSWORD_HASH);
         managedUser.setEmail("managedUser@Test.com");

--- a/src/test/java/org/dependencytrack/notification/publisher/SlackPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/SlackPublisherTest.java
@@ -19,7 +19,7 @@
 package org.dependencytrack.notification.publisher;
 
 import alpine.model.ConfigProperty;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -28,15 +28,15 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.dependencytrack.model.ConfigPropertyConstants.GENERAL_BASE_URL;
 
-public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublisher> {
+class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublisher> {
 
     public SlackPublisherTest() {
         super(DefaultNotificationPublishers.SLACK, new SlackPublisher());
     }
 
-    @Override
+    @Test
     public void testInformWithBomConsumedNotification() {
-        super.testInformWithBomConsumedNotification();
+        super.baseTestInformWithBomConsumedNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -81,9 +81,9 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithBomProcessingFailedNotification() {
-        super.testInformWithBomProcessingFailedNotification();
+        super.baseTestInformWithBomProcessingFailedNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -128,9 +128,9 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithBomValidationFailedNotification() {
-        super.testInformWithBomValidationFailedNotification();
+        super.baseTestInformWithBomValidationFailedNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -182,9 +182,9 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject() {
-        super.testInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject();
+        super.baseTestInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -229,9 +229,9 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithDataSourceMirroringNotification() {
-        super.testInformWithDataSourceMirroringNotification();
+        super.baseTestInformWithDataSourceMirroringNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -276,9 +276,9 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithNewVulnerabilityNotification() {
-        super.testInformWithNewVulnerabilityNotification();
+        super.baseTestInformWithNewVulnerabilityNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -373,9 +373,9 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithNewVulnerableDependencyNotification() {
-        super.testInformWithNewVulnerableDependencyNotification();
+        super.baseTestInformWithNewVulnerableDependencyNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -454,9 +454,9 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithProjectAuditChangeNotification() {
-        super.testInformWithProjectAuditChangeNotification();
+        super.baseTestInformWithProjectAuditChangeNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -591,7 +591,7 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
     }
 
     @Test
-    public void testInformWithNewVulnerabilityNotificationWithoutBaseUrl() {
+    void testInformWithNewVulnerabilityNotificationWithoutBaseUrl() {
         final ConfigProperty baseUrlProperty = qm.getConfigProperty(
                 GENERAL_BASE_URL.getGroupName(),
                 GENERAL_BASE_URL.getPropertyName()
@@ -599,7 +599,7 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
         baseUrlProperty.setPropertyValue(null);
         qm.persist(baseUrlProperty);
 
-        super.testInformWithNewVulnerabilityNotification();
+        super.baseTestInformWithNewVulnerabilityNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -672,7 +672,7 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
     }
 
     @Test
-    public void testInformWithNewVulnerableDependencyNotificationWithoutBaseUrl() {
+    void testInformWithNewVulnerableDependencyNotificationWithoutBaseUrl() {
         final ConfigProperty baseUrlProperty = qm.getConfigProperty(
                 GENERAL_BASE_URL.getGroupName(),
                 GENERAL_BASE_URL.getPropertyName()
@@ -680,7 +680,7 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
         baseUrlProperty.setPropertyValue(null);
         qm.persist(baseUrlProperty);
 
-        super.testInformWithNewVulnerableDependencyNotification();
+        super.baseTestInformWithNewVulnerableDependencyNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -737,7 +737,7 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
     }
 
     @Test
-    public void testInformWithProjectAuditChangeNotificationWithoutBaseUrl() {
+    void testInformWithProjectAuditChangeNotificationWithoutBaseUrl() {
         final ConfigProperty baseUrlProperty = qm.getConfigProperty(
                 GENERAL_BASE_URL.getGroupName(),
                 GENERAL_BASE_URL.getPropertyName()
@@ -745,7 +745,7 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
         baseUrlProperty.setPropertyValue(null);
         qm.persist(baseUrlProperty);
 
-        super.testInformWithProjectAuditChangeNotification();
+        super.baseTestInformWithProjectAuditChangeNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -847,9 +847,9 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
                         """)));
     }
 
-    @Override
+    @Test
     public void testPublishWithScheduledNewVulnerabilitiesNotification() {
-        super.testPublishWithScheduledNewVulnerabilitiesNotification();
+        super.baseTestPublishWithScheduledNewVulnerabilitiesNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -894,9 +894,9 @@ public class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublis
                         """)));
     }
 
-    @Override
+    @Test
     public void testPublishWithScheduledNewPolicyViolationsNotification() {
-        super.testPublishWithScheduledNewPolicyViolationsNotification();
+        super.baseTestPublishWithScheduledNewPolicyViolationsNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))

--- a/src/test/java/org/dependencytrack/notification/publisher/WebhookPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/WebhookPublisherTest.java
@@ -18,6 +18,8 @@
  */
 package org.dependencytrack.notification.publisher;
 
+import org.junit.jupiter.api.Test;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
@@ -30,9 +32,9 @@ public class WebhookPublisherTest extends AbstractWebhookPublisherTest<WebhookPu
         super(DefaultNotificationPublishers.WEBHOOK, new WebhookPublisher());
     }
 
-    @Override
+    @Test
     public void testInformWithBomConsumedNotification() {
-        super.testInformWithBomConsumedNotification();
+        super.baseTestInformWithBomConsumedNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -65,9 +67,9 @@ public class WebhookPublisherTest extends AbstractWebhookPublisherTest<WebhookPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithBomProcessingFailedNotification() {
-        super.testInformWithBomProcessingFailedNotification();
+        super.baseTestInformWithBomProcessingFailedNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -101,9 +103,9 @@ public class WebhookPublisherTest extends AbstractWebhookPublisherTest<WebhookPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithBomValidationFailedNotification() {
-        super.testInformWithBomValidationFailedNotification();
+        super.baseTestInformWithBomValidationFailedNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -136,9 +138,9 @@ public class WebhookPublisherTest extends AbstractWebhookPublisherTest<WebhookPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject() {
-        super.testInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject();
+        super.baseTestInformWithBomProcessingFailedNotificationAndNoSpecVersionInSubject();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -172,9 +174,9 @@ public class WebhookPublisherTest extends AbstractWebhookPublisherTest<WebhookPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithDataSourceMirroringNotification() {
-        super.testInformWithDataSourceMirroringNotification();
+        super.baseTestInformWithDataSourceMirroringNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -193,9 +195,9 @@ public class WebhookPublisherTest extends AbstractWebhookPublisherTest<WebhookPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithNewVulnerabilityNotification() {
-        super.testInformWithNewVulnerabilityNotification();
+        super.baseTestInformWithNewVulnerabilityNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -266,9 +268,9 @@ public class WebhookPublisherTest extends AbstractWebhookPublisherTest<WebhookPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithNewVulnerableDependencyNotification() {
-        super.testInformWithNewVulnerableDependencyNotification();
+        super.baseTestInformWithNewVulnerableDependencyNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -338,9 +340,9 @@ public class WebhookPublisherTest extends AbstractWebhookPublisherTest<WebhookPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testInformWithProjectAuditChangeNotification() {
-        super.testInformWithProjectAuditChangeNotification();
+        super.baseTestInformWithProjectAuditChangeNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -417,9 +419,9 @@ public class WebhookPublisherTest extends AbstractWebhookPublisherTest<WebhookPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testPublishWithScheduledNewVulnerabilitiesNotification() {
-        super.testPublishWithScheduledNewVulnerabilitiesNotification();
+        super.baseTestPublishWithScheduledNewVulnerabilitiesNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -533,9 +535,9 @@ public class WebhookPublisherTest extends AbstractWebhookPublisherTest<WebhookPu
                         """)));
     }
 
-    @Override
+    @Test
     public void testPublishWithScheduledNewPolicyViolationsNotification() {
-        super.testPublishWithScheduledNewPolicyViolationsNotification();
+        super.baseTestPublishWithScheduledNewPolicyViolationsNotification();
 
         verify(postRequestedFor(anyUrl())
                 .withHeader("Content-Type", equalTo("application/json"))

--- a/src/test/java/org/dependencytrack/notification/vo/AnalysisDecisionChangeTest.java
+++ b/src/test/java/org/dependencytrack/notification/vo/AnalysisDecisionChangeTest.java
@@ -22,24 +22,21 @@ import org.dependencytrack.model.Analysis;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vulnerability;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import java.util.HashSet;
-import java.util.Set;
-
-public class AnalysisDecisionChangeTest {
+class AnalysisDecisionChangeTest {
 
     @Test
-    public void testVo() {
+    void testVo() {
         Vulnerability vuln = new Vulnerability();
         Component component = new Component();
         Project project = new Project();
         Analysis analysis = new Analysis();
         AnalysisDecisionChange vo = new AnalysisDecisionChange(vuln, component, project, analysis);
-        Assert.assertEquals(vuln, vo.getVulnerability());
-        Assert.assertEquals(component, vo.getComponent());
-        Assert.assertEquals(project, vo.getProject());
-        Assert.assertEquals(analysis, vo.getAnalysis());
+        Assertions.assertEquals(vuln, vo.getVulnerability());
+        Assertions.assertEquals(component, vo.getComponent());
+        Assertions.assertEquals(project, vo.getProject());
+        Assertions.assertEquals(analysis, vo.getAnalysis());
     }
 }

--- a/src/test/java/org/dependencytrack/notification/vo/NewVulnerabilityIdentifiedTest.java
+++ b/src/test/java/org/dependencytrack/notification/vo/NewVulnerabilityIdentifiedTest.java
@@ -22,16 +22,16 @@ import org.dependencytrack.model.VulnerabilityAnalysisLevel;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vulnerability;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
 
-public class NewVulnerabilityIdentifiedTest {
+class NewVulnerabilityIdentifiedTest {
 
     @Test
-    public void testVo() {
+    void testVo() {
         Vulnerability vuln = new Vulnerability();
         Component component = new Component();
         VulnerabilityAnalysisLevel vulnerabilityAnalysisLevel = VulnerabilityAnalysisLevel.PERIODIC_ANALYSIS;
@@ -39,10 +39,10 @@ public class NewVulnerabilityIdentifiedTest {
         Project project = new Project();
         affectedProjects.add(project);
         NewVulnerabilityIdentified vo = new NewVulnerabilityIdentified(vuln, component, affectedProjects, vulnerabilityAnalysisLevel);
-        Assert.assertEquals(vuln, vo.getVulnerability());
-        Assert.assertEquals(component, vo.getComponent());
-        Assert.assertEquals(1, vo.getAffectedProjects().size());
-        Assert.assertEquals(project, vo.getAffectedProjects().iterator().next());
-        Assert.assertEquals(VulnerabilityAnalysisLevel.PERIODIC_ANALYSIS, vo.getVulnerabilityAnalysisLevel());
+        Assertions.assertEquals(vuln, vo.getVulnerability());
+        Assertions.assertEquals(component, vo.getComponent());
+        Assertions.assertEquals(1, vo.getAffectedProjects().size());
+        Assertions.assertEquals(project, vo.getAffectedProjects().iterator().next());
+        Assertions.assertEquals(VulnerabilityAnalysisLevel.PERIODIC_ANALYSIS, vo.getVulnerabilityAnalysisLevel());
     }
 }

--- a/src/test/java/org/dependencytrack/notification/vo/NewVulnerableDependencyTest.java
+++ b/src/test/java/org/dependencytrack/notification/vo/NewVulnerableDependencyTest.java
@@ -20,23 +20,23 @@ package org.dependencytrack.notification.vo;
 
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Vulnerability;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class NewVulnerableDependencyTest {
+class NewVulnerableDependencyTest {
 
     @Test
-    public void testVo() {
+    void testVo() {
         Component component = new Component();
         List<Vulnerability> vulns = new ArrayList<>();
         Vulnerability vuln = new Vulnerability();
         vulns.add(vuln);
         NewVulnerableDependency vo = new NewVulnerableDependency(component, vulns);
-        Assert.assertEquals(component, vo.getComponent());
-        Assert.assertEquals(1, vo.getVulnerabilities().size());
-        Assert.assertEquals(vuln, vo.getVulnerabilities().get(0));
+        Assertions.assertEquals(component, vo.getComponent());
+        Assertions.assertEquals(1, vo.getVulnerabilities().size());
+        Assertions.assertEquals(vuln, vo.getVulnerabilities().get(0));
     }
 }

--- a/src/test/java/org/dependencytrack/parser/common/resolver/CweResolverTest.java
+++ b/src/test/java/org/dependencytrack/parser/common/resolver/CweResolverTest.java
@@ -20,47 +20,41 @@ package org.dependencytrack.parser.common.resolver;
 
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Cwe;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class CweResolverTest extends PersistenceCapableTest {
-
-    @Before
-    public void before() throws Exception {
-        super.before();
-    }
+class CweResolverTest extends PersistenceCapableTest {
 
     @Test
-    public void testPositiveResolutionByCweId() {
+    void testPositiveResolutionByCweId() {
         Cwe cwe = CweResolver.getInstance().lookup("CWE-79");
-        Assert.assertNotNull(cwe);
-        Assert.assertEquals(79, cwe.getCweId());
+        Assertions.assertNotNull(cwe);
+        Assertions.assertEquals(79, cwe.getCweId());
     }
 
     @Test
-    public void testPositiveResolutionByCweIdIntegerOnly() {
+    void testPositiveResolutionByCweIdIntegerOnly() {
         Cwe cwe = CweResolver.getInstance().lookup("79");
-        Assert.assertNotNull(cwe);
-        Assert.assertEquals(79, cwe.getCweId());
+        Assertions.assertNotNull(cwe);
+        Assertions.assertEquals(79, cwe.getCweId());
     }
 
     @Test
-    public void testPositiveResolutionByCweIdAndName() {
+    void testPositiveResolutionByCweIdAndName() {
         Cwe cwe = CweResolver.getInstance().lookup("CWE-79 Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')");
-        Assert.assertNotNull(cwe);
-        Assert.assertEquals(79, cwe.getCweId());
+        Assertions.assertNotNull(cwe);
+        Assertions.assertEquals(79, cwe.getCweId());
     }
 
     @Test
-    public void testNegativeResolutionByCweId() {
+    void testNegativeResolutionByCweId() {
         Cwe cwe = CweResolver.getInstance().lookup("CWE-9999");
-        Assert.assertNull(cwe);
+        Assertions.assertNull(cwe);
     }
 
     @Test
-    public void testNegativeResolutionByInvalidCweId() {
+    void testNegativeResolutionByInvalidCweId() {
         Cwe cwe = CweResolver.getInstance().lookup("CWE-A");
-        Assert.assertNull(cwe);
+        Assertions.assertNull(cwe);
     }
 }

--- a/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporterTest.java
+++ b/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporterTest.java
@@ -11,8 +11,7 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.jdo.Query;
 import java.io.IOException;
@@ -24,12 +23,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 
-public class CycloneDXVexImporterTest extends PersistenceCapableTest {
+class CycloneDXVexImporterTest extends PersistenceCapableTest {
 
     private CycloneDXVexImporter vexImporter = new CycloneDXVexImporter();
 
     @Test
-    public void shouldAuditVulnerabilityFromAllSourcesUsingVex() throws URISyntaxException, IOException, ParseException {
+    void shouldAuditVulnerabilityFromAllSourcesUsingVex() throws URISyntaxException, IOException, ParseException {
         // Arrange
         var sources = Arrays.asList(Vulnerability.Source.values());
         var project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
@@ -109,7 +108,7 @@ public class CycloneDXVexImporterTest extends PersistenceCapableTest {
         query.setParameters(project);
         final List<Analysis> analyses = query.executeList();
         // CVE-2020-256[49|50|51] are not audited otherwise analyses.size would have been equal to sources.size()+3
-        Assert.assertEquals(sources.size(), analyses.size());
+        org.junit.jupiter.api.Assertions.assertEquals(sources.size(), analyses.size());
         Assertions.assertThat(analyses).allSatisfy(analysis -> {
             Assertions.assertThat(analysis.getVulnerability().getVulnId()).isNotEqualTo("CVE-2020-25649");
             Assertions.assertThat(analysis.getVulnerability().getVulnId()).isNotEqualTo("CVE-2020-25650");

--- a/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidatorTest.java
+++ b/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidatorTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
+@DefaultLocale("en-US")
 class CycloneDxValidatorTest {
 
     private CycloneDxValidator validator;

--- a/src/test/java/org/dependencytrack/parser/osv/OsvAdvisoryParserTest.java
+++ b/src/test/java/org/dependencytrack/parser/osv/OsvAdvisoryParserTest.java
@@ -4,69 +4,69 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.dependencytrack.parser.osv.model.OsvAdvisory;
 import org.dependencytrack.parser.osv.model.OsvAffectedPackage;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 
-public class OsvAdvisoryParserTest {
+class OsvAdvisoryParserTest {
 
     OsvAdvisoryParser parser = new OsvAdvisoryParser();
 
     @Test
-    public void testTrimSummary() {
+    void testTrimSummary() {
 
         String osvLongSummary = "In uvc_scan_chain_forward of uvc_driver.c, there is a possible linked list corruption due to an unusual root cause. This could lead to local escalation of privilege in the kernel with no additional execution privileges needed. User interaction is not needed for exploitation.";
         String trimmedSummary = parser.trimSummary(osvLongSummary);
-        Assert.assertNotNull(trimmedSummary);
-        Assert.assertEquals(255, trimmedSummary.length());
-        Assert.assertEquals("In uvc_scan_chain_forward of uvc_driver.c, there is a possible linked list corruption due to an unusual root cause. This could lead to local escalation of privilege in the kernel with no additional execution privileges needed. User interaction is not ne..", trimmedSummary);
+        Assertions.assertNotNull(trimmedSummary);
+        Assertions.assertEquals(255, trimmedSummary.length());
+        Assertions.assertEquals("In uvc_scan_chain_forward of uvc_driver.c, there is a possible linked list corruption due to an unusual root cause. This could lead to local escalation of privilege in the kernel with no additional execution privileges needed. User interaction is not ne..", trimmedSummary);
 
         osvLongSummary = "I'm a short Summary";
         trimmedSummary = parser.trimSummary(osvLongSummary);
-        Assert.assertNotNull(trimmedSummary);
-        Assert.assertEquals("I'm a short Summary", trimmedSummary);
+        Assertions.assertNotNull(trimmedSummary);
+        Assertions.assertEquals("I'm a short Summary", trimmedSummary);
 
         osvLongSummary = null;
         trimmedSummary = parser.trimSummary(osvLongSummary);
-        Assert.assertNull(trimmedSummary);
+        Assertions.assertNull(trimmedSummary);
     }
 
     @Test
-    public void testVulnerabilityRangeEmpty() throws IOException {
+    void testVulnerabilityRangeEmpty() throws IOException {
 
         String jsonFile = "src/test/resources/unit/osv.jsons/osv-vulnerability-no-range.json";
         String jsonString = new String(Files.readAllBytes(Paths.get(jsonFile)));
         JSONObject jsonObject = new JSONObject(jsonString);
         final JSONArray affected = jsonObject.optJSONArray("affected");
         List<OsvAffectedPackage> affectedPackages = parser.parseAffectedPackageRange(affected.getJSONObject(0));
-        Assert.assertNotNull(affectedPackages);
-        Assert.assertEquals(1, affectedPackages.size());
+        Assertions.assertNotNull(affectedPackages);
+        Assertions.assertEquals(1, affectedPackages.size());
     }
 
     @Test
-    public void testVulnerabilityRangeSingle() throws IOException {
+    void testVulnerabilityRangeSingle() throws IOException {
 
         String jsonFile = "src/test/resources/unit/osv.jsons/osv-vulnerability-with-ranges.json";
         String jsonString = new String(Files.readAllBytes(Paths.get(jsonFile)));
         JSONObject jsonObject = new JSONObject(jsonString);
         final JSONArray affected = jsonObject.optJSONArray("affected");
         List<OsvAffectedPackage> affectedPackages = parser.parseAffectedPackageRange(affected.getJSONObject(1));
-        Assert.assertNotNull(affectedPackages);
-        Assert.assertEquals(1, affectedPackages.size());
+        Assertions.assertNotNull(affectedPackages);
+        Assertions.assertEquals(1, affectedPackages.size());
         OsvAffectedPackage affectedPackage = affectedPackages.get(0);
-        Assert.assertEquals("pkg:maven/org.springframework.security.oauth/spring-security-oauth", affectedPackage.getPurl());
-        Assert.assertEquals("0", affectedPackage.getLowerVersionRange());
-        Assert.assertEquals("2.0.17", affectedPackage.getUpperVersionRangeExcluding());
-        Assert.assertEquals("Maven", affectedPackage.getPackageEcosystem());
+        Assertions.assertEquals("pkg:maven/org.springframework.security.oauth/spring-security-oauth", affectedPackage.getPurl());
+        Assertions.assertEquals("0", affectedPackage.getLowerVersionRange());
+        Assertions.assertEquals("2.0.17", affectedPackage.getUpperVersionRangeExcluding());
+        Assertions.assertEquals("Maven", affectedPackage.getPackageEcosystem());
 
     }
 
     @Test
-    public void testVulnerabilityRangeMultiple() throws IOException {
+    void testVulnerabilityRangeMultiple() throws IOException {
 
         String jsonFile = "src/test/resources/unit/osv.jsons/osv-vulnerability-with-ranges.json";
         String jsonString = new String(Files.readAllBytes(Paths.get(jsonFile)));
@@ -75,24 +75,24 @@ public class OsvAdvisoryParserTest {
 
         // range test full pairs
         List<OsvAffectedPackage> affectedPackages = parser.parseAffectedPackageRange(affected.getJSONObject(2));
-        Assert.assertNotNull(affectedPackages);
-        Assert.assertEquals(3, affectedPackages.size());
-        Assert.assertEquals("1", affectedPackages.get(0).getLowerVersionRange());
-        Assert.assertEquals("2", affectedPackages.get(0).getUpperVersionRangeExcluding());
-        Assert.assertEquals("3", affectedPackages.get(1).getLowerVersionRange());
-        Assert.assertEquals("4", affectedPackages.get(1).getUpperVersionRangeExcluding());
+        Assertions.assertNotNull(affectedPackages);
+        Assertions.assertEquals(3, affectedPackages.size());
+        Assertions.assertEquals("1", affectedPackages.get(0).getLowerVersionRange());
+        Assertions.assertEquals("2", affectedPackages.get(0).getUpperVersionRangeExcluding());
+        Assertions.assertEquals("3", affectedPackages.get(1).getLowerVersionRange());
+        Assertions.assertEquals("4", affectedPackages.get(1).getUpperVersionRangeExcluding());
 
         // range test half pairs
         affectedPackages = parser.parseAffectedPackageRange(affected.getJSONObject(3));
-        Assert.assertNotNull(affectedPackages);
-        Assert.assertEquals(2, affectedPackages.size());
-        Assert.assertEquals("3", affectedPackages.get(0).getLowerVersionRange());
-        Assert.assertEquals("4", affectedPackages.get(1).getLowerVersionRange());
-        Assert.assertEquals("5", affectedPackages.get(1).getUpperVersionRangeExcluding());
+        Assertions.assertNotNull(affectedPackages);
+        Assertions.assertEquals(2, affectedPackages.size());
+        Assertions.assertEquals("3", affectedPackages.get(0).getLowerVersionRange());
+        Assertions.assertEquals("4", affectedPackages.get(1).getLowerVersionRange());
+        Assertions.assertEquals("5", affectedPackages.get(1).getUpperVersionRangeExcluding());
     }
 
     @Test
-    public void testVulnerabilityRangeTypes() throws IOException {
+    void testVulnerabilityRangeTypes() throws IOException {
 
         String jsonFile = "src/test/resources/unit/osv.jsons/osv-vulnerability-with-ranges.json";
         String jsonString = new String(Files.readAllBytes(Paths.get(jsonFile)));
@@ -101,60 +101,61 @@ public class OsvAdvisoryParserTest {
 
         // type last_affected
         List<OsvAffectedPackage> affectedPackages = parser.parseAffectedPackageRange(vulnerabilities.getJSONObject(5));
-        Assert.assertNotNull(affectedPackages);
-        Assert.assertEquals(1, affectedPackages.size());
-        Assert.assertEquals("10", affectedPackages.get(0).getLowerVersionRange());
-        Assert.assertEquals("13", affectedPackages.get(0).getUpperVersionRangeExcluding());
+        Assertions.assertNotNull(affectedPackages);
+        Assertions.assertEquals(1, affectedPackages.size());
+        Assertions.assertEquals("10", affectedPackages.get(0).getLowerVersionRange());
+        Assertions.assertEquals("13", affectedPackages.get(0).getUpperVersionRangeExcluding());
 
         // type last_affected
         affectedPackages = parser.parseAffectedPackageRange(vulnerabilities.getJSONObject(6));
-        Assert.assertNotNull(affectedPackages);
-        Assert.assertEquals(1, affectedPackages.size());
-        Assert.assertEquals("10", affectedPackages.get(0).getLowerVersionRange());
-        Assert.assertEquals(null, affectedPackages.get(0).getUpperVersionRangeExcluding());
-        Assert.assertEquals("29.0", affectedPackages.get(0).getUpperVersionRangeIncluding());
+        Assertions.assertNotNull(affectedPackages);
+        Assertions.assertEquals(1, affectedPackages.size());
+        Assertions.assertEquals("10", affectedPackages.get(0).getLowerVersionRange());
+        Assertions.assertEquals(null, affectedPackages.get(0).getUpperVersionRangeExcluding());
+        Assertions.assertEquals("29.0", affectedPackages.get(0).getUpperVersionRangeIncluding());
 
     }
 
     @Test
-    public void testParseOSVJson() throws IOException {
+    void testParseOSVJson() throws IOException {
 
         String jsonFile = "src/test/resources/unit/osv.jsons/osv-GHSA-77rv-6vfw-x4gc.json";
         String jsonString = new String(Files.readAllBytes(Paths.get(jsonFile)));
         JSONObject jsonObject = new JSONObject(jsonString);
         OsvAdvisory advisory = parser.parse(jsonObject);
-        Assert.assertNotNull(advisory);
-        Assert.assertEquals("GHSA-77rv-6vfw-x4gc", advisory.getId());
-        Assert.assertEquals("LOW", advisory.getSeverity());
-        Assert.assertEquals(1, advisory.getCweIds().size());
-        Assert.assertEquals(6, advisory.getReferences().size());
-        Assert.assertEquals(2, advisory.getCredits().size());
-        Assert.assertEquals(8, advisory.getAffectedPackages().size());
-        Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H", advisory.getCvssV3Vector());
-        Assert.assertEquals("CVE-2019-3778", advisory.getAliases().get(0));
-        Assert.assertEquals("2022-06-09T07:01:32.587163Z", advisory.getModified().toString());
+        Assertions.assertNotNull(advisory);
+        Assertions.assertEquals("GHSA-77rv-6vfw-x4gc", advisory.getId());
+        Assertions.assertEquals("LOW", advisory.getSeverity());
+        Assertions.assertEquals(1, advisory.getCweIds().size());
+        Assertions.assertEquals(6, advisory.getReferences().size());
+        Assertions.assertEquals(2, advisory.getCredits().size());
+        Assertions.assertEquals(8, advisory.getAffectedPackages().size());
+        Assertions.assertEquals("CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H", advisory.getCvssV3Vector());
+        Assertions.assertEquals("CVE-2019-3778", advisory.getAliases().get(0));
+        Assertions.assertEquals("2022-06-09T07:01:32.587163Z", advisory.getModified().toString());
     }
 
     @Test
-    public void testCommitHashRanges() throws IOException {
+    void testCommitHashRanges() throws IOException {
 
         String jsonFile = "src/test/resources/unit/osv.jsons/osv-git-commit-hash-ranges.json";
         String jsonString = new String(Files.readAllBytes(Paths.get(jsonFile)));
         JSONObject jsonObject = new JSONObject(jsonString);
         OsvAdvisory advisory = parser.parse(jsonObject);
-        Assert.assertNotNull(advisory);
-        Assert.assertEquals("OSV-2021-1820", advisory.getId());
-        Assert.assertEquals(22, advisory.getAffectedPackages().size());
-        Assert.assertEquals("4.4.0", advisory.getAffectedPackages().get(0).getVersion());
+        Assertions.assertNotNull(advisory);
+        Assertions.assertEquals("OSV-2021-1820", advisory.getId());
+        Assertions.assertEquals(22, advisory.getAffectedPackages().size());
+        Assertions.assertEquals("4.4.0", advisory.getAffectedPackages().get(0).getVersion());
     }
 
-    @Test // https://github.com/DependencyTrack/dependency-track/issues/3185
-    public void testIssue3185() throws Exception {
+    @Test
+        // https://github.com/DependencyTrack/dependency-track/issues/3185
+    void testIssue3185() throws Exception {
         String jsonFile = "src/test/resources/unit/osv.jsons/osv-CVE-2016-10012.json";
         String jsonString = new String(Files.readAllBytes(Paths.get(jsonFile)));
         JSONObject jsonObject = new JSONObject(jsonString);
         OsvAdvisory advisory = parser.parse(jsonObject);
-        Assert.assertNotNull(advisory);
+        Assertions.assertNotNull(advisory);
     }
 
 }

--- a/src/test/java/org/dependencytrack/parser/snyk/SnykParserTest.java
+++ b/src/test/java/org/dependencytrack/parser/snyk/SnykParserTest.java
@@ -24,9 +24,9 @@ import org.json.JSONObject;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.parser.snyk.model.SnykError;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -39,119 +39,119 @@ import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_SNYK_API
 import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_SNYK_CVSS_SOURCE;
 import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_SNYK_ENABLED;
 
-public class SnykParserTest extends PersistenceCapableTest {
+class SnykParserTest extends PersistenceCapableTest {
 
     private SnykParser parser;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         parser = new SnykParser();
     }
 
     @Test
-    public void testParseVersionRanges() throws IOException {
+    void testParseVersionRanges() throws IOException {
 
         String jsonString = new String(Files.readAllBytes(Paths.get("src/test/resources/unit/snyk.jsons/ranges.json")));
         final JSONObject jsonObject = new JSONObject(jsonString);
         JSONArray ranges = jsonObject.optJSONArray("range0");
         String purl = "pkg:npm/bootstrap-table@1.20.0";
         List<VulnerableSoftware> vulnerableSoftwares = parser.parseVersionRanges(qm, purl, ranges, false);
-        Assert.assertNotNull(vulnerableSoftwares);
-        Assert.assertEquals(1, vulnerableSoftwares.size());
+        Assertions.assertNotNull(vulnerableSoftwares);
+        Assertions.assertEquals(1, vulnerableSoftwares.size());
 
         VulnerableSoftware vs = vulnerableSoftwares.get(0);
-        Assert.assertEquals("2.13.0", vs.getVersionStartIncluding());
-        Assert.assertEquals("2.13.2.1", vs.getVersionEndExcluding());
+        Assertions.assertEquals("2.13.0", vs.getVersionStartIncluding());
+        Assertions.assertEquals("2.13.2.1", vs.getVersionEndExcluding());
     }
 
     @Test
-    public void testParseVersionRanges_v3() throws IOException {
+    void testParseVersionRanges_v3() throws IOException {
 
         String jsonString = new String(Files.readAllBytes(Paths.get("src/test/resources/unit/snyk.jsons/ranges.json")));
         final JSONObject jsonObject = new JSONObject(jsonString);
         JSONArray ranges = jsonObject.optJSONArray("range0_v3");
         String purl = "pkg:npm/bootstrap-table@1.20.0";
         List<VulnerableSoftware> vulnerableSoftwares = parser.parseVersionRanges(qm, purl, ranges, true);
-        Assert.assertNotNull(vulnerableSoftwares);
-        Assert.assertEquals(1, vulnerableSoftwares.size());
+        Assertions.assertNotNull(vulnerableSoftwares);
+        Assertions.assertEquals(1, vulnerableSoftwares.size());
 
         VulnerableSoftware vs = vulnerableSoftwares.get(0);
-        Assert.assertEquals("2.13.0", vs.getVersionStartIncluding());
-        Assert.assertEquals("2.13.2.1", vs.getVersionEndExcluding());
+        Assertions.assertEquals("2.13.0", vs.getVersionStartIncluding());
+        Assertions.assertEquals("2.13.2.1", vs.getVersionEndExcluding());
     }
 
     @Test
-    public void testParseVersionRangesStar() throws IOException {
+    void testParseVersionRangesStar() throws IOException {
 
         String jsonString = new String(Files.readAllBytes(Paths.get("src/test/resources/unit/snyk.jsons/ranges.json")));
         final JSONObject jsonObject = new JSONObject(jsonString);
         JSONArray ranges = jsonObject.optJSONArray("range2");
         String purl = "pkg:npm/bootstrap-table@1.20.0";
         List<VulnerableSoftware> vulnerableSoftwares = parser.parseVersionRanges(qm, purl, ranges, false);
-        Assert.assertNotNull(vulnerableSoftwares);
-        Assert.assertEquals(0, vulnerableSoftwares.size());
+        Assertions.assertNotNull(vulnerableSoftwares);
+        Assertions.assertEquals(0, vulnerableSoftwares.size());
     }
 
     @Test
-    public void testParseVersionRangesStar_v3() throws IOException {
+    void testParseVersionRangesStar_v3() throws IOException {
 
         String jsonString = new String(Files.readAllBytes(Paths.get("src/test/resources/unit/snyk.jsons/ranges.json")));
         final JSONObject jsonObject = new JSONObject(jsonString);
         JSONArray ranges = jsonObject.optJSONArray("range2_v3");
         String purl = "pkg:npm/bootstrap-table@1.20.0";
         List<VulnerableSoftware> vulnerableSoftwares = parser.parseVersionRanges(qm, purl, ranges, true);
-        Assert.assertNotNull(vulnerableSoftwares);
-        Assert.assertEquals(0, vulnerableSoftwares.size());
+        Assertions.assertNotNull(vulnerableSoftwares);
+        Assertions.assertEquals(0, vulnerableSoftwares.size());
     }
 
     @Test
-    public void testParseVersionIndefiniteRanges() throws IOException {
+    void testParseVersionIndefiniteRanges() throws IOException {
 
         String jsonString = new String(Files.readAllBytes(Paths.get("src/test/resources/unit/snyk.jsons/ranges.json")));
         final JSONObject jsonObject = new JSONObject(jsonString);
         JSONArray ranges = jsonObject.optJSONArray("range1");
         String purl = "pkg:npm/bootstrap-table@1.20.0";
         List<VulnerableSoftware> vulnerableSoftwares = parser.parseVersionRanges(qm, purl, ranges, false);
-        Assert.assertNotNull(vulnerableSoftwares);
-        Assert.assertEquals(0, vulnerableSoftwares.size());
+        Assertions.assertNotNull(vulnerableSoftwares);
+        Assertions.assertEquals(0, vulnerableSoftwares.size());
     }
 
     @Test
-    public void testParseVersionIndefiniteRanges_v3() throws IOException {
+    void testParseVersionIndefiniteRanges_v3() throws IOException {
 
         String jsonString = new String(Files.readAllBytes(Paths.get("src/test/resources/unit/snyk.jsons/ranges.json")));
         final JSONObject jsonObject = new JSONObject(jsonString);
         JSONArray ranges = jsonObject.optJSONArray("range1_v3");
         String purl = "pkg:npm/bootstrap-table@1.20.0";
         List<VulnerableSoftware> vulnerableSoftwares = parser.parseVersionRanges(qm, purl, ranges, true);
-        Assert.assertNotNull(vulnerableSoftwares);
-        Assert.assertEquals(0, vulnerableSoftwares.size());
+        Assertions.assertNotNull(vulnerableSoftwares);
+        Assertions.assertEquals(0, vulnerableSoftwares.size());
     }
 
     @Test
-    public void testParseSeveritiesNvd() throws IOException {
+    void testParseSeveritiesNvd() throws IOException {
 
         // By default NVD is first priority for CVSS, no need to set config property.
         String jsonString = new String(Files.readAllBytes(Paths.get("src/test/resources/unit/snyk.jsons/severities.json")));
         final JSONObject jsonObject = new JSONObject(jsonString);
         JSONArray severities = jsonObject.optJSONArray("severities1");
         JSONObject cvss = parser.selectCvssObjectBasedOnSource(severities);
-        Assert.assertNotNull(cvss);
-        Assert.assertEquals("NVD", cvss.optString("source"));
+        Assertions.assertNotNull(cvss);
+        Assertions.assertEquals("NVD", cvss.optString("source"));
 
         severities = jsonObject.optJSONArray("severities2");
         cvss = parser.selectCvssObjectBasedOnSource(severities);
-        Assert.assertNotNull(cvss);
-        Assert.assertEquals("SNYK", cvss.optString("source"));
+        Assertions.assertNotNull(cvss);
+        Assertions.assertEquals("SNYK", cvss.optString("source"));
 
         severities = jsonObject.optJSONArray("severities5");
         cvss = parser.selectCvssObjectBasedOnSource(severities);
-        Assert.assertNotNull(cvss);
-        Assert.assertEquals("RHEL", cvss.optString("source"));
+        Assertions.assertNotNull(cvss);
+        Assertions.assertEquals("RHEL", cvss.optString("source"));
     }
 
     @Test
-    public void testParseSeveritiesSnyk() throws IOException {
+    void testParseSeveritiesSnyk() throws IOException {
 
         qm.createConfigProperty(SCANNER_SNYK_CVSS_SOURCE.getGroupName(),
                 SCANNER_SNYK_CVSS_SOURCE.getPropertyName(),
@@ -163,22 +163,22 @@ public class SnykParserTest extends PersistenceCapableTest {
         final JSONObject jsonObject = new JSONObject(jsonString);
         JSONArray severities = jsonObject.optJSONArray("severities1");
         JSONObject cvss = parser.selectCvssObjectBasedOnSource(severities);
-        Assert.assertNotNull(cvss);
-        Assert.assertEquals("SNYK", cvss.optString("source"));
+        Assertions.assertNotNull(cvss);
+        Assertions.assertEquals("SNYK", cvss.optString("source"));
 
         severities = jsonObject.optJSONArray("severities3");
         cvss = parser.selectCvssObjectBasedOnSource(severities);
-        Assert.assertNotNull(cvss);
-        Assert.assertEquals("NVD", cvss.optString("source"));
+        Assertions.assertNotNull(cvss);
+        Assertions.assertEquals("NVD", cvss.optString("source"));
 
         severities = jsonObject.optJSONArray("severities4");
         cvss = parser.selectCvssObjectBasedOnSource(severities);
-        Assert.assertNotNull(cvss);
-        Assert.assertEquals("RHEL", cvss.optString("source"));
+        Assertions.assertNotNull(cvss);
+        Assertions.assertEquals("RHEL", cvss.optString("source"));
     }
 
     @Test
-    public void testGetSnykCvssConfig() {
+    void testGetSnykCvssConfig() {
         qm.createConfigProperty(SCANNER_SNYK_API_TOKEN.getGroupName(),
                 SCANNER_SNYK_API_TOKEN.getPropertyName(),
                 "token",
@@ -191,57 +191,57 @@ public class SnykParserTest extends PersistenceCapableTest {
                 "username");
 
         String config = parser.getSnykCvssConfig(SCANNER_SNYK_CVSS_SOURCE);
-        Assert.assertNotNull(config);
-        Assert.assertEquals("NVD", config);
+        Assertions.assertNotNull(config);
+        Assertions.assertEquals("NVD", config);
         config = parser.getSnykCvssConfig(SCANNER_SNYK_ENABLED);
-        Assert.assertNotNull(config);
-        Assert.assertEquals("false", config);
+        Assertions.assertNotNull(config);
+        Assertions.assertEquals("false", config);
         config = parser.getSnykCvssConfig(SCANNER_SNYK_API_TOKEN);
-        Assert.assertNotNull(config);
-        Assert.assertEquals("token", config);
+        Assertions.assertNotNull(config);
+        Assertions.assertEquals("token", config);
         config = parser.getSnykCvssConfig(SCANNER_OSSINDEX_API_USERNAME);
-        Assert.assertNotNull(config);
-        Assert.assertEquals("username", config);
+        Assertions.assertNotNull(config);
+        Assertions.assertEquals("username", config);
     }
 
     @Test
-    public void testSelectCvssObjectBasedOnSource() throws IOException {
+    void testSelectCvssObjectBasedOnSource() throws IOException {
         String jsonString = new String(Files.readAllBytes(Paths.get("src/test/resources/unit/snyk.jsons/severities.json")));
         final JSONObject jsonObject = new JSONObject(jsonString);
         JSONArray severities = jsonObject.optJSONArray("severities1");
         JSONObject cvss = parser.selectCvssObjectBasedOnSource(severities);
-        Assert.assertNotNull(cvss);
-        Assert.assertEquals("NVD", cvss.optString("source"));
-        Assert.assertEquals("high", cvss.optString("level"));
-        Assert.assertEquals("7.5", cvss.optString("score"));
-        Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H", cvss.optString("vector"));
+        Assertions.assertNotNull(cvss);
+        Assertions.assertEquals("NVD", cvss.optString("source"));
+        Assertions.assertEquals("high", cvss.optString("level"));
+        Assertions.assertEquals("7.5", cvss.optString("score"));
+        Assertions.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H", cvss.optString("vector"));
 
         severities = jsonObject.optJSONArray("severities4");
         cvss = parser.selectCvssObjectBasedOnSource(severities);
-        Assert.assertNotNull(cvss);
-        Assert.assertEquals("RHEL", cvss.optString("source"));
-        Assert.assertEquals("high", cvss.optString("level"));
-        Assert.assertEquals("7.5", cvss.optString("score"));
-        Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H", cvss.optString("vector"));
+        Assertions.assertNotNull(cvss);
+        Assertions.assertEquals("RHEL", cvss.optString("source"));
+        Assertions.assertEquals("high", cvss.optString("level"));
+        Assertions.assertEquals("7.5", cvss.optString("score"));
+        Assertions.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H", cvss.optString("vector"));
 
         severities = jsonObject.optJSONArray("severities2");
         cvss = parser.selectCvssObjectBasedOnSource(severities);
-        Assert.assertNotNull(cvss);
-        Assert.assertEquals("SNYK", cvss.optString("source"));
-        Assert.assertEquals("high", cvss.optString("level"));
-        Assert.assertEquals("7.5", cvss.optString("score"));
-        Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P", cvss.optString("vector"));
+        Assertions.assertNotNull(cvss);
+        Assertions.assertEquals("SNYK", cvss.optString("source"));
+        Assertions.assertEquals("high", cvss.optString("level"));
+        Assertions.assertEquals("7.5", cvss.optString("score"));
+        Assertions.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P", cvss.optString("vector"));
         severities = jsonObject.optJSONArray("severities3");
         cvss = parser.selectCvssObjectBasedOnSource(severities);
-        Assert.assertNotNull(cvss);
-        Assert.assertEquals("NVD", cvss.optString("source"));
-        Assert.assertEquals("high", cvss.optString("level"));
-        Assert.assertEquals("7.5", cvss.optString("score"));
-        Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H", cvss.optString("vector"));
+        Assertions.assertNotNull(cvss);
+        Assertions.assertEquals("NVD", cvss.optString("source"));
+        Assertions.assertEquals("high", cvss.optString("level"));
+        Assertions.assertEquals("7.5", cvss.optString("score"));
+        Assertions.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H", cvss.optString("vector"));
     }
 
     @Test
-    public void testParseErrors() {
+    void testParseErrors() {
         final JSONObject jsonObject = new JSONObject("""
                 {
                    "jsonapi": {
@@ -279,12 +279,12 @@ public class SnykParserTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testParseErrorsWhenInputIsNull() {
+    void testParseErrorsWhenInputIsNull() {
         assertThat(parser.parseErrors(null)).isEmpty();
     }
 
     @Test
-    public void testParseErrorsWhenInputHasNoErrorsField() {
+    void testParseErrorsWhenInputHasNoErrorsField() {
         assertThat(parser.parseErrors(new JSONObject("{}"))).isEmpty();
     }
 

--- a/src/test/java/org/dependencytrack/parser/spdx/expression/SpdxExpressionParserTest.java
+++ b/src/test/java/org/dependencytrack/parser/spdx/expression/SpdxExpressionParserTest.java
@@ -1,65 +1,63 @@
 package org.dependencytrack.parser.spdx.expression;
 
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 
 import org.dependencytrack.parser.spdx.expression.model.SpdxExpression;
-import org.dependencytrack.persistence.QueryManager;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class SpdxExpressionParserTest {
+class SpdxExpressionParserTest {
     
     private SpdxExpressionParser parser;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         parser = new SpdxExpressionParser();
     }
 
     @Test
-    public void testParsingOfSuperfluousParentheses() throws IOException {
+    void testParsingOfSuperfluousParentheses() throws IOException {
         var exp = parser.parse("(Apache OR MIT WITH (CPE) AND GPL WITH ((CC0 OR GPL-2)))");
-        assertEquals("OR(Apache, AND(WITH(MIT, CPE), WITH(GPL, OR(CC0, GPL-2))))", exp.toString());
+        Assertions.assertEquals("OR(Apache, AND(WITH(MIT, CPE), WITH(GPL, OR(CC0, GPL-2))))", exp.toString());
     }
 
     @Test
-    public void testThatAndOperatorBindsStrongerThanOrOperator() throws IOException {
+    void testThatAndOperatorBindsStrongerThanOrOperator() throws IOException {
         var exp = parser.parse("LGPL-2.1-only OR BSD-3-Clause AND MIT");
-        assertEquals("OR(LGPL-2.1-only, AND(BSD-3-Clause, MIT))", exp.toString());
+        Assertions.assertEquals("OR(LGPL-2.1-only, AND(BSD-3-Clause, MIT))", exp.toString());
     }
 
     @Test
-    public void testThatWithOperatorBindsStrongerThanAndOperator() throws IOException {
+    void testThatWithOperatorBindsStrongerThanAndOperator() throws IOException {
         var exp = parser.parse("LGPL-2.1-only WITH CPE AND MIT OR BSD-3-Clause");
-        assertEquals("OR(AND(WITH(LGPL-2.1-only, CPE), MIT), BSD-3-Clause)", exp.toString());
+        Assertions.assertEquals("OR(AND(WITH(LGPL-2.1-only, CPE), MIT), BSD-3-Clause)", exp.toString());
     }
 
     @Test
-    public void testThatParenthesesOverrideOperatorPrecedence() throws IOException {
+    void testThatParenthesesOverrideOperatorPrecedence() throws IOException {
         var exp = parser.parse("MIT AND (LGPL-2.1-or-later OR BSD-3-Clause)");
-        assertEquals("AND(MIT, OR(LGPL-2.1-or-later, BSD-3-Clause))", exp.toString());
+        Assertions.assertEquals("AND(MIT, OR(LGPL-2.1-or-later, BSD-3-Clause))", exp.toString());
     }
 
     @Test
-    public void testParsingWithMissingSpaceAfterParenthesis() throws IOException {
+    void testParsingWithMissingSpaceAfterParenthesis() throws IOException {
         var exp = parser.parse("(MIT)AND(LGPL-2.1-or-later WITH(CC0 OR GPL-2))");
-        assertEquals("AND(MIT, WITH(LGPL-2.1-or-later, OR(CC0, GPL-2)))", exp.toString());
+        Assertions.assertEquals("AND(MIT, WITH(LGPL-2.1-or-later, OR(CC0, GPL-2)))", exp.toString());
     }
 
     @Test
-    public void testMissingClosingParenthesis() throws IOException {
+    void testMissingClosingParenthesis() throws IOException {
         var exp = parser.parse("MIT (OR BSD-3-Clause");
-        assertEquals(SpdxExpression.INVALID, exp);
+        Assertions.assertEquals(SpdxExpression.INVALID, exp);
     }
 
     @Test
-    public void testMissingOpeningParenthesis() throws IOException {
+    void testMissingOpeningParenthesis() throws IOException {
         var exp = parser.parse("MIT )(OR BSD-3-Clause");
-        assertEquals(SpdxExpression.INVALID, exp);
+        Assertions.assertEquals(SpdxExpression.INVALID, exp);
     }
 
 }

--- a/src/test/java/org/dependencytrack/parser/vulndb/ModelConverterTest.java
+++ b/src/test/java/org/dependencytrack/parser/vulndb/ModelConverterTest.java
@@ -12,18 +12,17 @@ import org.dependencytrack.model.VulnerabilityAlias;
 import org.dependencytrack.parser.vulndb.model.CvssV3Metric;
 import org.dependencytrack.parser.vulndb.model.Results;
 import org.dependencytrack.persistence.QueryManager;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
-public class ModelConverterTest {
+class ModelConverterTest {
     private List<?> resultList;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         String filePath = "src/test/resources/unit/vulndb.jsons/vulnerabilities_0.json";
         File file = new File(filePath);
@@ -36,42 +35,42 @@ public class ModelConverterTest {
         }
     }
     @Test
-    public void testConvert() {
+    void testConvert() {
         final OffsetDateTime odt = OffsetDateTime.parse("2021-12-20T21:34:04Z");
         final org.dependencytrack.parser.vulndb.model.Vulnerability vulnDbVuln = (org.dependencytrack.parser.vulndb.model.Vulnerability) resultList.get(0);
         Vulnerability vulnerability = ModelConverter.convert(mock(QueryManager.class), vulnDbVuln);
-        assertNotNull(vulnerability);
-        assertEquals("1", vulnerability.getVulnId());
-        assertEquals("test title", vulnerability.getTitle());
-        assertEquals(Date.from(odt.toInstant()), vulnerability.getUpdated());
-        assertEquals("(AV:N/AC:M/Au:N/C:P/I:N/A:N)", vulnerability.getCvssV2Vector());
-        assertEquals("CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N", vulnerability.getCvssV3Vector());
-        assertEquals(BigDecimal.valueOf(4.3), vulnerability.getCvssV2BaseScore());
-        assertEquals(BigDecimal.valueOf(4.3), vulnerability.getCvssV3BaseScore());
-        assertEquals("* [http://example.com](http://example.com)\n", vulnerability.getReferences());
+        Assertions.assertNotNull(vulnerability);
+        Assertions.assertEquals("1", vulnerability.getVulnId());
+        Assertions.assertEquals("test title", vulnerability.getTitle());
+        Assertions.assertEquals(Date.from(odt.toInstant()), vulnerability.getUpdated());
+        Assertions.assertEquals("(AV:N/AC:M/Au:N/C:P/I:N/A:N)", vulnerability.getCvssV2Vector());
+        Assertions.assertEquals("CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N", vulnerability.getCvssV3Vector());
+        Assertions.assertEquals(BigDecimal.valueOf(4.3), vulnerability.getCvssV2BaseScore());
+        Assertions.assertEquals(BigDecimal.valueOf(4.3), vulnerability.getCvssV3BaseScore());
+        Assertions.assertEquals("* [http://example.com](http://example.com)\n", vulnerability.getReferences());
         VulnerabilityAlias alias = vulnerability.getAliases().get(0);
-        assertEquals("CVE-1234-0000", alias.getCveId());
+        Assertions.assertEquals("CVE-1234-0000", alias.getCveId());
     }
     @Test
-    public void testConvertWithoutNvdAdditionalInfo() {
+    void testConvertWithoutNvdAdditionalInfo() {
         final org.dependencytrack.parser.vulndb.model.Vulnerability vulnDbVuln = (org.dependencytrack.parser.vulndb.model.Vulnerability) resultList.get(1);
         Vulnerability vulnerability = ModelConverter.convert(mock(QueryManager.class), vulnDbVuln);
-        assertNotNull(vulnerability);
+        Assertions.assertNotNull(vulnerability);
         for (final CvssV3Metric metric : vulnDbVuln.cvssV3Metrics()) {
-            assertEquals("1234-0000" ,metric.cveId());
+            Assertions.assertEquals("1234-0000", metric.cveId());
         }
         VulnerabilityAlias alias = vulnerability.getAliases().get(0);
-        assertEquals("CVE-1234-0000", alias.getCveId());
+        Assertions.assertEquals("CVE-1234-0000", alias.getCveId());
     }
     @Test
-    public void testConvertWithoutAnyCve() {
+    void testConvertWithoutAnyCve() {
             final org.dependencytrack.parser.vulndb.model.Vulnerability vulnDbVuln = (org.dependencytrack.parser.vulndb.model.Vulnerability) resultList.get(2);
             Vulnerability vulnerability = ModelConverter.convert(mock(QueryManager.class), vulnDbVuln);
-            assertNotNull(vulnerability);
+            Assertions.assertNotNull(vulnerability);
             for (final CvssV3Metric metric : vulnDbVuln.cvssV3Metrics()) {
-                assertNull(metric.cveId());
+                Assertions.assertNull(metric.cveId());
             }
-            assertNull(vulnerability.getAliases());
+            Assertions.assertNull(vulnerability.getAliases());
 
     }
 }

--- a/src/test/java/org/dependencytrack/parser/vulndb/VulnDbParserTest.java
+++ b/src/test/java/org/dependencytrack/parser/vulndb/VulnDbParserTest.java
@@ -20,17 +20,17 @@ package org.dependencytrack.parser.vulndb;
 
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.parser.vulndb.model.Results;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class VulnDbParserTest {
+class VulnDbParserTest {
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         String filePath = "src/test/resources/unit/vulndb.jsons/vulnerabilities_0.json";
         File file = new File(filePath);
         final VulnDbParser parser = new VulnDbParser();

--- a/src/test/java/org/dependencytrack/persistence/CollectionIntegerConverterTest.java
+++ b/src/test/java/org/dependencytrack/persistence/CollectionIntegerConverterTest.java
@@ -1,15 +1,15 @@
 package org.dependencytrack.persistence;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CollectionIntegerConverterTest {
+class CollectionIntegerConverterTest {
 
     @Test
-    public void convertToDatastoreTest() {
+    void convertToDatastoreTest() {
         assertThat(new CollectionIntegerConverter().convertToDatastore(null)).isNull();
         assertThat(new CollectionIntegerConverter().convertToDatastore(List.of())).isEmpty();
         assertThat(new CollectionIntegerConverter().convertToDatastore(List.of(666))).isEqualTo("666");
@@ -17,7 +17,7 @@ public class CollectionIntegerConverterTest {
     }
 
     @Test
-    public void convertToAttributeTest() {
+    void convertToAttributeTest() {
         assertThat(new CollectionIntegerConverter().convertToAttribute(null)).isNull();
         assertThat(new CollectionIntegerConverter().convertToAttribute("")).isNull();
         assertThat(new CollectionIntegerConverter().convertToAttribute(" ")).isNull();

--- a/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
+++ b/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
@@ -23,17 +23,17 @@ import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.License;
 import org.dependencytrack.notification.publisher.DefaultNotificationPublishers;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DefaultObjectGeneratorTest extends PersistenceCapableTest {
+class DefaultObjectGeneratorTest extends PersistenceCapableTest {
 
     @Test
-    public void testContextInitialized() throws Exception {
+    void testContextInitialized() throws Exception {
         testLoadDefaultPermissions();
         testLoadDefaultPersonas();
         testLoadDefaultLicenses();
@@ -43,16 +43,16 @@ public class DefaultObjectGeneratorTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testLoadDefaultLicenses() throws Exception {
+    void testLoadDefaultLicenses() throws Exception {
         DefaultObjectGenerator generator = new DefaultObjectGenerator();
         Method method = generator.getClass().getDeclaredMethod("loadDefaultLicenses");
         method.setAccessible(true);
         method.invoke(generator);
-        Assert.assertEquals(757, qm.getAllLicensesConcise().size());
+        Assertions.assertEquals(757, qm.getAllLicensesConcise().size());
     }
 
     @Test
-    public void testLoadDefaultLicensesUpdatesExistingLicenses() throws Exception {
+    void testLoadDefaultLicensesUpdatesExistingLicenses() throws Exception {
         final var license = new License();
         license.setLicenseId("LGPL-2.1+");
         license.setName("name");
@@ -79,47 +79,47 @@ public class DefaultObjectGeneratorTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testLoadDefaultPermissions() throws Exception {
+    void testLoadDefaultPermissions() throws Exception {
         DefaultObjectGenerator generator = new DefaultObjectGenerator();
         Method method = generator.getClass().getDeclaredMethod("loadDefaultPermissions");
         method.setAccessible(true);
         method.invoke(generator);
-        Assert.assertEquals(Permissions.values().length, qm.getPermissions().size());
+        Assertions.assertEquals(Permissions.values().length, qm.getPermissions().size());
     }
 
     @Test
-    public void testLoadDefaultPersonas() throws Exception {
+    void testLoadDefaultPersonas() throws Exception {
         DefaultObjectGenerator generator = new DefaultObjectGenerator();
         Method method = generator.getClass().getDeclaredMethod("loadDefaultPersonas");
         method.setAccessible(true);
         method.invoke(generator);
-        Assert.assertEquals(4, qm.getTeams().size());
+        Assertions.assertEquals(4, qm.getTeams().size());
     }
 
     @Test
-    public void testLoadDefaultRepositories() throws Exception {
+    void testLoadDefaultRepositories() throws Exception {
         DefaultObjectGenerator generator = new DefaultObjectGenerator();
         Method method = generator.getClass().getDeclaredMethod("loadDefaultRepositories");
         method.setAccessible(true);
         method.invoke(generator);
-        Assert.assertEquals(17, qm.getAllRepositories().size());
+        Assertions.assertEquals(17, qm.getAllRepositories().size());
     }
 
     @Test
-    public void testLoadDefaultConfigProperties() throws Exception {
+    void testLoadDefaultConfigProperties() throws Exception {
         DefaultObjectGenerator generator = new DefaultObjectGenerator();
         Method method = generator.getClass().getDeclaredMethod("loadDefaultConfigProperties");
         method.setAccessible(true);
         method.invoke(generator);
-        Assert.assertEquals(ConfigPropertyConstants.values().length, qm.getConfigProperties().size());
+        Assertions.assertEquals(ConfigPropertyConstants.values().length, qm.getConfigProperties().size());
     }
 
     @Test
-    public void testLoadDefaultNotificationPublishers() throws Exception {
+    void testLoadDefaultNotificationPublishers() throws Exception {
         DefaultObjectGenerator generator = new DefaultObjectGenerator();
         Method method = generator.getClass().getDeclaredMethod("loadDefaultNotificationPublishers");
         method.setAccessible(true);
         method.invoke(generator);
-        Assert.assertEquals(DefaultNotificationPublishers.values().length, qm.getAllNotificationPublishers().size());
+        Assertions.assertEquals(DefaultNotificationPublishers.values().length, qm.getAllNotificationPublishers().size());
     }
 }

--- a/src/test/java/org/dependencytrack/persistence/PackageURLStringConverterTest.java
+++ b/src/test/java/org/dependencytrack/persistence/PackageURLStringConverterTest.java
@@ -19,22 +19,22 @@
 package org.dependencytrack.persistence;
 
 import com.github.packageurl.PackageURL;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class PackageURLStringConverterTest { 
+class PackageURLStringConverterTest {
 
     @Test
-    public void testConvertToAttributeStr() throws Exception {
+    void testConvertToAttributeStr() throws Exception {
         PackageURLStringConverter converter = new PackageURLStringConverter();
         PackageURL purl = converter.convertToAttribute("pkg:maven/acme/example@1.0.0?type=jar");
-        Assert.assertEquals(purl.toString(), "pkg:maven/acme/example@1.0.0?type=jar");
+        Assertions.assertEquals(purl.toString(), "pkg:maven/acme/example@1.0.0?type=jar");
     } 
 
     @Test
-    public void testConvertToDatastoreUrl() throws Exception {
+    void testConvertToDatastoreUrl() throws Exception {
         PackageURLStringConverter converter = new PackageURLStringConverter();
         String purlString = converter.convertToDatastore(new PackageURL("pkg:maven/acme/example@1.0.0?type=jar"));
-        Assert.assertEquals("pkg:maven/acme/example@1.0.0?type=jar", purlString);
+        Assertions.assertEquals("pkg:maven/acme/example@1.0.0?type=jar", purlString);
     }
 } 

--- a/src/test/java/org/dependencytrack/persistence/PolicyQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/PolicyQueryManagerTest.java
@@ -26,8 +26,9 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ViolationAnalysis;
 import org.dependencytrack.model.ViolationAnalysisComment;
 import org.dependencytrack.model.ViolationAnalysisState;
-import org.junit.Test;
-import org.junit.Assert;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -35,10 +36,10 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PolicyQueryManagerTest extends PersistenceCapableTest {
+class PolicyQueryManagerTest extends PersistenceCapableTest {
 
     @Test
-    public void testRemoveProjectFromPolicies() {
+    void testRemoveProjectFromPolicies() {
         final Project project = qm.createProject("ACME Example", null, "1.0", null, null, null, true, false);
 
         // Create multiple policies that all reference the project
@@ -56,7 +57,7 @@ public class PolicyQueryManagerTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testclonePolicyViolation() throws Exception{
+    void testclonePolicyViolation() throws Exception{
         PolicyViolation policyViolation = new PolicyViolation();
         policyViolation.setId(1);
 
@@ -90,18 +91,18 @@ public class PolicyQueryManagerTest extends PersistenceCapableTest {
         policyViolation.setAnalysis(violationAnalysis);
 
         PolicyViolation clonedPolicyViolation = qm.clonePolicyViolation(policyViolation, component);
-        Assert.assertEquals(policyViolation.getText(), clonedPolicyViolation.getText());
-        Assert.assertEquals(policyViolation.getType(), clonedPolicyViolation.getType());
-        Assert.assertEquals(policyViolation.getTimestamp(), clonedPolicyViolation.getTimestamp());
-        Assert.assertEquals(policyViolation.getAnalysis().isSuppressed(), clonedPolicyViolation.getAnalysis().isSuppressed());
-        Assert.assertEquals(policyViolation.getAnalysis().getAnalysisState(), clonedPolicyViolation.getAnalysis().getAnalysisState());
-        Assert.assertEquals(policyViolation.getAnalysis().getAnalysisComments().get(0).getComment(), clonedPolicyViolation.getAnalysis().getAnalysisComments().get(0).getComment());
-        Assert.assertEquals(policyViolation.getAnalysis().getAnalysisComments().get(0).getCommenter(), clonedPolicyViolation.getAnalysis().getAnalysisComments().get(0).getCommenter());
-        Assert.assertEquals(policyViolation.getAnalysis().getAnalysisComments().get(0).getTimestamp(), clonedPolicyViolation.getAnalysis().getAnalysisComments().get(0).getTimestamp());
-        Assert.assertEquals(policyViolation.getComponent().getId(), clonedPolicyViolation.getComponent().getId());
-        Assert.assertEquals(policyViolation.getComponent().getName(), clonedPolicyViolation.getComponent().getName());
-        Assert.assertEquals(policyViolation.getComponent().getCopyright(), clonedPolicyViolation.getComponent().getCopyright());
-        Assert.assertEquals(policyViolation.getComponent().getVersion(), clonedPolicyViolation.getComponent().getVersion());
+        Assertions.assertEquals(policyViolation.getText(), clonedPolicyViolation.getText());
+        Assertions.assertEquals(policyViolation.getType(), clonedPolicyViolation.getType());
+        Assertions.assertEquals(policyViolation.getTimestamp(), clonedPolicyViolation.getTimestamp());
+        Assertions.assertEquals(policyViolation.getAnalysis().isSuppressed(), clonedPolicyViolation.getAnalysis().isSuppressed());
+        Assertions.assertEquals(policyViolation.getAnalysis().getAnalysisState(), clonedPolicyViolation.getAnalysis().getAnalysisState());
+        Assertions.assertEquals(policyViolation.getAnalysis().getAnalysisComments().get(0).getComment(), clonedPolicyViolation.getAnalysis().getAnalysisComments().get(0).getComment());
+        Assertions.assertEquals(policyViolation.getAnalysis().getAnalysisComments().get(0).getCommenter(), clonedPolicyViolation.getAnalysis().getAnalysisComments().get(0).getCommenter());
+        Assertions.assertEquals(policyViolation.getAnalysis().getAnalysisComments().get(0).getTimestamp(), clonedPolicyViolation.getAnalysis().getAnalysisComments().get(0).getTimestamp());
+        Assertions.assertEquals(policyViolation.getComponent().getId(), clonedPolicyViolation.getComponent().getId());
+        Assertions.assertEquals(policyViolation.getComponent().getName(), clonedPolicyViolation.getComponent().getName());
+        Assertions.assertEquals(policyViolation.getComponent().getCopyright(), clonedPolicyViolation.getComponent().getCopyright());
+        Assertions.assertEquals(policyViolation.getComponent().getVersion(), clonedPolicyViolation.getComponent().getVersion());
     }
 
 }

--- a/src/test/java/org/dependencytrack/persistence/ProjectQueryFilterBuilderTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ProjectQueryFilterBuilderTest.java
@@ -1,37 +1,34 @@
 package org.dependencytrack.persistence;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-public class ProjectQueryFilterBuilderTest {
+class ProjectQueryFilterBuilderTest {
 
     @Test
-    public void testEmptyBuilderBuildsEmptyFilter() {
+    void testEmptyBuilderBuildsEmptyFilter() {
         var builder = new ProjectQueryFilterBuilder();
         var filter = builder.buildFilter();
-        assertNotNull(filter);
-        assertTrue(filter.isEmpty());
+        Assertions.assertNotNull(filter);
+        Assertions.assertTrue(filter.isEmpty());
     }
 
     @Test
-    public void testEmptyBuilderBuildsEmptyParams() {
+    void testEmptyBuilderBuildsEmptyParams() {
         var builder = new ProjectQueryFilterBuilder();
         var params = builder.getParams();
-        assertNotNull(params);
-        assertTrue(params.isEmpty());
+        Assertions.assertNotNull(params);
+        Assertions.assertTrue(params.isEmpty());
     }
 
     @Test
-    public void testBuilderBuildsFilterAndParams() {
+    void testBuilderBuildsFilterAndParams() {
         var testName = "test";
         var builder = new ProjectQueryFilterBuilder().withName(testName);
-        assertEquals(Map.of("name", testName), builder.getParams());
-        assertEquals("(name == :name)", builder.buildFilter());
+        Assertions.assertEquals(Map.of("name", testName), builder.getParams());
+        Assertions.assertEquals("(name == :name)", builder.buildFilter());
     }
 
 }

--- a/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
@@ -21,18 +21,18 @@ package org.dependencytrack.persistence;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.*;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class ProjectQueryManagerTest extends PersistenceCapableTest {
+class ProjectQueryManagerTest extends PersistenceCapableTest {
 
     @Test
-    public void testCloneProjectPreservesVulnerabilityAttributionDate() throws Exception {
+    void testCloneProjectPreservesVulnerabilityAttributionDate() throws Exception {
         Project project = qm.createProject("Example Project 1", "Description 1", "1.0", null, null, null, true, false);
         Component comp = new Component();
         comp.setId(111L);
@@ -50,15 +50,15 @@ public class ProjectQueryManagerTest extends PersistenceCapableTest {
         Project clonedProject = qm.clone(project.getUuid(), "1.1.0", false, false,
                 true, false, false, false, false, false);
         List<Finding> findings = qm.getFindings(clonedProject);
-        Assert.assertEquals(1, findings.size());
+        Assertions.assertEquals(1, findings.size());
         Finding finding = findings.get(0);
-        Assert.assertNotNull(finding);
-        Assert.assertFalse(finding.getAttribution().isEmpty());
-        Assert.assertEquals(new Date(1708559165229L),finding.getAttribution().get("attributedOn"));
+        Assertions.assertNotNull(finding);
+        Assertions.assertFalse(finding.getAttribution().isEmpty());
+        Assertions.assertEquals(new Date(1708559165229L), finding.getAttribution().get("attributedOn"));
     }
 
     @Test
-    public void testUpdateProjectPreventCollectionProjectWithExistingComponentsTest() {
+    void testUpdateProjectPreventCollectionProjectWithExistingComponentsTest() {
         Project project = qm.createProject("Example Project 1", "Description 1", "1.0", null, null, null, true, false);
         Component comp = new Component();
         comp.setId(111L);
@@ -78,7 +78,7 @@ public class ProjectQueryManagerTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testUpdateProjectPreventCollectionProjectWithExistingServiceTest() {
+    void testUpdateProjectPreventCollectionProjectWithExistingServiceTest() {
         Project project = qm.createProject("Example Project 1", "Description 1", "1.0", null, null, null, true, false);
         ServiceComponent service = new ServiceComponent();
         service.setName("name");

--- a/src/test/java/org/dependencytrack/persistence/VulnerabilityQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/VulnerabilityQueryManagerTest.java
@@ -18,16 +18,15 @@
  */
 package org.dependencytrack.persistence;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
 
 import javax.jdo.Query;
 import java.util.ArrayList;
@@ -41,15 +40,14 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.persistence.VulnerabilityQueryManagerTest.SynchronizeVulnerabilityAliasTest.VulnerabilityAliasBuilder.anAlias;
 
-@RunWith(Suite.class)
-@SuiteClasses(VulnerabilityQueryManagerTest.SynchronizeVulnerabilityAliasTest.class)
+@RunWith(Enclosed.class)
 public class VulnerabilityQueryManagerTest {
 
-    @RunWith(JUnitParamsRunner.class)
-    public static class SynchronizeVulnerabilityAliasTest extends PersistenceCapableTest {
+    @Nested
+    class SynchronizeVulnerabilityAliasTest extends PersistenceCapableTest {
 
         @Test
-        public void updateVulnerabilityNoChangesInUpdated() {
+        void updateVulnerabilityNoChangesInUpdated() {
             Vulnerability vuln = new Vulnerability();
             final Date updated = new Date();
             vuln.setId(124L);
@@ -74,7 +72,7 @@ public class VulnerabilityQueryManagerTest {
         }
 
         @Test
-        public void testUpdateVulnerabilityExecutionTime() {
+        void testUpdateVulnerabilityExecutionTime() {
         Vulnerability vuln = new Vulnerability();
         final Date updated = new Date();
         vuln.setId(124L);
@@ -107,7 +105,7 @@ public class VulnerabilityQueryManagerTest {
         }
 
         @Test
-        public void updateVulnerabilitySourceChanges() {
+        void updateVulnerabilitySourceChanges() {
             Vulnerability vuln = new Vulnerability();
             final Date updated = new Date();
             vuln.setId(124L);
@@ -138,12 +136,12 @@ public class VulnerabilityQueryManagerTest {
             assertThat(dbVuln.getSource()).isEqualTo("GITHUB");
         }
 
-        @Test
-        @SuppressWarnings({"unchecked", "resource", "JUnitMalformedDeclaration"})
-        @Parameters(method = "synchronizeVulnerabilityAliasTestParams")
-        public void synchronizeVulnerabilityAliasTest(final String description,
-                                                      final List<VulnerabilityAlias> reportedAliases,
-                                                      final List<VulnerabilityAlias> expectedAliases) {
+        @ParameterizedTest
+        @MethodSource("synchronizeVulnerabilityAliasTestParams")
+        @SuppressWarnings({"unchecked", "resource"})
+        void synchronizeVulnerabilityAliasTest(final String description,
+                                               final List<VulnerabilityAlias> reportedAliases,
+                                               final List<VulnerabilityAlias> expectedAliases) {
             for (final VulnerabilityAlias reportedAlias : reportedAliases) {
                 qm.synchronizeVulnerabilityAlias(reportedAlias);
             }
@@ -169,7 +167,7 @@ public class VulnerabilityQueryManagerTest {
         }
 
         @SuppressWarnings("unused")
-        private Object[] synchronizeVulnerabilityAliasTestParams() {
+        private static Object[] synchronizeVulnerabilityAliasTestParams() {
             return new Object[]{
                     new Object[]{
                             "Aliases must not be merged when identifiers do not match",

--- a/src/test/java/org/dependencytrack/persistence/converter/OrganizationalContactsJsonConverterTest.java
+++ b/src/test/java/org/dependencytrack/persistence/converter/OrganizationalContactsJsonConverterTest.java
@@ -19,17 +19,17 @@
 package org.dependencytrack.persistence.converter;
 
 import org.dependencytrack.model.OrganizationalContact;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OrganizationalContactsJsonConverterTest {
+class OrganizationalContactsJsonConverterTest {
 
     @Test
-    public void testConvertToDatastore() {
+    void testConvertToDatastore() {
         final var contact = new OrganizationalContact();
         contact.setName("Foo");
         contact.setEmail("foo@example.com");
@@ -48,7 +48,7 @@ public class OrganizationalContactsJsonConverterTest {
     }
 
     @Test
-    public void testConvertToAttribute() {
+    void testConvertToAttribute() {
         final List<OrganizationalContact> contacts = new OrganizationalContactsJsonConverter().convertToAttribute("""
                 [
                   {
@@ -67,12 +67,12 @@ public class OrganizationalContactsJsonConverterTest {
     }
 
     @Test
-    public void testConvertToDatastoreNull() {
+    void testConvertToDatastoreNull() {
         assertThat(new OrganizationalContactsJsonConverter().convertToDatastore(null)).isNull();
     }
 
     @Test
-    public void testConvertToAttributeNull() {
+    void testConvertToAttributeNull() {
         assertThat(new OrganizationalContactsJsonConverter().convertToAttribute(null)).isNull();
     }
 

--- a/src/test/java/org/dependencytrack/persistence/converter/OrganizationalEntityJsonConverterTest.java
+++ b/src/test/java/org/dependencytrack/persistence/converter/OrganizationalEntityJsonConverterTest.java
@@ -20,17 +20,17 @@ package org.dependencytrack.persistence.converter;
 
 import org.dependencytrack.model.OrganizationalContact;
 import org.dependencytrack.model.OrganizationalEntity;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OrganizationalEntityJsonConverterTest {
+class OrganizationalEntityJsonConverterTest {
 
     @Test
-    public void testConvertToDatastore() {
+    void testConvertToDatastore() {
         final var contact = new OrganizationalContact();
         contact.setName("Foo");
         contact.setEmail("foo@example.com");
@@ -60,7 +60,7 @@ public class OrganizationalEntityJsonConverterTest {
     }
 
     @Test
-    public void testConvertToAttribute() {
+    void testConvertToAttribute() {
         final OrganizationalEntity entity = new OrganizationalEntityJsonConverter().convertToAttribute("""
                 {
                   "name": "foo",
@@ -88,12 +88,12 @@ public class OrganizationalEntityJsonConverterTest {
     }
 
     @Test
-    public void testConvertToDatastoreNull() {
+    void testConvertToDatastoreNull() {
         assertThat(new OrganizationalEntityJsonConverter().convertToDatastore(null)).isNull();
     }
 
     @Test
-    public void testConvertToAttributeNull() {
+    void testConvertToAttributeNull() {
         assertThat(new OrganizationalEntityJsonConverter().convertToAttribute(null)).isNull();
     }
 

--- a/src/test/java/org/dependencytrack/policy/ComponentHashPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/ComponentHashPolicyEvaluatorTest.java
@@ -30,23 +30,23 @@ package org.dependencytrack.policy;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-public class ComponentHashPolicyEvaluatorTest {
+class ComponentHashPolicyEvaluatorTest {
 
     private ComponentHashPolicyEvaluator evaluator;
 
-    @Before
+    @BeforeEach
     public void initEvaluator() {
         evaluator = new ComponentHashPolicyEvaluator();
     }
 
     @Test
-    public void testIsConditionWithMatch() {
+    void testIsConditionWithMatch() {
         String hashJson = "{ 'algorithm': 'SHA-1', 'value': 'da39a3ee5e6b4b0d3255bfef95601890afd80709' }";
         Policy policy = new Policy();
         policy.setOperator(Policy.Operator.ANY);
@@ -62,11 +62,11 @@ public class ComponentHashPolicyEvaluatorTest {
         component.setSha1("da39a3ee5e6b4b0d3255bfef95601890afd80709");
 
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size()); // No violation expected
+        Assertions.assertEquals(1, violations.size()); // No violation expected
     }
 
     @Test
-    public void testIsConditionNoMatch() {
+    void testIsConditionNoMatch() {
         String hashJson = "{ 'algorithm': 'SHA-1', 'value': 'da39a3ee5e6b4b0d3255bfef95601890afd80709' }";
         Policy policy = new Policy();
         policy.setOperator(Policy.Operator.ANY);
@@ -82,11 +82,11 @@ public class ComponentHashPolicyEvaluatorTest {
         component.setSha1("abcdef1234567890abcdef1234567890abcdef12");
 
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size()); //  Violation expected
+        Assertions.assertEquals(0, violations.size()); //  Violation expected
     }
 
     @Test
-    public void testIsNotConditionWithMatch() {
+    void testIsNotConditionWithMatch() {
         String hashJson = "{ 'algorithm': 'SHA-1', 'value': 'da39a3ee5e6b4b0d3255bfef95601890afd80709' }";
         Policy policy = new Policy();
         policy.setOperator(Policy.Operator.ANY);
@@ -102,11 +102,11 @@ public class ComponentHashPolicyEvaluatorTest {
         component.setSha1("da39a3ee5e6b4b0d3255bfef95601890afd80709");
 
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size()); //  Violation expected
+        Assertions.assertEquals(0, violations.size()); //  Violation expected
     }
 
     @Test
-    public void testIsNotConditionNoMatch() {
+    void testIsNotConditionNoMatch() {
         String hashJson = "{ 'algorithm': 'SHA-1', 'value': 'da39a3ee5e6b4b0d3255bfef95601890afd80709' }";
         Policy policy = new Policy();
         policy.setOperator(Policy.Operator.ANY);
@@ -122,6 +122,6 @@ public class ComponentHashPolicyEvaluatorTest {
         component.setSha1("abcdef1234567890abcdef1234567890abcdef12");
 
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size()); // No violation expected
+        Assertions.assertEquals(1, violations.size()); // No violation expected
     }
 }

--- a/src/test/java/org/dependencytrack/policy/CoordinatesPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/CoordinatesPolicyEvaluatorTest.java
@@ -22,24 +22,24 @@ import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
+class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
 
     private PolicyEvaluator evaluator;
 
-    @Before
-    public void initEvaluator() {
+    @BeforeEach
+    public void initEvaluator() throws Exception {
         evaluator = new CoordinatesPolicyEvaluator();
         evaluator.setQueryManager(qm);
     }
 
     @Test
-    public void hasFullMatch() {
+    void hasFullMatch() {
         String def = "{ 'group': 'Acme', 'name': 'Test Component', 'version': '1.0.0' }";
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
@@ -48,14 +48,14 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         component.setName("Test Component");
         component.setVersion("1.0.0");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void hasMatchWithoutGroup() {
+    void hasMatchWithoutGroup() {
         String def = "{ 'name': 'Test Component', 'version': '1.0.0' }";
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
@@ -63,14 +63,14 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         component.setName("Test Component");
         component.setVersion("1.0.0");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void hasWildcardMatch() {
+    void hasWildcardMatch() {
         String def = "{ 'group': '*', 'name': 'Test Component', 'version': '1.0.0' }";
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
@@ -79,14 +79,14 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         component.setName("Test Component");
         component.setVersion("1.0.0");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void hasPartialMatch1() {
+    void hasPartialMatch1() {
         String def = "{ 'group': 'Acme', 'name': 'Test Component', 'version': '1.0.0' }";
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
@@ -95,11 +95,11 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         component.setName("Test Component");
         component.setVersion("2.0.0");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void hasPartialMatch2() {
+    void hasPartialMatch2() {
         String def = "{ 'group': 'Acme', 'name': 'Test Component', 'version': '1.0.0' }";
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
@@ -108,11 +108,11 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         component.setName("Test");
         component.setVersion("1.0.0");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void hasPartialMatch3() {
+    void hasPartialMatch3() {
         String def = "{ 'group': 'Acme', 'name': 'Test Component', 'version': '1.0.0' }";
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
@@ -121,11 +121,11 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         component.setName("Test Component");
         component.setVersion("1.0.0");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void hasPartialMatch4() {
+    void hasPartialMatch4() {
         String def = "{ 'group': 'Acme', 'name': 'Test Component', 'version': '1.0.0' }";
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
@@ -133,55 +133,55 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         component.setName("Test Component");
         component.setVersion("1.0.0");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void noMatch() {
+    void noMatch() {
         String def = "{ 'name': 'Test Component' }";
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
         Component component = new Component();
         component.setName("Example Component");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void wrongSubject() {
+    void wrongSubject() {
         String def = "{ 'name': 'Test Component' }";
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.MATCHES, def);
         Component component = new Component();
         component.setName("Test Component");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void wrongOperator() {
+    void wrongOperator() {
         String def = "{ 'name': 'Test Component' }";
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.IS, def);
         Component component = new Component();
         component.setName("Test Component");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void matchWithComponentVersionAndConditionVersionNull() {
+    void matchWithComponentVersionAndConditionVersionNull() {
         final String def = "{}";
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
 
         final var component = new Component();
 
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void noMatchWithConditionVersionNull() {
+    void noMatchWithConditionVersionNull() {
         final String def = "{}";
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
@@ -189,11 +189,11 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         final var component = new Component();
         component.setVersion("1.0.0");
 
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void matchWithVersionOperatorLessThan() {
+    void matchWithVersionOperatorLessThan() {
         final String def = "{ 'version': '< 1.1.1' }";
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
@@ -202,19 +202,19 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void noMatchWithVersionOperatorLessThan() {
+    void noMatchWithVersionOperatorLessThan() {
         final String def = "{ 'version': '< 1.1.1' }";
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
@@ -223,19 +223,19 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void matchWithVersionOperatorLessThanOrEqual() {
+    void matchWithVersionOperatorLessThanOrEqual() {
         final String def = "{ 'version': '<= 1.1.1' }";
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
@@ -244,19 +244,19 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void noMatchWithVersionOperatorLessThanOrEqual() {
+    void noMatchWithVersionOperatorLessThanOrEqual() {
         final String def = "{ 'version': '<= 1.1.1' }";
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
@@ -265,19 +265,19 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void matchWithVersionOperatorEqual() {
+    void matchWithVersionOperatorEqual() {
         final String def = "{ 'version': '== 1.1.1' }";
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
@@ -286,19 +286,19 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void noMatchWithVersionOperatorEqual() {
+    void noMatchWithVersionOperatorEqual() {
         final String def = "{ 'version': '== 1.1.1' }";
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
@@ -307,19 +307,19 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void matchWithVersionOperatorNotEqual() {
+    void matchWithVersionOperatorNotEqual() {
         final String def = "{ 'version': '!= 1.1.1' }";
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
@@ -328,19 +328,19 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void noMatchWithVersionOperatorNotEqual() {
+    void noMatchWithVersionOperatorNotEqual() {
         final String def = "{ 'version': '!= 1.1.1' }";
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
@@ -349,19 +349,19 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void matchWithVersionOperatorGreaterThan() {
+    void matchWithVersionOperatorGreaterThan() {
         final String def = "{ 'version': '> 1.1.1' }";
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
@@ -370,19 +370,19 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void noMatchWithVersionOperatorGreaterThan() {
+    void noMatchWithVersionOperatorGreaterThan() {
         final String def = "{ 'version': '> 1.1.1' }";
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
@@ -391,19 +391,19 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void matchWithVersionOperatorGreaterThanOrEqual() {
+    void matchWithVersionOperatorGreaterThanOrEqual() {
         final String def = "{ 'version': '>= 1.1.1' }";
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, def);
@@ -412,19 +412,19 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void noMatchWithVersionOperatorGreaterThanOrEqual() {
+    void noMatchWithVersionOperatorGreaterThanOrEqual() {
         final String def = "{ 'version': '>= 1.1.1' }";
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
@@ -433,15 +433,15 @@ public class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
     }
 
 }

--- a/src/test/java/org/dependencytrack/policy/CpePolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/CpePolicyEvaluatorTest.java
@@ -22,76 +22,76 @@ import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-public class CpePolicyEvaluatorTest extends PersistenceCapableTest {
+class CpePolicyEvaluatorTest extends PersistenceCapableTest {
 
     private PolicyEvaluator evaluator;
 
-    @Before
+    @BeforeEach
     public void initEvaluator() {
         evaluator = new CpePolicyEvaluator();
         evaluator.setQueryManager(qm);
     }
 
     @Test
-    public void hasMatch() {
+    void hasMatch() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.CPE, PolicyCondition.Operator.MATCHES, "cpe:/a:acme:application:1.0.0");
         Component component = new Component();
         component.setCpe("cpe:/a:acme:application:1.0.0");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void hasMatchNullCpe() {
+    void hasMatchNullCpe() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.CPE, PolicyCondition.Operator.NO_MATCH, ".+");
         Component component = new Component();
         component.setCpe(null);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void noMatch() {
+    void noMatch() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.CPE, PolicyCondition.Operator.MATCHES, "cpe:/a:acme:application:1.0.0");
         Component component = new Component();
         component.setCpe("cpe:/a:acme:application:2.0.0");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void wrongSubject() {
+    void wrongSubject() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, "cpe:/a:acme:application:1.0.0");
         Component component = new Component();
         component.setCpe("cpe:/a:acme:application:1.0.0");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void wrongOperator() {
+    void wrongOperator() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.CPE, PolicyCondition.Operator.IS, "cpe:/a:acme:application:1.0.0");
         Component component = new Component();
         component.setCpe("cpe:/a:acme:application:1.0.0");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
 }

--- a/src/test/java/org/dependencytrack/policy/CwePolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/CwePolicyEvaluatorTest.java
@@ -25,17 +25,17 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.PolicyCondition;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-public class CwePolicyEvaluatorTest extends PersistenceCapableTest {
+class CwePolicyEvaluatorTest extends PersistenceCapableTest {
 
     CwePolicyEvaluator cwePolicyEvaluator = new CwePolicyEvaluator();
 
     @Test
-    public void hasMatch() {
+    void hasMatch() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.CWE, PolicyCondition.Operator.CONTAINS_ANY, "CWE-123");
         Project project = new Project();
@@ -55,14 +55,14 @@ public class CwePolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyEvaluator evaluator = new CwePolicyEvaluator();
         evaluator.setQueryManager(qm);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component.getId(), violation.getComponent().getId());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component.getId(), violation.getComponent().getId());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void noMatch() {
+    void noMatch() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.CWE, PolicyCondition.Operator.CONTAINS_ALL, "CWE-123, CWE-567");
         Project project = new Project();
@@ -82,18 +82,18 @@ public class CwePolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyEvaluator evaluator = new CpePolicyEvaluator();
         evaluator.setQueryManager(qm);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void testMatchesMethod() {
+    void testMatchesMethod() {
         List<Integer> cwes = List.of(123, 456, 789);
-        Assert.assertTrue(cwePolicyEvaluator.matches(PolicyCondition.Operator.CONTAINS_ANY, cwes, "CWE-123, CWE-999"));
-        Assert.assertTrue(cwePolicyEvaluator.matches(PolicyCondition.Operator.CONTAINS_ANY, cwes, "CWE-123"));
-        Assert.assertTrue(cwePolicyEvaluator.matches(PolicyCondition.Operator.CONTAINS_ALL, cwes, "CWE-123, CWE-456"));
-        Assert.assertFalse(cwePolicyEvaluator.matches(PolicyCondition.Operator.CONTAINS_ALL, cwes, "CWE-123, CWE-456, CWE-999"));
-        Assert.assertTrue(cwePolicyEvaluator.matches(PolicyCondition.Operator.CONTAINS_ANY, cwes, "*"));
-        Assert.assertFalse(cwePolicyEvaluator.matches(PolicyCondition.Operator.CONTAINS_ALL, cwes, " , "));
-        Assert.assertFalse(cwePolicyEvaluator.matches(PolicyCondition.Operator.CONTAINS_ALL, cwes, " "));
+        Assertions.assertTrue(cwePolicyEvaluator.matches(PolicyCondition.Operator.CONTAINS_ANY, cwes, "CWE-123, CWE-999"));
+        Assertions.assertTrue(cwePolicyEvaluator.matches(PolicyCondition.Operator.CONTAINS_ANY, cwes, "CWE-123"));
+        Assertions.assertTrue(cwePolicyEvaluator.matches(PolicyCondition.Operator.CONTAINS_ALL, cwes, "CWE-123, CWE-456"));
+        Assertions.assertFalse(cwePolicyEvaluator.matches(PolicyCondition.Operator.CONTAINS_ALL, cwes, "CWE-123, CWE-456, CWE-999"));
+        Assertions.assertTrue(cwePolicyEvaluator.matches(PolicyCondition.Operator.CONTAINS_ANY, cwes, "*"));
+        Assertions.assertFalse(cwePolicyEvaluator.matches(PolicyCondition.Operator.CONTAINS_ALL, cwes, " , "));
+        Assertions.assertFalse(cwePolicyEvaluator.matches(PolicyCondition.Operator.CONTAINS_ALL, cwes, " "));
     }
 }

--- a/src/test/java/org/dependencytrack/policy/EpssPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/EpssPolicyEvaluatorTest.java
@@ -28,14 +28,14 @@ import org.dependencytrack.model.PolicyCondition;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class EpssPolicyEvaluatorTest extends PersistenceCapableTest {
+class EpssPolicyEvaluatorTest extends PersistenceCapableTest {
     CwePolicyEvaluator cwePolicyEvaluator = new CwePolicyEvaluator();
 
     @Test
-    public void hasMatch() {
+    void hasMatch() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.EPSS, PolicyCondition.Operator.NUMERIC_LESS_THAN, "0.99");
         Project project = new Project();
@@ -55,14 +55,14 @@ public class EpssPolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyEvaluator evaluator = new EpssPolicyEvaluator();
         evaluator.setQueryManager(qm);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component.getId(), violation.getComponent().getId());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component.getId(), violation.getComponent().getId());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void wrongOperator() {
+    void wrongOperator() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EPSS, PolicyCondition.Operator.MATCHES, "0.99");
         Project project = new Project();
@@ -82,6 +82,6 @@ public class EpssPolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyEvaluator evaluator = new EpssPolicyEvaluator();
         evaluator.setQueryManager(qm);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 }

--- a/src/test/java/org/dependencytrack/policy/LicenseGroupPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/LicenseGroupPolicyEvaluatorTest.java
@@ -24,32 +24,28 @@ import org.dependencytrack.model.License;
 import org.dependencytrack.model.LicenseGroup;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
-@RunWith(JUnitParamsRunner.class)
-public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
+class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
 
     private PolicyEvaluator evaluator;
 
-    @Before
+    @BeforeEach
     public void initEvaluator() {
         evaluator = new LicenseGroupPolicyEvaluator();
         evaluator.setQueryManager(qm);
     }
 
     @Test
-    public void hasMatch() {
+    void hasMatch() {
         License license = new License();
         license.setName("Apache 2.0");
         license.setLicenseId("Apache-2.0");
@@ -67,12 +63,12 @@ public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setResolvedLicense(license);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
     }
 
-    @Test
-    @Parameters(method = "forbiddenListTestcases")
-    public void spdxExpressionForbiddenList(String expression, Integer expectedViolations) {
+    @ParameterizedTest
+    @MethodSource("forbiddenListTestcases")
+    void spdxExpressionForbiddenList(String expression, Integer expectedViolations) {
         {
             License license = new License();
             license.setName("MIT License");
@@ -101,10 +97,10 @@ public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setLicenseExpression(expression);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(expectedViolations.intValue(), violations.size());
+        Assertions.assertEquals(expectedViolations.intValue(), violations.size());
     }
     
-    private Object[] forbiddenListTestcases() {
+    private static Object[] forbiddenListTestcases() {
         return new Object[] {
             // nonexistent license means it is not on the negative list
             new Object[] { "Apache-2.0 OR NonexistentLicense", 0 },
@@ -117,9 +113,9 @@ public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
         };
     }
 
-    @Test
-    @Parameters(method = "allowListTestcases")
-    public void spdxExpressionAllowList(String licenseName, Integer expectedViolations) {
+    @ParameterizedTest
+    @MethodSource("allowListTestcases")
+    void spdxExpressionAllowList(String licenseName, Integer expectedViolations) {
         {
             License license = new License();
             license.setName("MIT License");
@@ -150,10 +146,10 @@ public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setLicenseExpression(licenseName);
         List<PolicyConditionViolation> violations = evaluator.evaluate(_policy, component);
-        Assert.assertEquals("Error for: " + licenseName, expectedViolations.intValue(), violations.size());
+        Assertions.assertEquals(expectedViolations.intValue(), violations.size(), "Error for: " + licenseName);
     }
     
-    private Object[] allowListTestcases() {
+    private static Object[] allowListTestcases() {
         return new Object[] {
             // Nonexistent license is not in positive list, violation
             //new Object[] { "NonexistentLicense", 1},
@@ -169,7 +165,7 @@ public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void noMatch() {
+    void noMatch() {
         License license = new License();
         license.setName("Apache 2.0");
         license.setLicenseId("Apache-2.0");
@@ -186,11 +182,11 @@ public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setResolvedLicense(license);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void unknownLicenseViolateWhitelist() {
+    void unknownLicenseViolateWhitelist() {
         LicenseGroup lg = qm.createLicenseGroup("Test License Group");
         lg = qm.persist(lg);
         lg = qm.detach(LicenseGroup.class, lg.getId());
@@ -202,11 +198,11 @@ public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
         component.setResolvedLicense(null);
 
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
     }
 
     @Test
-    public void wrongSubject() {
+    void wrongSubject() {
         License license = new License();
         license.setName("Apache 2.0");
         license.setLicenseId("Apache-2.0");
@@ -222,11 +218,11 @@ public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setResolvedLicense(license);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void wrongOperator() {
+    void wrongOperator() {
         License license = new License();
         license.setName("Apache 2.0");
         license.setLicenseId("Apache-2.0");
@@ -242,11 +238,11 @@ public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setResolvedLicense(license);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void licenseGroupDoesNotExist() {
+    void licenseGroupDoesNotExist() {
         License license = new License();
         license.setName("Apache 2.0");
         license.setLicenseId("Apache-2.0");
@@ -259,7 +255,7 @@ public class LicenseGroupPolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setResolvedLicense(license);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
 }

--- a/src/test/java/org/dependencytrack/policy/LicensePolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/LicensePolicyEvaluatorTest.java
@@ -23,25 +23,25 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.License;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.UUID;
 
-public class LicensePolicyEvaluatorTest extends PersistenceCapableTest {
+class LicensePolicyEvaluatorTest extends PersistenceCapableTest {
 
     private PolicyEvaluator evaluator;
 
-    @Before
+    @BeforeEach
     public void initEvaluator() {
         evaluator = new LicensePolicyEvaluator();
         evaluator.setQueryManager(qm);
     }
 
     @Test
-    public void hasMatch() {
+    void hasMatch() {
         License license = new License();
         license.setName("Apache 2.0");
         license.setLicenseId("Apache-2.0");
@@ -53,14 +53,14 @@ public class LicensePolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setResolvedLicense(license);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void noMatch() {
+    void noMatch() {
         License license = new License();
         license.setName("Apache 2.0");
         license.setLicenseId("Apache-2.0");
@@ -79,11 +79,11 @@ public class LicensePolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setResolvedLicense(license);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void wrongSubject() {
+    void wrongSubject() {
         License license = new License();
         license.setName("Apache 2.0");
         license.setLicenseId("Apache-2.0");
@@ -95,11 +95,11 @@ public class LicensePolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setResolvedLicense(license);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void wrongOperator() {
+    void wrongOperator() {
         License license = new License();
         license.setName("Apache 2.0");
         license.setLicenseId("Apache-2.0");
@@ -111,11 +111,11 @@ public class LicensePolicyEvaluatorTest extends PersistenceCapableTest {
         Component component = new Component();
         component.setResolvedLicense(license);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void valueIsUnresolved() {
+    void valueIsUnresolved() {
         License license = new License();
         license.setName("Apache 2.0");
         license.setLicenseId("Apache-2.0");
@@ -131,10 +131,10 @@ public class LicensePolicyEvaluatorTest extends PersistenceCapableTest {
         Component componentWithoutLicense = new Component();
 
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, componentWithLicense);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
 
         violations = evaluator.evaluate(policy, componentWithoutLicense);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
     }
 
 }

--- a/src/test/java/org/dependencytrack/policy/MatcherTest.java
+++ b/src/test/java/org/dependencytrack/policy/MatcherTest.java
@@ -18,40 +18,40 @@
  */
 package org.dependencytrack.policy;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class MatcherTest {
+class MatcherTest {
 
     @Test
-    public void checkNulls() {
-        Assert.assertTrue(Matcher.matches(null, null));
-        Assert.assertFalse(Matcher.matches("", null));
-        Assert.assertFalse(Matcher.matches(null, ""));
+    void checkNulls() {
+        Assertions.assertTrue(Matcher.matches(null, null));
+        Assertions.assertFalse(Matcher.matches("", null));
+        Assertions.assertFalse(Matcher.matches(null, ""));
     }
 
     @Test
-    public void checkExact() {
-        Assert.assertTrue(Matcher.matches("", ""));
-        Assert.assertTrue(Matcher.matches("something", "something"));
+    void checkExact() {
+        Assertions.assertTrue(Matcher.matches("", ""));
+        Assertions.assertTrue(Matcher.matches("something", "something"));
     }
 
     @Test
-    public void checkPartials() {
-        Assert.assertTrue(Matcher.matches("something", "some"));
-        Assert.assertTrue(Matcher.matches("something", "meth"));
-        Assert.assertTrue(Matcher.matches("something", "thing"));
+    void checkPartials() {
+        Assertions.assertTrue(Matcher.matches("something", "some"));
+        Assertions.assertTrue(Matcher.matches("something", "meth"));
+        Assertions.assertTrue(Matcher.matches("something", "thing"));
     }
 
     @Test
-    public void checkWildcards() {
-        Assert.assertTrue(Matcher.matches("something", "some*"));
-        Assert.assertTrue(Matcher.matches("something", "*thing"));
+    void checkWildcards() {
+        Assertions.assertTrue(Matcher.matches("something", "some*"));
+        Assertions.assertTrue(Matcher.matches("something", "*thing"));
     }
 
     @Test
-    public void checkRegex() {
-        Assert.assertTrue(Matcher.matches("something", "^some.*"));
-        Assert.assertTrue(Matcher.matches("something", ".*thing$"));
+    void checkRegex() {
+        Assertions.assertTrue(Matcher.matches("something", "^some.*"));
+        Assertions.assertTrue(Matcher.matches("something", ".*thing$"));
     }
 }

--- a/src/test/java/org/dependencytrack/policy/PackageURLPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/PackageURLPolicyEvaluatorTest.java
@@ -18,188 +18,189 @@
  */
 package org.dependencytrack.policy;
 
-import java.util.List;
+import com.github.packageurl.PackageURL;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import com.github.packageurl.PackageURL;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
+import java.util.List;
+
+class PackageURLPolicyEvaluatorTest extends PersistenceCapableTest {
 
     private PolicyEvaluator evaluator;
 
-    @Before
-    public void initEvaluator() {
+    @BeforeEach
+    public void initEvaluator() throws Exception {
         evaluator = new PackageURLPolicyEvaluator();
         evaluator.setQueryManager(qm);
     }
 
     @Test
-    public void hasMatch() throws Exception {
+    void hasMatch() throws Exception {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.MATCHES, "pkg:generic/acme/example-component@1.0");
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/acme/example-component@1.0"));
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void hasMatchNullPurl() throws Exception {
+    void hasMatchNullPurl() throws Exception {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.NO_MATCH, ".+");
         Component component = new Component();
         component.setPurl((PackageURL)null);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void noMatch() throws Exception {
+    void noMatch() throws Exception {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.MATCHES, "pkg:generic/acme/example-component@1.0");
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/acme/web-component@6.9"));
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void wrongSubject() throws Exception {
+    void wrongSubject() throws Exception {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, "pkg:generic/acme/example-component@1.0");
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/acme/example-component@1.0"));
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void wrongOperator() throws Exception {
+    void wrongOperator() throws Exception {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.IS, "pkg:generic/acme/example-component@1.0");
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/acme/example-component@1.0"));
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void issue1925_matches() throws Exception {
+    void issue1925_matches() throws Exception {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.MATCHES, "pkg:generic/acme/example-component@1.0");
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/acme/example-component@1.0?type=jar"));
         component.setPurlCoordinates(new PackageURL("pkg:generic/acme/example-component@1.0"));
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void issue1925_no_match() throws Exception {
+    void issue1925_no_match() throws Exception {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.NO_MATCH, "pkg:generic/acme/example-component@1.0");
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/acme/example-component@1.0?type=jar"));
         component.setPurlCoordinates(new PackageURL("pkg:generic/acme/example-component@1.0"));
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void issue2144_existing1() throws Exception {
+    void issue2144_existing1() throws Exception {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.MATCHES, "pkg:generic/com/acme/example-component@1.0");
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/com/acme/example-component@1.0?type=jar"));
         component.setPurlCoordinates(new PackageURL("pkg:generic/com/acme/example-component@1.0"));
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void issue2144_existing2() throws Exception {
+    void issue2144_existing2() throws Exception {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.MATCHES, "/com/acme/");
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/com/acme/example-component@1.0?type=jar"));
         component.setPurlCoordinates(new PackageURL("pkg:generic/com/acme/example-component@1.0"));
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void issue2144_groupIdWithDotMatchesSlash() throws Exception {
+    void issue2144_groupIdWithDotMatchesSlash() throws Exception {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.MATCHES, "/com.acme/");
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/com/acme/example-component@1.0?type=jar"));
         component.setPurlCoordinates(new PackageURL("pkg:generic/com/acme/example-component@1.0"));
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void issue2144_wildcard() throws Exception {
+    void issue2144_wildcard() throws Exception {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.MATCHES, ".*com.acme.*");
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/com/acme/example-component@1.0?type=jar"));
         component.setPurlCoordinates(new PackageURL("pkg:generic/com/acme/example-component@1.0"));
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void issue2144_wildcard2() throws Exception {
+    void issue2144_wildcard2() throws Exception {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.MATCHES, ".*acme.*myCompany.*");
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/com/acme/example-component@1.0-myCompanyFix-1?type=jar"));
         component.setPurlCoordinates(new PackageURL("pkg:generic/com/acme/example-component@1.0-myCompanyFix-1"));
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void issue2144_wildcard3() throws Exception {
+    void issue2144_wildcard3() throws Exception {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.MATCHES, ".*(a|b|c)cme.*");
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:generic/com/acme/example-component@1.0?type=jar"));
         component.setPurlCoordinates(new PackageURL("pkg:generic/com/acme/example-component@1.0"));
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 }

--- a/src/test/java/org/dependencytrack/policy/PolicyEngineTest.java
+++ b/src/test/java/org/dependencytrack/policy/PolicyEngineTest.java
@@ -75,15 +75,16 @@ class PolicyEngineTest extends PersistenceCapableTest {
     }
 
     private static final ConcurrentLinkedQueue<Notification> NOTIFICATIONS = new ConcurrentLinkedQueue<>();
+    private static final Subscription SUBSCRIBER = new Subscription(NotificationSubscriber.class);
 
     @BeforeAll
     public static void setUpClass() {
-        NotificationService.getInstance().subscribe(new Subscription(NotificationSubscriber.class));
+        NotificationService.getInstance().subscribe(SUBSCRIBER);
     }
 
     @AfterAll
     public static void tearDownClass() {
-        NotificationService.getInstance().unsubscribe(new Subscription(NotificationSubscriber.class));
+        NotificationService.getInstance().unsubscribe(SUBSCRIBER);
     }
 
     @BeforeEach

--- a/src/test/java/org/dependencytrack/policy/PolicyEngineTest.java
+++ b/src/test/java/org/dependencytrack/policy/PolicyEngineTest.java
@@ -43,13 +43,12 @@ import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationScope;
 import org.dependencytrack.notification.vo.PolicyViolationIdentified;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -64,7 +63,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-public class PolicyEngineTest extends PersistenceCapableTest {
+class PolicyEngineTest extends PersistenceCapableTest {
 
     public static class NotificationSubscriber implements Subscriber {
 
@@ -77,28 +76,28 @@ public class PolicyEngineTest extends PersistenceCapableTest {
 
     private static final ConcurrentLinkedQueue<Notification> NOTIFICATIONS = new ConcurrentLinkedQueue<>();
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() {
         NotificationService.getInstance().subscribe(new Subscription(NotificationSubscriber.class));
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() {
         NotificationService.getInstance().unsubscribe(new Subscription(NotificationSubscriber.class));
     }
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    public void setup() throws Exception {
         NOTIFICATIONS.clear();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         NOTIFICATIONS.clear();
     }
 
     @Test
-    public void hasTagMatchPolicyLimitedToTag() {
+    void hasTagMatchPolicyLimitedToTag() {
         Policy policy = qm.createPolicy("Test Policy", Operator.ANY, ViolationState.INFO);
         qm.createPolicyCondition(policy, Subject.SEVERITY, PolicyCondition.Operator.IS, Severity.CRITICAL.name());
         Tag commonTag = qm.createTag("Tag 1");
@@ -118,11 +117,11 @@ public class PolicyEngineTest extends PersistenceCapableTest {
         qm.addVulnerability(vulnerability, component, AnalyzerIdentity.INTERNAL_ANALYZER);
         PolicyEngine policyEngine = new PolicyEngine();
         List<PolicyViolation> violations = policyEngine.evaluate(List.of(component));
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
     }
 
     @Test
-    public void noTagMatchPolicyLimitedToTag() {
+    void noTagMatchPolicyLimitedToTag() {
         Policy policy = qm.createPolicy("Test Policy", Operator.ANY, ViolationState.INFO);
         qm.createPolicyCondition(policy, Subject.SEVERITY, PolicyCondition.Operator.IS, Severity.CRITICAL.name());
         qm.bind(policy, List.of(qm.createTag("Tag 1")));
@@ -141,11 +140,11 @@ public class PolicyEngineTest extends PersistenceCapableTest {
         qm.addVulnerability(vulnerability, component, AnalyzerIdentity.INTERNAL_ANALYZER);
         PolicyEngine policyEngine = new PolicyEngine();
         List<PolicyViolation> violations = policyEngine.evaluate(List.of(component));
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void hasPolicyAssignedToParentProject() {
+    void hasPolicyAssignedToParentProject() {
         Policy policy = qm.createPolicy("Test Policy", Operator.ANY, ViolationState.INFO);
         qm.createPolicyCondition(policy, Subject.SEVERITY, PolicyCondition.Operator.IS, Severity.CRITICAL.name());
         policy.setIncludeChildren(true);
@@ -169,11 +168,11 @@ public class PolicyEngineTest extends PersistenceCapableTest {
         qm.addVulnerability(vulnerability, component, AnalyzerIdentity.INTERNAL_ANALYZER);
         PolicyEngine policyEngine = new PolicyEngine();
         List<PolicyViolation> violations = policyEngine.evaluate(List.of(component));
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
     }
 
     @Test
-    public void noPolicyAssignedToParentProject() {
+    void noPolicyAssignedToParentProject() {
         Policy policy = qm.createPolicy("Test Policy", Operator.ANY, ViolationState.INFO);
         qm.createPolicyCondition(policy, Subject.SEVERITY, PolicyCondition.Operator.IS, Severity.CRITICAL.name());
         Project parent = qm.createProject("Parent", null, "1", null, null, null, true, false);
@@ -196,11 +195,11 @@ public class PolicyEngineTest extends PersistenceCapableTest {
         qm.addVulnerability(vulnerability, component, AnalyzerIdentity.INTERNAL_ANALYZER);
         PolicyEngine policyEngine = new PolicyEngine();
         List<PolicyViolation> violations = policyEngine.evaluate(List.of(component));
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void policyForLatestTriggersOnLatestVersion() {
+    void policyForLatestTriggersOnLatestVersion() {
         Policy policy = qm.createPolicy("Test Policy", Operator.ANY, ViolationState.INFO, true);
         qm.createPolicyCondition(policy, Subject.SEVERITY, PolicyCondition.Operator.IS, Severity.CRITICAL.name());
         Project project = qm.createProject("My Project", null, "1", null, null,
@@ -219,11 +218,11 @@ public class PolicyEngineTest extends PersistenceCapableTest {
         qm.addVulnerability(vulnerability, component, AnalyzerIdentity.INTERNAL_ANALYZER);
         PolicyEngine policyEngine = new PolicyEngine();
         List<PolicyViolation> violations = policyEngine.evaluate(List.of(component));
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
     }
 
     @Test
-    public void policyForLatestTriggersNotOnNotLatestVersion() {
+    void policyForLatestTriggersNotOnNotLatestVersion() {
         Policy policy = qm.createPolicy("Test Policy", Operator.ANY, ViolationState.INFO, true);
         qm.createPolicyCondition(policy, Subject.SEVERITY, PolicyCondition.Operator.IS, Severity.CRITICAL.name());
         Project project = qm.createProject("My Project", null, "1", null, null,
@@ -242,11 +241,11 @@ public class PolicyEngineTest extends PersistenceCapableTest {
         qm.addVulnerability(vulnerability, component, AnalyzerIdentity.INTERNAL_ANALYZER);
         PolicyEngine policyEngine = new PolicyEngine();
         List<PolicyViolation> violations = policyEngine.evaluate(List.of(component));
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void determineViolationTypeTest() {
+    void determineViolationTypeTest() {
         PolicyCondition policyCondition = new PolicyCondition();
         policyCondition.setSubject(null);
         PolicyEngine policyEngine = new PolicyEngine();
@@ -254,7 +253,7 @@ public class PolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void issue1924() {
+    void issue1924() {
         Policy policy = qm.createPolicy("Policy 1924", Operator.ALL, ViolationState.INFO);
         qm.createPolicyCondition(policy, Subject.SEVERITY, PolicyCondition.Operator.IS, Severity.CRITICAL.name());
         qm.createPolicyCondition(policy, Subject.PACKAGE_URL, PolicyCondition.Operator.NO_MATCH, "pkg:deb");
@@ -301,20 +300,20 @@ public class PolicyEngineTest extends PersistenceCapableTest {
         qm.addVulnerability(vulnerability, component, AnalyzerIdentity.INTERNAL_ANALYZER);
         PolicyEngine policyEngine = new PolicyEngine();
         List<PolicyViolation> violations = policyEngine.evaluate(components);
-        Assert.assertEquals(3, violations.size());
+        Assertions.assertEquals(3, violations.size());
         PolicyViolation policyViolation = violations.get(0);
-        Assert.assertEquals("Log4J", policyViolation.getComponent().getName());
-        Assert.assertEquals(Subject.SEVERITY, policyViolation.getPolicyCondition().getSubject());
+        Assertions.assertEquals("Log4J", policyViolation.getComponent().getName());
+        Assertions.assertEquals(Subject.SEVERITY, policyViolation.getPolicyCondition().getSubject());
         policyViolation = violations.get(1);
-        Assert.assertEquals("Log4J", policyViolation.getComponent().getName());
-        Assert.assertEquals(Subject.SEVERITY, policyViolation.getPolicyCondition().getSubject());
+        Assertions.assertEquals("Log4J", policyViolation.getComponent().getName());
+        Assertions.assertEquals(Subject.SEVERITY, policyViolation.getPolicyCondition().getSubject());
         policyViolation = violations.get(2);
-        Assert.assertEquals("Log4J", policyViolation.getComponent().getName());
-        Assert.assertEquals(Subject.PACKAGE_URL, policyViolation.getPolicyCondition().getSubject());
+        Assertions.assertEquals("Log4J", policyViolation.getComponent().getName());
+        Assertions.assertEquals(Subject.PACKAGE_URL, policyViolation.getPolicyCondition().getSubject());
     }
 
     @Test
-    public void issue2455() {
+    void issue2455() {
         Policy policy = qm.createPolicy("Policy 1924", Operator.ALL, ViolationState.INFO);
 
         License license = new License();
@@ -360,17 +359,17 @@ public class PolicyEngineTest extends PersistenceCapableTest {
 
         PolicyEngine policyEngine = new PolicyEngine();
         List<PolicyViolation> violations = policyEngine.evaluate(components);
-        Assert.assertEquals(2, violations.size());
+        Assertions.assertEquals(2, violations.size());
         PolicyViolation policyViolation = violations.get(0);
-        Assert.assertEquals("Log4J", policyViolation.getComponent().getName());
-        Assert.assertEquals(Subject.LICENSE_GROUP, policyViolation.getPolicyCondition().getSubject());
+        Assertions.assertEquals("Log4J", policyViolation.getComponent().getName());
+        Assertions.assertEquals(Subject.LICENSE_GROUP, policyViolation.getPolicyCondition().getSubject());
         policyViolation = violations.get(1);
-        Assert.assertEquals("Log4J", policyViolation.getComponent().getName());
-        Assert.assertEquals(Subject.LICENSE_GROUP, policyViolation.getPolicyCondition().getSubject());
+        Assertions.assertEquals("Log4J", policyViolation.getComponent().getName());
+        Assertions.assertEquals(Subject.LICENSE_GROUP, policyViolation.getPolicyCondition().getSubject());
     }
 
     @Test
-    public void notificationTest() {
+    void notificationTest() {
         final var policy = qm.createPolicy("Test", Operator.ANY, ViolationState.FAIL);
 
         // Create a policy condition that matches on any coordinates.
@@ -433,7 +432,7 @@ public class PolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void violationReconciliationTest() {
+    void violationReconciliationTest() {
         final var project = new Project();
         project.setName("acme-app");
         project.setVersion("1.0.0");
@@ -471,7 +470,7 @@ public class PolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void violationReconciliationWithDuplicatesTest() {
+    void violationReconciliationWithDuplicatesTest() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);

--- a/src/test/java/org/dependencytrack/policy/SeverityPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/SeverityPolicyEvaluatorTest.java
@@ -26,15 +26,15 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-public class SeverityPolicyEvaluatorTest extends PersistenceCapableTest {
+class SeverityPolicyEvaluatorTest extends PersistenceCapableTest {
 
     @Test
-    public void hasMatch() {
+    void hasMatch() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.SEVERITY, PolicyCondition.Operator.IS, Severity.CRITICAL.name());
         Project project = new Project();
@@ -54,14 +54,14 @@ public class SeverityPolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyEvaluator evaluator = new SeverityPolicyEvaluator();
         evaluator.setQueryManager(qm);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component.getId(), violation.getComponent().getId());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component.getId(), violation.getComponent().getId());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void noMatch() {
+    void noMatch() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.SEVERITY, PolicyCondition.Operator.IS, Severity.CRITICAL.name());
         Project project = new Project();
@@ -81,11 +81,11 @@ public class SeverityPolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyEvaluator evaluator = new CpePolicyEvaluator();
         evaluator.setQueryManager(qm);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void wrongSubject() {
+    void wrongSubject() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.IS, Severity.CRITICAL.name());
         Project project = new Project();
@@ -105,11 +105,11 @@ public class SeverityPolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyEvaluator evaluator = new CpePolicyEvaluator();
         evaluator.setQueryManager(qm);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void wrongOperator() {
+    void wrongOperator() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.SEVERITY, PolicyCondition.Operator.MATCHES, Severity.CRITICAL.name());
         Project project = new Project();
@@ -129,6 +129,6 @@ public class SeverityPolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyEvaluator evaluator = new CpePolicyEvaluator();
         evaluator.setQueryManager(qm);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 }

--- a/src/test/java/org/dependencytrack/policy/SwidTagIdPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/SwidTagIdPolicyEvaluatorTest.java
@@ -23,74 +23,74 @@ import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class SwidTagIdPolicyEvaluatorTest extends PersistenceCapableTest {
+class SwidTagIdPolicyEvaluatorTest extends PersistenceCapableTest {
 
     private PolicyEvaluator evaluator;
 
-    @Before
+    @BeforeEach
     public void initEvaluator() {
         evaluator = new SwidTagIdPolicyEvaluator();
         evaluator.setQueryManager(qm);
     }
 
     @Test
-    public void hasMatch() {
+    void hasMatch() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.SWID_TAGID, PolicyCondition.Operator.MATCHES, "0123456789");
         Component component = new Component();
         component.setSwidTagId("0123456789");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void hasMatchNullTag() {
+    void hasMatchNullTag() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.SWID_TAGID, PolicyCondition.Operator.NO_MATCH, ".+");
         Component component = new Component();
         component.setSwidTagId(null);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component, violation.getComponent());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component, violation.getComponent());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void noMatch() {
+    void noMatch() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.SWID_TAGID, PolicyCondition.Operator.MATCHES, "0123456789");
         Component component = new Component();
         component.setSwidTagId("0000000000");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void wrongSubject() {
+    void wrongSubject() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.MATCHES, "0123456789");
         Component component = new Component();
         component.setSwidTagId("0123456789");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void wrongOperator() {
+    void wrongOperator() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.SWID_TAGID, PolicyCondition.Operator.IS, "0123456789");
         Component component = new Component();
         component.setSwidTagId("0123456789");
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
 }

--- a/src/test/java/org/dependencytrack/policy/VersionDistancePolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/VersionDistancePolicyEvaluatorTest.java
@@ -18,13 +18,6 @@
  */
 package org.dependencytrack.policy;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Policy;
@@ -33,92 +26,87 @@ import org.dependencytrack.model.PolicyCondition.Subject;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public class VersionDistancePolicyEvaluatorTest extends PersistenceCapableTest {
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
 
-    @Parameterized.Parameters(name = "[{index}] version={0} latestVersion={1} operator={2} distance={3} shouldViolate={4}")
-    public static Collection<?> testParameters() {
-        return Arrays.asList(new Object[][]{
-            {"1.0.0", "1.0.0", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
-            {"1.0.0", "1.0.0", Operator.NUMERIC_GREATER_THAN, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
-            // Latest version is 1 minor newer than current version
-            {"1.2.3", "1.3.1", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", true},
-            {"1.2.3", "1.3.1", Operator.NUMERIC_GREATER_THAN, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", false},
-            {"1.2.3", "1.3.1", Operator.NUMERIC_EQUAL, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", true},
-            {"1.2.3", "1.3.1", Operator.NUMERIC_NOT_EQUAL, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", false},
-            {"1.2.3", "1.3.1", Operator.NUMERIC_LESS_THAN, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", false},
-            {"1.2.3", "1.3.1", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", true},
-            // Latest version is 1 major newer than current version
-            {"1.2.3", "2.1.1", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
-            {"1.2.3", "2.1.1", Operator.NUMERIC_GREATER_THAN, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
-            {"1.2.3", "2.1.1", Operator.NUMERIC_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
-            {"1.2.3", "2.1.1", Operator.NUMERIC_NOT_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
-            {"1.2.3", "2.1.1", Operator.NUMERIC_LESS_THAN, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
-            {"1.2.3", "2.1.1", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
-            // Latest version is 2 major newer than current version
-            {"1.2.3", "3.0.1", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", true},
-            {"1.2.3", "3.0.1", Operator.NUMERIC_GREATER_THAN, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", false},
-            {"1.2.3", "3.0.1", Operator.NUMERIC_EQUAL, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", true},
-            {"1.2.3", "3.0.1", Operator.NUMERIC_NOT_EQUAL, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", false},
-            {"1.2.3", "3.0.1", Operator.NUMERIC_LESS_THAN, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", false},
-            {"1.2.3", "3.0.1", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", true},
-            // Component is latest version.
-            {"1.2.3", "1.2.3", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", true},
-            {"1.2.3", "1.2.3", Operator.NUMERIC_GREATER_THAN, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", false},
-            {"1.2.3", "1.2.3", Operator.NUMERIC_EQUAL, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", true},
-            {"1.2.3", "1.2.3", Operator.NUMERIC_NOT_EQUAL, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", false},
-            {"1.2.3", "1.2.3", Operator.NUMERIC_LESS_THAN, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", false},
-            {"1.2.3", "1.2.3", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", true},
-            // Negative distanse.
-            {"2.3.4", "1.2.3", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
-            {"2.3.4", "1.2.3", Operator.NUMERIC_GREATER_THAN, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
-            {"2.3.4", "1.2.3", Operator.NUMERIC_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
-            {"2.3.4", "1.2.3", Operator.NUMERIC_NOT_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
-            {"2.3.4", "1.2.3", Operator.NUMERIC_LESS_THAN, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
-            {"2.3.4", "1.2.3", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
-            // Combined policies.
-            {"2.0.0", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
-            {"1:1.0.0", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
-            {"1:2.0.0", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
-            {"1.0.0", "1.0.0", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
-            {"1.0.0", "1.0.0", Operator.NUMERIC_LESS_THAN, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true},
-            {"1.0.0", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
-            {"1.0.0", "1.0.0", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
-            {"1.0.0", "1.0.0", Operator.NUMERIC_GREATER_THAN, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
-            {"2:2.0.0", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
-            {"3.2.2", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"0\", \"major\": \"1\", \"minor\": \"1\", \"patch\": \"1\" }", false},
-            {"1.2.2", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"0\", \"major\": \"0\", \"minor\": \"1\", \"patch\": \"1\" }", false},
-            {"0.2.2", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"0\", \"major\": \"0\", \"minor\": \"1\", \"patch\": \"1\" }", false},
-            // Unsupported operator.
-            {"1.2.3", "2.1.1", Operator.MATCHES, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false},
-            // Invalid distanse format.
-            {"1.2.3", "2.1.1", Operator.NUMERIC_EQUAL, "{ \"major\": \"1a\" }", false},
-            // No known latestVersion.
-            {"1.2.3", null, Operator.NUMERIC_EQUAL, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", false},
-        });
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VersionDistancePolicyEvaluatorTest extends PersistenceCapableTest {
+
+    public static Collection<Arguments> testParameters() {
+        return Arrays.asList(
+                Arguments.of("1.0.0", "1.0.0", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false),
+                Arguments.of("1.0.0", "1.0.0", Operator.NUMERIC_GREATER_THAN, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false),
+                // Latest version is 1 minor newer than current version
+                Arguments.of("1.2.3", "1.3.1", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", true),
+                Arguments.of("1.2.3", "1.3.1", Operator.NUMERIC_GREATER_THAN, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", false),
+                Arguments.of("1.2.3", "1.3.1", Operator.NUMERIC_EQUAL, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", true),
+                Arguments.of("1.2.3", "1.3.1", Operator.NUMERIC_NOT_EQUAL, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", false),
+                Arguments.of("1.2.3", "1.3.1", Operator.NUMERIC_LESS_THAN, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", false),
+                Arguments.of("1.2.3", "1.3.1", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{ \"major\": \"0\", \"minor\": \"1\", \"patch\": \"?\" }", true),
+                // Latest version is 1 major newer than current version
+                Arguments.of("1.2.3", "2.1.1", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true),
+                Arguments.of("1.2.3", "2.1.1", Operator.NUMERIC_GREATER_THAN, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false),
+                Arguments.of("1.2.3", "2.1.1", Operator.NUMERIC_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true),
+                Arguments.of("1.2.3", "2.1.1", Operator.NUMERIC_NOT_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false),
+                Arguments.of("1.2.3", "2.1.1", Operator.NUMERIC_LESS_THAN, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false),
+                Arguments.of("1.2.3", "2.1.1", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true),
+                // Latest version is 2 major newer than current version
+                Arguments.of("1.2.3", "3.0.1", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", true),
+                Arguments.of("1.2.3", "3.0.1", Operator.NUMERIC_GREATER_THAN, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", false),
+                Arguments.of("1.2.3", "3.0.1", Operator.NUMERIC_EQUAL, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", true),
+                Arguments.of("1.2.3", "3.0.1", Operator.NUMERIC_NOT_EQUAL, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", false),
+                Arguments.of("1.2.3", "3.0.1", Operator.NUMERIC_LESS_THAN, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", false),
+                Arguments.of("1.2.3", "3.0.1", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{ \"major\": \"2\", \"minor\": \"?\", \"patch\": \"?\" }", true),
+                // Component is latest version.
+                Arguments.of("1.2.3", "1.2.3", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", true),
+                Arguments.of("1.2.3", "1.2.3", Operator.NUMERIC_GREATER_THAN, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", false),
+                Arguments.of("1.2.3", "1.2.3", Operator.NUMERIC_EQUAL, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", true),
+                Arguments.of("1.2.3", "1.2.3", Operator.NUMERIC_NOT_EQUAL, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", false),
+                Arguments.of("1.2.3", "1.2.3", Operator.NUMERIC_LESS_THAN, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", false),
+                Arguments.of("1.2.3", "1.2.3", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", true),
+                // Negative distanse.
+                Arguments.of("2.3.4", "1.2.3", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true),
+                Arguments.of("2.3.4", "1.2.3", Operator.NUMERIC_GREATER_THAN, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false),
+                Arguments.of("2.3.4", "1.2.3", Operator.NUMERIC_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true),
+                Arguments.of("2.3.4", "1.2.3", Operator.NUMERIC_NOT_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false),
+                Arguments.of("2.3.4", "1.2.3", Operator.NUMERIC_LESS_THAN, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false),
+                Arguments.of("2.3.4", "1.2.3", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true),
+                // Combined policies.
+                Arguments.of("2.0.0", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true),
+                Arguments.of("1:1.0.0", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true),
+                Arguments.of("1:2.0.0", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true),
+                Arguments.of("1.0.0", "1.0.0", Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true),
+                Arguments.of("1.0.0", "1.0.0", Operator.NUMERIC_LESS_THAN, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", true),
+                Arguments.of("1.0.0", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false),
+                Arguments.of("1.0.0", "1.0.0", Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false),
+                Arguments.of("1.0.0", "1.0.0", Operator.NUMERIC_GREATER_THAN, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false),
+                Arguments.of("2:2.0.0", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"1\", \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false),
+                Arguments.of("3.2.2", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"0\", \"major\": \"1\", \"minor\": \"1\", \"patch\": \"1\" }", false),
+                Arguments.of("1.2.2", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"0\", \"major\": \"0\", \"minor\": \"1\", \"patch\": \"1\" }", false),
+                Arguments.of("0.2.2", "1.0.0", Operator.NUMERIC_EQUAL, "{\"epoch\": \"0\", \"major\": \"0\", \"minor\": \"1\", \"patch\": \"1\" }", false),
+                // Unsupported operator.
+                Arguments.of("1.2.3", "2.1.1", Operator.MATCHES, "{ \"major\": \"1\", \"minor\": \"?\", \"patch\": \"?\" }", false),
+                // Invalid distanse format.
+                Arguments.of("1.2.3", "2.1.1", Operator.NUMERIC_EQUAL, "{ \"major\": \"1a\" }", false),
+                // No known latestVersion.
+                Arguments.of("1.2.3", null, Operator.NUMERIC_EQUAL, "{ \"major\": \"0\", \"minor\": \"0\", \"patch\": \"0\" }", false)
+        );
     }
 
-    private final String version;
-    private final String latestVersion;
-    private final Operator operator;
-    private final String versionDistance;
-    private final boolean shouldViolate;
-
-    public VersionDistancePolicyEvaluatorTest(final String version, String latestVersion,
-            Operator operator, String versionDistance, boolean shouldViolate) {
-        this.version = version;
-        this.latestVersion = latestVersion;
-        this.operator = operator;
-        this.versionDistance = versionDistance;
-        this.shouldViolate = shouldViolate;
-    }
-
-    @Test
-    public void evaluateTest() {
+    @ParameterizedTest
+    @MethodSource("testParameters")
+    void evaluateTest(final String version,
+                      String latestVersion,
+                      Operator operator,
+                      String versionDistance,
+                      boolean shouldViolate) {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         final var condition = qm.createPolicyCondition(policy, Subject.VERSION_DISTANCE, operator, versionDistance);
 
@@ -165,6 +153,12 @@ public class VersionDistancePolicyEvaluatorTest extends PersistenceCapableTest {
         } else {
             assertThat(violations).isEmpty();
         }
+
+        qm.delete(condition);
+        qm.delete(policy);
+        qm.delete(component);
+        qm.delete(metaComponent);
+        qm.delete(project);
     }
 
 }

--- a/src/test/java/org/dependencytrack/policy/VersionPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/VersionPolicyEvaluatorTest.java
@@ -4,22 +4,22 @@ import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class VersionPolicyEvaluatorTest extends PersistenceCapableTest {
+class VersionPolicyEvaluatorTest extends PersistenceCapableTest {
 
     private VersionPolicyEvaluator evaluator;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         evaluator = new VersionPolicyEvaluator();
         evaluator.setQueryManager(qm);
     }
 
     @Test
-    public void testLessThanOperator() {
+    void testLessThanOperator() {
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.VERSION, PolicyCondition.Operator.NUMERIC_LESS_THAN, "1.1.1");
 
@@ -29,19 +29,19 @@ public class VersionPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void testLessThanOrEqualOperator() {
+    void testLessThanOrEqualOperator() {
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.VERSION, PolicyCondition.Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "1.1.1");
 
@@ -51,19 +51,19 @@ public class VersionPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void testEqualOperator() {
+    void testEqualOperator() {
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.VERSION, PolicyCondition.Operator.NUMERIC_EQUAL, "1.1.1");
 
@@ -73,19 +73,19 @@ public class VersionPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void testNotEqualOperator() {
+    void testNotEqualOperator() {
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.VERSION, PolicyCondition.Operator.NUMERIC_NOT_EQUAL, "1.1.1");
 
@@ -95,19 +95,19 @@ public class VersionPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void testGreaterThanOperator() {
+    void testGreaterThanOperator() {
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.VERSION, PolicyCondition.Operator.NUMERIC_GREATER_THAN, "1.1.1");
 
@@ -117,19 +117,19 @@ public class VersionPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
     }
 
     @Test
-    public void testGreaterThanOrEqualOperator() {
+    void testGreaterThanOrEqualOperator() {
         final var policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.VERSION, PolicyCondition.Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "1.1.1");
 
@@ -139,15 +139,15 @@ public class VersionPolicyEvaluatorTest extends PersistenceCapableTest {
 
         // Component version is lower
         component.setVersion("1.1.0");
-        Assert.assertEquals(0, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
 
         // Component version is equal
         component.setVersion("1.1.1");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
 
         // Component version is higher
         component.setVersion("1.1.2");
-        Assert.assertEquals(1, evaluator.evaluate(policy, component).size());
+        Assertions.assertEquals(1, evaluator.evaluate(policy, component).size());
     }
 
 }

--- a/src/test/java/org/dependencytrack/policy/VulnerabilityIdPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/VulnerabilityIdPolicyEvaluatorTest.java
@@ -25,15 +25,15 @@ import org.dependencytrack.model.PolicyCondition;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-public class VulnerabilityIdPolicyEvaluatorTest extends PersistenceCapableTest {
+class VulnerabilityIdPolicyEvaluatorTest extends PersistenceCapableTest {
 
     @Test
-    public void hasMatch() {
+    void hasMatch() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.VULNERABILITY_ID, PolicyCondition.Operator.IS, "test-123");
         Project project = new Project();
@@ -51,14 +51,14 @@ public class VulnerabilityIdPolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyEvaluator evaluator = new VulnerabilityIdPolicyEvaluator();
         evaluator.setQueryManager(qm);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(1, violations.size());
+        Assertions.assertEquals(1, violations.size());
         PolicyConditionViolation violation = violations.get(0);
-        Assert.assertEquals(component.getId(), violation.getComponent().getId());
-        Assert.assertEquals(condition, violation.getPolicyCondition());
+        Assertions.assertEquals(component.getId(), violation.getComponent().getId());
+        Assertions.assertEquals(condition, violation.getPolicyCondition());
     }
 
     @Test
-    public void noMatch() {
+    void noMatch() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.VULNERABILITY_ID, PolicyCondition.Operator.IS, "test-123");
         Project project = new Project();
@@ -77,11 +77,11 @@ public class VulnerabilityIdPolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyEvaluator evaluator = new VulnerabilityIdPolicyEvaluator();
         evaluator.setQueryManager(qm);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 
     @Test
-    public void noMatchIsNotOperator() {
+    void noMatchIsNotOperator() {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.VULNERABILITY_ID, PolicyCondition.Operator.IS_NOT, "test-123");
         Project project = new Project();
@@ -100,6 +100,6 @@ public class VulnerabilityIdPolicyEvaluatorTest extends PersistenceCapableTest {
         PolicyEvaluator evaluator = new VulnerabilityIdPolicyEvaluator();
         evaluator.setQueryManager(qm);
         List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
-        Assert.assertEquals(0, violations.size());
+        Assertions.assertEquals(0, violations.size());
     }
 }

--- a/src/test/java/org/dependencytrack/resources/OpenApiResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/OpenApiResourceTest.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class OpenApiResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(OpenApiResource.class)
                     .register(ApiFilter.class));
 

--- a/src/test/java/org/dependencytrack/resources/OpenApiResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/OpenApiResourceTest.java
@@ -21,27 +21,27 @@ package org.dependencytrack.resources;
 import alpine.server.filters.ApiFilter;
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
-import org.dependencytrack.JerseyTestRule;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import jakarta.ws.rs.core.Response;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OpenApiResourceTest extends ResourceTest {
+class OpenApiResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(OpenApiResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(OpenApiResource.class)
                     .register(ApiFilter.class));
 
     @Test
-    public void testOpenApiJson() {
+    void testOpenApiJson() {
         final Response response = jersey.target("/openapi.json")
                 // NB: Initial generation of the OpenAPI spec can take a while in CI.
                 .property(ClientProperties.READ_TIMEOUT, "60000")
@@ -60,7 +60,7 @@ public class OpenApiResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testOpenApiYaml() {
+    void testOpenApiYaml() {
         final Response response = jersey.target("/openapi.yaml")
                 // NB: Initial generation of the OpenAPI spec can take a while in CI.
                 .property(ClientProperties.READ_TIMEOUT, "60000")

--- a/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
@@ -71,7 +71,7 @@ import static org.dependencytrack.assertion.Assertions.assertConditionWithTimeou
 class AnalysisResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(AnalysisResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class)

--- a/src/test/java/org/dependencytrack/resources/v1/BadgeResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BadgeResourceTest.java
@@ -45,7 +45,7 @@ import static org.dependencytrack.model.ConfigPropertyConstants.GENERAL_BADGE_EN
 class BadgeResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(BadgeResource.class)
                     .register(ApiFilter.class));
 

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -23,6 +23,11 @@ import alpine.model.IConfigProperty;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import com.fasterxml.jackson.core.StreamReadConstraints;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
 import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
@@ -51,15 +56,10 @@ import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.jupiter.api.Test;
-
-import jakarta.json.JsonObject;
-import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -81,6 +81,7 @@ import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_T
 import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE;
 import static org.hamcrest.CoreMatchers.equalTo;
 
+@DefaultLocale("en-US")
 class BomResourceTest extends ResourceTest {
 
     @RegisterExtension

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -85,7 +85,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 class BomResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(BomResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class)

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -24,7 +24,7 @@ import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import com.fasterxml.jackson.core.StreamReadConstraints;
 import org.apache.http.HttpStatus;
-import org.dependencytrack.JerseyTestRule;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.AnalysisResponse;
@@ -51,15 +51,16 @@ import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -80,18 +81,18 @@ import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_T
 import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE;
 import static org.hamcrest.CoreMatchers.equalTo;
 
-public class BomResourceTest extends ResourceTest {
+class BomResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(BomResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(BomResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class)
                     .register(MultiPartFeature.class)
                     .register(JsonMappingExceptionMapper.class));
 
     @Test
-    public void exportProjectAsCycloneDxTest() {
+    void exportProjectAsCycloneDxTest() {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         Component c = new Component();
         c.setProject(project);
@@ -101,25 +102,25 @@ public class BomResourceTest extends ResourceTest {
         Response response = jersey.target(V1_BOM + "/cyclonedx/project/" + project.getUuid()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertTrue(body.startsWith("{"));
+        Assertions.assertTrue(body.startsWith("{"));
     }
 
     @Test
-    public void exportProjectAsCycloneDxInvalidTest() {
+    void exportProjectAsCycloneDxInvalidTest() {
         Response response = jersey.target(V1_BOM + "/cyclonedx/project/" + UUID.randomUUID()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The project could not be found.", body);
+        Assertions.assertEquals("The project could not be found.", body);
     }
 
     @Test
-    public void exportProjectAsCycloneDxInventoryTest() {
+    void exportProjectAsCycloneDxInventoryTest() {
         var vulnerability = new Vulnerability();
         vulnerability.setVulnId("INT-001");
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
@@ -334,7 +335,7 @@ public class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    public void exportProjectAsCycloneDxLicenseTest() {
+    void exportProjectAsCycloneDxLicenseTest() {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         Component c = new Component();
         c.setProject(project);
@@ -409,7 +410,7 @@ public class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    public void exportProjectAsCycloneDxInventoryWithVulnerabilitiesTest() {
+    void exportProjectAsCycloneDxInventoryWithVulnerabilitiesTest() {
         var vulnerability = new Vulnerability();
         vulnerability.setVulnId("INT-001");
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
@@ -603,7 +604,7 @@ public class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    public void exportProjectAsCycloneDxVdrTest() {
+    void exportProjectAsCycloneDxVdrTest() {
         var vulnerability = new Vulnerability();
         vulnerability.setVulnId("INT-001");
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
@@ -790,7 +791,7 @@ public class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    public void exportComponentAsCycloneDx() {
+    void exportComponentAsCycloneDx() {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, false, false);
         Component c = new Component();
         c.setProject(project);
@@ -800,25 +801,25 @@ public class BomResourceTest extends ResourceTest {
         Response response = jersey.target(V1_BOM + "/cyclonedx/component/" + component.getUuid()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertTrue(body.startsWith("{"));
+        Assertions.assertTrue(body.startsWith("{"));
     }
 
     @Test
-    public void exportComponentAsCycloneDxInvalid() {
+    void exportComponentAsCycloneDxInvalid() {
         Response response = jersey.target(V1_BOM + "/cyclonedx/component/" + UUID.randomUUID()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The component could not be found.", body);
+        Assertions.assertEquals("The component could not be found.", body);
     }
 
     @Test
-    public void uploadBomTest() throws Exception {
+    void uploadBomTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
@@ -826,46 +827,46 @@ public class BomResourceTest extends ResourceTest {
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertNotNull(json.getString("token"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
+        Assertions.assertNotNull(json);
+        Assertions.assertNotNull(json.getString("token"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
     }
 
     @Test
-    public void uploadBomInvalidProjectTest() throws Exception {
+    void uploadBomInvalidProjectTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
         String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
         BomSubmitRequest request = new BomSubmitRequest(UUID.randomUUID().toString(), null, null, null, false, false, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The project could not be found.", body);
+        Assertions.assertEquals("The project could not be found.", body);
     }
 
     @Test
-    public void uploadBomAutoCreateTest() throws Exception {
+    void uploadBomAutoCreateTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
         String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
         BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0", null, true, false, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertNotNull(json.getString("token"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
+        Assertions.assertNotNull(json);
+        Assertions.assertNotNull(json.getString("token"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
         Project project = qm.getProject("Acme Example", "1.0");
-        Assert.assertNotNull(project);
+        Assertions.assertNotNull(project);
     }
 
     @Test
-    public void uploadBomAutoCreateWithTagsTest() throws Exception {
+    void uploadBomAutoCreateWithTagsTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
         String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
         List<Tag> tags = Stream.of("tag1", "tag2").map(name -> {
@@ -878,20 +879,20 @@ public class BomResourceTest extends ResourceTest {
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertNotNull(json.getString("token"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
+        Assertions.assertNotNull(json);
+        Assertions.assertNotNull(json.getString("token"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
         Project project = qm.getProject("Acme Example", "1.0");
-        Assert.assertNotNull(project);
+        Assertions.assertNotNull(project);
         assertThat(project.getTags())
           .extracting(Tag::getName)
           .containsExactlyInAnyOrder("tag1", "tag2");
     }
 
     @Test
-    public void uploadBomAutoCreateWithTagsMultipartTest() throws Exception {
+    void uploadBomAutoCreateWithTagsMultipartTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
 
         final var multiPart = new FormDataMultiPart()
@@ -924,20 +925,20 @@ public class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadBomUnauthorizedTest() throws Exception {
+    void uploadBomUnauthorizedTest() throws Exception {
         String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
         BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0",
                 null, true, false, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(401, response.getStatus(), 0);
+        Assertions.assertEquals(401, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The principal does not have permission to create project.", body);
+        Assertions.assertEquals("The principal does not have permission to create project.", body);
     }
 
     @Test
-    public void uploadBomAutoCreateLatestWithAclTest() throws Exception {
+    void uploadBomAutoCreateLatestWithAclTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
         enablePortfolioAccessControl();
 
@@ -954,14 +955,14 @@ public class BomResourceTest extends ResourceTest {
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertNotNull(json.getString("token"));
+        Assertions.assertNotNull(json);
+        Assertions.assertNotNull(json.getString("token"));
     }
 
     @Test
-    public void uploadBomAutoCreateLatestWithAclNoAccessTest() throws Exception {
+    void uploadBomAutoCreateLatestWithAclNoAccessTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
         enablePortfolioAccessControl();
 
@@ -977,11 +978,11 @@ public class BomResourceTest extends ResourceTest {
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(403, response.getStatus(), 0);
+        Assertions.assertEquals(403, response.getStatus(), 0);
     }
 
     @Test
-    public void uploadBomAutoCreateTestWithParentTest() throws Exception {
+    void uploadBomAutoCreateTestWithParentTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
         String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
         // Upload parent project
@@ -990,11 +991,11 @@ public class BomResourceTest extends ResourceTest {
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
+        Assertions.assertNotNull(json);
         Project parent = qm.getProject("Acme Parent", "1.0");
-        Assert.assertNotNull(parent);
+        Assertions.assertNotNull(parent);
         String parentUUID = parent.getUuid().toString();
 
         // Upload first child, search parent by UUID
@@ -1002,15 +1003,15 @@ public class BomResourceTest extends ResourceTest {
         response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertNotNull(json.getString("token"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
+        Assertions.assertNotNull(json);
+        Assertions.assertNotNull(json.getString("token"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
         Project child = qm.getProject("Acme Example", "1.0");
-        Assert.assertNotNull(child);
-        Assert.assertNotNull(child.getParent());
-        Assert.assertEquals(parentUUID, child.getParent().getUuid().toString());
+        Assertions.assertNotNull(child);
+        Assertions.assertNotNull(child.getParent());
+        Assertions.assertEquals(parentUUID, child.getParent().getUuid().toString());
 
 
         // Upload second child, search parent by name+ver
@@ -1018,55 +1019,55 @@ public class BomResourceTest extends ResourceTest {
         response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertNotNull(json.getString("token"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
+        Assertions.assertNotNull(json);
+        Assertions.assertNotNull(json.getString("token"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
         child = qm.getProject("Acme Example", "2.0");
-        Assert.assertNotNull(child);
-        Assert.assertNotNull(child.getParent());
-        Assert.assertEquals(parentUUID, child.getParent().getUuid().toString());
+        Assertions.assertNotNull(child);
+        Assertions.assertNotNull(child.getParent());
+        Assertions.assertEquals(parentUUID, child.getParent().getUuid().toString());
 
         // Upload third child, specify parent's UUID, name, ver. Name and ver are ignored when UUID is specified.
         request = new BomSubmitRequest(null, "Acme Example", "3.0", null, true, parentUUID, "Non-existent parent", "1.0", false, bomString);
         response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertNotNull(json.getString("token"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
+        Assertions.assertNotNull(json);
+        Assertions.assertNotNull(json.getString("token"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
         child = qm.getProject("Acme Example", "3.0");
-        Assert.assertNotNull(child);
-        Assert.assertNotNull(child.getParent());
-        Assert.assertEquals(parentUUID, child.getParent().getUuid().toString());
+        Assertions.assertNotNull(child);
+        Assertions.assertNotNull(child.getParent());
+        Assertions.assertEquals(parentUUID, child.getParent().getUuid().toString());
     }
 
     @Test
-    public void uploadBomInvalidParentTest() throws Exception {
+    void uploadBomInvalidParentTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
         String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
         BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0", null, true, UUID.randomUUID().toString(), null, null, false, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertEquals(404, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The parent component could not be found.", body);
+        Assertions.assertEquals("The parent component could not be found.", body);
 
         request = new BomSubmitRequest(null, "Acme Example", "2.0", null, true, null, "Non-existent parent", null, false, bomString);
         response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertEquals(404, response.getStatus(), 0);
         body = getPlainTextBody(response);
-        Assert.assertEquals("The parent component could not be found.", body);
+        Assertions.assertEquals("The parent component could not be found.", body);
     }
 
     @Test
-    public void uploadBomInvalidJsonTest() {
+    void uploadBomInvalidJsonTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
 
         qm.createConfigProperty(
@@ -1122,7 +1123,7 @@ public class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadBomInvalidXmlTest() {
+    void uploadBomInvalidXmlTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
 
         qm.createConfigProperty(
@@ -1175,7 +1176,7 @@ public class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadBomWithValidationModeDisabledTest() {
+    void uploadBomWithValidationModeDisabledTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
 
         qm.createConfigProperty(
@@ -1220,7 +1221,7 @@ public class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadBomWithValidationModeEnabledForTagsTest() {
+    void uploadBomWithValidationModeEnabledForTagsTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
 
         qm.createConfigProperty(
@@ -1287,7 +1288,7 @@ public class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadBomWithValidationModeDisabledForTagsTest() {
+    void uploadBomWithValidationModeDisabledForTagsTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
 
         qm.createConfigProperty(
@@ -1354,7 +1355,7 @@ public class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadBomWithValidationTagsInvalidTest() {
+    void uploadBomWithValidationTagsInvalidTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
 
         qm.createConfigProperty(
@@ -1424,7 +1425,7 @@ public class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadBomTooLargeViaPutTest() {
+    void uploadBomTooLargeViaPutTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
 
         final var project = new Project();
@@ -1455,7 +1456,7 @@ public class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadBomUpdateTagsOfExistingProjectWithoutTagsTest() {
+    void uploadBomUpdateTagsOfExistingProjectWithoutTagsTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PORTFOLIO_MANAGEMENT);
 
         final var project = new Project();
@@ -1497,7 +1498,7 @@ public class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadBomUpdateTagsOfExistingProjectWithTagsTest() {
+    void uploadBomUpdateTagsOfExistingProjectWithTagsTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PORTFOLIO_MANAGEMENT);
 
         final var project = new Project();
@@ -1543,7 +1544,7 @@ public class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadBomNoUpdateTagsOfExistingProjectWithTagsTest() {
+    void uploadBomNoUpdateTagsOfExistingProjectWithTagsTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PORTFOLIO_MANAGEMENT);
 
         final var project = new Project();
@@ -1581,7 +1582,7 @@ public class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadBomNoUpdateTagsOfExistingProjectWithTagsWithoutPortfolioManagementPermissionTest() {
+    void uploadBomNoUpdateTagsOfExistingProjectWithTagsWithoutPortfolioManagementPermissionTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
 
         final var project = new Project();
@@ -1624,13 +1625,13 @@ public class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    public void validateCycloneDxBomWithMultipleNamespacesTest() throws Exception {
+    void validateCycloneDxBomWithMultipleNamespacesTest() throws Exception {
         byte[] bom = resourceToByteArray("/unit/bom-issue4008.xml");
         assertThatNoException().isThrownBy(() -> CycloneDxValidator.getInstance().validate(bom));
     }
 
     @Test
-    public void uploadBomCollectionProjectTest() throws Exception {
+    void uploadBomCollectionProjectTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
@@ -1643,10 +1644,10 @@ public class BomResourceTest extends ResourceTest {
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("BOM cannot be uploaded to collection project.", body);
+        Assertions.assertEquals("BOM cannot be uploaded to collection project.", body);
     }
 
 }

--- a/src/test/java/org/dependencytrack/resources/v1/CalculatorResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/CalculatorResourceTest.java
@@ -33,7 +33,7 @@ import us.springett.owasp.riskrating.Level;
 class CalculatorResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(CalculatorResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/CalculatorResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/CalculatorResourceTest.java
@@ -20,99 +20,98 @@ package org.dependencytrack.resources.v1;
 
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import org.dependencytrack.JerseyTestRule;
-import org.dependencytrack.ResourceTest;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
-import us.springett.owasp.riskrating.Level;
-
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import us.springett.owasp.riskrating.Level;
 
-public class CalculatorResourceTest extends ResourceTest {
+class CalculatorResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(CalculatorResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(CalculatorResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
     @Test
-    public void getCvssScoresV3Test() {
+    void getCvssScoresV3Test() {
         Response response = jersey.target(V1_CALCULATOR + "/cvss")
                 .queryParam("vector", "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(9.8, json.getJsonNumber("baseScore").doubleValue(), 0);
-        Assert.assertEquals(5.9, json.getJsonNumber("impactSubScore").doubleValue(), 0);
-        Assert.assertEquals(3.9, json.getJsonNumber("exploitabilitySubScore").doubleValue(), 0);
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(9.8, json.getJsonNumber("baseScore").doubleValue(), 0);
+        Assertions.assertEquals(5.9, json.getJsonNumber("impactSubScore").doubleValue(), 0);
+        Assertions.assertEquals(3.9, json.getJsonNumber("exploitabilitySubScore").doubleValue(), 0);
     }
 
     @Test
-    public void getCvssScoresV2Test() {
+    void getCvssScoresV2Test() {
         Response response = jersey.target(V1_CALCULATOR + "/cvss")
                 .queryParam("vector", "(AV:N/AC:L/Au:N/C:P/I:P/A:P)")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(7.5, json.getJsonNumber("baseScore").doubleValue(), 0);
-        Assert.assertEquals(6.4, json.getJsonNumber("impactSubScore").doubleValue(), 0);
-        Assert.assertEquals(10.0, json.getJsonNumber("exploitabilitySubScore").doubleValue(), 0);
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(7.5, json.getJsonNumber("baseScore").doubleValue(), 0);
+        Assertions.assertEquals(6.4, json.getJsonNumber("impactSubScore").doubleValue(), 0);
+        Assertions.assertEquals(10.0, json.getJsonNumber("exploitabilitySubScore").doubleValue(), 0);
     }
 
     @Test
-    public void getCvssScoresInvalidTest() {
+    void getCvssScoresInvalidTest() {
         Response response = jersey.target(V1_CALCULATOR + "/cvss")
                 .queryParam("vector", "foobar")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("An invalid CVSSv2 or CVSSv3 vector submitted.", body);
+        Assertions.assertEquals("An invalid CVSSv2 or CVSSv3 vector submitted.", body);
     }
 
     @Test
-    public void getOwaspRRScoresTest() {
+    void getOwaspRRScoresTest() {
         Response response = jersey.target(V1_CALCULATOR + "/owasp")
                 .queryParam("vector", "SL:1/M:1/O:0/S:2/ED:1/EE:1/A:1/ID:1/LC:2/LI:1/LAV:1/LAC:1/FD:1/RD:1/NC:2/PV:3")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(1.0, json.getJsonNumber("likelihoodScore").doubleValue(), 0);
-        Assert.assertEquals(1.25, json.getJsonNumber("technicalImpactScore").doubleValue(), 0);
-        Assert.assertEquals(1.75, json.getJsonNumber("businessImpactScore").doubleValue(), 0);
-        Assert.assertEquals(Level.LOW.name(), json.getJsonString("likelihood").getString());
-        Assert.assertEquals(Level.LOW.name(), json.getJsonString("technicalImpact").getString());
-        Assert.assertEquals(Level.LOW.name(), json.getJsonString("businessImpact").getString());
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(1.0, json.getJsonNumber("likelihoodScore").doubleValue(), 0);
+        Assertions.assertEquals(1.25, json.getJsonNumber("technicalImpactScore").doubleValue(), 0);
+        Assertions.assertEquals(1.75, json.getJsonNumber("businessImpactScore").doubleValue(), 0);
+        Assertions.assertEquals(Level.LOW.name(), json.getJsonString("likelihood").getString());
+        Assertions.assertEquals(Level.LOW.name(), json.getJsonString("technicalImpact").getString());
+        Assertions.assertEquals(Level.LOW.name(), json.getJsonString("businessImpact").getString());
     }
 
     @Test
-    public void getOwaspScoresInvalidTest() {
+    void getOwaspScoresInvalidTest() {
         Response response = jersey.target(V1_CALCULATOR + "/owasp")
                 .queryParam("vector", "foobar")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("Provided vector foobar does not match OWASP RR Vector pattern SL:\\d/M:\\d/O:\\d/S:\\d/ED:\\d/EE:\\d/A:\\d/ID:\\d/LC:\\d/LI:\\d/LAV:\\d/LAC:\\d/FD:\\d/RD:\\d/NC:\\d/PV:\\d", body);
+        Assertions.assertEquals("Provided vector foobar does not match OWASP RR Vector pattern SL:\\d/M:\\d/O:\\d/S:\\d/ED:\\d/EE:\\d/A:\\d/ID:\\d/LC:\\d/LI:\\d/LAV:\\d/LAC:\\d/FD:\\d/RD:\\d/NC:\\d/PV:\\d", body);
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/ComponentPropertyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ComponentPropertyResourceTest.java
@@ -42,7 +42,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 class ComponentPropertyResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(ComponentPropertyResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/ComponentPropertyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ComponentPropertyResourceTest.java
@@ -21,34 +21,34 @@ package org.dependencytrack.resources.v1;
 import alpine.model.IConfigProperty.PropertyType;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import org.dependencytrack.JerseyTestRule;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentProperty;
 import org.dependencytrack.model.Project;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.util.UUID;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 
-public class ComponentPropertyResourceTest extends ResourceTest {
+class ComponentPropertyResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(ComponentPropertyResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(ComponentPropertyResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
     @Test
-    public void getPropertiesTest() {
+    void getPropertiesTest() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -108,7 +108,7 @@ public class ComponentPropertyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getPropertiesInvalidTest() {
+    void getPropertiesInvalidTest() {
         final Response response = jersey.target("%s/%s/property".formatted(V1_COMPONENT, UUID.randomUUID())).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -119,7 +119,7 @@ public class ComponentPropertyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createPropertyTest() {
+    void createPropertyTest() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -156,7 +156,7 @@ public class ComponentPropertyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createPropertyWithoutGroupTest() {
+    void createPropertyWithoutGroupTest() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -191,7 +191,7 @@ public class ComponentPropertyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createPropertyDuplicateTest() {
+    void createPropertyDuplicateTest() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -228,7 +228,7 @@ public class ComponentPropertyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createPropertyDisallowedPropertyTypeTest() {
+    void createPropertyDisallowedPropertyTypeTest() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -265,7 +265,7 @@ public class ComponentPropertyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createPropertyComponentNotFoundTest() {
+    void createPropertyComponentNotFoundTest() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -293,7 +293,7 @@ public class ComponentPropertyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void deletePropertyTest() {
+    void deletePropertyTest() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);

--- a/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
@@ -23,8 +23,13 @@ import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
-import org.dependencytrack.JerseyTestRule;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.Classifier;
 import org.dependencytrack.model.Component;
@@ -35,38 +40,32 @@ import org.dependencytrack.model.ProjectCollectionLogic;
 import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ComponentResourceTest extends ResourceTest {
+class ComponentResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(ComponentResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(ComponentResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
     @Test
-    public void getComponentsDefaultRequestTest() {
+    void getComponentsDefaultRequestTest() {
         Response response = jersey.target(V1_COMPONENT).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(405, response.getStatus()); // No longer prohibited in DT 4.0+
+        Assertions.assertEquals(405, response.getStatus()); // No longer prohibited in DT 4.0+
     }
 
     /**
@@ -166,7 +165,7 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getOutdatedComponentsTest() throws MalformedPackageURLException {
+    void getOutdatedComponentsTest() throws MalformedPackageURLException {
         final Project project = prepareProject();
 
         final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
@@ -183,7 +182,7 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getUngroupedOutdatedComponentsTest() throws MalformedPackageURLException {
+    void getUngroupedOutdatedComponentsTest() throws MalformedPackageURLException {
         final Project project = prepareProjectUngroupedComponents();
 
         final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
@@ -200,7 +199,7 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getOutdatedDirectComponentsTest() throws MalformedPackageURLException {
+    void getOutdatedDirectComponentsTest() throws MalformedPackageURLException {
         final Project project = prepareProject();
 
         final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
@@ -217,7 +216,7 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getUngroupedOutdatedDirectComponentsTest() throws MalformedPackageURLException {
+    void getUngroupedOutdatedDirectComponentsTest() throws MalformedPackageURLException {
         final Project project = prepareProjectUngroupedComponents();
 
         final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
@@ -234,7 +233,7 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getAllComponentsTest() throws MalformedPackageURLException {
+    void getAllComponentsTest() throws MalformedPackageURLException {
         final Project project = prepareProject();
 
         final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
@@ -249,7 +248,7 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getAllDirectComponentsTest() throws MalformedPackageURLException {
+    void getAllDirectComponentsTest() throws MalformedPackageURLException {
         final Project project = prepareProject();
 
         final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
@@ -265,7 +264,7 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getComponentsByNameTest() throws MalformedPackageURLException {
+    void getComponentsByNameTest() throws MalformedPackageURLException {
         final Project project = prepareProject();
 
         final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
@@ -281,7 +280,7 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getComponentsByGroupTest() throws MalformedPackageURLException {
+    void getComponentsByGroupTest() throws MalformedPackageURLException {
         final Project project = prepareProject();
 
         final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
@@ -297,7 +296,7 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getComponentByUuidTest() {
+    void getComponentByUuidTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         Component component = new Component();
         component.setProject(project);
@@ -305,25 +304,25 @@ public class ComponentResourceTest extends ResourceTest {
         component = qm.createComponent(component, false);
         Response response = jersey.target(V1_COMPONENT + "/" + component.getUuid())
                 .request().header(X_API_KEY, apiKey).get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("ABC", json.getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("ABC", json.getString("name"));
     }
 
     @Test
-    public void getComponentByInvalidUuidTest() {
+    void getComponentByInvalidUuidTest() {
         Response response = jersey.target(V1_COMPONENT + "/" + UUID.randomUUID())
                 .request().header(X_API_KEY, apiKey).get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The component could not be found.", body);
+        Assertions.assertEquals("The component could not be found.", body);
     }
 
     @Test
-    public void getComponentByUuidWithRepositoryMetaDataTest() {
+    void getComponentByUuidWithRepositoryMetaDataTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         Component component = new Component();
         component.setProject(project);
@@ -341,20 +340,20 @@ public class ComponentResourceTest extends ResourceTest {
         Response response = jersey.target(V1_COMPONENT + "/" + component.getUuid())
                 .queryParam("includeRepositoryMetaData", true)
                 .request().header(X_API_KEY, apiKey).get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("ABC", json.getString("name"));
-        Assert.assertEquals("MAVEN", json.getJsonObject("repositoryMeta").getString("repositoryType"));
-        Assert.assertEquals("org.acme", json.getJsonObject("repositoryMeta").getString("namespace"));
-        Assert.assertEquals("abc", json.getJsonObject("repositoryMeta").getString("name"));
-        Assert.assertEquals("2.0.0", json.getJsonObject("repositoryMeta").getString("latestVersion"));
-        Assert.assertEquals(lastCheck.getTime(), json.getJsonObject("repositoryMeta").getJsonNumber("lastCheck").longValue());
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("ABC", json.getString("name"));
+        Assertions.assertEquals("MAVEN", json.getJsonObject("repositoryMeta").getString("repositoryType"));
+        Assertions.assertEquals("org.acme", json.getJsonObject("repositoryMeta").getString("namespace"));
+        Assertions.assertEquals("abc", json.getJsonObject("repositoryMeta").getString("name"));
+        Assertions.assertEquals("2.0.0", json.getJsonObject("repositoryMeta").getString("latestVersion"));
+        Assertions.assertEquals(lastCheck.getTime(), json.getJsonObject("repositoryMeta").getJsonNumber("lastCheck").longValue());
     }
 
     @Test
-    public void getComponentByIdentityWithCoordinatesTest() {
+    void getComponentByIdentityWithCoordinatesTest() {
         final Project projectA = qm.createProject("projectA", null, "1.0", null, null, null, true, false);
         var componentA = new Component();
         componentA.setProject(projectA);
@@ -394,7 +393,7 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getComponentByIdentityWithPurlTest() {
+    void getComponentByIdentityWithPurlTest() {
         final Project projectA = qm.createProject("projectA", null, "1.0", null, null, null, true, false);
         var componentA = new Component();
         componentA.setProject(projectA);
@@ -432,7 +431,7 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getComponentByIdentityWithCpeTest() {
+    void getComponentByIdentityWithCpeTest() {
         final Project projectA = qm.createProject("projectA", null, "1.0", null, null, null, true, false);
         var componentA = new Component();
         componentA.setProject(projectA);
@@ -470,7 +469,7 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getComponentByIdentityWithProjectTest() {
+    void getComponentByIdentityWithProjectTest() {
         final Project projectA = qm.createProject("projectA", null, "1.0", null, null, null, true, false);
         var componentA = new Component();
         componentA.setProject(projectA);
@@ -507,7 +506,7 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getComponentByIdentityWithProjectWhenProjectDoesNotExistTest() {
+    void getComponentByIdentityWithProjectWhenProjectDoesNotExistTest() {
         final Response response = jersey.target(V1_COMPONENT + "/identity")
                 .queryParam("purl", "pkg:maven/group/name@version")
                 .queryParam("project", UUID.randomUUID())
@@ -520,7 +519,7 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getComponentByHashTest() {
+    void getComponentByHashTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         Component component = new Component();
         component.setProject(project);
@@ -529,23 +528,23 @@ public class ComponentResourceTest extends ResourceTest {
         component = qm.createComponent(component, false);
         Response response = jersey.target(V1_COMPONENT + "/hash/" + component.getSha1())
                 .request().header(X_API_KEY, apiKey).get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(response.getHeaderString(TOTAL_COUNT_HEADER), "1");
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(response.getHeaderString(TOTAL_COUNT_HEADER), "1");
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("ABC", json.getJsonObject(0).getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("ABC", json.getJsonObject(0).getString("name"));
     }
 
     @Test
-    public void getComponentByInvalidHashTest() {
+    void getComponentByInvalidHashTest() {
         Response response = jersey.target(V1_COMPONENT + "/hash/c5a8829aa3da800216b933e265dd0b97eb6f9341")
                 .request().header(X_API_KEY, apiKey).get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(response.getHeaderString(TOTAL_COUNT_HEADER), "0");
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(response.getHeaderString(TOTAL_COUNT_HEADER), "0");
     }
 
     @Test
-    public void getComponentByHashWithAclTest() {
+    void getComponentByHashWithAclTest() {
         // Enable portfolio access control.
         qm.createConfigProperty(
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
@@ -581,7 +580,7 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createComponentTest() {
+    void createComponentTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         Component component = new Component();
         component.setProject(project);
@@ -592,19 +591,19 @@ public class ComponentResourceTest extends ResourceTest {
         Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(component, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertEquals(201, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("My Component", json.getString("name"));
-        Assert.assertEquals("SampleAuthor" ,json.getJsonArray("authors").getJsonObject(0).getString("name"));
-        Assert.assertEquals("SampleAuthor", json.getString("author"));
-        Assert.assertEquals("1.0", json.getString("version"));
-        Assert.assertEquals("APPLICATION", json.getString("classifier"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("My Component", json.getString("name"));
+        Assertions.assertEquals("SampleAuthor" ,json.getJsonArray("authors").getJsonObject(0).getString("name"));
+        Assertions.assertEquals("SampleAuthor", json.getString("author"));
+        Assertions.assertEquals("1.0", json.getString("version"));
+        Assertions.assertEquals("APPLICATION", json.getString("classifier"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
     }
 
     @Test
-    public void createComponentUpperCaseHashTest() {
+    void createComponentUpperCaseHashTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         Component component = new Component();
         component.setProject(project);
@@ -622,25 +621,25 @@ public class ComponentResourceTest extends ResourceTest {
         Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(component, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertEquals(201, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("My Component", json.getString("name"));
-        Assert.assertEquals("1.0", json.getString("version"));
-        Assert.assertEquals("APPLICATION", json.getString("classifier"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
-        Assert.assertEquals(component.getSha1(), json.getString("sha1"));
-        Assert.assertEquals(component.getSha256(), json.getString("sha256"));
-        Assert.assertEquals(component.getSha3_256(), json.getString("sha3_256"));
-        Assert.assertEquals(component.getSha384(), json.getString("sha384"));
-        Assert.assertEquals(component.getSha3_384(), json.getString("sha3_384"));
-        Assert.assertEquals(component.getSha512(), json.getString("sha512"));
-        Assert.assertEquals(component.getSha3_512(), json.getString("sha3_512"));
-        Assert.assertEquals(component.getMd5(), json.getString("md5"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("My Component", json.getString("name"));
+        Assertions.assertEquals("1.0", json.getString("version"));
+        Assertions.assertEquals("APPLICATION", json.getString("classifier"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
+        Assertions.assertEquals(component.getSha1(), json.getString("sha1"));
+        Assertions.assertEquals(component.getSha256(), json.getString("sha256"));
+        Assertions.assertEquals(component.getSha3_256(), json.getString("sha3_256"));
+        Assertions.assertEquals(component.getSha384(), json.getString("sha384"));
+        Assertions.assertEquals(component.getSha3_384(), json.getString("sha3_384"));
+        Assertions.assertEquals(component.getSha512(), json.getString("sha512"));
+        Assertions.assertEquals(component.getSha3_512(), json.getString("sha3_512"));
+        Assertions.assertEquals(component.getMd5(), json.getString("md5"));
     }
 
     @Test
-    public void createComponentCollectionProjectTest() {
+    void createComponentCollectionProjectTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         // make project a collection project
         project.setCollectionLogic(ProjectCollectionLogic.AGGREGATE_DIRECT_CHILDREN);
@@ -653,11 +652,11 @@ public class ComponentResourceTest extends ResourceTest {
         Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(component, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertEquals(400, response.getStatus(), 0);
     }
 
     @Test
-    public void updateComponentTest() {
+    void updateComponentTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         Component component = new Component();
         component.setProject(project);
@@ -680,17 +679,17 @@ public class ComponentResourceTest extends ResourceTest {
         Response response = jersey.target(V1_COMPONENT).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(jsonComponent, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("My Component", json.getString("name"));
-        Assert.assertEquals("1.0", json.getString("version"));
-        Assert.assertEquals("Test component", json.getString("description"));
-        Assert.assertEquals(1, json.getJsonArray("externalReferences").size());
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("My Component", json.getString("name"));
+        Assertions.assertEquals("1.0", json.getString("version"));
+        Assertions.assertEquals("Test component", json.getString("description"));
+        Assertions.assertEquals(1, json.getJsonArray("externalReferences").size());
     }
 
     @Test
-    public void updateComponentEmptyNameTest() {
+    void updateComponentEmptyNameTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         Component component = new Component();
         component.setProject(project);
@@ -701,11 +700,11 @@ public class ComponentResourceTest extends ResourceTest {
         Response response = jersey.target(V1_COMPONENT).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(component, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertEquals(400, response.getStatus(), 0);
     }
 
     @Test
-    public void updateComponentInvalidLicenseExpressionTest() {
+    void updateComponentInvalidLicenseExpressionTest() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -748,7 +747,7 @@ public class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    public void deleteComponentTest() {
+    void deleteComponentTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         Component component = new Component();
         component.setProject(project);
@@ -757,11 +756,11 @@ public class ComponentResourceTest extends ResourceTest {
         component = qm.createComponent(component, false);
         Response response = jersey.target(V1_COMPONENT + "/" + component.getUuid().toString())
                 .request().header(X_API_KEY, apiKey).delete();
-        Assert.assertEquals(204, response.getStatus(), 0);
+        Assertions.assertEquals(204, response.getStatus(), 0);
     }
 
     @Test
-    public void deleteComponentInvalidUuidTest() {
+    void deleteComponentInvalidUuidTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         Component component = new Component();
         component.setProject(project);
@@ -770,18 +769,18 @@ public class ComponentResourceTest extends ResourceTest {
         qm.createComponent(component, false);
         Response response = jersey.target(V1_COMPONENT + "/" + UUID.randomUUID())
                 .request().header(X_API_KEY, apiKey).delete();
-        Assert.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertEquals(404, response.getStatus(), 0);
     }
 
     @Test
-    public void internalComponentIdentificationTest() {
+    void internalComponentIdentificationTest() {
         Response response = jersey.target(V1_COMPONENT + "/internal/identify")
                 .request().header(X_API_KEY, apiKey).get();
-        Assert.assertEquals(204, response.getStatus(), 0);
+        Assertions.assertEquals(204, response.getStatus(), 0);
     }
 
     @Test
-    public void getDependencyGraphForComponentTest() {
+    void getDependencyGraphForComponentTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
 
         Component component1 = new Component();
@@ -829,20 +828,20 @@ public class ComponentResourceTest extends ResourceTest {
         Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid() + "/dependencyGraph/" + component1_1_1.getUuid())
                 .request().header(X_API_KEY, apiKey).get();
         JsonObject json = parseJsonObject(response);
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
 
-        Assert.assertTrue(json.get(component1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
-        Assert.assertTrue(json.get(component1_1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
-        Assert.assertFalse(json.get(component1_1_1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
-        Assert.assertFalse(json.get(component2.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
-        Assert.assertFalse(json.get(component2_1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
-        Assert.assertFalse(json.get(component2_1_1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
+        Assertions.assertTrue(json.get(component1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
+        Assertions.assertTrue(json.get(component1_1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
+        Assertions.assertFalse(json.get(component1_1_1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
+        Assertions.assertFalse(json.get(component2.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
+        Assertions.assertFalse(json.get(component2_1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
+        Assertions.assertFalse(json.get(component2_1_1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
         Component finalComponent2_1_1_1 = component2_1_1_1;
-        Assert.assertThrows(NullPointerException.class, () -> json.get(finalComponent2_1_1_1.getUuid().toString()).asJsonObject().asJsonObject());
+        Assertions.assertThrows(NullPointerException.class, () -> json.get(finalComponent2_1_1_1.getUuid().toString()).asJsonObject().asJsonObject());
     }
 
     @Test
-    public void getDependencyGraphForComponentTestWithRepositoryMetaData() {
+    void getDependencyGraphForComponentTestWithRepositoryMetaData() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
 
         Component component1 = new Component();
@@ -895,18 +894,18 @@ public class ComponentResourceTest extends ResourceTest {
         Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid() + "/dependencyGraph/" + component1_1_1.getUuid())
                 .request().header(X_API_KEY, apiKey).get();
         JsonObject json = parseJsonObject(response);
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
 
-        Assert.assertTrue(json.get(component1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
-        Assert.assertEquals("2.0.0", json.get(component1.getUuid().toString()).asJsonObject().get("repositoryMeta").asJsonObject().getString("latestVersion"));
-        Assert.assertTrue(json.get(component1_1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
-        Assert.assertEquals("3.0.0", json.get(component1_1.getUuid().toString()).asJsonObject().get("repositoryMeta").asJsonObject().getString("latestVersion"));
-        Assert.assertFalse(json.get(component1_1_1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
-        Assert.assertEquals("4.0.0", json.get(component1_1_1.getUuid().toString()).asJsonObject().get("repositoryMeta").asJsonObject().getString("latestVersion"));
+        Assertions.assertTrue(json.get(component1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
+        Assertions.assertEquals("2.0.0", json.get(component1.getUuid().toString()).asJsonObject().get("repositoryMeta").asJsonObject().getString("latestVersion"));
+        Assertions.assertTrue(json.get(component1_1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
+        Assertions.assertEquals("3.0.0", json.get(component1_1.getUuid().toString()).asJsonObject().get("repositoryMeta").asJsonObject().getString("latestVersion"));
+        Assertions.assertFalse(json.get(component1_1_1.getUuid().toString()).asJsonObject().getBoolean("expandDependencyGraph"));
+        Assertions.assertEquals("4.0.0", json.get(component1_1_1.getUuid().toString()).asJsonObject().get("repositoryMeta").asJsonObject().getString("latestVersion"));
     }
 
     @Test
-    public void getDependencyGraphForComponentInvalidProjectUuidTest() {
+    void getDependencyGraphForComponentInvalidProjectUuidTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         Component component = new Component();
         component.setProject(project);
@@ -915,19 +914,19 @@ public class ComponentResourceTest extends ResourceTest {
         component = qm.createComponent(component, false);
         Response response = jersey.target(V1_COMPONENT + "/project/" + UUID.randomUUID() + "/dependencyGraph/" + component.getUuid())
                 .request().header(X_API_KEY, apiKey).get();
-        Assert.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertEquals(404, response.getStatus(), 0);
     }
 
     @Test
-    public void getDependencyGraphForComponentInvalidComponentUuidTest() {
+    void getDependencyGraphForComponentInvalidComponentUuidTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid() + "/dependencyGraph/" + UUID.randomUUID())
                 .request().header(X_API_KEY, apiKey).get();
-        Assert.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertEquals(404, response.getStatus(), 0);
     }
 
     @Test
-    public void getDependencyGraphForComponentNoDependencyGraphTest() {
+    void getDependencyGraphForComponentNoDependencyGraphTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         Component component = new Component();
         component.setProject(project);
@@ -937,12 +936,12 @@ public class ComponentResourceTest extends ResourceTest {
         Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid() + "/dependencyGraph/" + component.getUuid())
                 .request().header(X_API_KEY, apiKey).get();
         JsonObject json = parseJsonObject(response);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(0, json.size());
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(0, json.size());
     }
 
     @Test
-    public void getDependencyGraphForComponentIsNotComponentOfProject() {
+    void getDependencyGraphForComponentIsNotComponentOfProject() {
         Project projectWithComponent = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         Component component = new Component();
         component.setProject(projectWithComponent);
@@ -954,13 +953,13 @@ public class ComponentResourceTest extends ResourceTest {
         Response responseWithComponent = jersey.target(V1_COMPONENT + "/project/" + projectWithComponent.getUuid() + "/dependencyGraph/" + component.getUuid())
                 .request().header(X_API_KEY, apiKey).get();
         JsonObject jsonWithComponent = parseJsonObject(responseWithComponent);
-        Assert.assertEquals(200, responseWithComponent.getStatus(), 0);
-        Assert.assertEquals(1, jsonWithComponent.size());
+        Assertions.assertEquals(200, responseWithComponent.getStatus(), 0);
+        Assertions.assertEquals(1, jsonWithComponent.size());
         Response responseWithoutComponent = jersey.target(V1_COMPONENT + "/project/" + projectWithoutComponent.getUuid() + "/dependencyGraph/" + component.getUuid())
                 .request().header(X_API_KEY, apiKey).get();
         JsonObject jsonWithoutComponent = parseJsonObject(responseWithoutComponent);
-        Assert.assertEquals(200, responseWithoutComponent.getStatus(), 0);
-        Assert.assertEquals(0, jsonWithoutComponent.size());
+        Assertions.assertEquals(200, responseWithoutComponent.getStatus(), 0);
+        Assertions.assertEquals(0, jsonWithoutComponent.size());
     }
 
 }

--- a/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
@@ -55,7 +55,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ComponentResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(ComponentResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
@@ -22,198 +22,198 @@ import alpine.model.ConfigProperty;
 import alpine.model.IConfigProperty;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import org.dependencytrack.JerseyTestRule;
-import org.dependencytrack.ResourceTest;
-import org.dependencytrack.model.ConfigPropertyConstants;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.model.ConfigPropertyConstants;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import java.util.Arrays;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ConfigPropertyResourceTest extends ResourceTest {
+class ConfigPropertyResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(ConfigPropertyResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(ConfigPropertyResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
     @Test
-    public void getConfigPropertiesTest() {
+    void getConfigPropertiesTest() {
         qm.createConfigProperty("my.group", "my.string", "ABC", IConfigProperty.PropertyType.STRING, "A string");
         qm.createConfigProperty("my.group", "my.integer", "1", IConfigProperty.PropertyType.INTEGER, "A integer");
         qm.createConfigProperty("my.group", "my.password", "password", IConfigProperty.PropertyType.ENCRYPTEDSTRING, "A password");
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(3, json.size());
-        Assert.assertEquals("my.group", json.getJsonObject(0).getString("groupName"));
-        Assert.assertEquals("my.integer", json.getJsonObject(0).getString("propertyName"));
-        Assert.assertEquals("1", json.getJsonObject(0).getString("propertyValue"));
-        Assert.assertEquals("INTEGER", json.getJsonObject(0).getString("propertyType"));
-        Assert.assertEquals("A integer", json.getJsonObject(0).getString("description"));
-        Assert.assertEquals("my.group", json.getJsonObject(2).getString("groupName"));
-        Assert.assertEquals("my.string", json.getJsonObject(2).getString("propertyName"));
-        Assert.assertEquals("ABC", json.getJsonObject(2).getString("propertyValue"));
-        Assert.assertEquals("STRING", json.getJsonObject(2).getString("propertyType"));
-        Assert.assertEquals("A string", json.getJsonObject(2).getString("description"));
-        Assert.assertEquals("my.group", json.getJsonObject(1).getString("groupName"));
-        Assert.assertEquals("my.password", json.getJsonObject(1).getString("propertyName"));
-        Assert.assertEquals("HiddenDecryptedPropertyPlaceholder", json.getJsonObject(1).getString("propertyValue"));
-        Assert.assertEquals("ENCRYPTEDSTRING", json.getJsonObject(1).getString("propertyType"));
-        Assert.assertEquals("A password", json.getJsonObject(1).getString("description"));
+        Assertions.assertNotNull(json);
+        assertEquals(3, json.size());
+        assertEquals("my.group", json.getJsonObject(0).getString("groupName"));
+        assertEquals("my.integer", json.getJsonObject(0).getString("propertyName"));
+        assertEquals("1", json.getJsonObject(0).getString("propertyValue"));
+        assertEquals("INTEGER", json.getJsonObject(0).getString("propertyType"));
+        assertEquals("A integer", json.getJsonObject(0).getString("description"));
+        assertEquals("my.group", json.getJsonObject(2).getString("groupName"));
+        assertEquals("my.string", json.getJsonObject(2).getString("propertyName"));
+        assertEquals("ABC", json.getJsonObject(2).getString("propertyValue"));
+        assertEquals("STRING", json.getJsonObject(2).getString("propertyType"));
+        assertEquals("A string", json.getJsonObject(2).getString("description"));
+        assertEquals("my.group", json.getJsonObject(1).getString("groupName"));
+        assertEquals("my.password", json.getJsonObject(1).getString("propertyName"));
+        assertEquals("HiddenDecryptedPropertyPlaceholder", json.getJsonObject(1).getString("propertyValue"));
+        assertEquals("ENCRYPTEDSTRING", json.getJsonObject(1).getString("propertyType"));
+        assertEquals("A password", json.getJsonObject(1).getString("description"));
     }
 
     @Test
-    public void updateConfigPropertyStringTest() {
+    void updateConfigPropertyStringTest() {
         ConfigProperty property = qm.createConfigProperty("my.group", "my.string", "ABC", IConfigProperty.PropertyType.STRING, "A string");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("DEF");
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("my.group", json.getString("groupName"));
-        Assert.assertEquals("my.string", json.getString("propertyName"));
-        Assert.assertEquals("DEF", json.getString("propertyValue"));
-        Assert.assertEquals("STRING", json.getString("propertyType"));
-        Assert.assertEquals("A string", json.getString("description"));
+        Assertions.assertNotNull(json);
+        assertEquals("my.group", json.getString("groupName"));
+        assertEquals("my.string", json.getString("propertyName"));
+        assertEquals("DEF", json.getString("propertyValue"));
+        assertEquals("STRING", json.getString("propertyType"));
+        assertEquals("A string", json.getString("description"));
     }
 
     @Test
-    public void updateConfigPropertyBooleanTest() {
+    void updateConfigPropertyBooleanTest() {
         ConfigProperty property = qm.createConfigProperty("my.group", "my.boolean", "false", IConfigProperty.PropertyType.BOOLEAN, "A boolean");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("true");
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("my.group", json.getString("groupName"));
-        Assert.assertEquals("my.boolean", json.getString("propertyName"));
-        Assert.assertEquals("true", json.getString("propertyValue"));
-        Assert.assertEquals("BOOLEAN", json.getString("propertyType"));
-        Assert.assertEquals("A boolean", json.getString("description"));
+        Assertions.assertNotNull(json);
+        assertEquals("my.group", json.getString("groupName"));
+        assertEquals("my.boolean", json.getString("propertyName"));
+        assertEquals("true", json.getString("propertyValue"));
+        assertEquals("BOOLEAN", json.getString("propertyType"));
+        assertEquals("A boolean", json.getString("description"));
     }
 
     @Test
-    public void updateConfigPropertyNumberTest() {
+    void updateConfigPropertyNumberTest() {
         ConfigProperty property = qm.createConfigProperty("my.group", "my.number", "7.75", IConfigProperty.PropertyType.NUMBER, "A number");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("5.50");
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("my.group", json.getString("groupName"));
-        Assert.assertEquals("my.number", json.getString("propertyName"));
-        Assert.assertEquals("5.50", json.getString("propertyValue"));
-        Assert.assertEquals("NUMBER", json.getString("propertyType"));
-        Assert.assertEquals("A number", json.getString("description"));
+        Assertions.assertNotNull(json);
+        assertEquals("my.group", json.getString("groupName"));
+        assertEquals("my.number", json.getString("propertyName"));
+        assertEquals("5.50", json.getString("propertyValue"));
+        assertEquals("NUMBER", json.getString("propertyType"));
+        assertEquals("A number", json.getString("description"));
     }
 
     @Test
-    public void updateBadTaskSchedulerCadenceConfigPropertyTest() {
+    void updateBadTaskSchedulerCadenceConfigPropertyTest() {
         ConfigProperty property = qm.createConfigProperty(ConfigPropertyConstants.TASK_SCHEDULER_LDAP_SYNC_CADENCE.getGroupName(), "my.cadence", "24", IConfigProperty.PropertyType.INTEGER, "A cadence");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("-2");
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        assertEquals(400, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("A Task scheduler cadence ("+request.getPropertyName()+") cannot be inferior to one hour.A value of -2 was provided.", body);
+        assertEquals("A Task scheduler cadence ("+request.getPropertyName()+") cannot be inferior to one hour.A value of -2 was provided.", body);
     }
 
     @Test
-    public void updateBadIndexConsistencyThresholdConfigPropertyTest() {
+    void updateBadIndexConsistencyThresholdConfigPropertyTest() {
         ConfigProperty property = qm.createConfigProperty(ConfigPropertyConstants.SEARCH_INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getGroupName(), ConfigPropertyConstants.SEARCH_INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getPropertyName(), "24", IConfigProperty.PropertyType.INTEGER, ConfigPropertyConstants.SEARCH_INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getDescription());
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("-1");
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        assertEquals(400, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("Lucene index delta threshold ("+request.getPropertyName()+") cannot be inferior to 1 or superior to 100.A value of -1 was provided.", body);
+        assertEquals("Lucene index delta threshold ("+request.getPropertyName()+") cannot be inferior to 1 or superior to 100.A value of -1 was provided.", body);
     }
 
     @Test
-    public void updateConfigPropertyUrlTest() {
+    void updateConfigPropertyUrlTest() {
         ConfigProperty property = qm.createConfigProperty("my.group", "my.url", "http://localhost", IConfigProperty.PropertyType.URL, "A url");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("http://localhost/path");
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("my.group", json.getString("groupName"));
-        Assert.assertEquals("my.url", json.getString("propertyName"));
-        Assert.assertEquals("http://localhost/path", json.getString("propertyValue"));
-        Assert.assertEquals("URL", json.getString("propertyType"));
-        Assert.assertEquals("A url", json.getString("description"));
+        Assertions.assertNotNull(json);
+        assertEquals("my.group", json.getString("groupName"));
+        assertEquals("my.url", json.getString("propertyName"));
+        assertEquals("http://localhost/path", json.getString("propertyValue"));
+        assertEquals("URL", json.getString("propertyType"));
+        assertEquals("A url", json.getString("description"));
     }
 
     @Test
-    public void updateConfigPropertyUuidTest() {
+    void updateConfigPropertyUuidTest() {
         ConfigProperty property = qm.createConfigProperty("my.group", "my.uuid", "a496cabc-749d-4751-b9e5-3b49b656d018", IConfigProperty.PropertyType.UUID, "A uuid");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("fe03c401-b5a1-4b86-bc3b-1b7a68f0f78d");
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("my.group", json.getString("groupName"));
-        Assert.assertEquals("my.uuid", json.getString("propertyName"));
-        Assert.assertEquals("fe03c401-b5a1-4b86-bc3b-1b7a68f0f78d", json.getString("propertyValue"));
-        Assert.assertEquals("UUID", json.getString("propertyType"));
-        Assert.assertEquals("A uuid", json.getString("description"));
+        Assertions.assertNotNull(json);
+        assertEquals("my.group", json.getString("groupName"));
+        assertEquals("my.uuid", json.getString("propertyName"));
+        assertEquals("fe03c401-b5a1-4b86-bc3b-1b7a68f0f78d", json.getString("propertyValue"));
+        assertEquals("UUID", json.getString("propertyType"));
+        assertEquals("A uuid", json.getString("description"));
     }
 
     @Test
-    public void updateConfigPropertyEncryptedStringTest() {
+    void updateConfigPropertyEncryptedStringTest() {
         ConfigProperty property = qm.createConfigProperty("my.group", "my.encryptedString", "aaaaa", IConfigProperty.PropertyType.ENCRYPTEDSTRING, "A encrypted string");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("bbbbb");
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("my.group", json.getString("groupName"));
-        Assert.assertEquals("my.encryptedString", json.getString("propertyName"));
-        Assert.assertEquals("HiddenDecryptedPropertyPlaceholder", json.getString("propertyValue"));
-        Assert.assertEquals("ENCRYPTEDSTRING", json.getString("propertyType"));
-        Assert.assertEquals("A encrypted string", json.getString("description"));
+        Assertions.assertNotNull(json);
+        assertEquals("my.group", json.getString("groupName"));
+        assertEquals("my.encryptedString", json.getString("propertyName"));
+        assertEquals("HiddenDecryptedPropertyPlaceholder", json.getString("propertyValue"));
+        assertEquals("ENCRYPTEDSTRING", json.getString("propertyType"));
+        assertEquals("A encrypted string", json.getString("description"));
     }
 
     @Test
-    public void updateConfigPropertiesAggregateTest() {
+    void updateConfigPropertiesAggregateTest() {
         ConfigProperty prop1 = qm.createConfigProperty("my.group", "my.string1", "ABC", IConfigProperty.PropertyType.STRING, "A string");
         ConfigProperty prop2 = qm.createConfigProperty("my.group", "my.string2", "DEF", IConfigProperty.PropertyType.STRING, "A string");
         ConfigProperty prop3 = qm.createConfigProperty("my.group", "my.string3", "GHI", IConfigProperty.PropertyType.STRING, "A string");
@@ -227,36 +227,36 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_CONFIG_PROPERTY+"/aggregate").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(Arrays.asList(prop1, prop2, prop3, prop4), MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonArray json = parseJsonArray(response);
         JsonObject modifiedProp = json.getJsonObject(2);
-        Assert.assertNotNull(modifiedProp);
-        Assert.assertEquals("my.group", modifiedProp.getString("groupName"));
-        Assert.assertEquals("my.string3", modifiedProp.getString("propertyName"));
-        Assert.assertEquals("XYZ", modifiedProp.getString("propertyValue"));
-        Assert.assertEquals("STRING", modifiedProp.getString("propertyType"));
-        Assert.assertEquals("A string", modifiedProp.getString("description"));
+        Assertions.assertNotNull(modifiedProp);
+        assertEquals("my.group", modifiedProp.getString("groupName"));
+        assertEquals("my.string3", modifiedProp.getString("propertyName"));
+        assertEquals("XYZ", modifiedProp.getString("propertyValue"));
+        assertEquals("STRING", modifiedProp.getString("propertyType"));
+        assertEquals("A string", modifiedProp.getString("description"));
         String body = json.getString(3);
-        Assert.assertEquals("A Task scheduler cadence ("+prop4.getPropertyName()+") cannot be inferior to one hour.A value of -2 was provided.", body);
+        assertEquals("A Task scheduler cadence ("+prop4.getPropertyName()+") cannot be inferior to one hour.A value of -2 was provided.", body);
     }
 
     @Test
-    public void updateConfigPropertyOsvEcosystemTest() {
+    void updateConfigPropertyOsvEcosystemTest() {
         ConfigProperty property = qm.createConfigProperty("my.group", ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getPropertyName(), "maven;npm;maven", IConfigProperty.PropertyType.STRING, "List of ecosystems");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("maven;npm;maven");
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getPropertyName(), json.getString("propertyName"));
-        Assert.assertEquals("maven;npm", json.getString("propertyValue"));
+        Assertions.assertNotNull(json);
+        assertEquals(ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getPropertyName(), json.getString("propertyName"));
+        assertEquals("maven;npm", json.getString("propertyValue"));
     }
 
     @Test
-    public void updateConfigPropertyBomValidationModeTest() {
+    void updateConfigPropertyBomValidationModeTest() {
         qm.createConfigProperty(
                 ConfigPropertyConstants.BOM_VALIDATION_MODE.getGroupName(),
                 ConfigPropertyConstants.BOM_VALIDATION_MODE.getPropertyName(),
@@ -299,7 +299,7 @@ public class ConfigPropertyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void updateConfigPropertyBomValidationTagsExclusiveTest() {
+    void updateConfigPropertyBomValidationTagsExclusiveTest() {
         qm.createConfigProperty(
                 ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE.getGroupName(),
                 ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE.getPropertyName(),
@@ -342,7 +342,7 @@ public class ConfigPropertyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void updateConfigPropertyBomValidationTagsInclusiveTest() {
+    void updateConfigPropertyBomValidationTagsInclusiveTest() {
         qm.createConfigProperty(
                 ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE.getGroupName(),
                 ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE.getPropertyName(),
@@ -385,7 +385,7 @@ public class ConfigPropertyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getPublicAllPropertiesTest() {
+    void getPublicAllPropertiesTest() {
         for (ConfigPropertyConstants configProperty : ConfigPropertyConstants.values()) {
             String groupName = configProperty.getGroupName();
             String propertyName = configProperty.getPropertyName();

--- a/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ConfigPropertyResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(ConfigPropertyResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/CweResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/CweResourceTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CweResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(CweResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/CweResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/CweResourceTest.java
@@ -20,45 +20,45 @@ package org.dependencytrack.resources.v1;
 
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import org.dependencytrack.JerseyTestRule;
-import org.dependencytrack.ResourceTest;
-import org.dependencytrack.parser.common.resolver.CweDictionary;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.parser.common.resolver.CweDictionary;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CweResourceTest extends ResourceTest {
+class CweResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(CweResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(CweResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
     @Test
-    public void getCwesTest() {
+    void getCwesTest() {
         Response response = jersey.target(V1_CWE).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(1429), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(1429), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(100, json.size());
-        Assert.assertEquals(1, json.getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals("DEPRECATED: Location", json.getJsonObject(0).getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(100, json.size());
+        Assertions.assertEquals(1, json.getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals("DEPRECATED: Location", json.getJsonObject(0).getString("name"));
     }
 
     @Test
-    public void getCwesPaginationTest() {
+    void getCwesPaginationTest() {
         int pageNumber = 1;
         final var cwesSeen = new HashSet<Integer>();
         while (cwesSeen.size() < CweDictionary.DICTIONARY.size()) {
@@ -83,16 +83,16 @@ public class CweResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getCweTest() {
+    void getCweTest() {
         Response response = jersey.target(V1_CWE + "/79").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(79, json.getInt("cweId"));
-        Assert.assertEquals("Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')", json.getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(79, json.getInt("cweId"));
+        Assertions.assertEquals("Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')", json.getString("name"));
     }
 
 }

--- a/src/test/java/org/dependencytrack/resources/v1/DependencyGraphResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/DependencyGraphResourceTest.java
@@ -50,7 +50,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 class DependencyGraphResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(DependencyGraphResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/DependencyGraphResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/DependencyGraphResourceTest.java
@@ -21,9 +21,11 @@ package org.dependencytrack.resources.v1;
 
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import jakarta.json.JsonArray;
+import jakarta.ws.rs.core.Response;
 import net.javacrumbs.jsonunit.core.Option;
 import org.apache.http.HttpStatus;
-import org.dependencytrack.JerseyTestRule;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentIdentity;
@@ -33,11 +35,9 @@ import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.model.ServiceComponent;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.json.JSONArray;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import jakarta.json.JsonArray;
-import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -47,16 +47,16 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 
-public class DependencyGraphResourceTest extends ResourceTest {
+class DependencyGraphResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(DependencyGraphResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(DependencyGraphResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
     @Test
-    public void getComponentsAndServicesByComponentUuidTests() {
+    void getComponentsAndServicesByComponentUuidTests() {
         final int nbIteration = 100;
         final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
 
@@ -110,7 +110,7 @@ public class DependencyGraphResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getComponentsAndServicesByComponentUuidWithRepositoryMetaTests() {
+    void getComponentsAndServicesByComponentUuidWithRepositoryMetaTests() {
         final int nbIteration = 100;
         final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
 
@@ -192,7 +192,7 @@ public class DependencyGraphResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getComponentsAndServicesByProjectUuidTests() {
+    void getComponentsAndServicesByProjectUuidTests() {
         final int nbIteration = 100;
         final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
 
@@ -240,7 +240,7 @@ public class DependencyGraphResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getComponentsAndServicesByProjectUuidWithRepositoryMetaTests() {
+    void getComponentsAndServicesByProjectUuidWithRepositoryMetaTests() {
         final int nbIteration = 100;
         final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
 
@@ -316,7 +316,7 @@ public class DependencyGraphResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getComponentsAndServicesByProjectUuidWithComponentsWithoutPurlTest() {
+    void getComponentsAndServicesByProjectUuidWithComponentsWithoutPurlTest() {
         final var project = new Project();
         project.setName("acme-app");
         project.setVersion("1.0.0");

--- a/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -25,7 +25,11 @@ import alpine.model.ConfigProperty;
 import alpine.model.Team;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import org.dependencytrack.JerseyTestRule;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ConfigPropertyConstants;
@@ -36,14 +40,10 @@ import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.Response;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -54,16 +54,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.resources.v1.FindingResource.MEDIA_TYPE_SARIF_JSON;
 import static org.hamcrest.CoreMatchers.equalTo;
 
-public class FindingResourceTest extends ResourceTest {
+class FindingResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(FindingResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(FindingResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
     @Test
-    public void getFindingsByProjectTest() {
+    void getFindingsByProjectTest() {
         Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         Project p2 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         Component c1 = createComponent(p1, "Component A", "1.0");
@@ -83,45 +83,45 @@ public class FindingResourceTest extends ResourceTest {
         Response response = jersey.target(V1_FINDING + "/project/" + p1.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(3, json.size());
-        Assert.assertEquals("Component A", json.getJsonObject(0).getJsonObject("component").getString("name"));
-        Assert.assertEquals("1.0", json.getJsonObject(0).getJsonObject("component").getString("version"));
-        Assert.assertEquals("Vuln-1", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.CRITICAL.name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getInt("cweId"));
-        Assert.assertEquals(2, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertFalse(json.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
-        Assert.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v1.getUuid().toString(), json.getJsonObject(0).getString("matrix"));
-        Assert.assertEquals("Component A", json.getJsonObject(1).getJsonObject("component").getString("name"));
-        Assert.assertEquals("1.0", json.getJsonObject(1).getJsonObject("component").getString("version"));
-        Assert.assertEquals("Vuln-2", json.getJsonObject(1).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.HIGH.name(), json.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getInt("cweId"));
-        Assert.assertEquals(2, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertFalse(json.getJsonObject(1).getJsonObject("analysis").getBoolean("isSuppressed"));
-        Assert.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v2.getUuid().toString(), json.getJsonObject(1).getString("matrix"));
-        Assert.assertEquals("Component B", json.getJsonObject(2).getJsonObject("component").getString("name"));
-        Assert.assertEquals("1.0", json.getJsonObject(2).getJsonObject("component").getString("version"));
-        Assert.assertEquals("Vuln-3", json.getJsonObject(2).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.MEDIUM.name(), json.getJsonObject(2).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getInt("cweId"));
-        Assert.assertEquals(2, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertFalse(json.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
-        Assert.assertEquals(p1.getUuid().toString() + ":" + c2.getUuid().toString() + ":" + v3.getUuid().toString(), json.getJsonObject(2).getString("matrix"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(3, json.size());
+        Assertions.assertEquals("Component A", json.getJsonObject(0).getJsonObject("component").getString("name"));
+        Assertions.assertEquals("1.0", json.getJsonObject(0).getJsonObject("component").getString("version"));
+        Assertions.assertEquals("Vuln-1", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.CRITICAL.name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getInt("cweId"));
+        Assertions.assertEquals(2, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertFalse(json.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
+        Assertions.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v1.getUuid().toString(), json.getJsonObject(0).getString("matrix"));
+        Assertions.assertEquals("Component A", json.getJsonObject(1).getJsonObject("component").getString("name"));
+        Assertions.assertEquals("1.0", json.getJsonObject(1).getJsonObject("component").getString("version"));
+        Assertions.assertEquals("Vuln-2", json.getJsonObject(1).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.HIGH.name(), json.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getInt("cweId"));
+        Assertions.assertEquals(2, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertFalse(json.getJsonObject(1).getJsonObject("analysis").getBoolean("isSuppressed"));
+        Assertions.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v2.getUuid().toString(), json.getJsonObject(1).getString("matrix"));
+        Assertions.assertEquals("Component B", json.getJsonObject(2).getJsonObject("component").getString("name"));
+        Assertions.assertEquals("1.0", json.getJsonObject(2).getJsonObject("component").getString("version"));
+        Assertions.assertEquals("Vuln-3", json.getJsonObject(2).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.MEDIUM.name(), json.getJsonObject(2).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getInt("cweId"));
+        Assertions.assertEquals(2, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertFalse(json.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
+        Assertions.assertEquals(p1.getUuid().toString() + ":" + c2.getUuid().toString() + ":" + v3.getUuid().toString(), json.getJsonObject(2).getString("matrix"));
     }
 
     @Test
-    public void getFindingsByProjectEmptyTest() {
+    void getFindingsByProjectEmptyTest() {
         final var metaComponent = new RepositoryMetaComponent();
         metaComponent.setRepositoryType(RepositoryType.MAVEN);
         metaComponent.setNamespace("com.acme");
@@ -144,18 +144,18 @@ public class FindingResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getFindingsByProjectInvalidTest() {
+    void getFindingsByProjectInvalidTest() {
         Response response = jersey.target(V1_FINDING + "/project/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The project could not be found.", body);
+        Assertions.assertEquals("The project could not be found.", body);
     }
 
     @Test
-    public void exportFindingsByProjectTest() {
+    void exportFindingsByProjectTest() {
         Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         Project p2 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         Component c1 = createComponent(p1, "Component A", "1.0");
@@ -175,64 +175,64 @@ public class FindingResourceTest extends ResourceTest {
         Response response = jersey.target(V1_FINDING + "/project/" + p1.getUuid().toString() + "/export").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(Config.getInstance().getApplicationName(), json.getJsonObject("meta").getString("application"));
-        Assert.assertEquals(Config.getInstance().getApplicationVersion(), json.getJsonObject("meta").getString("version"));
-        Assert.assertNotNull(json.getJsonObject("meta").getString("timestamp"));
-        Assert.assertEquals("Acme Example", json.getJsonObject("project").getString("name"));
-        Assert.assertEquals("1.0", json.getJsonObject("project").getString("version"));
-        Assert.assertEquals(p1.getUuid().toString(), json.getJsonObject("project").getString("uuid"));
-        Assert.assertEquals("1.2", json.getString("version")); // FPF version
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(Config.getInstance().getApplicationName(), json.getJsonObject("meta").getString("application"));
+        Assertions.assertEquals(Config.getInstance().getApplicationVersion(), json.getJsonObject("meta").getString("version"));
+        Assertions.assertNotNull(json.getJsonObject("meta").getString("timestamp"));
+        Assertions.assertEquals("Acme Example", json.getJsonObject("project").getString("name"));
+        Assertions.assertEquals("1.0", json.getJsonObject("project").getString("version"));
+        Assertions.assertEquals(p1.getUuid().toString(), json.getJsonObject("project").getString("uuid"));
+        Assertions.assertEquals("1.2", json.getString("version")); // FPF version
         JsonArray findings = json.getJsonArray("findings");
-        Assert.assertEquals(3, findings.size());
-        Assert.assertEquals("Component A", findings.getJsonObject(0).getJsonObject("component").getString("name"));
-        Assert.assertEquals("1.0", findings.getJsonObject(0).getJsonObject("component").getString("version"));
-        Assert.assertEquals("Vuln-1", findings.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.CRITICAL.name(), findings.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getInt("cweId"));
-        Assert.assertEquals(2, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertFalse(findings.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
-        Assert.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v1.getUuid().toString(), findings.getJsonObject(0).getString("matrix"));
-        Assert.assertEquals("Component A", findings.getJsonObject(1).getJsonObject("component").getString("name"));
-        Assert.assertEquals("1.0", findings.getJsonObject(1).getJsonObject("component").getString("version"));
-        Assert.assertEquals("Vuln-2", findings.getJsonObject(1).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.HIGH.name(), findings.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getInt("cweId"));
-        Assert.assertEquals(2, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertFalse(findings.getJsonObject(1).getJsonObject("analysis").getBoolean("isSuppressed"));
-        Assert.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v2.getUuid().toString(), findings.getJsonObject(1).getString("matrix"));
-        Assert.assertEquals("Component B", findings.getJsonObject(2).getJsonObject("component").getString("name"));
-        Assert.assertEquals("1.0", findings.getJsonObject(2).getJsonObject("component").getString("version"));
-        Assert.assertEquals("Vuln-3", findings.getJsonObject(2).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.MEDIUM.name(), findings.getJsonObject(2).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getInt("cweId"));
-        Assert.assertEquals(2, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertFalse(findings.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
-        Assert.assertEquals(p1.getUuid().toString() + ":" + c2.getUuid().toString() + ":" + v3.getUuid().toString(), findings.getJsonObject(2).getString("matrix"));
+        Assertions.assertEquals(3, findings.size());
+        Assertions.assertEquals("Component A", findings.getJsonObject(0).getJsonObject("component").getString("name"));
+        Assertions.assertEquals("1.0", findings.getJsonObject(0).getJsonObject("component").getString("version"));
+        Assertions.assertEquals("Vuln-1", findings.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.CRITICAL.name(), findings.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getInt("cweId"));
+        Assertions.assertEquals(2, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertFalse(findings.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
+        Assertions.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v1.getUuid().toString(), findings.getJsonObject(0).getString("matrix"));
+        Assertions.assertEquals("Component A", findings.getJsonObject(1).getJsonObject("component").getString("name"));
+        Assertions.assertEquals("1.0", findings.getJsonObject(1).getJsonObject("component").getString("version"));
+        Assertions.assertEquals("Vuln-2", findings.getJsonObject(1).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.HIGH.name(), findings.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getInt("cweId"));
+        Assertions.assertEquals(2, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertFalse(findings.getJsonObject(1).getJsonObject("analysis").getBoolean("isSuppressed"));
+        Assertions.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v2.getUuid().toString(), findings.getJsonObject(1).getString("matrix"));
+        Assertions.assertEquals("Component B", findings.getJsonObject(2).getJsonObject("component").getString("name"));
+        Assertions.assertEquals("1.0", findings.getJsonObject(2).getJsonObject("component").getString("version"));
+        Assertions.assertEquals("Vuln-3", findings.getJsonObject(2).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.MEDIUM.name(), findings.getJsonObject(2).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getInt("cweId"));
+        Assertions.assertEquals(2, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertFalse(findings.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
+        Assertions.assertEquals(p1.getUuid().toString() + ":" + c2.getUuid().toString() + ":" + v3.getUuid().toString(), findings.getJsonObject(2).getString("matrix"));
     }
 
     @Test
-    public void exportFindingsByProjectInvalidTest() {
+    void exportFindingsByProjectInvalidTest() {
         Response response = jersey.target(V1_FINDING + "/project/" + UUID.randomUUID().toString() + "/export").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The project could not be found.", body);
+        Assertions.assertEquals("The project could not be found.", body);
     }
 
     @Test
-    public void getFindingsByProjectWithComponentLatestVersionTest() {
+    void getFindingsByProjectWithComponentLatestVersionTest() {
         Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         Project p2 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         Component c1 = createComponent(p1, "Component A", "1.0");
@@ -283,48 +283,48 @@ public class FindingResourceTest extends ResourceTest {
         Response response = jersey.target(V1_FINDING + "/project/" + p1.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(3, json.size());
-        Assert.assertEquals("Component A", json.getJsonObject(0).getJsonObject("component").getString("name"));
-        Assert.assertEquals("1.0", json.getJsonObject(0).getJsonObject("component").getString("version"));
-        Assert.assertEquals("Vuln-1", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.CRITICAL.name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getInt("cweId"));
-        Assert.assertEquals(2, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertFalse(json.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
-        Assert.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v1.getUuid().toString(), json.getJsonObject(0).getString("matrix"));
-        Assert.assertEquals("2.0.0", json.getJsonObject(0).getJsonObject("component").getString("latestVersion"));
-        Assert.assertEquals("Component A", json.getJsonObject(1).getJsonObject("component").getString("name"));
-        Assert.assertEquals("1.0", json.getJsonObject(1).getJsonObject("component").getString("version"));
-        Assert.assertEquals("Vuln-2", json.getJsonObject(1).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.HIGH.name(), json.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getInt("cweId"));
-        Assert.assertEquals(2, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertFalse(json.getJsonObject(1).getJsonObject("analysis").getBoolean("isSuppressed"));
-        Assert.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v2.getUuid().toString(), json.getJsonObject(1).getString("matrix"));
-        Assert.assertEquals("2.0.0", json.getJsonObject(1).getJsonObject("component").getString("latestVersion"));
-        Assert.assertEquals("Component B", json.getJsonObject(2).getJsonObject("component").getString("name"));
-        Assert.assertEquals("1.0", json.getJsonObject(2).getJsonObject("component").getString("version"));
-        Assert.assertEquals("Vuln-3", json.getJsonObject(2).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.MEDIUM.name(), json.getJsonObject(2).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getInt("cweId"));
-        Assert.assertEquals(2, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertFalse(json.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
-        Assert.assertEquals(p1.getUuid().toString() + ":" + c2.getUuid().toString() + ":" + v3.getUuid().toString(), json.getJsonObject(2).getString("matrix"));
-        Assert.assertEquals("3.0.0", json.getJsonObject(2).getJsonObject("component").getString("latestVersion"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(3, json.size());
+        Assertions.assertEquals("Component A", json.getJsonObject(0).getJsonObject("component").getString("name"));
+        Assertions.assertEquals("1.0", json.getJsonObject(0).getJsonObject("component").getString("version"));
+        Assertions.assertEquals("Vuln-1", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.CRITICAL.name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getInt("cweId"));
+        Assertions.assertEquals(2, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertFalse(json.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
+        Assertions.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v1.getUuid().toString(), json.getJsonObject(0).getString("matrix"));
+        Assertions.assertEquals("2.0.0", json.getJsonObject(0).getJsonObject("component").getString("latestVersion"));
+        Assertions.assertEquals("Component A", json.getJsonObject(1).getJsonObject("component").getString("name"));
+        Assertions.assertEquals("1.0", json.getJsonObject(1).getJsonObject("component").getString("version"));
+        Assertions.assertEquals("Vuln-2", json.getJsonObject(1).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.HIGH.name(), json.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getInt("cweId"));
+        Assertions.assertEquals(2, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertFalse(json.getJsonObject(1).getJsonObject("analysis").getBoolean("isSuppressed"));
+        Assertions.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v2.getUuid().toString(), json.getJsonObject(1).getString("matrix"));
+        Assertions.assertEquals("2.0.0", json.getJsonObject(1).getJsonObject("component").getString("latestVersion"));
+        Assertions.assertEquals("Component B", json.getJsonObject(2).getJsonObject("component").getString("name"));
+        Assertions.assertEquals("1.0", json.getJsonObject(2).getJsonObject("component").getString("version"));
+        Assertions.assertEquals("Vuln-3", json.getJsonObject(2).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.MEDIUM.name(), json.getJsonObject(2).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getInt("cweId"));
+        Assertions.assertEquals(2, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertFalse(json.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
+        Assertions.assertEquals(p1.getUuid().toString() + ":" + c2.getUuid().toString() + ":" + v3.getUuid().toString(), json.getJsonObject(2).getString("matrix"));
+        Assertions.assertEquals("3.0.0", json.getJsonObject(2).getJsonObject("component").getString("latestVersion"));
     }
 
     @Test
-    public void getFindingsByProjectWithComponentLatestVersionWithoutRepositoryMetaComponent() {
+    void getFindingsByProjectWithComponentLatestVersionWithoutRepositoryMetaComponent() {
         Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         Component c1 = createComponent(p1, "Component A", "1.0");
         c1.setPurl("pkg:/maven/org.acme/component-a@1.0.0");
@@ -334,26 +334,26 @@ public class FindingResourceTest extends ResourceTest {
         Response response = jersey.target(V1_FINDING + "/project/" + p1.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(1, json.size());
-        Assert.assertEquals("Component A", json.getJsonObject(0).getJsonObject("component").getString("name"));
-        Assert.assertEquals("1.0", json.getJsonObject(0).getJsonObject("component").getString("version"));
-        Assert.assertEquals("Vuln-1", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.CRITICAL.name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getInt("cweId"));
-        Assert.assertEquals(2, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertFalse(json.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
-        Assert.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v1.getUuid().toString(), json.getJsonObject(0).getString("matrix"));
-        Assert.assertThrows(NullPointerException.class, () -> json.getJsonObject(0).getJsonObject("component").getString("latestVersion"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(1, json.size());
+        Assertions.assertEquals("Component A", json.getJsonObject(0).getJsonObject("component").getString("name"));
+        Assertions.assertEquals("1.0", json.getJsonObject(0).getJsonObject("component").getString("version"));
+        Assertions.assertEquals("Vuln-1", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.CRITICAL.name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getInt("cweId"));
+        Assertions.assertEquals(2, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertFalse(json.getJsonObject(0).getJsonObject("analysis").getBoolean("isSuppressed"));
+        Assertions.assertEquals(p1.getUuid().toString() + ":" + c1.getUuid().toString() + ":" + v1.getUuid().toString(), json.getJsonObject(0).getString("matrix"));
+        Assertions.assertThrows(NullPointerException.class, () -> json.getJsonObject(0).getJsonObject("component").getString("latestVersion"));
     }
 
     @Test
-    public void getAllFindings() {
+    void getAllFindings() {
         Project p1 = qm.createProject("Acme Example 1", null, "1.0", null, null, null, true, false);
         Project p1_child = qm.createProject("Acme Example 2", null, "1.0", null, p1, null, true, false);
         Project p2 = qm.createProject("Acme Example 3", null, "1.0", null, null, null, true, false);
@@ -383,35 +383,35 @@ public class FindingResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(5), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(5), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(5, json.size());
-        Assert.assertEquals(date.getTime() ,json.getJsonObject(0).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        Assert.assertEquals(p1.getName() ,json.getJsonObject(0).getJsonObject("component").getString("projectName"));
-        Assert.assertEquals(p1.getVersion() ,json.getJsonObject(0).getJsonObject("component").getString("projectVersion"));
-        Assert.assertEquals(p1.getUuid().toString(), json.getJsonObject(0).getJsonObject("component").getString("project"));
-        Assert.assertEquals(date.getTime() ,json.getJsonObject(1).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        Assert.assertEquals(p1.getName() ,json.getJsonObject(1).getJsonObject("component").getString("projectName"));
-        Assert.assertEquals(p1.getVersion() ,json.getJsonObject(1).getJsonObject("component").getString("projectVersion"));
-        Assert.assertEquals(p1.getUuid().toString(), json.getJsonObject(1).getJsonObject("component").getString("project"));
-        Assert.assertEquals(date.getTime() ,json.getJsonObject(2).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        Assert.assertEquals(p1.getName() ,json.getJsonObject(2).getJsonObject("component").getString("projectName"));
-        Assert.assertEquals(p1.getVersion() ,json.getJsonObject(2).getJsonObject("component").getString("projectVersion"));
-        Assert.assertEquals(p1.getUuid().toString(), json.getJsonObject(2).getJsonObject("component").getString("project"));
-        Assert.assertEquals(date.getTime() ,json.getJsonObject(3).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        Assert.assertEquals(p1_child.getName() ,json.getJsonObject(3).getJsonObject("component").getString("projectName"));
-        Assert.assertEquals(p1_child.getVersion() ,json.getJsonObject(3).getJsonObject("component").getString("projectVersion"));
-        Assert.assertEquals(p1_child.getUuid().toString(), json.getJsonObject(3).getJsonObject("component").getString("project"));
-        Assert.assertEquals(date.getTime() ,json.getJsonObject(4).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        Assert.assertEquals(p2.getName() ,json.getJsonObject(4).getJsonObject("component").getString("projectName"));
-        Assert.assertEquals(p2.getVersion() ,json.getJsonObject(4).getJsonObject("component").getString("projectVersion"));
-        Assert.assertEquals(p2.getUuid().toString(), json.getJsonObject(4).getJsonObject("component").getString("project"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(5, json.size());
+        Assertions.assertEquals(date.getTime() ,json.getJsonObject(0).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        Assertions.assertEquals(p1.getName() ,json.getJsonObject(0).getJsonObject("component").getString("projectName"));
+        Assertions.assertEquals(p1.getVersion() ,json.getJsonObject(0).getJsonObject("component").getString("projectVersion"));
+        Assertions.assertEquals(p1.getUuid().toString(), json.getJsonObject(0).getJsonObject("component").getString("project"));
+        Assertions.assertEquals(date.getTime() ,json.getJsonObject(1).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        Assertions.assertEquals(p1.getName() ,json.getJsonObject(1).getJsonObject("component").getString("projectName"));
+        Assertions.assertEquals(p1.getVersion() ,json.getJsonObject(1).getJsonObject("component").getString("projectVersion"));
+        Assertions.assertEquals(p1.getUuid().toString(), json.getJsonObject(1).getJsonObject("component").getString("project"));
+        Assertions.assertEquals(date.getTime() ,json.getJsonObject(2).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        Assertions.assertEquals(p1.getName() ,json.getJsonObject(2).getJsonObject("component").getString("projectName"));
+        Assertions.assertEquals(p1.getVersion() ,json.getJsonObject(2).getJsonObject("component").getString("projectVersion"));
+        Assertions.assertEquals(p1.getUuid().toString(), json.getJsonObject(2).getJsonObject("component").getString("project"));
+        Assertions.assertEquals(date.getTime() ,json.getJsonObject(3).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        Assertions.assertEquals(p1_child.getName() ,json.getJsonObject(3).getJsonObject("component").getString("projectName"));
+        Assertions.assertEquals(p1_child.getVersion() ,json.getJsonObject(3).getJsonObject("component").getString("projectVersion"));
+        Assertions.assertEquals(p1_child.getUuid().toString(), json.getJsonObject(3).getJsonObject("component").getString("project"));
+        Assertions.assertEquals(date.getTime() ,json.getJsonObject(4).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        Assertions.assertEquals(p2.getName() ,json.getJsonObject(4).getJsonObject("component").getString("projectName"));
+        Assertions.assertEquals(p2.getVersion() ,json.getJsonObject(4).getJsonObject("component").getString("projectVersion"));
+        Assertions.assertEquals(p2.getUuid().toString(), json.getJsonObject(4).getJsonObject("component").getString("project"));
     }
 
     @Test
-    public void getAllFindingsWithAclEnabled() {
+    void getAllFindingsWithAclEnabled() {
         Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         Project p1_child = qm.createProject("Acme Example", null, "1.0", null, p1, null, true, false);
         Project p2 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
@@ -448,27 +448,27 @@ public class FindingResourceTest extends ResourceTest {
         Response response = jersey.target(V1_FINDING).request()
                 .header(X_API_KEY, apiKey.getKey())
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(3, json.size());
-        Assert.assertEquals(date.getTime() ,json.getJsonObject(0).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        Assert.assertEquals(p1.getName() ,json.getJsonObject(0).getJsonObject("component").getString("projectName"));
-        Assert.assertEquals(p1.getVersion() ,json.getJsonObject(0).getJsonObject("component").getString("projectVersion"));
-        Assert.assertEquals(p1.getUuid().toString(), json.getJsonObject(0).getJsonObject("component").getString("project"));
-        Assert.assertEquals(date.getTime() ,json.getJsonObject(1).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        Assert.assertEquals(p1.getName() ,json.getJsonObject(1).getJsonObject("component").getString("projectName"));
-        Assert.assertEquals(p1.getVersion() ,json.getJsonObject(1).getJsonObject("component").getString("projectVersion"));
-        Assert.assertEquals(p1.getUuid().toString(), json.getJsonObject(1).getJsonObject("component").getString("project"));
-        Assert.assertEquals(date.getTime() ,json.getJsonObject(2).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        Assert.assertEquals(p1.getName() ,json.getJsonObject(2).getJsonObject("component").getString("projectName"));
-        Assert.assertEquals(p1.getVersion() ,json.getJsonObject(2).getJsonObject("component").getString("projectVersion"));
-        Assert.assertEquals(p1.getUuid().toString(), json.getJsonObject(2).getJsonObject("component").getString("project"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(3, json.size());
+        Assertions.assertEquals(date.getTime() ,json.getJsonObject(0).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        Assertions.assertEquals(p1.getName() ,json.getJsonObject(0).getJsonObject("component").getString("projectName"));
+        Assertions.assertEquals(p1.getVersion() ,json.getJsonObject(0).getJsonObject("component").getString("projectVersion"));
+        Assertions.assertEquals(p1.getUuid().toString(), json.getJsonObject(0).getJsonObject("component").getString("project"));
+        Assertions.assertEquals(date.getTime() ,json.getJsonObject(1).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        Assertions.assertEquals(p1.getName() ,json.getJsonObject(1).getJsonObject("component").getString("projectName"));
+        Assertions.assertEquals(p1.getVersion() ,json.getJsonObject(1).getJsonObject("component").getString("projectVersion"));
+        Assertions.assertEquals(p1.getUuid().toString(), json.getJsonObject(1).getJsonObject("component").getString("project"));
+        Assertions.assertEquals(date.getTime() ,json.getJsonObject(2).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        Assertions.assertEquals(p1.getName() ,json.getJsonObject(2).getJsonObject("component").getString("projectName"));
+        Assertions.assertEquals(p1.getVersion() ,json.getJsonObject(2).getJsonObject("component").getString("projectVersion"));
+        Assertions.assertEquals(p1.getUuid().toString(), json.getJsonObject(2).getJsonObject("component").getString("project"));
     }
 
     @Test
-    public void getAllFindingsGroupedByVulnerability() {
+    void getAllFindingsGroupedByVulnerability() {
         Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         Project p1_child = qm.createProject("Acme Example", null, "1.0", null, p1, null, true, false);
         Project p2 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
@@ -497,54 +497,54 @@ public class FindingResourceTest extends ResourceTest {
         Response response = jersey.target(V1_FINDING + "/grouped").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(4), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(4), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(4, json.size());
-        Assert.assertEquals("INTERNAL", json.getJsonObject(0).getJsonObject("vulnerability").getString("source"));
-        Assert.assertEquals("Vuln-1", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.CRITICAL.name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals("NONE", json.getJsonObject(0).getJsonObject("attribution").getString("analyzerIdentity"));
-        Assert.assertEquals(date.getTime(), json.getJsonObject(0).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        Assert.assertEquals(2, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertEquals(1, json.getJsonObject(0).getJsonObject("vulnerability").getInt("affectedProjectCount"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(4, json.size());
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(0).getJsonObject("vulnerability").getString("source"));
+        Assertions.assertEquals("Vuln-1", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.CRITICAL.name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals("NONE", json.getJsonObject(0).getJsonObject("attribution").getString("analyzerIdentity"));
+        Assertions.assertEquals(date.getTime(), json.getJsonObject(0).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        Assertions.assertEquals(2, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertEquals(1, json.getJsonObject(0).getJsonObject("vulnerability").getInt("affectedProjectCount"));
 
-        Assert.assertEquals("INTERNAL", json.getJsonObject(1).getJsonObject("vulnerability").getString("source"));
-        Assert.assertEquals("Vuln-2", json.getJsonObject(1).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.HIGH.name(), json.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals("NONE", json.getJsonObject(1).getJsonObject("attribution").getString("analyzerIdentity"));
-        Assert.assertEquals(date.getTime(), json.getJsonObject(1).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        Assert.assertEquals(2, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertEquals(3, json.getJsonObject(1).getJsonObject("vulnerability").getInt("affectedProjectCount"));
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(1).getJsonObject("vulnerability").getString("source"));
+        Assertions.assertEquals("Vuln-2", json.getJsonObject(1).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.HIGH.name(), json.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals("NONE", json.getJsonObject(1).getJsonObject("attribution").getString("analyzerIdentity"));
+        Assertions.assertEquals(date.getTime(), json.getJsonObject(1).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        Assertions.assertEquals(2, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertEquals(3, json.getJsonObject(1).getJsonObject("vulnerability").getInt("affectedProjectCount"));
 
-        Assert.assertEquals("INTERNAL", json.getJsonObject(2).getJsonObject("vulnerability").getString("source"));
-        Assert.assertEquals("Vuln-3", json.getJsonObject(2).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.MEDIUM.name(), json.getJsonObject(2).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals("NONE", json.getJsonObject(2).getJsonObject("attribution").getString("analyzerIdentity"));
-        Assert.assertEquals(date.getTime(), json.getJsonObject(2).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        Assert.assertEquals(2, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertEquals(2, json.getJsonObject(2).getJsonObject("vulnerability").getInt("affectedProjectCount"));
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(2).getJsonObject("vulnerability").getString("source"));
+        Assertions.assertEquals("Vuln-3", json.getJsonObject(2).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.MEDIUM.name(), json.getJsonObject(2).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals("NONE", json.getJsonObject(2).getJsonObject("attribution").getString("analyzerIdentity"));
+        Assertions.assertEquals(date.getTime(), json.getJsonObject(2).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        Assertions.assertEquals(2, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertEquals(2, json.getJsonObject(2).getJsonObject("vulnerability").getInt("affectedProjectCount"));
 
-        Assert.assertEquals("INTERNAL", json.getJsonObject(3).getJsonObject("vulnerability").getString("source"));
-        Assert.assertEquals("Vuln-4", json.getJsonObject(3).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.LOW.name(), json.getJsonObject(3).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals("NONE", json.getJsonObject(3).getJsonObject("attribution").getString("analyzerIdentity"));
-        Assert.assertEquals(date.getTime(), json.getJsonObject(3).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        Assert.assertEquals(2, json.getJsonObject(3).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonObject(3).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, json.getJsonObject(3).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertEquals(1, json.getJsonObject(3).getJsonObject("vulnerability").getInt("affectedProjectCount"));
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(3).getJsonObject("vulnerability").getString("source"));
+        Assertions.assertEquals("Vuln-4", json.getJsonObject(3).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.LOW.name(), json.getJsonObject(3).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals("NONE", json.getJsonObject(3).getJsonObject("attribution").getString("analyzerIdentity"));
+        Assertions.assertEquals(date.getTime(), json.getJsonObject(3).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        Assertions.assertEquals(2, json.getJsonObject(3).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonObject(3).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, json.getJsonObject(3).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertEquals(1, json.getJsonObject(3).getJsonObject("vulnerability").getInt("affectedProjectCount"));
     }
 
     @Test
-    public void getAllFindingsGroupedByVulnerabilityWithAclEnabled() {
+    void getAllFindingsGroupedByVulnerabilityWithAclEnabled() {
         Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         Project p1_child = qm.createProject("Acme Example", null, "1.0", null, p1, null, true, false);
         Project p2 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
@@ -583,44 +583,44 @@ public class FindingResourceTest extends ResourceTest {
         Response response = jersey.target(V1_FINDING + "/grouped").request()
                 .header(X_API_KEY, apiKey.getKey())
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(3, json.size());
-        Assert.assertEquals("INTERNAL", json.getJsonObject(0).getJsonObject("vulnerability").getString("source"));
-        Assert.assertEquals("Vuln-1", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.CRITICAL.name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals("NONE", json.getJsonObject(0).getJsonObject("attribution").getString("analyzerIdentity"));
-        Assert.assertEquals(date.getTime(), json.getJsonObject(0).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        Assert.assertEquals(2, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertEquals(1, json.getJsonObject(0).getJsonObject("vulnerability").getInt("affectedProjectCount"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(3, json.size());
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(0).getJsonObject("vulnerability").getString("source"));
+        Assertions.assertEquals("Vuln-1", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.CRITICAL.name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals("NONE", json.getJsonObject(0).getJsonObject("attribution").getString("analyzerIdentity"));
+        Assertions.assertEquals(date.getTime(), json.getJsonObject(0).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        Assertions.assertEquals(2, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertEquals(1, json.getJsonObject(0).getJsonObject("vulnerability").getInt("affectedProjectCount"));
 
-        Assert.assertEquals("INTERNAL", json.getJsonObject(1).getJsonObject("vulnerability").getString("source"));
-        Assert.assertEquals("Vuln-2", json.getJsonObject(1).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.HIGH.name(), json.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals("NONE", json.getJsonObject(1).getJsonObject("attribution").getString("analyzerIdentity"));
-        Assert.assertEquals(date.getTime(), json.getJsonObject(1).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        Assert.assertEquals(2, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertEquals(1, json.getJsonObject(1).getJsonObject("vulnerability").getInt("affectedProjectCount"));
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(1).getJsonObject("vulnerability").getString("source"));
+        Assertions.assertEquals("Vuln-2", json.getJsonObject(1).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.HIGH.name(), json.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals("NONE", json.getJsonObject(1).getJsonObject("attribution").getString("analyzerIdentity"));
+        Assertions.assertEquals(date.getTime(), json.getJsonObject(1).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        Assertions.assertEquals(2, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertEquals(1, json.getJsonObject(1).getJsonObject("vulnerability").getInt("affectedProjectCount"));
 
-        Assert.assertEquals("INTERNAL", json.getJsonObject(2).getJsonObject("vulnerability").getString("source"));
-        Assert.assertEquals("Vuln-3", json.getJsonObject(2).getJsonObject("vulnerability").getString("vulnId"));
-        Assert.assertEquals(Severity.MEDIUM.name(), json.getJsonObject(2).getJsonObject("vulnerability").getString("severity"));
-        Assert.assertEquals("NONE", json.getJsonObject(2).getJsonObject("attribution").getString("analyzerIdentity"));
-        Assert.assertEquals(date.getTime(), json.getJsonObject(2).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        Assert.assertEquals(2, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals(666, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertEquals(1, json.getJsonObject(2).getJsonObject("vulnerability").getInt("affectedProjectCount"));
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(2).getJsonObject("vulnerability").getString("source"));
+        Assertions.assertEquals("Vuln-3", json.getJsonObject(2).getJsonObject("vulnerability").getString("vulnId"));
+        Assertions.assertEquals(Severity.MEDIUM.name(), json.getJsonObject(2).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals("NONE", json.getJsonObject(2).getJsonObject("attribution").getString("analyzerIdentity"));
+        Assertions.assertEquals(date.getTime(), json.getJsonObject(2).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        Assertions.assertEquals(2, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals(666, json.getJsonObject(2).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
+        Assertions.assertEquals(1, json.getJsonObject(2).getJsonObject("vulnerability").getInt("affectedProjectCount"));
     }
 
     @Test
-    public void getSARIFFindingsByProjectTest() {
+    void getSARIFFindingsByProjectTest() {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         Component c1 = createComponent(project, "Component 1", "1.1.4");
         Component c2 = createComponent(project, "Component 2", "2.78.123");
@@ -644,8 +644,8 @@ public class FindingResourceTest extends ResourceTest {
             .header(X_API_KEY, apiKey)
             .get(Response.class);
 
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(MEDIA_TYPE_SARIF_JSON, response.getHeaderString(HttpHeaders.CONTENT_TYPE));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(MEDIA_TYPE_SARIF_JSON, response.getHeaderString(HttpHeaders.CONTENT_TYPE));
         final String jsonResponse = getPlainTextBody(response);
 
         assertThatJson(jsonResponse)

--- a/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -57,7 +57,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 class FindingResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(FindingResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/IntegrationResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/IntegrationResourceTest.java
@@ -21,31 +21,31 @@ package org.dependencytrack.resources.v1;
 import alpine.model.IConfigProperty;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import org.dependencytrack.JerseyTestRule;
-import org.dependencytrack.ResourceTest;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import jakarta.json.JsonArray;
 import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_BASE_URL;
 import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED;
 
-public class IntegrationResourceTest extends ResourceTest {
+class IntegrationResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(IntegrationResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(IntegrationResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
-    @Before
+
+
+    @BeforeEach
     public void before() throws Exception {
-        super.before();
         qm.createConfigProperty(VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getGroupName(),
                 VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getPropertyName(),
                 "Maven;npm;Maven",
@@ -59,23 +59,23 @@ public class IntegrationResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getEcosystemsTest() {
+    void getEcosystemsTest() {
         Response response = jersey.target(V1_OSV_ECOSYSTEM).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertFalse(json.isEmpty());
+        Assertions.assertNotNull(json);
+        Assertions.assertFalse(json.isEmpty());
         var total = json.size();
 
         response = jersey.target(V1_OSV_ECOSYSTEM + "/inactive").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(total-2, json.size());
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(total-2, json.size());
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/IntegrationResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/IntegrationResourceTest.java
@@ -37,7 +37,7 @@ import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SO
 class IntegrationResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(IntegrationResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/LdapResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/LdapResourceTest.java
@@ -39,7 +39,7 @@ import java.util.UUID;
 class LdapResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(LdapResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/LdapResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/LdapResourceTest.java
@@ -21,36 +21,36 @@ package org.dependencytrack.resources.v1;
 import alpine.model.MappedLdapGroup;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import org.dependencytrack.JerseyTestRule;
-import org.dependencytrack.ResourceTest;
-import org.dependencytrack.resources.v1.vo.MappedLdapGroupRequest;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.resources.v1.vo.MappedLdapGroupRequest;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import java.util.UUID;
 
-public class LdapResourceTest extends ResourceTest {
+class LdapResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(LdapResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(LdapResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
     @Test
-    public void retrieveLdapGroupsNotEnabledTest() {
+    void retrieveLdapGroupsNotEnabledTest() {
         Response response = jersey.target(V1_LDAP + "/groups").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     //@Test TODO: Add integration test to get back actual LDAP groups from a directory server
@@ -58,64 +58,64 @@ public class LdapResourceTest extends ResourceTest {
     }
 
     @Test
-    public void retrieveLdapGroupsTest() {
+    void retrieveLdapGroupsTest() {
         qm.createMappedLdapGroup(team, "CN=Developers,OU=R&D,O=Acme");
         qm.createMappedLdapGroup(team, "CN=QA,OU=R&D,O=Acme");
         Response response = jersey.target(V1_LDAP + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(2, json.size());
-        Assert.assertEquals("CN=Developers,OU=R&D,O=Acme", json.getJsonObject(0).getString("dn"));
-        Assert.assertEquals("CN=QA,OU=R&D,O=Acme", json.getJsonObject(1).getString("dn"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(2, json.size());
+        Assertions.assertEquals("CN=Developers,OU=R&D,O=Acme", json.getJsonObject(0).getString("dn"));
+        Assertions.assertEquals("CN=QA,OU=R&D,O=Acme", json.getJsonObject(1).getString("dn"));
     }
 
     @Test
-    public void addMappingTest() {
+    void addMappingTest() {
         MappedLdapGroupRequest request = new MappedLdapGroupRequest(team.getUuid().toString(), "CN=Administrators,OU=R&D,O=Acme");
         Response response = jersey.target(V1_LDAP + "/mapping").request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("CN=Administrators,OU=R&D,O=Acme", json.getString("dn"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("CN=Administrators,OU=R&D,O=Acme", json.getString("dn"));
     }
 
     @Test
-    public void addMappingInvalidTest() {
+    void addMappingInvalidTest() {
         MappedLdapGroupRequest request = new MappedLdapGroupRequest(UUID.randomUUID().toString(), "CN=Administrators,OU=R&D,O=Acme");
         Response response = jersey.target(V1_LDAP + "/mapping").request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The UUID of the team could not be found.", body);
+        Assertions.assertEquals("The UUID of the team could not be found.", body);
     }
 
     @Test
-    public void deleteMappingTest() {
+    void deleteMappingTest() {
         MappedLdapGroup mapping = qm.createMappedLdapGroup(team, "CN=Finance,OU=R&D,O=Acme");
         Response response = jersey.target(V1_LDAP + "/mapping/" + mapping.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete(Response.class);
-        Assert.assertEquals(204, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(204, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void deleteMappingInvalidTest() {
+    void deleteMappingInvalidTest() {
         Response response = jersey.target(V1_LDAP + "/mapping/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The UUID of the mapping could not be found.", body);
+        Assertions.assertEquals("The UUID of the mapping could not be found.", body);
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/LicenseResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/LicenseResourceTest.java
@@ -26,92 +26,90 @@ import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.dependencytrack.JerseyTestRule;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.License;
 import org.dependencytrack.persistence.DefaultObjectGenerator;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class LicenseResourceTest extends ResourceTest {
+class LicenseResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(LicenseResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(LicenseResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
-    @Before
-    @Override
+    @BeforeEach
     public void before() throws Exception {
-        super.before();
         final var generator = new DefaultObjectGenerator();
         generator.loadDefaultLicenses();
     }
 
     @Test
-    public void getLicensesTest() {
+    void getLicensesTest() {
         Response response = jersey.target(V1_LICENSE).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(757), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(757), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(100, json.size());
-        Assert.assertNotNull(json.getJsonObject(0).getString("name"));
-        Assert.assertNotNull(json.getJsonObject(0).getString("licenseText"));
-        Assert.assertNotNull(json.getJsonObject(0).getString("licenseComments"));
-        Assert.assertNotNull(json.getJsonObject(0).getString("licenseId"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(100, json.size());
+        Assertions.assertNotNull(json.getJsonObject(0).getString("name"));
+        Assertions.assertNotNull(json.getJsonObject(0).getString("licenseText"));
+        Assertions.assertNotNull(json.getJsonObject(0).getString("licenseComments"));
+        Assertions.assertNotNull(json.getJsonObject(0).getString("licenseId"));
     }
 
     @Test
-    public void getLicensesConciseTest() {
+    void getLicensesConciseTest() {
         Response response = jersey.target(V1_LICENSE + "/concise").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(757, json.size());
-        Assert.assertNotNull(json.getJsonObject(0).getString("name"));
-        Assert.assertNull(json.getJsonObject(0).getString("licenseText", null));
-        Assert.assertNull(json.getJsonObject(0).getString("licenseComments", null));
-        Assert.assertNotNull(json.getJsonObject(0).getString("licenseId"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(757, json.size());
+        Assertions.assertNotNull(json.getJsonObject(0).getString("name"));
+        Assertions.assertNull(json.getJsonObject(0).getString("licenseText", null));
+        Assertions.assertNull(json.getJsonObject(0).getString("licenseComments", null));
+        Assertions.assertNotNull(json.getJsonObject(0).getString("licenseId"));
     }
 
     @Test
-    public void getLicense() {
+    void getLicense() {
         Response response = jersey.target(V1_LICENSE + "/Apache-2.0").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Apache License 2.0", json.getString("name"));
-        Assert.assertNotNull(json.getString("licenseText", null));
-        Assert.assertNotNull(json.getString("licenseComments", null));
-        Assert.assertNotNull(json.getString("licenseId"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Apache License 2.0", json.getString("name"));
+        Assertions.assertNotNull(json.getString("licenseText", null));
+        Assertions.assertNotNull(json.getString("licenseComments", null));
+        Assertions.assertNotNull(json.getString("licenseId"));
     }
 
     @Test
-    public void getLicenseInvalid() {
+    void getLicenseInvalid() {
         Response response = jersey.target(V1_LICENSE + "/blah").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The license could not be found.", body);
+        Assertions.assertEquals("The license could not be found.", body);
     }
 
     @Test
-    public void createCustomLicense() {
+    void createCustomLicense() {
         License license = new License();
         license.setName("Acme Example");
         license.setLicenseId("Acme-Example-License");
@@ -119,20 +117,20 @@ public class LicenseResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(license, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertEquals(201, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Acme Example", json.getString("name"));
-        Assert.assertEquals("Acme-Example-License", json.getString("licenseId"));
-        Assert.assertFalse(json.getBoolean("isOsiApproved"));
-        Assert.assertFalse(json.getBoolean("isFsfLibre"));
-        Assert.assertFalse(json.getBoolean("isDeprecatedLicenseId"));
-        Assert.assertTrue(json.getBoolean("isCustomLicense"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Acme Example", json.getString("name"));
+        Assertions.assertEquals("Acme-Example-License", json.getString("licenseId"));
+        Assertions.assertFalse(json.getBoolean("isOsiApproved"));
+        Assertions.assertFalse(json.getBoolean("isFsfLibre"));
+        Assertions.assertFalse(json.getBoolean("isDeprecatedLicenseId"));
+        Assertions.assertTrue(json.getBoolean("isCustomLicense"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
     }
 
     @Test
-    public void createCustomLicenseDuplicate() {
+    void createCustomLicenseDuplicate() {
         License license = new License();
         license.setName("Apache License 2.0");
         license.setLicenseId("Apache-2.0");
@@ -140,26 +138,26 @@ public class LicenseResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(license, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(409, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(409, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("A license with the specified name already exists.", body);
+        Assertions.assertEquals("A license with the specified name already exists.", body);
     }
 
     @Test
-    public void createCustomLicenseWithoutLicenseId() {
+    void createCustomLicenseWithoutLicenseId() {
         License license = new License();
         license.setName("Acme Example");
         Response response = jersey.target(V1_LICENSE)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(license, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void deleteCustomLicense() {
+    void deleteCustomLicense() {
         License license = new License();
         license.setLicenseId("Acme-Example-License");
         license.setName("Acme Example");
@@ -170,12 +168,12 @@ public class LicenseResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(204, response.getStatus(), 0);
-        Assert.assertTrue(license.isCustomLicense());
+        Assertions.assertEquals(204, response.getStatus(), 0);
+        Assertions.assertTrue(license.isCustomLicense());
     }
 
     @Test
-    public void deleteNotCustomLicense() {
+    void deleteNotCustomLicense() {
         License license1 = new License();
         license1.setLicenseId("Acme-Example-License");
         license1.setName("Acme Example");
@@ -185,10 +183,10 @@ public class LicenseResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(409, response.getStatus(), 0);
-        Assert.assertFalse(license2.isCustomLicense());
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(409, response.getStatus(), 0);
+        Assertions.assertFalse(license2.isCustomLicense());
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("Only custom licenses can be deleted.", body);
+        Assertions.assertEquals("Only custom licenses can be deleted.", body);
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/LicenseResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/LicenseResourceTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class LicenseResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(LicenseResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
@@ -76,7 +76,7 @@ import static org.awaitility.Awaitility.await;
 public class NotificationPublisherResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(NotificationPublisherResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
@@ -25,7 +25,15 @@ import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
-import org.dependencytrack.JerseyTestRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.NotificationPublisher;
@@ -40,17 +48,11 @@ import org.dependencytrack.notification.publisher.SlackPublisher;
 import org.dependencytrack.notification.publisher.WebhookPublisher;
 import org.dependencytrack.persistence.DefaultObjectGenerator;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.Form;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -63,22 +65,24 @@ import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+@WireMockTest
 public class NotificationPublisherResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(NotificationPublisherResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(NotificationPublisherResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
-        super.before();
         final var generator = new DefaultObjectGenerator();
         generator.loadDefaultNotificationPublishers();
     }
@@ -88,17 +92,17 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(8, json.size());
-        Assert.assertEquals("Console", json.getJsonObject(1).getString("name"));
-        Assert.assertEquals("Displays notifications on the system console", json.getJsonObject(1).getString("description"));
-        Assert.assertEquals("text/plain", json.getJsonObject(1).getString("templateMimeType"));
-        Assert.assertNotNull("template");
-        Assert.assertTrue(json.getJsonObject(1).getBoolean("defaultPublisher"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(1).getString("uuid")));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(8, json.size());
+        Assertions.assertEquals("Console", json.getJsonObject(1).getString("name"));
+        Assertions.assertEquals("Displays notifications on the system console", json.getJsonObject(1).getString("description"));
+        Assertions.assertEquals("text/plain", json.getJsonObject(1).getString("templateMimeType"));
+        Assertions.assertNotNull("template");
+        Assertions.assertTrue(json.getJsonObject(1).getBoolean("defaultPublisher"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(1).getString("uuid")));
     }
 
     @Test
@@ -113,16 +117,16 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(publisher, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertEquals(201, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Example Publisher", json.getString("name"));
-        Assert.assertFalse(json.getBoolean("defaultPublisher"));
-        Assert.assertEquals("Publisher description", json.getString("description"));
-        Assert.assertEquals("template", json.getString("template"));
-        Assert.assertEquals("application/json", json.getString("templateMimeType"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
-        Assert.assertEquals(SendMailPublisher.class.getName(), json.getString("publisherClass"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Example Publisher", json.getString("name"));
+        Assertions.assertFalse(json.getBoolean("defaultPublisher"));
+        Assertions.assertEquals("Publisher description", json.getString("description"));
+        Assertions.assertEquals("template", json.getString("template"));
+        Assertions.assertEquals("application/json", json.getString("templateMimeType"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
+        Assertions.assertEquals(SendMailPublisher.class.getName(), json.getString("publisherClass"));
     }
 
     @Test
@@ -137,9 +141,9 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(publisher, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertEquals(400, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The creation of a new default publisher is forbidden", body);
+        Assertions.assertEquals("The creation of a new default publisher is forbidden", body);
     }
 
     @Test
@@ -154,9 +158,9 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(publisher, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(409, response.getStatus(), 0);
+        Assertions.assertEquals(409, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The notification with the name " + DefaultNotificationPublishers.SLACK.getPublisherName() + " already exist", body);
+        Assertions.assertEquals("The notification with the name " + DefaultNotificationPublishers.SLACK.getPublisherName() + " already exist", body);
     }
 
     @Test
@@ -171,9 +175,9 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(publisher, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertEquals(400, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The class " + NotificationPublisherResource.class.getName() + " does not implement " + Publisher.class.getName(), body);
+        Assertions.assertEquals("The class " + NotificationPublisherResource.class.getName() + " does not implement " + Publisher.class.getName(), body);
     }
 
     @Test
@@ -188,9 +192,9 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(publisher, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertEquals(400, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The class invalidClassFqcn cannot be found", body);
+        Assertions.assertEquals("The class invalidClassFqcn cannot be found", body);
     }
 
     @Test
@@ -204,16 +208,16 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(notificationPublisher, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Updated Publisher name", json.getString("name"));
-        Assert.assertFalse(json.getBoolean("defaultPublisher"));
-        Assert.assertEquals("Publisher description", json.getString("description"));
-        Assert.assertEquals("template", json.getString("template"));
-        Assert.assertEquals("text/html", json.getString("templateMimeType"));
-        Assert.assertEquals(notificationPublisher.getUuid().toString(), json.getString("uuid"));
-        Assert.assertEquals(SendMailPublisher.class.getName(), json.getString("publisherClass"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Updated Publisher name", json.getString("name"));
+        Assertions.assertFalse(json.getBoolean("defaultPublisher"));
+        Assertions.assertEquals("Publisher description", json.getString("description"));
+        Assertions.assertEquals("template", json.getString("template"));
+        Assertions.assertEquals("text/html", json.getString("templateMimeType"));
+        Assertions.assertEquals(notificationPublisher.getUuid().toString(), json.getString("uuid"));
+        Assertions.assertEquals(SendMailPublisher.class.getName(), json.getString("publisherClass"));
     }
 
     @Test
@@ -228,10 +232,10 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(notificationPublisher, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The UUID of the notification publisher could not be found.", body);
+        Assertions.assertEquals("The UUID of the notification publisher could not be found.", body);
     }
 
     @Test
@@ -241,10 +245,10 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(notificationPublisher, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The modification of a default publisher is forbidden", body);
+        Assertions.assertEquals("The modification of a default publisher is forbidden", body);
     }
 
     @Test
@@ -259,10 +263,10 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(notificationPublisher, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(409, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(409, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("An existing publisher with the name '" + DefaultNotificationPublishers.MS_TEAMS.getPublisherName() + "' already exist", body);
+        Assertions.assertEquals("An existing publisher with the name '" + DefaultNotificationPublishers.MS_TEAMS.getPublisherName() + "' already exist", body);
     }
 
     @Test
@@ -276,10 +280,10 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(notificationPublisher, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The class unknownClass cannot be found", body);
+        Assertions.assertEquals("The class unknownClass cannot be found", body);
     }
 
     @Test
@@ -293,10 +297,10 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(notificationPublisher, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The class " + NotificationPublisherResource.class.getName() + " does not implement " + Publisher.class.getName(), body);
+        Assertions.assertEquals("The class " + NotificationPublisherResource.class.getName() + " does not implement " + Publisher.class.getName(), body);
     }
 
     @Test
@@ -309,8 +313,8 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER + "/" + publisher.getUuid()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(204, response.getStatus(), 0);
-        Assert.assertNull(qm.getObjectByUuid(NotificationPublisher.class, publisher.getUuid()));
+        Assertions.assertEquals(204, response.getStatus(), 0);
+        Assertions.assertNull(qm.getObjectByUuid(NotificationPublisher.class, publisher.getUuid()));
     }
 
     @Test
@@ -325,10 +329,10 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER + "/" + publisher.getUuid()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(204, response.getStatus(), 0);
-        Assert.assertNull(qm.getObjectByUuid(NotificationPublisher.class, publisher.getUuid()));
-        Assert.assertNull(qm.getObjectByUuid(NotificationRule.class, firstRule.getUuid()));
-        Assert.assertNull(qm.getObjectByUuid(NotificationRule.class, secondRule.getUuid()));
+        Assertions.assertEquals(204, response.getStatus(), 0);
+        Assertions.assertNull(qm.getObjectByUuid(NotificationPublisher.class, publisher.getUuid()));
+        Assertions.assertNull(qm.getObjectByUuid(NotificationRule.class, firstRule.getUuid()));
+        Assertions.assertNull(qm.getObjectByUuid(NotificationRule.class, secondRule.getUuid()));
     }
 
     @Test
@@ -336,7 +340,7 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER + "/" + UUID.randomUUID()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertEquals(404, response.getStatus(), 0);
     }
 
     @Test
@@ -345,10 +349,10 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER + "/" + notificationPublisher.getUuid()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("Deleting a default notification publisher is forbidden.", body);
+        Assertions.assertEquals("Deleting a default notification publisher is forbidden.", body);
     }
 
     @Test
@@ -358,7 +362,7 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_PUBLISHER + "/test/smtp").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
     }
 
     @Test
@@ -382,11 +386,11 @@ public class NotificationPublisherResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity("", MediaType.APPLICATION_FORM_URLENCODED_TYPE));
 
-        Assert.assertEquals(200, sendMailResponse.getStatus());
+        Assertions.assertEquals(200, sendMailResponse.getStatus());
     }
 
     @Test
-    public void testScheduledNotificationRuleTest() {
+    public void testScheduledNotificationRuleTest(WireMockRuntimeInfo wmRuntimeInfo) {
         final var notificationPublisher = qm.getDefaultNotificationPublisher(WebhookPublisher.class);
         final NotificationRule rule = qm.createScheduledNotificationRule(
                 "rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, notificationPublisher);
@@ -395,26 +399,20 @@ public class NotificationPublisherResourceTest extends ResourceTest {
                         .filter(group -> group.getSupportedTriggerType() == NotificationTriggerType.SCHEDULE)
                         .collect(Collectors.toSet()));
 
-        final var wireMock = new WireMockServer(options().dynamicPort());
-        wireMock.start();
-        try {
-            rule.setPublisherConfig("{\"destination\":\"%s\"}".formatted(wireMock.baseUrl()));
+        rule.setPublisherConfig("{\"destination\":\"%s\"}".formatted(wmRuntimeInfo.getHttpBaseUrl()));
 
-            wireMock.stubFor(WireMock.post(WireMock.anyUrl())
-                    .willReturn(aResponse()
-                            .withStatus(200)));
+        stubFor(WireMock.post(WireMock.anyUrl())
+                .willReturn(aResponse()
+                        .withStatus(200)));
 
-            final Response response = jersey.target(V1_NOTIFICATION_PUBLISHER + "/test/" + rule.getUuid()).request()
-                    .header(X_API_KEY, apiKey)
-                    .post(Entity.entity("", MediaType.APPLICATION_FORM_URLENCODED_TYPE));
-            assertThat(response.getStatus()).isEqualTo(200);
+        final Response response = jersey.target(V1_NOTIFICATION_PUBLISHER + "/test/" + rule.getUuid()).request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.entity("", MediaType.APPLICATION_FORM_URLENCODED_TYPE));
+        assertThat(response.getStatus()).isEqualTo(200);
 
-            await("Notification Delivery")
-                    .atMost(Duration.ofSeconds(5))
-                    .untilAsserted(() -> wireMock.verify(rule.getNotifyOn().size(), anyRequestedFor(anyUrl())));
-        } finally {
-            wireMock.stop();
-        }
+        await("Notification Delivery")
+                .atMost(Duration.ofSeconds(5))
+                .untilAsserted(() -> verify(rule.getNotifyOn().size(), anyRequestedFor(anyUrl())));
     }
 
     @Test
@@ -457,7 +455,7 @@ public class NotificationPublisherResourceTest extends ResourceTest {
                     ConfigPropertyConstants.JIRA_PASSWORD.getPropertyType(),
                     ConfigPropertyConstants.JIRA_PASSWORD.getDescription());
 
-            wireMock.stubFor(WireMock.post(WireMock.anyUrl())
+            stubFor(WireMock.post(WireMock.anyUrl())
                     .willReturn(aResponse()
                             .withStatus(200)));
 
@@ -513,9 +511,9 @@ public class NotificationPublisherResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
         qm.getPersistenceManager().refreshAll();
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertFalse(qm.isEnabled(ConfigPropertyConstants.NOTIFICATION_TEMPLATE_DEFAULT_OVERRIDE_ENABLED));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertFalse(qm.isEnabled(ConfigPropertyConstants.NOTIFICATION_TEMPLATE_DEFAULT_OVERRIDE_ENABLED));
         slackPublisher = qm.getDefaultNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherClass());
-        Assert.assertEquals(DefaultNotificationPublishers.SLACK.getPublisherName(), slackPublisher.getName());
+        Assertions.assertEquals(DefaultNotificationPublishers.SLACK.getPublisherName(), slackPublisher.getName());
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
@@ -23,7 +23,6 @@ import alpine.model.Team;
 import alpine.notification.NotificationLevel;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import org.dependencytrack.ResourceTest;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Entity;
@@ -31,6 +30,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import net.javacrumbs.jsonunit.core.Option;
 import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.NotificationPublisher;
 import org.dependencytrack.model.NotificationRule;
 import org.dependencytrack.model.Project;
@@ -60,7 +60,7 @@ import static org.hamcrest.Matchers.greaterThan;
 class NotificationRuleResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(NotificationRuleResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
@@ -23,9 +23,14 @@ import alpine.model.Team;
 import alpine.notification.NotificationLevel;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import net.javacrumbs.jsonunit.core.Option;
-import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import net.javacrumbs.jsonunit.core.Option;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.model.NotificationPublisher;
 import org.dependencytrack.model.NotificationRule;
 import org.dependencytrack.model.Project;
@@ -36,16 +41,11 @@ import org.dependencytrack.notification.publisher.SendMailPublisher;
 import org.dependencytrack.persistence.DefaultObjectGenerator;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -57,23 +57,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
-public class NotificationRuleResourceTest extends ResourceTest {
+class NotificationRuleResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(NotificationRuleResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(NotificationRuleResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
-        super.before();
         final var generator = new DefaultObjectGenerator();
         generator.loadDefaultNotificationPublishers();
     }
 
     @Test
-    public void getAllNotificationRulesTest() {
+    void getAllNotificationRulesTest() {
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule r1 = qm.createNotificationRule("Rule 1", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         NotificationRule r2 = qm.createNotificationRule("Rule 2", NotificationScope.PORTFOLIO, NotificationLevel.WARNING, publisher);
@@ -81,22 +80,22 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_RULE).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(3, json.size());
-        Assert.assertEquals("Rule 1", json.getJsonObject(0).getString("name"));
-        Assert.assertTrue(json.getJsonObject(0).getBoolean("enabled"));
-        Assert.assertEquals("PORTFOLIO", json.getJsonObject(0).getString("scope"));
-        Assert.assertEquals("INFORMATIONAL", json.getJsonObject(0).getString("notificationLevel"));
-        Assert.assertEquals(0, json.getJsonObject(0).getJsonArray("notifyOn").size());
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(0).getString("uuid")));
-        Assert.assertEquals("Slack", json.getJsonObject(0).getJsonObject("publisher").getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(3, json.size());
+        Assertions.assertEquals("Rule 1", json.getJsonObject(0).getString("name"));
+        Assertions.assertTrue(json.getJsonObject(0).getBoolean("enabled"));
+        Assertions.assertEquals("PORTFOLIO", json.getJsonObject(0).getString("scope"));
+        Assertions.assertEquals("INFORMATIONAL", json.getJsonObject(0).getString("notificationLevel"));
+        Assertions.assertEquals(0, json.getJsonObject(0).getJsonArray("notifyOn").size());
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(0).getString("uuid")));
+        Assertions.assertEquals("Slack", json.getJsonObject(0).getJsonObject("publisher").getString("name"));
     }
 
     @Test
-    public void createNotificationRuleTest() {
+    void createNotificationRuleTest() {
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = new NotificationRule();
         rule.setName("Example Rule");
@@ -109,20 +108,20 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_RULE).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(rule, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertEquals(201, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Example Rule", json.getString("name"));
-        Assert.assertTrue(json.getBoolean("enabled"));
-        Assert.assertEquals("SYSTEM", json.getString("scope"));
-        Assert.assertEquals("WARNING", json.getString("notificationLevel"));
-        Assert.assertEquals(0, json.getJsonArray("notifyOn").size());
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
-        Assert.assertEquals("Slack", json.getJsonObject("publisher").getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Example Rule", json.getString("name"));
+        Assertions.assertTrue(json.getBoolean("enabled"));
+        Assertions.assertEquals("SYSTEM", json.getString("scope"));
+        Assertions.assertEquals("WARNING", json.getString("notificationLevel"));
+        Assertions.assertEquals(0, json.getJsonArray("notifyOn").size());
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
+        Assertions.assertEquals("Slack", json.getJsonObject("publisher").getString("name"));
     }
 
     @Test
-    public void createNotificationRuleInvalidPublisherTest() {
+    void createNotificationRuleInvalidPublisherTest() {
         NotificationPublisher publisher = new NotificationPublisher();
         publisher.setUuid(UUID.randomUUID());
         NotificationRule rule = new NotificationRule();
@@ -136,10 +135,10 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_RULE).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(rule, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The UUID of the notification rule could not be found.", body);
+        Assertions.assertEquals("The UUID of the notification rule could not be found.", body);
     }
 
     @Test
@@ -217,7 +216,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
     }
 
     @Test
-    public void updateNotificationRuleTest() {
+    void updateNotificationRuleTest() {
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Rule 1", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         rule.setName("Example Rule");
@@ -225,20 +224,20 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_RULE).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(rule, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Example Rule", json.getString("name"));
-        Assert.assertTrue(json.getBoolean("enabled"));
-        Assert.assertEquals("PORTFOLIO", json.getString("scope"));
-        Assert.assertEquals("INFORMATIONAL", json.getString("notificationLevel"));
-        Assert.assertEquals("NEW_VULNERABILITY", json.getJsonArray("notifyOn").getString(0));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
-        Assert.assertEquals("Slack", json.getJsonObject("publisher").getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Example Rule", json.getString("name"));
+        Assertions.assertTrue(json.getBoolean("enabled"));
+        Assertions.assertEquals("PORTFOLIO", json.getString("scope"));
+        Assertions.assertEquals("INFORMATIONAL", json.getString("notificationLevel"));
+        Assertions.assertEquals("NEW_VULNERABILITY", json.getJsonArray("notifyOn").getString(0));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
+        Assertions.assertEquals("Slack", json.getJsonObject("publisher").getString("name"));
     }
 
     @Test
-    public void updateNotificationRuleInvalidTest() {
+    void updateNotificationRuleInvalidTest() {
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Rule 1", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         rule = qm.detach(NotificationRule.class, rule.getId());
@@ -246,14 +245,14 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_RULE).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(rule, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The UUID of the notification rule could not be found.", body);
+        Assertions.assertEquals("The UUID of the notification rule could not be found.", body);
     }
 
     @Test
-    public void updateNotificationRuleWithTagsTest() {
+    void updateNotificationRuleWithTagsTest() {
         final NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         final NotificationRule rule = qm.createNotificationRule("Rule 1", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
 
@@ -497,7 +496,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
     }
 
     @Test
-    public void deleteNotificationRuleTest() {
+    void deleteNotificationRuleTest() {
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Rule 1", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         rule.setName("Example Rule");
@@ -506,68 +505,68 @@ public class NotificationRuleResourceTest extends ResourceTest {
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true) // HACK
                 .method("DELETE", Entity.entity(rule, MediaType.APPLICATION_JSON)); // HACK
         // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
-        Assert.assertEquals(204, response.getStatus(), 0);
+        Assertions.assertEquals(204, response.getStatus(), 0);
     }
 
     @Test
-    public void addProjectToRuleTest() {
+    void addProjectToRuleTest() {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, true, false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Example Rule", json.getString("name"));
-        Assert.assertEquals(1, json.getJsonArray("projects").size());
-        Assert.assertEquals("Acme Example", json.getJsonArray("projects").getJsonObject(0).getString("name"));
-        Assert.assertEquals(project.getUuid().toString(), json.getJsonArray("projects").getJsonObject(0).getString("uuid"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Example Rule", json.getString("name"));
+        Assertions.assertEquals(1, json.getJsonArray("projects").size());
+        Assertions.assertEquals("Acme Example", json.getJsonArray("projects").getJsonObject(0).getString("name"));
+        Assertions.assertEquals(project.getUuid().toString(), json.getJsonArray("projects").getJsonObject(0).getString("uuid"));
     }
 
     @Test
-    public void addProjectToRuleInvalidRuleTest() {
+    void addProjectToRuleInvalidRuleTest() {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, true, false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + UUID.randomUUID().toString() + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The notification rule could not be found.", body);
+        Assertions.assertEquals("The notification rule could not be found.", body);
     }
 
     @Test
-    public void addProjectToRuleInvalidScopeTest() {
+    void addProjectToRuleInvalidScopeTest() {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, true, false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.SYSTEM, NotificationLevel.INFORMATIONAL, publisher);
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
-        Assert.assertEquals(406, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(406, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("Project limitations are only possible on notification rules with PORTFOLIO scope.", body);
+        Assertions.assertEquals("Project limitations are only possible on notification rules with PORTFOLIO scope.", body);
     }
 
     @Test
-    public void addProjectToRuleInvalidProjectTest() {
+    void addProjectToRuleInvalidProjectTest() {
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The project could not be found.", body);
+        Assertions.assertEquals("The project could not be found.", body);
     }
 
     @Test
-    public void addProjectToRuleDuplicateProjectTest() {
+    void addProjectToRuleDuplicateProjectTest() {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, true, false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -578,12 +577,12 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
-        Assert.assertEquals(304, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(304, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void removeProjectFromRuleTest() {
+    void removeProjectFromRuleTest() {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, true, false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -594,107 +593,107 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void removeProjectFromRuleInvalidRuleTest() {
+    void removeProjectFromRuleInvalidRuleTest() {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, true, false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + UUID.randomUUID().toString() + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The notification rule could not be found.", body);
+        Assertions.assertEquals("The notification rule could not be found.", body);
     }
 
     @Test
-    public void removeProjectFromRuleInvalidScopeTest() {
+    void removeProjectFromRuleInvalidScopeTest() {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, true, false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.SYSTEM, NotificationLevel.INFORMATIONAL, publisher);
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(406, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(406, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("Project limitations are only possible on notification rules with PORTFOLIO scope.", body);
+        Assertions.assertEquals("Project limitations are only possible on notification rules with PORTFOLIO scope.", body);
     }
 
     @Test
-    public void removeProjectFromRuleInvalidProjectTest() {
+    void removeProjectFromRuleInvalidProjectTest() {
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The project could not be found.", body);
+        Assertions.assertEquals("The project could not be found.", body);
     }
 
     @Test
-    public void removeProjectFromRuleDuplicateProjectTest() {
+    void removeProjectFromRuleDuplicateProjectTest() {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, true, false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(304, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(304, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void addTeamToRuleTest(){
+    void addTeamToRuleTest(){
         Team team = qm.createTeam("Team Example");
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Example Rule", json.getString("name"));
-        Assert.assertEquals(1, json.getJsonArray("teams").size());
-        Assert.assertEquals("Team Example", json.getJsonArray("teams").getJsonObject(0).getString("name"));
-        Assert.assertEquals(team.getUuid().toString(), json.getJsonArray("teams").getJsonObject(0).getString("uuid"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Example Rule", json.getString("name"));
+        Assertions.assertEquals(1, json.getJsonArray("teams").size());
+        Assertions.assertEquals("Team Example", json.getJsonArray("teams").getJsonObject(0).getString("name"));
+        Assertions.assertEquals(team.getUuid().toString(), json.getJsonArray("teams").getJsonObject(0).getString("uuid"));
     }
 
     @Test
-    public void addTeamToRuleInvalidRuleTest(){
+    void addTeamToRuleInvalidRuleTest(){
         Team team = qm.createTeam("Team Example");
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + UUID.randomUUID().toString() + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The notification rule could not be found.", body);
+        Assertions.assertEquals("The notification rule could not be found.", body);
     }
 
     @Test
-    public void addTeamToRuleInvalidTeamTest() {
+    void addTeamToRuleInvalidTeamTest() {
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The team could not be found.", body);
+        Assertions.assertEquals("The team could not be found.", body);
     }
 
     @Test
-    public void addTeamToRuleDuplicateTeamTest() {
+    void addTeamToRuleDuplicateTeamTest() {
         Team team = qm.createTeam("Team Example");
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -705,26 +704,26 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
-        Assert.assertEquals(304, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(304, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void addTeamToRuleInvalidPublisherTest(){
+    void addTeamToRuleInvalidPublisherTest(){
         Team team = qm.createTeam("Team Example");
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
-        Assert.assertEquals(406, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(406, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("Team subscriptions are only possible on notification rules with EMAIL publisher.", body);
+        Assertions.assertEquals("Team subscriptions are only possible on notification rules with EMAIL publisher.", body);
     }
 
     @Test
-    public void addTeamToRuleWithCustomEmailPublisherTest() {
+    void addTeamToRuleWithCustomEmailPublisherTest() {
         final Team team = qm.createTeam("Team Example");
         final NotificationPublisher publisher = qm.createNotificationPublisher("foo", "description", SendMailPublisher.class, "template", "templateMimeType", false);
         final NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -769,7 +768,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
     }
 
     @Test
-    public void removeTeamFromRuleTest() {
+    void removeTeamFromRuleTest() {
         Team team = qm.createTeam("Team Example");
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
@@ -780,59 +779,59 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void removeTeamFromRuleInvalidRuleTest() {
+    void removeTeamFromRuleInvalidRuleTest() {
         Team team = qm.createTeam("Team Example");
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + UUID.randomUUID().toString() + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The notification rule could not be found.", body);
+        Assertions.assertEquals("The notification rule could not be found.", body);
     }
 
     @Test
-    public void removeTeamFromRuleInvalidTeamTest() {
+    void removeTeamFromRuleInvalidTeamTest() {
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The team could not be found.", body);
+        Assertions.assertEquals("The team could not be found.", body);
     }
 
     @Test
-    public void removeTeamFromRuleDuplicateTeamTest() {
+    void removeTeamFromRuleDuplicateTeamTest() {
         Team team = qm.createTeam("Team Example");
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(304, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(304, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void removeTeamToRuleInvalidPublisherTest(){
+    void removeTeamToRuleInvalidPublisherTest(){
         Team team = qm.createTeam("Team Example");
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(406, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(406, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("Team subscriptions are only possible on notification rules with EMAIL publisher.", body);
+        Assertions.assertEquals("Team subscriptions are only possible on notification rules with EMAIL publisher.", body);
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/OidcResourceAuthenticatedTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/OidcResourceAuthenticatedTest.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class OidcResourceAuthenticatedTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(OidcResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/OidcResourceAuthenticatedTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/OidcResourceAuthenticatedTest.java
@@ -22,32 +22,32 @@ import alpine.model.OidcGroup;
 import alpine.model.Team;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import org.dependencytrack.JerseyTestRule;
-import org.dependencytrack.ResourceTest;
-import org.dependencytrack.resources.v1.vo.MappedOidcGroupRequest;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.resources.v1.vo.MappedOidcGroupRequest;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OidcResourceAuthenticatedTest extends ResourceTest {
+class OidcResourceAuthenticatedTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(OidcResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(OidcResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
     @Test
-    public void retrieveGroupsShouldReturnListOfGroups() {
+    void retrieveGroupsShouldReturnListOfGroups() {
         final OidcGroup oidcGroup = new OidcGroup();
         oidcGroup.setName("groupName");
         qm.persist(oidcGroup);
@@ -63,7 +63,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void retrieveGroupsShouldReturnEmptyListWhenNoGroupsWhereFound() {
+    void retrieveGroupsShouldReturnEmptyListWhenNoGroupsWhereFound() {
         final Response response = jersey.target(V1_OIDC + "/group")
                 .request().header(X_API_KEY, apiKey).get();
 
@@ -74,7 +74,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void createGroupShouldReturnCreatedGroup() {
+    void createGroupShouldReturnCreatedGroup() {
         final OidcGroup oidcGroup = new OidcGroup();
         oidcGroup.setName("groupName");
 
@@ -92,7 +92,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void createGroupShouldIndicateConflictWhenGroupAlreadyExists() {
+    void createGroupShouldIndicateConflictWhenGroupAlreadyExists() {
         qm.createOidcGroup("groupName");
 
         final OidcGroup oidcGroup = new OidcGroup();
@@ -107,7 +107,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void createGroupShouldIndicateBadRequestWhenRequestIsInvalid() {
+    void createGroupShouldIndicateBadRequestWhenRequestIsInvalid() {
         final OidcGroup oidcGroup = new OidcGroup();
         oidcGroup.setName(" ");
 
@@ -120,7 +120,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void updateGroupShouldUpdateAndReturnGroup() {
+    void updateGroupShouldUpdateAndReturnGroup() {
         final OidcGroup existingGroup = qm.createOidcGroup("groupName");
 
         final OidcGroup jsonGroup = new OidcGroup();
@@ -139,7 +139,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void updateGroupShouldIndicateBadRequestWhenRequestBodyIsInvalid() {
+    void updateGroupShouldIndicateBadRequestWhenRequestBodyIsInvalid() {
         final OidcGroup jsonGroup = new OidcGroup();
 
         final Response response = jersey.target(V1_OIDC + "/group").request()
@@ -150,7 +150,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void updateGroupShouldIndicateNotFoundWhenGroupDoesNotExist() {
+    void updateGroupShouldIndicateNotFoundWhenGroupDoesNotExist() {
         final OidcGroup jsonGroup = new OidcGroup();
         jsonGroup.setUuid(UUID.randomUUID());
         jsonGroup.setName("groupName");
@@ -163,7 +163,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void deleteGroupShouldDeleteGroupAndIndicateNoContent() {
+    void deleteGroupShouldDeleteGroupAndIndicateNoContent() {
         final OidcGroup existingOidcGroup = qm.createOidcGroup("groupName");
 
         final Response response = jersey.target(V1_OIDC + "/group/" + existingOidcGroup.getUuid())
@@ -176,7 +176,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void deleteGroupShouldIndicateNotFoundWhenGroupDoesNotExist() {
+    void deleteGroupShouldIndicateNotFoundWhenGroupDoesNotExist() {
         final Response response = jersey.target(V1_OIDC + "/group/" + UUID.randomUUID())
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -186,7 +186,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void retrieveTeamsMappedToGroupShouldReturnTeamsMappedToSpecifiedGroup() {
+    void retrieveTeamsMappedToGroupShouldReturnTeamsMappedToSpecifiedGroup() {
         final OidcGroup oidcGroup = qm.createOidcGroup("groupName");
         final Team team = qm.createTeam("teamName");
         qm.createMappedOidcGroup(team, oidcGroup);
@@ -202,7 +202,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void retrieveTeamsMappedToGroupShouldIndicateNotFoundWhenGroupDoesNotExit() {
+    void retrieveTeamsMappedToGroupShouldIndicateNotFoundWhenGroupDoesNotExit() {
         final Response response = jersey.target(V1_OIDC + "/group/" + UUID.randomUUID() + "/team")
                 .request().header(X_API_KEY, apiKey).get();
 
@@ -210,7 +210,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void addMappingShouldIndicateBadRequestWhenRequestIsInvalid() {
+    void addMappingShouldIndicateBadRequestWhenRequestIsInvalid() {
         final MappedOidcGroupRequest request = new MappedOidcGroupRequest("not-a-uuid", "not-a-uuid");
 
         final Response response = jersey.target(V1_OIDC + "/mapping")
@@ -222,7 +222,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void addMappingShouldIndicateNotFoundWhenTeamDoesNotExist() {
+    void addMappingShouldIndicateNotFoundWhenTeamDoesNotExist() {
         final OidcGroup group = qm.createOidcGroup("groupName");
 
         final MappedOidcGroupRequest request = new MappedOidcGroupRequest(UUID.randomUUID().toString(), group.getUuid().toString());
@@ -236,7 +236,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void addMappingShouldIndicateNotFoundWhenGroupDoesNotExist() {
+    void addMappingShouldIndicateNotFoundWhenGroupDoesNotExist() {
         final Team team = qm.createTeam("teamName");
 
         final MappedOidcGroupRequest request = new MappedOidcGroupRequest(team.getUuid().toString(), UUID.randomUUID().toString());
@@ -250,7 +250,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void addMappingShouldIndicateConflictWhenMappingAlreadyExists() {
+    void addMappingShouldIndicateConflictWhenMappingAlreadyExists() {
         final Team team = qm.createTeam("teamName");
         final OidcGroup group = qm.createOidcGroup("groupName");
         qm.createMappedOidcGroup(team, group);
@@ -266,7 +266,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void addMappingShouldReturnCreatedMapping() {
+    void addMappingShouldReturnCreatedMapping() {
         final Team team = qm.createTeam("teamName");
         final OidcGroup group = qm.createOidcGroup("groupName");
 
@@ -287,7 +287,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void deleteMappingByUuidShouldDeleteMappingAndIndicateNoContent() {
+    void deleteMappingByUuidShouldDeleteMappingAndIndicateNoContent() {
         final Team team = qm.createTeam("teamName");
         final OidcGroup group = qm.createOidcGroup("groupName");
         final MappedOidcGroup mapping = qm.createMappedOidcGroup(team, group);
@@ -302,7 +302,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void deleteMappingByUuidShouldIndicateNotFoundWhenMappingDoesNotExist() {
+    void deleteMappingByUuidShouldIndicateNotFoundWhenMappingDoesNotExist() {
         final Response response = jersey.target(V1_OIDC + "/mapping/" + UUID.randomUUID())
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -312,7 +312,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void deleteMappingShouldDeleteMappingAndIndicateNoContent() {
+    void deleteMappingShouldDeleteMappingAndIndicateNoContent() {
         final OidcGroup oidcGroup = qm.createOidcGroup("groupName");
         final Team team = qm.createTeam("teamName");
         final MappedOidcGroup mapping = qm.createMappedOidcGroup(team, oidcGroup);
@@ -326,7 +326,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void deleteMappingShouldIndicateNotFoundWhenTeamDoesNotExist() {
+    void deleteMappingShouldIndicateNotFoundWhenTeamDoesNotExist() {
         final OidcGroup oidcGroup = qm.createOidcGroup("groupName");
 
         final Response response = jersey.target(V1_OIDC + "/group/" + oidcGroup.getUuid() + "/team/" + UUID.randomUUID() + "/mapping").request()
@@ -337,7 +337,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void deleteMappingShouldIndicateNotFoundWhenGroupDoesNotExist() {
+    void deleteMappingShouldIndicateNotFoundWhenGroupDoesNotExist() {
         final Team team = qm.createTeam("teamName");
 
         final Response response = jersey.target(V1_OIDC + "/group/" + UUID.randomUUID() + "/team/" + team.getUuid() + "/mapping").request()
@@ -348,7 +348,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void deleteMappingShouldIndicateNotFoundWhenMappingDoesNotExist() {
+    void deleteMappingShouldIndicateNotFoundWhenMappingDoesNotExist() {
         final OidcGroup oidcGroup = qm.createOidcGroup("groupName");
         final Team team = qm.createTeam("teamName");
 

--- a/src/test/java/org/dependencytrack/resources/v1/OidcResourceUnauthenticatedTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/OidcResourceUnauthenticatedTest.java
@@ -18,25 +18,24 @@
 package org.dependencytrack.resources.v1;
 
 import alpine.server.filters.ApiFilter;
-import org.dependencytrack.JerseyTestRule;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.ClassRule;
-import org.junit.Test;
-
-import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OidcResourceUnauthenticatedTest extends ResourceTest {
+class OidcResourceUnauthenticatedTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(OidcResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(OidcResource.class)
                     .register(ApiFilter.class));
 
     @Test
-    public void isAvailableShouldReturnFalseWhenOidcIsNotAvailable() {
+    void isAvailableShouldReturnFalseWhenOidcIsNotAvailable() {
         final Response response = jersey.target(V1_OIDC + "/available")
                 .request().get();
 

--- a/src/test/java/org/dependencytrack/resources/v1/OidcResourceUnauthenticatedTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/OidcResourceUnauthenticatedTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class OidcResourceUnauthenticatedTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(OidcResource.class)
                     .register(ApiFilter.class));
 

--- a/src/test/java/org/dependencytrack/resources/v1/PermissionResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PermissionResourceTest.java
@@ -23,47 +23,46 @@ import alpine.model.Permission;
 import alpine.model.Team;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import net.javacrumbs.jsonunit.core.Option;
-import org.dependencytrack.JerseyTestRule;
-import org.dependencytrack.ResourceTest;
-import org.dependencytrack.auth.Permissions;
-import org.dependencytrack.persistence.DefaultObjectGenerator;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import net.javacrumbs.jsonunit.core.Option;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.persistence.DefaultObjectGenerator;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import java.util.UUID;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
-public class PermissionResourceTest extends ResourceTest {
+class PermissionResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(PermissionResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(PermissionResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
-        super.before();
         final var generator = new DefaultObjectGenerator();
         generator.loadDefaultPermissions();
     }
 
     @Test
-    public void getAllPermissionsTest() {
+    void getAllPermissionsTest() {
         Response response = jersey.target(V1_PERMISSION).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         assertThatJson(getPlainTextBody(response))
                 .withOptions(Option.IGNORING_ARRAY_ORDER)
                 .isEqualTo("""
@@ -129,48 +128,48 @@ public class PermissionResourceTest extends ResourceTest {
     }
 
     @Test
-    public void addPermissionToUserTest() {
+    void addPermissionToUserTest() {
         ManagedUser user = qm.createManagedUser("user1", TEST_USER_PASSWORD_HASH);
         String username = user.getUsername();
         qm.close();
         Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/user/" + username).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("user1", json.getString("username"));
-        Assert.assertEquals(1, json.getJsonArray("permissions").size());
-        Assert.assertEquals("PORTFOLIO_MANAGEMENT", json.getJsonArray("permissions").getJsonObject(0).getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("user1", json.getString("username"));
+        Assertions.assertEquals(1, json.getJsonArray("permissions").size());
+        Assertions.assertEquals("PORTFOLIO_MANAGEMENT", json.getJsonArray("permissions").getJsonObject(0).getString("name"));
     }
 
     @Test
-    public void addPermissionToUserInvalidUserTest() {
+    void addPermissionToUserInvalidUserTest() {
         Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/user/blah").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The user could not be found.", body);
+        Assertions.assertEquals("The user could not be found.", body);
     }
 
     @Test
-    public void addPermissionToUserInvalidPermissionTest() {
+    void addPermissionToUserInvalidPermissionTest() {
         ManagedUser user = qm.createManagedUser("user1", TEST_USER_PASSWORD_HASH);
         String username = user.getUsername();
         qm.close();
         Response response = jersey.target(V1_PERMISSION + "/BLAH/user/" + username).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The permission could not be found.", body);
+        Assertions.assertEquals("The permission could not be found.", body);
     }
 
     @Test
-    public void addPermissionToUserDuplicateTest() {
+    void addPermissionToUserDuplicateTest() {
         ManagedUser user = qm.createManagedUser("user1", TEST_USER_PASSWORD_HASH);
         String username = user.getUsername();
         Permission permission = qm.getPermission(Permissions.PORTFOLIO_MANAGEMENT.name());
@@ -180,12 +179,12 @@ public class PermissionResourceTest extends ResourceTest {
         Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/user/" + username).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(304, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(304, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void removePermissionFromUserTest() {
+    void removePermissionFromUserTest() {
         ManagedUser user = qm.createManagedUser("user1", TEST_USER_PASSWORD_HASH);
         String username = user.getUsername();
         Permission permission = qm.getPermission(Permissions.PORTFOLIO_MANAGEMENT.name());
@@ -195,92 +194,92 @@ public class PermissionResourceTest extends ResourceTest {
         Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/user/" + username).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("user1", json.getString("username"));
-        Assert.assertEquals(0, json.getJsonArray("permissions").size());
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("user1", json.getString("username"));
+        Assertions.assertEquals(0, json.getJsonArray("permissions").size());
     }
 
     @Test
-    public void removePermissionFromUserInvalidUserTest() {
+    void removePermissionFromUserInvalidUserTest() {
         Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/user/blah").request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The user could not be found.", body);
+        Assertions.assertEquals("The user could not be found.", body);
     }
 
     @Test
-    public void removePermissionFromUserInvalidPermissionTest() {
+    void removePermissionFromUserInvalidPermissionTest() {
         ManagedUser user = qm.createManagedUser("user1", TEST_USER_PASSWORD_HASH);
         String username = user.getUsername();
         qm.close();
         Response response = jersey.target(V1_PERMISSION + "/BLAH/user/" + username).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The permission could not be found.", body);
+        Assertions.assertEquals("The permission could not be found.", body);
     }
 
     @Test
-    public void removePermissionFromUserNoChangesTest() {
+    void removePermissionFromUserNoChangesTest() {
         ManagedUser user = qm.createManagedUser("user1", TEST_USER_PASSWORD_HASH);
         String username = user.getUsername();
         Response response = jersey.target(V1_PERMISSION + "/BOM_UPLOAD/user/" + username).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(304, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(304, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void addPermissionToTeamTest() {
+    void addPermissionToTeamTest() {
         Team team = qm.createTeam("team1");
         String teamUuid = team.getUuid().toString();
         qm.close();
         Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/team/" + teamUuid).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("team1", json.getString("name"));
-        Assert.assertEquals(1, json.getJsonArray("permissions").size());
-        Assert.assertEquals("PORTFOLIO_MANAGEMENT", json.getJsonArray("permissions").getJsonObject(0).getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("team1", json.getString("name"));
+        Assertions.assertEquals(1, json.getJsonArray("permissions").size());
+        Assertions.assertEquals("PORTFOLIO_MANAGEMENT", json.getJsonArray("permissions").getJsonObject(0).getString("name"));
     }
 
     @Test
-    public void addPermissionToTeamInvalidTeamTest() {
+    void addPermissionToTeamInvalidTeamTest() {
         Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/team/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The team could not be found.", body);
+        Assertions.assertEquals("The team could not be found.", body);
     }
 
     @Test
-    public void addPermissionToTeamInvalidPermissionTest() {
+    void addPermissionToTeamInvalidPermissionTest() {
         Team team = qm.createTeam("team1");
         String teamUuid = team.getUuid().toString();
         qm.close();
         Response response = jersey.target(V1_PERMISSION + "/BLAH/team/" + teamUuid).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The permission could not be found.", body);
+        Assertions.assertEquals("The permission could not be found.", body);
     }
 
     @Test
-    public void addPermissionToTeamDuplicateTest() {
+    void addPermissionToTeamDuplicateTest() {
         Team team = qm.createTeam("team1");
         String teamUuid = team.getUuid().toString();
         Permission permission = qm.getPermission(Permissions.PORTFOLIO_MANAGEMENT.name());
@@ -290,12 +289,12 @@ public class PermissionResourceTest extends ResourceTest {
         Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/team/" + teamUuid).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(304, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(304, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void removePermissionFromTeamTest() {
+    void removePermissionFromTeamTest() {
         Team team = qm.createTeam("team1");
         String teamUuid = team.getUuid().toString();
         Permission permission = qm.getPermission(Permissions.PORTFOLIO_MANAGEMENT.name());
@@ -305,46 +304,46 @@ public class PermissionResourceTest extends ResourceTest {
         Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/team/" + teamUuid).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("team1", json.getString("name"));
-        Assert.assertEquals(0, json.getJsonArray("permissions").size());
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("team1", json.getString("name"));
+        Assertions.assertEquals(0, json.getJsonArray("permissions").size());
     }
 
     @Test
-    public void removePermissionFromTeamInvalidTeamTest() {
+    void removePermissionFromTeamInvalidTeamTest() {
         Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/team/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The team could not be found.", body);
+        Assertions.assertEquals("The team could not be found.", body);
     }
 
     @Test
-    public void removePermissionFromTeamInvalidPermissionTest() {
+    void removePermissionFromTeamInvalidPermissionTest() {
         Team team = qm.createTeam("team1");
         String teamUuid = team.getUuid().toString();
         qm.close();
         Response response = jersey.target(V1_PERMISSION + "/BLAH/team/" + teamUuid).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The permission could not be found.", body);
+        Assertions.assertEquals("The permission could not be found.", body);
     }
 
     @Test
-    public void removePermissionFromTeamNoChangesTest() {
+    void removePermissionFromTeamNoChangesTest() {
         Team team = qm.createTeam("team1");
         String teamUuid = team.getUuid().toString();
         Response response = jersey.target(V1_PERMISSION + "/BOM_UPLOAD/team/" + teamUuid).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(304, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(304, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/PermissionResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PermissionResourceTest.java
@@ -45,7 +45,7 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 class PermissionResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(PermissionResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyConditionResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyConditionResourceTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 class PolicyConditionResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(PolicyConditionResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class)

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyConditionResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyConditionResourceTest.java
@@ -3,7 +3,9 @@ package org.dependencytrack.resources.v1;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import alpine.server.filters.AuthorizationFilter;
-import org.dependencytrack.JerseyTestRule;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Policy;
@@ -11,11 +13,9 @@ import org.dependencytrack.model.Policy.Operator;
 import org.dependencytrack.model.Policy.ViolationState;
 import org.dependencytrack.model.PolicyCondition;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.Response;
 import javax.jdo.JDOObjectNotFoundException;
 import java.util.UUID;
 
@@ -24,17 +24,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.hamcrest.CoreMatchers.equalTo;
 
-public class PolicyConditionResourceTest extends ResourceTest {
+class PolicyConditionResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(PolicyConditionResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(PolicyConditionResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class)
                     .register(AuthorizationFilter.class));
 
     @Test
-    public void testCreateCondition() {
+    void testCreateCondition() {
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
 
         final var policy = new Policy();
@@ -65,7 +65,7 @@ public class PolicyConditionResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testCreateConditionWhenPolicyDoesNotExist() {
+    void testCreateConditionWhenPolicyDoesNotExist() {
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
 
         final Response response = jersey.target("%s/cec42e01-62a7-4c86-9b8f-cd6650be2888/condition".formatted(V1_POLICY))
@@ -83,7 +83,7 @@ public class PolicyConditionResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testCreateConditionWhenUnauthorized() {
+    void testCreateConditionWhenUnauthorized() {
         final Response response = jersey.target("%s/cec42e01-62a7-4c86-9b8f-cd6650be2888/condition".formatted(V1_POLICY))
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -98,7 +98,7 @@ public class PolicyConditionResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testUpdateCondition() {
+    void testUpdateCondition() {
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
 
         final var policy = new Policy();
@@ -139,7 +139,7 @@ public class PolicyConditionResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testUpdateConditionWhenConditionDoesNotExist() {
+    void testUpdateConditionWhenConditionDoesNotExist() {
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
 
         final Response response = jersey.target("%s/condition".formatted(V1_POLICY))
@@ -158,7 +158,7 @@ public class PolicyConditionResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testUpdateConditionWhenUnauthorized() {
+    void testUpdateConditionWhenUnauthorized() {
         final Response response = jersey.target("%s/condition".formatted(V1_POLICY))
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -174,7 +174,7 @@ public class PolicyConditionResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testDeleteCondition() {
+    void testDeleteCondition() {
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
 
         final var policy = new Policy();
@@ -203,7 +203,7 @@ public class PolicyConditionResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testDeleteConditionWhenConditionDoesNotExist() {
+    void testDeleteConditionWhenConditionDoesNotExist() {
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
 
         final Response response = jersey.target("%s/condition/%s".formatted(V1_POLICY, UUID.randomUUID()))
@@ -215,7 +215,7 @@ public class PolicyConditionResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testDeleteConditionWhenUnauthorized() {
+    void testDeleteConditionWhenUnauthorized() {
         final Response response = jersey.target("%s/condition/%s".formatted(V1_POLICY, UUID.randomUUID()))
                 .request()
                 .header(X_API_KEY, apiKey)

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
@@ -22,7 +22,12 @@ package org.dependencytrack.resources.v1;
 import alpine.common.util.UuidUtil;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import org.dependencytrack.JerseyTestRule;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Policy;
@@ -31,30 +36,25 @@ import org.dependencytrack.model.PolicyViolation;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Tag;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.util.Date;
 import java.util.List;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PolicyResourceTest extends ResourceTest {
+class PolicyResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(PolicyResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(PolicyResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
     @Test
-    public void getPoliciesTest() {
+    void getPoliciesTest() {
         for (int i = 0; i < 1000; i++) {
             qm.createPolicy("policy" + i, Policy.Operator.ANY, Policy.ViolationState.INFO);
         }
@@ -74,7 +74,7 @@ public class PolicyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getPolicyByUuidTest() {
+    void getPolicyByUuidTest() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
 
         final Response response = jersey.target(V1_POLICY + "/" + policy.getUuid())
@@ -91,7 +91,7 @@ public class PolicyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createPolicyTest() {
+    void createPolicyTest() {
         final Policy policy = new Policy();
         policy.setName("policy");
         policy.setOperator(Policy.Operator.ANY);
@@ -114,7 +114,7 @@ public class PolicyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createPolicySpecifyOperatorAndViolationStateTest() {
+    void createPolicySpecifyOperatorAndViolationStateTest() {
         final Policy policy = new Policy();
         policy.setName("policy");
         policy.setOperator(Policy.Operator.ALL);
@@ -137,7 +137,7 @@ public class PolicyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createPolicyUseDefaultValueTest() {
+    void createPolicyUseDefaultValueTest() {
         final Policy policy = new Policy();
         policy.setName("policy");
 
@@ -158,7 +158,7 @@ public class PolicyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void updatePolicyTest() {
+    void updatePolicyTest() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
 
         policy.setViolationState(Policy.ViolationState.FAIL);
@@ -179,7 +179,7 @@ public class PolicyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void deletePolicyTest() {
+    void deletePolicyTest() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
 
         final Response response = jersey.target(V1_POLICY + "/" + policy.getUuid())
@@ -195,7 +195,7 @@ public class PolicyResourceTest extends ResourceTest {
      * This test verifies that associated conditions and violations get deleted as well when deleting a Policy.
      */
     @Test
-    public void deletePolicyCascadingTest() {
+    void deletePolicyCascadingTest() {
         final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
 
         Component component = new Component();
@@ -225,7 +225,7 @@ public class PolicyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void addProjectToPolicyTest() {
+    void addProjectToPolicyTest() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
 
@@ -242,7 +242,7 @@ public class PolicyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void addProjectToPolicyProjectAlreadyAddedTest() {
+    void addProjectToPolicyProjectAlreadyAddedTest() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
 
@@ -258,7 +258,7 @@ public class PolicyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void removeProjectFromPolicyTest() {
+    void removeProjectFromPolicyTest() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
 
@@ -274,7 +274,7 @@ public class PolicyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void removeProjectFromPolicyProjectAlreadyRemovedTest() {
+    void removeProjectFromPolicyProjectAlreadyRemovedTest() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
 
@@ -287,7 +287,7 @@ public class PolicyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void addTagToPolicyTest() {
+    void addTagToPolicyTest() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         final Tag tag = qm.createTag("Policy Tag");
 
@@ -304,7 +304,7 @@ public class PolicyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void addTagToPolicyTagAlreadyAddedTest() {
+    void addTagToPolicyTagAlreadyAddedTest() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         final Tag tag = qm.createTag("Policy Tag");
 
@@ -319,7 +319,7 @@ public class PolicyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void removeTagFromPolicyTest() {
+    void removeTagFromPolicyTest() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         final Tag tag = qm.createTag("Policy Tag");
 
@@ -334,7 +334,7 @@ public class PolicyResourceTest extends ResourceTest {
     }
 
     @Test
-    public void removeTagFromPolicyTagDoesNotExistTest() {
+    void removeTagFromPolicyTagDoesNotExistTest() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         final Tag tag = qm.createTag("Policy Tag");
 

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
@@ -48,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PolicyResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(PolicyResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyViolationResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyViolationResourceTest.java
@@ -22,8 +22,10 @@ import alpine.model.ConfigProperty;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import alpine.server.filters.AuthorizationFilter;
-
-import org.dependencytrack.JerseyTestRule;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Component;
@@ -35,29 +37,26 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ViolationAnalysis;
 import org.dependencytrack.model.ViolationAnalysisState;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PolicyViolationResourceTest extends ResourceTest {
+class PolicyViolationResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(PolicyViolationResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(PolicyViolationResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class)
                     .register(AuthorizationFilter.class));
 
     @Test
-    public void getViolationsTest() {
+    void getViolationsTest() {
         initializeWithPermissions(Permissions.VIEW_POLICY_VIOLATION);
 
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
@@ -99,7 +98,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getViolationsUnauthorizedTest() {
+    void getViolationsUnauthorizedTest() {
         final Response response = jersey.target(V1_POLICY_VIOLATION)
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -109,7 +108,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getViolationsByProjectTest() {
+    void getViolationsByProjectTest() {
         initializeWithPermissions(Permissions.VIEW_POLICY_VIOLATION);
 
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
@@ -181,7 +180,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getViolationsByProjectIssue2766() {
+    void getViolationsByProjectIssue2766() {
         initializeWithPermissions(Permissions.VIEW_POLICY_VIOLATION);
 
         final Project projectA = qm.createProject("acme-app-a", null, "1.0", null, null, null, true, false);
@@ -221,7 +220,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getViolationsByProjectUnauthorizedTest() {
+    void getViolationsByProjectUnauthorizedTest() {
         final Response response = jersey.target(V1_POLICY_VIOLATION)
                 .path("/project/" + UUID.randomUUID())
                 .request()
@@ -232,7 +231,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getViolationsByProjectNotFoundTest() {
+    void getViolationsByProjectNotFoundTest() {
         initializeWithPermissions(Permissions.VIEW_POLICY_VIOLATION);
 
         final Response response = jersey.target(V1_POLICY_VIOLATION)
@@ -246,7 +245,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getViolationsByComponentTest() {
+    void getViolationsByComponentTest() {
         initializeWithPermissions(Permissions.VIEW_POLICY_VIOLATION);
 
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
@@ -288,7 +287,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getViolationsByComponentUnauthorizedTest() {
+    void getViolationsByComponentUnauthorizedTest() {
         final Response response = jersey.target(V1_POLICY_VIOLATION)
                 .path("/component/" + UUID.randomUUID())
                 .request()
@@ -299,7 +298,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getViolationsByComponentNotFoundTest() {
+    void getViolationsByComponentNotFoundTest() {
         initializeWithPermissions(Permissions.VIEW_POLICY_VIOLATION);
 
         final Response response = jersey.target(V1_POLICY_VIOLATION)
@@ -313,7 +312,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getViolationsWithAclEnabledTest() {
+    void getViolationsWithAclEnabledTest() {
         initializeWithPermissions(Permissions.VIEW_POLICY_VIOLATION);
 
         final Project projectA = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
@@ -423,7 +422,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getViolationsWithArrayFilter() {
+    void getViolationsWithArrayFilter() {
         initializeWithPermissions(Permissions.VIEW_POLICY_VIOLATION);
         
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
@@ -528,7 +527,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getViolationsWithInputFilter() {
+    void getViolationsWithInputFilter() {
         initializeWithPermissions(Permissions.VIEW_POLICY_VIOLATION);
 
         final Project projectA = qm.createProject("Project A", null, "1.0", null, null, null, true, false);

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyViolationResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyViolationResourceTest.java
@@ -49,7 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PolicyViolationResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(PolicyViolationResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class)

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectPropertyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectPropertyResourceTest.java
@@ -21,69 +21,69 @@ package org.dependencytrack.resources.v1;
 import alpine.model.IConfigProperty;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import org.dependencytrack.JerseyTestRule;
-import org.dependencytrack.ResourceTest;
-import org.dependencytrack.model.Project;
-import org.dependencytrack.model.ProjectProperty;
-import org.glassfish.jersey.client.ClientProperties;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.ProjectProperty;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import java.util.UUID;
 
-public class ProjectPropertyResourceTest extends ResourceTest {
+class ProjectPropertyResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(ProjectPropertyResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(ProjectPropertyResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
     @Test
-    public void getPropertiesTest() {
+    void getPropertiesTest() {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         qm.createProjectProperty(project, "mygroup", "prop1", "value1", IConfigProperty.PropertyType.STRING, "Test Property 1");
         qm.createProjectProperty(project, "mygroup", "prop2", "value2", IConfigProperty.PropertyType.ENCRYPTEDSTRING, "Test Property 2");
         Response response = jersey.target(V1_PROJECT + "/" + project.getUuid().toString() + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(2, json.size());
-        Assert.assertEquals("mygroup", json.getJsonObject(0).getString("groupName"));
-        Assert.assertEquals("prop1", json.getJsonObject(0).getString("propertyName"));
-        Assert.assertEquals("value1", json.getJsonObject(0).getString("propertyValue"));
-        Assert.assertEquals("STRING", json.getJsonObject(0).getString("propertyType"));
-        Assert.assertEquals("Test Property 1", json.getJsonObject(0).getString("description"));
-        Assert.assertEquals("mygroup", json.getJsonObject(1).getString("groupName"));
-        Assert.assertEquals("prop2", json.getJsonObject(1).getString("propertyName"));
-        Assert.assertEquals("HiddenDecryptedPropertyPlaceholder", json.getJsonObject(1).getString("propertyValue"));
-        Assert.assertEquals("ENCRYPTEDSTRING", json.getJsonObject(1).getString("propertyType"));
-        Assert.assertEquals("Test Property 2", json.getJsonObject(1).getString("description"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(2, json.size());
+        Assertions.assertEquals("mygroup", json.getJsonObject(0).getString("groupName"));
+        Assertions.assertEquals("prop1", json.getJsonObject(0).getString("propertyName"));
+        Assertions.assertEquals("value1", json.getJsonObject(0).getString("propertyValue"));
+        Assertions.assertEquals("STRING", json.getJsonObject(0).getString("propertyType"));
+        Assertions.assertEquals("Test Property 1", json.getJsonObject(0).getString("description"));
+        Assertions.assertEquals("mygroup", json.getJsonObject(1).getString("groupName"));
+        Assertions.assertEquals("prop2", json.getJsonObject(1).getString("propertyName"));
+        Assertions.assertEquals("HiddenDecryptedPropertyPlaceholder", json.getJsonObject(1).getString("propertyValue"));
+        Assertions.assertEquals("ENCRYPTEDSTRING", json.getJsonObject(1).getString("propertyType"));
+        Assertions.assertEquals("Test Property 2", json.getJsonObject(1).getString("description"));
     }
 
     @Test
-    public void getPropertiesInvalidTest() {
+    void getPropertiesInvalidTest() {
        Response response = jersey.target(V1_PROJECT + "/" + UUID.randomUUID().toString() + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The project could not be found.", body);
+        Assertions.assertEquals("The project could not be found.", body);
     }
 
     @Test
-    public void createPropertyTest() {
+    void createPropertyTest() {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         ProjectProperty property = new ProjectProperty();
         property.setProject(project);
@@ -95,18 +95,18 @@ public class ProjectPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_PROJECT + "/" + project.getUuid().toString() + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(property, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertEquals(201, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("mygroup", json.getString("groupName"));
-        Assert.assertEquals("prop1", json.getString("propertyName"));
-        Assert.assertEquals("value1", json.getString("propertyValue"));
-        Assert.assertEquals("STRING", json.getString("propertyType"));
-        Assert.assertEquals("Test Property 1", json.getString("description"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("mygroup", json.getString("groupName"));
+        Assertions.assertEquals("prop1", json.getString("propertyName"));
+        Assertions.assertEquals("value1", json.getString("propertyValue"));
+        Assertions.assertEquals("STRING", json.getString("propertyType"));
+        Assertions.assertEquals("Test Property 1", json.getString("description"));
     }
 
     @Test
-    public void createPropertyEncryptedTest() {
+    void createPropertyEncryptedTest() {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         ProjectProperty property = new ProjectProperty();
         property.setProject(project);
@@ -118,18 +118,18 @@ public class ProjectPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_PROJECT + "/" + project.getUuid().toString() + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(property, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertEquals(201, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("mygroup", json.getString("groupName"));
-        Assert.assertEquals("prop1", json.getString("propertyName"));
-        Assert.assertEquals("HiddenDecryptedPropertyPlaceholder", json.getString("propertyValue"));
-        Assert.assertEquals("ENCRYPTEDSTRING", json.getString("propertyType"));
-        Assert.assertEquals("Test Property 1", json.getString("description"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("mygroup", json.getString("groupName"));
+        Assertions.assertEquals("prop1", json.getString("propertyName"));
+        Assertions.assertEquals("HiddenDecryptedPropertyPlaceholder", json.getString("propertyValue"));
+        Assertions.assertEquals("ENCRYPTEDSTRING", json.getString("propertyType"));
+        Assertions.assertEquals("Test Property 1", json.getString("description"));
     }
 
     @Test
-    public void createPropertyDuplicateTest() {
+    void createPropertyDuplicateTest() {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         qm.createProjectProperty(project, "mygroup", "prop1", "value1", IConfigProperty.PropertyType.STRING, null);
         String uuid = project.getUuid().toString();
@@ -144,14 +144,14 @@ public class ProjectPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_PROJECT + "/" + uuid + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(property, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(409, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(409, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("A property with the specified project/group/name combination already exists.", body);
+        Assertions.assertEquals("A property with the specified project/group/name combination already exists.", body);
     }
 
     @Test
-    public void createPropertyInvalidTest() {
+    void createPropertyInvalidTest() {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         ProjectProperty property = new ProjectProperty();
         property.setProject(project);
@@ -163,14 +163,14 @@ public class ProjectPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_PROJECT + "/" + UUID.randomUUID() + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(property, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The project could not be found.", body);
+        Assertions.assertEquals("The project could not be found.", body);
     }
 
     @Test
-    public void updatePropertyTest() {
+    void updatePropertyTest() {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         String uuid = project.getUuid().toString();
         ProjectProperty property = qm.createProjectProperty(project, "mygroup", "prop1", "value1", IConfigProperty.PropertyType.STRING, null);
@@ -180,17 +180,17 @@ public class ProjectPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_PROJECT + "/" + uuid + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(property, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("mygroup", json.getString("groupName"));
-        Assert.assertEquals("prop1", json.getString("propertyName"));
-        Assert.assertEquals("updatedValue", json.getString("propertyValue"));
-        Assert.assertEquals("STRING", json.getString("propertyType"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("mygroup", json.getString("groupName"));
+        Assertions.assertEquals("prop1", json.getString("propertyName"));
+        Assertions.assertEquals("updatedValue", json.getString("propertyValue"));
+        Assertions.assertEquals("STRING", json.getString("propertyType"));
     }
 
     @Test
-    public void updatePropertyInvalidTest() {
+    void updatePropertyInvalidTest() {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         ProjectProperty property = new ProjectProperty();
         property.setProject(project);
@@ -202,14 +202,14 @@ public class ProjectPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_PROJECT + "/" + UUID.randomUUID().toString() + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(property, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The project could not be found.", body);
+        Assertions.assertEquals("The project could not be found.", body);
     }
 
     @Test
-    public void deletePropertyTest() {
+    void deletePropertyTest() {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         ProjectProperty property = qm.createProjectProperty(project, "mygroup", "prop1", "value1", IConfigProperty.PropertyType.STRING, null);
         String uuid = project.getUuid().toString();
@@ -219,6 +219,6 @@ public class ProjectPropertyResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true) // HACK
                 .method("DELETE", Entity.entity(property, MediaType.APPLICATION_JSON)); // HACK
-        Assert.assertEquals(204, response.getStatus(), 0);
+        Assertions.assertEquals(204, response.getStatus(), 0);
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectPropertyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectPropertyResourceTest.java
@@ -41,7 +41,7 @@ import java.util.UUID;
 class ProjectPropertyResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(ProjectPropertyResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -28,8 +28,16 @@ import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.cyclonedx.model.ExternalReference.Type;
-import org.dependencytrack.JerseyTestRule;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.event.CloneProjectEvent;
@@ -58,19 +66,11 @@ import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.hamcrest.CoreMatchers;
 import org.json.JSONArray;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-import jakarta.ws.rs.HttpMethod;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -86,24 +86,22 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
-public class ProjectResourceTest extends ResourceTest {
+class ProjectResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(ProjectResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(ProjectResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class)
                     .register(ProjectOperationExceptionMapper.class));
 
-    @After
-    @Override
-    public void after() throws Exception {
+    @AfterEach
+    public void after() {
         EventService.getInstance().unsubscribe(CloneProjectTask.class);
-        super.after();
     }
 
     @Test
-    public void getProjectsDefaultRequestTest() {
+    void getProjectsDefaultRequestTest() {
         for (int i=0; i<1000; i++) {
             qm.createProject("Acme Example", null, String.valueOf(i), null, null, null, true, false);
         }
@@ -111,17 +109,17 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(1000), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(1000), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(100, json.size());
-        Assert.assertEquals("Acme Example", json.getJsonObject(0).getString("name"));
-        Assert.assertEquals("999", json.getJsonObject(0).getString("version"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(100, json.size());
+        Assertions.assertEquals("Acme Example", json.getJsonObject(0).getString("name"));
+        Assertions.assertEquals("999", json.getJsonObject(0).getString("version"));
     }
 
     @Test // https://github.com/DependencyTrack/dependency-track/issues/2583
-    public void getProjectsWithAclEnabledTest() {
+    void getProjectsWithAclEnabledTest() {
         enablePortfolioAccessControl();
 
         // Create project and give access to current principal's team.
@@ -136,17 +134,17 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals("1", response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals("1", response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(1, json.size());
-        Assert.assertEquals("acme-app-a", json.getJsonObject(0).getString("name"));
-        Assert.assertEquals("1.0.0", json.getJsonObject(0).getString("version"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(1, json.size());
+        Assertions.assertEquals("acme-app-a", json.getJsonObject(0).getString("name"));
+        Assertions.assertEquals("1.0.0", json.getJsonObject(0).getString("version"));
     }
 
     @Test
-    public void getProjectsByNameRequestTest() {
+    void getProjectsByNameRequestTest() {
         for (int i=0; i<1000; i++) {
             qm.createProject("Acme Example", null, String.valueOf(i), null, null, null, true, false);
         }
@@ -155,17 +153,17 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(1000), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(1000), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(100, json.size());
-        Assert.assertEquals("Acme Example", json.getJsonObject(0).getString("name"));
-        Assert.assertEquals("999", json.getJsonObject(0).getString("version"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(100, json.size());
+        Assertions.assertEquals("Acme Example", json.getJsonObject(0).getString("name"));
+        Assertions.assertEquals("999", json.getJsonObject(0).getString("version"));
     }
 
     @Test
-    public void getProjectsByInvalidNameRequestTest() {
+    void getProjectsByInvalidNameRequestTest() {
         for (int i=0; i<1000; i++) {
             qm.createProject("Acme Example", null, String.valueOf(i), null, null, null, true, false);
         }
@@ -174,15 +172,15 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(0), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(0), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(0, json.size());
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(0, json.size());
     }
 
     @Test
-    public void getProjectsByNameActiveOnlyRequestTest() {
+    void getProjectsByNameActiveOnlyRequestTest() {
         for (int i=0; i<500; i++) {
             qm.createProject("Acme Example", null, String.valueOf(i), null, null, null, true, false);
         }
@@ -195,15 +193,15 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(500), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(500), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(100, json.size());
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(100, json.size());
     }
 
     @Test
-    public void getProjectLookupTest() {
+    void getProjectLookupTest() {
         for (int i=0; i<500; i++) {
             qm.createProject("Acme Example", null, String.valueOf(i), null, null, null, false, false);
         }
@@ -213,20 +211,20 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-                Assert.assertEquals(200, response.getStatus(), 0);
-                Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+                Assertions.assertEquals(200, response.getStatus(), 0);
+                Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Acme Example", json.getString("name"));
-        Assert.assertEquals("10", json.getString("version"));
-        Assert.assertEquals(500, json.getJsonArray("versions").size());
-        Assert.assertNotNull(json.getJsonArray("versions").getJsonObject(100).getString("uuid"));
-        Assert.assertNotEquals("", json.getJsonArray("versions").getJsonObject(100).getString("uuid"));
-        Assert.assertEquals("100", json.getJsonArray("versions").getJsonObject(100).getString("version"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Acme Example", json.getString("name"));
+        Assertions.assertEquals("10", json.getString("version"));
+        Assertions.assertEquals(500, json.getJsonArray("versions").size());
+        Assertions.assertNotNull(json.getJsonArray("versions").getJsonObject(100).getString("uuid"));
+        Assertions.assertNotEquals("", json.getJsonArray("versions").getJsonObject(100).getString("uuid"));
+        Assertions.assertEquals("100", json.getJsonArray("versions").getJsonObject(100).getString("version"));
     }
 
     @Test
-    public void getProjectLookupNotFoundTest() {
+    void getProjectLookupNotFoundTest() {
         final var project = new Project();
         project.setName("acme-app");
         project.setVersion("1.2.3");
@@ -243,7 +241,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getProjectLookupNotPermittedTest() {
+    void getProjectLookupNotPermittedTest() {
         enablePortfolioAccessControl();
 
         final var project = new Project();
@@ -262,7 +260,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getProjectsAscOrderedRequestTest() {
+    void getProjectsAscOrderedRequestTest() {
         qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         qm.createProject("DEF", null, "1.0", null, null, null, true, false);
         Response response = jersey.target(V1_PROJECT)
@@ -271,15 +269,15 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(2), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(2), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("ABC", json.getJsonObject(0).getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("ABC", json.getJsonObject(0).getString("name"));
     }
 
     @Test
-    public void getProjectsDescOrderedRequestTest() {
+    void getProjectsDescOrderedRequestTest() {
         qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         qm.createProject("DEF", null, "1.0", null, null, null, true, false);
         Response response = jersey.target(V1_PROJECT)
@@ -288,15 +286,15 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(2), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(2), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("DEF", json.getJsonObject(0).getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("DEF", json.getJsonObject(0).getString("name"));
     }
 
     @Test
-    public void getProjectByUuidTest() {
+    void getProjectByUuidTest() {
         final var parentProject = new Project();
         parentProject.setName("acme-app-parent");
         parentProject.setVersion("1.0.0");
@@ -361,7 +359,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getProjectByUuidNotPermittedTest() {
+    void getProjectByUuidNotPermittedTest() {
         enablePortfolioAccessControl();
 
         final var project = new Project();
@@ -377,7 +375,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void validateProjectVersionsActiveInactiveTest() {
+    void validateProjectVersionsActiveInactiveTest() {
         Project project = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         qm.createProject("ABC", null, "2.0", null, null, null, false, false);
         qm.createProject("ABC", null, "3.0", null, null, null, true, false);
@@ -387,40 +385,40 @@ public class ProjectResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
 
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("ABC", json.getString("name"));
-        Assert.assertEquals(3, json.getJsonArray("versions").size());
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("ABC", json.getString("name"));
+        Assertions.assertEquals(3, json.getJsonArray("versions").size());
 
-        Assert.assertNotNull(json.getJsonArray("versions").getJsonObject(0).getJsonString("uuid").getString());
-        Assert.assertEquals("1.0", json.getJsonArray("versions").getJsonObject(0).getJsonString("version").getString());
-        Assert.assertTrue(json.getJsonArray("versions").getJsonObject(0).getBoolean("active"));
+        Assertions.assertNotNull(json.getJsonArray("versions").getJsonObject(0).getJsonString("uuid").getString());
+        Assertions.assertEquals("1.0", json.getJsonArray("versions").getJsonObject(0).getJsonString("version").getString());
+        Assertions.assertTrue(json.getJsonArray("versions").getJsonObject(0).getBoolean("active"));
 
-        Assert.assertNotNull(json.getJsonArray("versions").getJsonObject(1).getJsonString("uuid").getString());
-        Assert.assertEquals("2.0", json.getJsonArray("versions").getJsonObject(1).getJsonString("version").getString());
-        Assert.assertFalse(json.getJsonArray("versions").getJsonObject(1).getBoolean("active"));
+        Assertions.assertNotNull(json.getJsonArray("versions").getJsonObject(1).getJsonString("uuid").getString());
+        Assertions.assertEquals("2.0", json.getJsonArray("versions").getJsonObject(1).getJsonString("version").getString());
+        Assertions.assertFalse(json.getJsonArray("versions").getJsonObject(1).getBoolean("active"));
 
-        Assert.assertNotNull(json.getJsonArray("versions").getJsonObject(2).getJsonString("uuid").getString());
-        Assert.assertEquals("3.0", json.getJsonArray("versions").getJsonObject(2).getJsonString("version").getString());
-        Assert.assertTrue(json.getJsonArray("versions").getJsonObject(2).getBoolean("active"));
+        Assertions.assertNotNull(json.getJsonArray("versions").getJsonObject(2).getJsonString("uuid").getString());
+        Assertions.assertEquals("3.0", json.getJsonArray("versions").getJsonObject(2).getJsonString("version").getString());
+        Assertions.assertTrue(json.getJsonArray("versions").getJsonObject(2).getBoolean("active"));
     }
 
     @Test
-    public void getProjectByInvalidUuidTest() {
+    void getProjectByInvalidUuidTest() {
         qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         Response response = jersey.target(V1_PROJECT + "/" + UUID.randomUUID())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The project could not be found.", body);
+        Assertions.assertEquals("The project could not be found.", body);
     }
 
     @Test
-    public void getProjectByTagTest() {
+    void getProjectByTagTest() {
         List<Tag> tags = new ArrayList<>();
         Tag tag = qm.createTag("production");
         tags.add(tag);
@@ -430,15 +428,15 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("ABC", json.getJsonObject(0).getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("ABC", json.getJsonObject(0).getString("name"));
     }
 
     @Test
-    public void getProjectByCaseInsensitiveTagTest() {
+    void getProjectByCaseInsensitiveTagTest() {
         List<Tag> tags = new ArrayList<>();
         Tag tag = qm.createTag("PRODUCTION");
         tags.add(tag);
@@ -448,15 +446,15 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("ABC", json.getJsonObject(0).getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("ABC", json.getJsonObject(0).getString("name"));
     }
 
     @Test
-    public void getProjectByUnknownTagTest() {
+    void getProjectByUnknownTagTest() {
         List<Tag> tags = new ArrayList<>();
         Tag tag = qm.createTag("production");
         tags.add(tag);
@@ -466,15 +464,15 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(0), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(0), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(0, json.size());
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(0, json.size());
     }
 
     @Test
-    public void createProjectTest(){
+    void createProjectTest(){
         Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -490,20 +488,20 @@ public class ProjectResourceTest extends ResourceTest {
                           ]
                         }
                         """));
-        Assert.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertEquals(201, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Acme Example", json.getString("name"));
-        Assert.assertEquals("1.0", json.getString("version"));
-        Assert.assertEquals("Test project", json.getString("description"));
-        Assert.assertTrue(json.getBoolean("active"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Acme Example", json.getString("name"));
+        Assertions.assertEquals("1.0", json.getString("version"));
+        Assertions.assertEquals("Test project", json.getString("description"));
+        Assertions.assertTrue(json.getBoolean("active"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
         assertThat(json.getJsonArray("tags").getValuesAs(JsonObject.class)).satisfiesExactly(
                 jsonObject -> assertThat(jsonObject.getString("name")).isEqualTo("foo"));
     }
 
     @Test
-    public void createProjectDuplicateTest() {
+    void createProjectDuplicateTest() {
         Project project = new Project();
         project.setName("Acme Example");
         project.setVersion("1.0");
@@ -511,18 +509,18 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(project, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertEquals(201, response.getStatus(), 0);
         response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(project, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(409, response.getStatus(), 0);
+        Assertions.assertEquals(409, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("A project with the specified name already exists.", body);
+        Assertions.assertEquals("A project with the specified name already exists.", body);
     }
 
     @Test
-    public void createProjectInactiveParentTest() {
+    void createProjectInactiveParentTest() {
         final var parentProject = new Project();
         parentProject.setName("acme-app-parent");
         parentProject.setVersion("1.0.0");
@@ -546,36 +544,36 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createProjectWithoutVersionDuplicateTest() {
+    void createProjectWithoutVersionDuplicateTest() {
         Project project = new Project();
         project.setName("Acme Example");
         Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(project, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertEquals(201, response.getStatus(), 0);
         response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(project, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(409, response.getStatus(), 0);
+        Assertions.assertEquals(409, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("A project with the specified name already exists.", body);
+        Assertions.assertEquals("A project with the specified name already exists.", body);
     }
 
     @Test
-    public void createProjectEmptyTest() {
+    void createProjectEmptyTest() {
         Project project = new Project();
         project.setName(" ");
         Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(project, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertEquals(400, response.getStatus(), 0);
     }
 
     @Test
-    public void createProjectAsUserWithAclEnabledAndExistingTeamByUuidTest() {
+    void createProjectAsUserWithAclEnabledAndExistingTeamByUuidTest() {
         qm.createConfigProperty(
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
@@ -622,7 +620,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createProjectAsUserWithAclEnabledAndExistingTeamByNameTest() {
+    void createProjectAsUserWithAclEnabledAndExistingTeamByNameTest() {
         qm.createConfigProperty(
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
@@ -669,7 +667,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createProjectAsUserWithAclEnabledAndWithoutTeamTest() {
+    void createProjectAsUserWithAclEnabledAndWithoutTeamTest() {
         qm.createConfigProperty(
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
@@ -711,7 +709,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createProjectAsUserWithNotAllowedExistingTeamTest() {
+    void createProjectAsUserWithNotAllowedExistingTeamTest() {
         qm.createConfigProperty(
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
@@ -743,7 +741,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createProjectAsUserWithAclEnabledAndNotMemberOfTeamAdminTest() {
+    void createProjectAsUserWithAclEnabledAndNotMemberOfTeamAdminTest() {
         qm.createConfigProperty(
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
@@ -794,7 +792,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createProjectAsUserWithAclEnabledAndTeamNotExistingNoAdminTest() {
+    void createProjectAsUserWithAclEnabledAndTeamNotExistingNoAdminTest() {
         qm.createConfigProperty(
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
@@ -827,7 +825,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createProjectAsUserWithAclEnabledAndTeamNotExistingAdminTest() {
+    void createProjectAsUserWithAclEnabledAndTeamNotExistingAdminTest() {
         qm.createConfigProperty(
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
@@ -863,7 +861,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createProjectAsApiKeyWithAclEnabledAndWithExistentTeamTest() {
+    void createProjectAsApiKeyWithAclEnabledAndWithExistentTeamTest() {
         qm.createConfigProperty(
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
@@ -904,7 +902,7 @@ public class ProjectResourceTest extends ResourceTest {
                 assertThat(project.getAccessTeams()).extracting(Team::getName).containsOnly(team.getName()));
     }
     @Test
-    public void createProjectAsLatestTest() {
+    void createProjectAsLatestTest() {
         Project project = new Project();
         project.setName("Acme Example");
         project.setVersion("1.0");
@@ -912,10 +910,10 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(project, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertEquals(201, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
         // ensure initial value is false when not specified
-        Assert.assertFalse(json.getBoolean("isLatest"));
+        Assertions.assertFalse(json.getBoolean("isLatest"));
 
         project.setVersion("2.0");
         project.setIsLatest(true);
@@ -923,10 +921,10 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(project, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertEquals(201, response.getStatus(), 0);
         json = parseJsonObject(response);
         // ensure value of latest version is true when specified
-        Assert.assertTrue(json.getBoolean("isLatest"));
+        Assertions.assertTrue(json.getBoolean("isLatest"));
         String v20uuid = json.getString("uuid");
 
         project.setVersion("2.1");
@@ -934,16 +932,16 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(project, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertEquals(201, response.getStatus(), 0);
         json = parseJsonObject(response);
         // ensure value of latest version is true when specified
-        Assert.assertTrue(json.getBoolean("isLatest"));
+        Assertions.assertTrue(json.getBoolean("isLatest"));
         // ensure v2.0 is no longer latest
-        Assert.assertFalse(qm.getProject(v20uuid).isLatest());
+        Assertions.assertFalse(qm.getProject(v20uuid).isLatest());
     }
 
     @Test
-    public void createProjectAsLatestWithACLTest() {
+    void createProjectAsLatestWithACLTest() {
         enablePortfolioAccessControl();
 
         final var accessProject = new Project();
@@ -967,9 +965,9 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(project, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertEquals(201, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertTrue(json.getBoolean("isLatest"));
+        Assertions.assertTrue(json.getBoolean("isLatest"));
 
         project.setName(noAccessProject.getName());
         project.setVersion("3.0.0");
@@ -977,27 +975,27 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(project, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(403, response.getStatus(), 0);
+        Assertions.assertEquals(403, response.getStatus(), 0);
     }
 
     @Test
-    public void updateProjectTest() {
+    void updateProjectTest() {
         Project project = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         project.setDescription("Test project");
         Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(project, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("ABC", json.getString("name"));
-        Assert.assertEquals("1.0", json.getString("version"));
-        Assert.assertEquals("Test project", json.getString("description"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("ABC", json.getString("name"));
+        Assertions.assertEquals("1.0", json.getString("version"));
+        Assertions.assertEquals("Test project", json.getString("description"));
     }
 
     @Test
-    public void updateProjectNotFoundTest() {
+    void updateProjectNotFoundTest() {
         final Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -1013,7 +1011,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void updateProjectNotPermittedTest() {
+    void updateProjectNotPermittedTest() {
         enablePortfolioAccessControl();
 
         final var project = new Project();
@@ -1034,7 +1032,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void updateProjectTestIsActiveEqualsNull() {
+    void updateProjectTestIsActiveEqualsNull() {
         final Project project = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         final Response response = jersey.target(V1_PROJECT)
                 .request()
@@ -1047,17 +1045,17 @@ public class ProjectResourceTest extends ResourceTest {
                           "description": "Test project"
                         }
                         """.formatted(project.getUuid())));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("ABC", json.getString("name"));
-        Assert.assertEquals("1.0", json.getString("version"));
-        Assert.assertEquals("Test project", json.getString("description"));
-        Assert.assertTrue(json.getBoolean("active"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("ABC", json.getString("name"));
+        Assertions.assertEquals("1.0", json.getString("version"));
+        Assertions.assertEquals("Test project", json.getString("description"));
+        Assertions.assertTrue(json.getBoolean("active"));
     }
 
     @Test
-    public void updateProjectTagsTest() {
+    void updateProjectTagsTest() {
         final var tags = Stream.of("tag1", "tag2").map(qm::createTag).collect(Collectors.toUnmodifiableList());
         final var p1 = qm.createProject("ABC", "Test project", "1.0", tags, null, null, true, false);
 
@@ -1076,17 +1074,17 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(jsonProject, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         var json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(p1.getName(), json.getString("name"));
-        Assert.assertEquals(p1.getVersion(), json.getString("version"));
-        Assert.assertFalse(json.containsKey("description"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(p1.getName(), json.getString("name"));
+        Assertions.assertEquals(p1.getVersion(), json.getString("version"));
+        Assertions.assertFalse(json.containsKey("description"));
         var jsonTags = json.getJsonArray("tags");
-        Assert.assertEquals(3, jsonTags.size());
-        Assert.assertEquals("tag1", jsonTags.get(0).asJsonObject().getString("name"));
-        Assert.assertEquals("tag2", jsonTags.get(1).asJsonObject().getString("name"));
-        Assert.assertEquals("tag3", jsonTags.get(2).asJsonObject().getString("name"));
+        Assertions.assertEquals(3, jsonTags.size());
+        Assertions.assertEquals("tag1", jsonTags.get(0).asJsonObject().getString("name"));
+        Assertions.assertEquals("tag2", jsonTags.get(1).asJsonObject().getString("name"));
+        Assertions.assertEquals("tag3", jsonTags.get(2).asJsonObject().getString("name"));
 
         // and update again with the same tags ... issue #1165
         response = jersey.target(V1_PROJECT)
@@ -1095,10 +1093,10 @@ public class ProjectResourceTest extends ResourceTest {
                 .post(Entity.entity(jsonProject, MediaType.APPLICATION_JSON));
         json = parseJsonObject(response);
         jsonTags = json.getJsonArray("tags");
-        Assert.assertEquals(3, jsonTags.size());
-        Assert.assertEquals("tag1", jsonTags.get(0).asJsonObject().getString("name"));
-        Assert.assertEquals("tag2", jsonTags.get(1).asJsonObject().getString("name"));
-        Assert.assertEquals("tag3", jsonTags.get(2).asJsonObject().getString("name"));
+        Assertions.assertEquals(3, jsonTags.size());
+        Assertions.assertEquals("tag1", jsonTags.get(0).asJsonObject().getString("name"));
+        Assertions.assertEquals("tag2", jsonTags.get(1).asJsonObject().getString("name"));
+        Assertions.assertEquals("tag3", jsonTags.get(2).asJsonObject().getString("name"));
 
         // and finally delete one of the tags
         jsonProject.getTags().removeIf(tag -> "tag1".equals(tag.getName()));
@@ -1108,24 +1106,24 @@ public class ProjectResourceTest extends ResourceTest {
                 .post(Entity.entity(jsonProject, MediaType.APPLICATION_JSON));
         json = parseJsonObject(response);
         jsonTags = json.getJsonArray("tags");
-        Assert.assertEquals(2, jsonTags.size());
-        Assert.assertEquals("tag2", jsonTags.get(0).asJsonObject().getString("name"));
-        Assert.assertEquals("tag3", jsonTags.get(1).asJsonObject().getString("name"));
+        Assertions.assertEquals(2, jsonTags.size());
+        Assertions.assertEquals("tag2", jsonTags.get(0).asJsonObject().getString("name"));
+        Assertions.assertEquals("tag3", jsonTags.get(1).asJsonObject().getString("name"));
     }
 
     @Test
-    public void updateProjectEmptyNameTest() {
+    void updateProjectEmptyNameTest() {
         Project project = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         project.setName(" ");
         Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(project, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertEquals(400, response.getStatus(), 0);
     }
 
     @Test
-    public void updateProjectDuplicateTest() {
+    void updateProjectDuplicateTest() {
         qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         Project project = qm.createProject("DEF", null, "1.0", null, null, null, true, false);
         project.setName("ABC");
@@ -1133,13 +1131,13 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(project, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(409, response.getStatus(), 0);
+        Assertions.assertEquals(409, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("A project with the specified name and version already exists.", body);
+        Assertions.assertEquals("A project with the specified name and version already exists.", body);
     }
 
     @Test
-    public void updateProjectAsLatestTest() {
+    void updateProjectAsLatestTest() {
         // create project not as latest
         Project project = qm.createProject("ABC", null, "1.0", null, null, null,
                 true, false, false);
@@ -1151,9 +1149,9 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(jsonProject, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertTrue(json.getBoolean("isLatest"));
+        Assertions.assertTrue(json.getBoolean("isLatest"));
 
         // add another project version, "forget" to make it latest
         final Project newProject = qm.createProject("ABC", null, "1.0.1", null, null, null,
@@ -1165,16 +1163,16 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(jsonProject, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         json = parseJsonObject(response);
         // ensure is now latest
-        Assert.assertTrue(json.getBoolean("isLatest"));
+        Assertions.assertTrue(json.getBoolean("isLatest"));
         // ensure old is no longer latest
-        Assert.assertFalse(qm.getProject(project.getName(), project.getVersion()).isLatest());
+        Assertions.assertFalse(qm.getProject(project.getName(), project.getVersion()).isLatest());
     }
 
     @Test
-    public void updateProjectAsLatestWithACLAndAccessTest() {
+    void updateProjectAsLatestWithACLAndAccessTest() {
         enablePortfolioAccessControl();
 
         final var accessLatestProject = new Project();
@@ -1198,17 +1196,17 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(jsonProject, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
         // ensure is now latest
-        Assert.assertTrue(json.getBoolean("isLatest"));
+        Assertions.assertTrue(json.getBoolean("isLatest"));
         // ensure old is no longer latest (bypass db cache)
         qm.getPersistenceManager().refreshAll();
-        Assert.assertFalse(qm.getProject(accessLatestProject.getName(), accessLatestProject.getVersion()).isLatest());
+        Assertions.assertFalse(qm.getProject(accessLatestProject.getName(), accessLatestProject.getVersion()).isLatest());
     }
 
     @Test
-    public void updateProjectAsLatestWithACLAndNoAccessTest() {
+    void updateProjectAsLatestWithACLAndNoAccessTest() {
         enablePortfolioAccessControl();
 
         final var noAccessLatestProject = new Project();
@@ -1231,13 +1229,13 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(jsonProject, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(403, response.getStatus(), 0);
+        Assertions.assertEquals(403, response.getStatus(), 0);
         // ensure old is still latest
-        Assert.assertTrue(qm.getProject(noAccessLatestProject.getName(), noAccessLatestProject.getVersion()).isLatest());
+        Assertions.assertTrue(qm.getProject(noAccessLatestProject.getName(), noAccessLatestProject.getVersion()).isLatest());
     }
 
     @Test
-    public void updateProjectToCollectionProjectWhenHavingComponentsTest() {
+    void updateProjectToCollectionProjectWhenHavingComponentsTest() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -1264,7 +1262,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void updateProjectToCollectionProjectWhenHavingServicesTest() {
+    void updateProjectToCollectionProjectWhenHavingServicesTest() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -1291,23 +1289,34 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void deleteProjectTest() {
+    void deleteProjectTest() {
         Project project = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         Response response = jersey.target(V1_PROJECT + "/" + project.getUuid().toString())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(204, response.getStatus(), 0);
+        Assertions.assertEquals(204, response.getStatus(), 0);
     }
 
     @Test
-    public void deleteProjectInvalidUuidTest() {
+    void deleteProjectWithChildrenTest() {
+        Project parentProject = qm.createProject("ABC parent", null, "1.0", null, null, null, true, false);
+        Project project = qm.createProject("ABC", null, "1.0", null, parentProject, null, true, false);
+        Response response = jersey.target(V1_PROJECT + "/" + project.getUuid().toString())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+        Assertions.assertEquals(204, response.getStatus(), 0);
+    }
+
+    @Test
+    void deleteProjectInvalidUuidTest() {
         qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         Response response = jersey.target(V1_PROJECT + "/" + UUID.randomUUID().toString())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertEquals(404, response.getStatus(), 0);
     }
 
     List<UUID> createProjects(int size, boolean accessible) {
@@ -1324,7 +1333,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void batchDeleteProjectsTest() throws JsonProcessingException {
+    void batchDeleteProjectsTest() throws JsonProcessingException {
         // Enable portfolio access control.
         qm.createConfigProperty(
             ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
@@ -1342,7 +1351,7 @@ public class ProjectResourceTest extends ResourceTest {
             .request()
             .header(X_API_KEY, apiKey)
             .post(Entity.json(uuidsOfAccessibleProjects));
-        Assert.assertEquals(204, response.getStatus(), 0);
+        Assertions.assertEquals(204, response.getStatus(), 0);
 
         // Try to delete them again (they should now be gone)
         response = jersey.target(V1_PROJECT + "/batchDelete")
@@ -1350,7 +1359,7 @@ public class ProjectResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
                 .post(Entity.json(uuidsOfAccessibleProjects));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertEquals(400, response.getStatus(), 0);
         assertThat(response.getHeaderString("Content-Type")).isEqualTo("application/problem+json");
         Map<String, String> expectedErrors = uuidsOfAccessibleProjects.stream()
                 .collect(Collectors.toMap(UUID::toString, uuid -> "Project not found"));
@@ -1398,7 +1407,7 @@ public class ProjectResourceTest extends ResourceTest {
             .request()
             .header(X_API_KEY, apiKey)
             .post(Entity.json(uuidsOfMixedProjects));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertEquals(400, response.getStatus(), 0);
         assertThat(response.getHeaderString("Content-Type")).isEqualTo("application/problem+json");
         expectedErrors = uuidsOfInaccessibleProjects.stream()
                 .collect(Collectors.toMap(UUID::toString, uuid -> "Access denied to project"));
@@ -1415,7 +1424,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void patchProjectNotModifiedTest() {
+    void patchProjectNotModifiedTest() {
         final var tags = Stream.of("tag1", "tag2").map(qm::createTag).collect(Collectors.toUnmodifiableList());
         final var p1 = qm.createProject("ABC", "Test project", "1.0", tags, null, null, true, false);
 
@@ -1426,12 +1435,12 @@ public class ProjectResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
                 .method("PATCH", Entity.json(jsonProject));
-        Assert.assertEquals(Response.Status.NOT_MODIFIED.getStatusCode(), response.getStatus());
-        Assert.assertEquals(p1, qm.getObjectByUuid(Project.class, p1.getUuid()));
+        Assertions.assertEquals(Response.Status.NOT_MODIFIED.getStatusCode(), response.getStatus());
+        Assertions.assertEquals(p1, qm.getObjectByUuid(Project.class, p1.getUuid()));
     }
 
     @Test
-    public void patchProjectNameVersionConflictTest() {
+    void patchProjectNameVersionConflictTest() {
         final var tags = Stream.of("tag1", "tag2").map(qm::createTag).collect(Collectors.toUnmodifiableList());
         final var p1 = qm.createProject("ABC", "Test project", "1.0", tags, null, null, true, false);
         qm.createProject("ABC", "Test project", "0.9", null, null, null, false, false);
@@ -1442,22 +1451,22 @@ public class ProjectResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
                 .method("PATCH", Entity.json(jsonProject));
-        Assert.assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
-        Assert.assertEquals(p1, qm.getObjectByUuid(Project.class, p1.getUuid()));
+        Assertions.assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+        Assertions.assertEquals(p1, qm.getObjectByUuid(Project.class, p1.getUuid()));
     }
 
     @Test
-    public void patchProjectNotFoundTest() {
+    void patchProjectNotFoundTest() {
         final var response = jersey.target(V1_PROJECT + "/" + UUID.randomUUID())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
                 .method("PATCH", Entity.json(new Project()));
-        Assert.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+        Assertions.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
     }
 
     @Test
-    public void patchProjectNotPermittedTest() {
+    void patchProjectNotPermittedTest() {
         enablePortfolioAccessControl();
 
         final var project = new Project();
@@ -1478,7 +1487,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void patchProjectSuccessfullyPatchedTest() {
+    void patchProjectSuccessfullyPatchedTest() {
         final var tags = Stream.of("tag1", "tag2").map(qm::createTag).collect(Collectors.toUnmodifiableList());
         final var p1 = qm.createProject("ABC", "Test project", "1.0", tags, null, null, true, false);
         final var projectManufacturerContact = new OrganizationalContact();
@@ -1524,7 +1533,7 @@ public class ProjectResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
                 .method("PATCH", Entity.json(jsonProject));
-        Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         assertThatJson(getPlainTextBody(response))
                 .withMatcher("projectUuid", equalTo(p1.getUuid().toString()))
                 .isEqualTo("""
@@ -1571,7 +1580,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void patchProjectExternalReferencesTest() {
+    void patchProjectExternalReferencesTest() {
         final var project = qm.createProject("referred-project", "ExtRef test project", "1.0", null, null, null, true, false);
         final var ref1 = new ExternalReference();
         ref1.setType(Type.VCS);
@@ -1590,21 +1599,21 @@ public class ProjectResourceTest extends ResourceTest {
                 .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
                 .method("PATCH", Entity.json(jsonProject));
 
-        Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         final var json = parseJsonObject(response);
         final var patchedExternalReferences = json.getJsonArray("externalReferences");
-        Assert.assertEquals(2, patchedExternalReferences.size());
+        Assertions.assertEquals(2, patchedExternalReferences.size());
         final var patchedRef1 = patchedExternalReferences.getJsonObject(0);
         final var patchedRef2 = patchedExternalReferences.getJsonObject(1);
-        Assert.assertEquals("vcs", patchedRef1.getString("type"));
-        Assert.assertEquals("https://github.com/DependencyTrack/awesomeness", patchedRef1.getString("url"));
-        Assert.assertEquals("website", patchedRef2.getString("type"));
-        Assert.assertEquals("https://dependencytrack.org", patchedRef2.getString("url"));
-        Assert.assertEquals("Worth a visit!", patchedRef2.getString("comment"));
+        Assertions.assertEquals("vcs", patchedRef1.getString("type"));
+        Assertions.assertEquals("https://github.com/DependencyTrack/awesomeness", patchedRef1.getString("url"));
+        Assertions.assertEquals("website", patchedRef2.getString("type"));
+        Assertions.assertEquals("https://dependencytrack.org", patchedRef2.getString("url"));
+        Assertions.assertEquals("Worth a visit!", patchedRef2.getString("comment"));
     }
 
     @Test
-    public void patchProjectParentTest() {
+    void patchProjectParentTest() {
         final Project parent = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         final Project project = qm.createProject("DEF", null, "2.0", null, parent, null, true, false);
         final Project newParent = qm.createProject("GHI", null, "3.0", null, null, null, true, false);
@@ -1650,7 +1659,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void patchProjectParentNotFoundTest() {
+    void patchProjectParentNotFoundTest() {
         final Project parent = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         final Project project = qm.createProject("DEF", null, "2.0", null, parent, null, true, false);
 
@@ -1675,7 +1684,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void patchProjectAsLatestTest() {
+    void patchProjectAsLatestTest() {
         // create project not as latest
         Project project = qm.createProject("ABC", null, "1.0", null, null, null,
                 true, false, false);
@@ -1688,9 +1697,9 @@ public class ProjectResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
                 .method(HttpMethod.PATCH, Entity.json(jsonProject));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertTrue(json.getBoolean("isLatest"));
+        Assertions.assertTrue(json.getBoolean("isLatest"));
 
         // add another project version, "forget" to make it latest
         final Project newProject = qm.createProject("ABC", null, "1.0.1", null, null, null,
@@ -1703,16 +1712,16 @@ public class ProjectResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
                 .method(HttpMethod.PATCH, Entity.json(jsonProject));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         json = parseJsonObject(response);
         // ensure is now latest
-        Assert.assertTrue(json.getBoolean("isLatest"));
+        Assertions.assertTrue(json.getBoolean("isLatest"));
         // ensure old is no longer latest
-        Assert.assertFalse(qm.getProject(project.getName(), project.getVersion()).isLatest());
+        Assertions.assertFalse(qm.getProject(project.getName(), project.getVersion()).isLatest());
     }
 
     @Test
-    public void patchProjectAsLatestWithACLAndAccessTest() {
+    void patchProjectAsLatestWithACLAndAccessTest() {
         enablePortfolioAccessControl();
 
         final var accessLatestProject = new Project();
@@ -1737,17 +1746,17 @@ public class ProjectResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
                 .method(HttpMethod.PATCH, Entity.json(jsonProject));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
         // ensure is now latest
-        Assert.assertTrue(json.getBoolean("isLatest"));
+        Assertions.assertTrue(json.getBoolean("isLatest"));
         // ensure old is no longer latest (bypass db cache)
         qm.getPersistenceManager().refreshAll();
-        Assert.assertFalse(qm.getProject(accessLatestProject.getName(), accessLatestProject.getVersion()).isLatest());
+        Assertions.assertFalse(qm.getProject(accessLatestProject.getName(), accessLatestProject.getVersion()).isLatest());
     }
 
     @Test
-    public void patchProjectAsLatestWithACLAndNoAccessTest() {
+    void patchProjectAsLatestWithACLAndNoAccessTest() {
         enablePortfolioAccessControl();
 
         final var noAccessLatestProject = new Project();
@@ -1771,14 +1780,14 @@ public class ProjectResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
                 .method(HttpMethod.PATCH, Entity.json(jsonProject));
-        Assert.assertEquals(403, response.getStatus(), 0);
+        Assertions.assertEquals(403, response.getStatus(), 0);
         // ensure old is still latest
         qm.getPersistenceManager().refreshAll();
-        Assert.assertTrue(qm.getProject(noAccessLatestProject.getName(), noAccessLatestProject.getVersion()).isLatest());
+        Assertions.assertTrue(qm.getProject(noAccessLatestProject.getName(), noAccessLatestProject.getVersion()).isLatest());
     }
 
     @Test
-    public void getRootProjectsTest() {
+    void getRootProjectsTest() {
         Project parent = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         Project child = qm.createProject("DEF", null, "1.0", null, parent, null, true, false);
         qm.createProject("GHI", null, "1.0", null, child, null, true, false);
@@ -1787,16 +1796,16 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("ABC", json.getJsonObject(0).getString("name"));
-        Assert.assertThrows(IndexOutOfBoundsException.class, () -> json.getJsonObject(1));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("ABC", json.getJsonObject(0).getString("name"));
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> json.getJsonObject(1));
     }
 
     @Test
-    public void getChildrenProjectsTest() {
+    void getChildrenProjectsTest() {
         Project parent = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         Project child = qm.createProject("DEF", null, "1.0", null, parent, null, true, false);
         qm.createProject("GHI", null, "1.0", null, parent, null, true, false);
@@ -1805,16 +1814,16 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(2), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(2), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("DEF", json.getJsonObject(0).getString("name"));
-        Assert.assertEquals("GHI", json.getJsonObject(1).getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("DEF", json.getJsonObject(0).getString("name"));
+        Assertions.assertEquals("GHI", json.getJsonObject(1).getString("name"));
     }
 
     @Test
-    public void updateChildAsParentOfChild() {
+    void updateChildAsParentOfChild() {
         Project parent = qm.createProject("ABC",null, "1.0", null, null, null, true, false);
         Project child = qm.createProject("DEF", null, "1.0", null, parent, null, true, false);
 
@@ -1825,11 +1834,11 @@ public class ProjectResourceTest extends ResourceTest {
         tmpProject.setActive(true);
 
         tmpProject.setParent(child);
-        Assert.assertThrows(IllegalArgumentException.class, () -> qm.updateProject(tmpProject, true));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> qm.updateProject(tmpProject, true));
     }
 
     @Test
-    public void updateParentToInactiveWithActiveChild() {
+    void updateParentToInactiveWithActiveChild() {
         Project parent = qm.createProject("ABC",null, "1.0", null, null, null, true, false);
         qm.createProject("DEF", null, "1.0", null, parent, null, true, false);
 
@@ -1839,11 +1848,11 @@ public class ProjectResourceTest extends ResourceTest {
         tmpProject.setUuid(parent.getUuid());
         tmpProject.setActive(false);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> qm.updateProject(tmpProject, true));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> qm.updateProject(tmpProject, true));
     }
 
     @Test
-    public void updateProjectParentToSelf() {
+    void updateProjectParentToSelf() {
         Project parent = qm.createProject("ABC",null, "1.0", null, null, null, true, false);
 
         Project tmpProject = new Project();
@@ -1853,11 +1862,11 @@ public class ProjectResourceTest extends ResourceTest {
         tmpProject.setActive(parent.isActive());
         tmpProject.setParent(parent);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> qm.updateProject(tmpProject, true));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> qm.updateProject(tmpProject, true));
     }
 
     @Test
-    public void getProjectsWithoutDescendantsOfTest() {
+    void getProjectsWithoutDescendantsOfTest() {
         Project grandParent = qm.createProject("ABC",null, "1.0", null, null, null, true, false);
         Project parent = qm.createProject("DEF", null, "1.0", null, grandParent, null, true, false);
         Project child = qm.createProject("GHI", null, "1.0", null, parent, null, true, false);
@@ -1868,15 +1877,15 @@ public class ProjectResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
 
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("ABC", json.getJsonObject(0).getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("ABC", json.getJsonObject(0).getString("name"));
     }
 
     @Test
-    public void cloneProjectTest() {
+    void cloneProjectTest() {
         EventService.getInstance().subscribe(CloneProjectEvent.class, CloneProjectTask.class);
 
         final var projectManufacturer = new OrganizationalEntity();
@@ -1970,9 +1979,9 @@ public class ProjectResourceTest extends ResourceTest {
 
         assertThat(response.getStatus()).isEqualTo(200);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertNotNull(json.getString("token"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
+        Assertions.assertNotNull(json);
+        Assertions.assertNotNull(json.getString("token"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
 
         await("Cloning completion")
                 .atMost(Duration.ofSeconds(15))
@@ -2074,7 +2083,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void cloneProjectConflictTest() {
+    void cloneProjectConflictTest() {
         final var project = new Project();
         project.setName("acme-app");
         project.setVersion("1.0.0");
@@ -2094,7 +2103,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void cloneProjectWithAclTest() {
+    void cloneProjectWithAclTest() {
         enablePortfolioAccessControl();
 
         final var accessProject = new Project();
@@ -2129,13 +2138,13 @@ public class ProjectResourceTest extends ResourceTest {
                         """.formatted(accessProject.getUuid())));
         assertThat(response.getStatus()).isEqualTo(200);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertNotNull(json.getString("token"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
+        Assertions.assertNotNull(json);
+        Assertions.assertNotNull(json.getString("token"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
     }
 
     @Test
-    public void cloneProjectAsLatestTest() {
+    void cloneProjectAsLatestTest() {
         EventService.getInstance().subscribe(CloneProjectEvent.class, CloneProjectTask.class);
 
         final var project = new Project();
@@ -2155,9 +2164,9 @@ public class ProjectResourceTest extends ResourceTest {
                         """.formatted(project.getUuid())));
         assertThat(response.getStatus()).isEqualTo(200);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertNotNull(json.getString("token"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
+        Assertions.assertNotNull(json);
+        Assertions.assertNotNull(json.getString("token"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
 
         await("Cloning completion")
                 .atMost(Duration.ofSeconds(15))
@@ -2174,7 +2183,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test // https://github.com/DependencyTrack/dependency-track/issues/4413
-    public void cloneProjectWithBrokenDependencyGraphTest() {
+    void cloneProjectWithBrokenDependencyGraphTest() {
         EventService.getInstance().subscribe(CloneProjectEvent.class, CloneProjectTask.class);
 
         final var project = new Project();
@@ -2219,7 +2228,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test // https://github.com/DependencyTrack/dependency-track/issues/3883
-    public void issue3883RegressionTest() {
+    void issue3883RegressionTest() {
         Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -2318,7 +2327,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test // https://github.com/DependencyTrack/dependency-track/issues/4048
-    public void issue4048RegressionTest() {
+    void issue4048RegressionTest() {
         final int projectsPerLevel = 10;
         final int maxDepth = 5;
 
@@ -2390,7 +2399,7 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getLatestProjectTest() {
+    void getLatestProjectTest() {
         qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
         qm.createProject("Acme Example", null, "1.0.2", null, null, null, true, true, false);
         qm.createProject("Different project", null, "1.0.3", null, null, null, true, true, false);
@@ -2399,15 +2408,15 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Acme Example", json.getString("name"));
-        Assert.assertEquals("1.0.2", json.getString("version"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Acme Example", json.getString("name"));
+        Assertions.assertEquals("1.0.2", json.getString("version"));
     }
 
     @Test
-    public void getLatestProjectWithAclEnabledTest() {
+    void getLatestProjectWithAclEnabledTest() {
         enablePortfolioAccessControl();
 
         // Create project and give access to current principal's team.
@@ -2423,15 +2432,15 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("acme-app-a", json.getString("name"));
-        Assert.assertEquals("1.0.2", json.getString("version"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("acme-app-a", json.getString("name"));
+        Assertions.assertEquals("1.0.2", json.getString("version"));
     }
 
     @Test
-    public void getLatestProjectWithAclEnabledNoAccessTest() {
+    void getLatestProjectWithAclEnabledNoAccessTest() {
         enablePortfolioAccessControl();
 
         // Create projects and give NO access
@@ -2442,6 +2451,6 @@ public class ProjectResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(403, response.getStatus(), 0);
+        Assertions.assertEquals(403, response.getStatus(), 0);
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -89,7 +89,7 @@ import static org.hamcrest.Matchers.not;
 class ProjectResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(ProjectResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class)

--- a/src/test/java/org/dependencytrack/resources/v1/RepositoryResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/RepositoryResourceTest.java
@@ -44,7 +44,7 @@ import java.util.List;
 class RepositoryResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(RepositoryResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/RepositoryResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/RepositoryResourceTest.java
@@ -20,7 +20,12 @@ package org.dependencytrack.resources.v1;
 
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import org.dependencytrack.JerseyTestRule;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.Repository;
 import org.dependencytrack.model.RepositoryMetaComponent;
@@ -28,74 +33,68 @@ import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.persistence.DefaultObjectGenerator;
 import org.dependencytrack.persistence.QueryManager;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.util.Date;
 import java.util.List;
 
-public class RepositoryResourceTest extends ResourceTest {
+class RepositoryResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(RepositoryResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(RepositoryResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
-        super.before();
         final var generator = new DefaultObjectGenerator();
         generator.loadDefaultRepositories();
     }
 
     @Test
-    public void getRepositoriesTest() {
+    void getRepositoriesTest() {
         Response response = jersey.target(V1_REPOSITORY).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(17), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(17), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(17, json.size());
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(17, json.size());
         for (int i = 0; i < json.size(); i++) {
-            Assert.assertNotNull(json.getJsonObject(i).getString("type"));
-            Assert.assertNotNull(json.getJsonObject(i).getString("identifier"));
-            Assert.assertNotNull(json.getJsonObject(i).getString("url"));
-            Assert.assertTrue(json.getJsonObject(i).getInt("resolutionOrder") > 0);
-            Assert.assertTrue(json.getJsonObject(i).getBoolean("enabled"));
+            Assertions.assertNotNull(json.getJsonObject(i).getString("type"));
+            Assertions.assertNotNull(json.getJsonObject(i).getString("identifier"));
+            Assertions.assertNotNull(json.getJsonObject(i).getString("url"));
+            Assertions.assertTrue(json.getJsonObject(i).getInt("resolutionOrder") > 0);
+            Assertions.assertTrue(json.getJsonObject(i).getBoolean("enabled"));
         }
     }
 
     @Test
-    public void getRepositoriesByTypeTest() {
+    void getRepositoriesByTypeTest() {
         Response response = jersey.target(V1_REPOSITORY + "/MAVEN").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(5), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(5), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(5, json.size());
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(5, json.size());
         for (int i = 0; i < json.size(); i++) {
-            Assert.assertEquals("MAVEN", json.getJsonObject(i).getString("type"));
-            Assert.assertNotNull(json.getJsonObject(i).getString("identifier"));
-            Assert.assertNotNull(json.getJsonObject(i).getString("url"));
-            Assert.assertTrue(json.getJsonObject(i).getInt("resolutionOrder") > 0);
-            Assert.assertTrue(json.getJsonObject(i).getBoolean("enabled"));
+            Assertions.assertEquals("MAVEN", json.getJsonObject(i).getString("type"));
+            Assertions.assertNotNull(json.getJsonObject(i).getString("identifier"));
+            Assertions.assertNotNull(json.getJsonObject(i).getString("url"));
+            Assertions.assertTrue(json.getJsonObject(i).getInt("resolutionOrder") > 0);
+            Assertions.assertTrue(json.getJsonObject(i).getBoolean("enabled"));
         }
     }
 
     @Test
-    public void getRepositoryMetaComponentTest() {
+    void getRepositoryMetaComponentTest() {
         RepositoryMetaComponent meta = new RepositoryMetaComponent();
         Date lastCheck = new Date();
         meta.setLastCheck(lastCheck);
@@ -109,19 +108,19 @@ public class RepositoryResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("MAVEN", json.getString("repositoryType"));
-        Assert.assertEquals("org.acme", json.getString("namespace"));
-        Assert.assertEquals("example-component", json.getString("name"));
-        Assert.assertEquals("2.0.0", json.getString("latestVersion"));
-        Assert.assertEquals(lastCheck.getTime(), json.getJsonNumber("lastCheck").longValue());
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("MAVEN", json.getString("repositoryType"));
+        Assertions.assertEquals("org.acme", json.getString("namespace"));
+        Assertions.assertEquals("example-component", json.getString("name"));
+        Assertions.assertEquals("2.0.0", json.getString("latestVersion"));
+        Assertions.assertEquals(lastCheck.getTime(), json.getJsonNumber("lastCheck").longValue());
     }
 
     @Test
-    public void getRepositoryMetaComponentInvalidRepoTypeTest() {
+    void getRepositoryMetaComponentInvalidRepoTypeTest() {
         RepositoryMetaComponent meta = new RepositoryMetaComponent();
         Date lastCheck = new Date();
         meta.setLastCheck(lastCheck);
@@ -135,12 +134,12 @@ public class RepositoryResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(204, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(204, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void getRepositoryMetaComponentInvalidPurlTest() {
+    void getRepositoryMetaComponentInvalidPurlTest() {
         RepositoryMetaComponent meta = new RepositoryMetaComponent();
         Date lastCheck = new Date();
         meta.setLastCheck(lastCheck);
@@ -154,26 +153,26 @@ public class RepositoryResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void getRepositoryMetaUntrackedComponentTest() {
+    void getRepositoryMetaUntrackedComponentTest() {
         Response response = jersey.target(V1_REPOSITORY + "/latest")
                 .queryParam("purl", "pkg:/maven/org.acme/example-component@1.0.0")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The repository metadata for the specified component cannot be found.", body);
+        Assertions.assertEquals("The repository metadata for the specified component cannot be found.", body);
     }
 
 
     @Test
-    public void createRepositoryTest() {
+    void createRepositoryTest() {
         Repository repository = new Repository();
         repository.setAuthenticationRequired(true);
         repository.setEnabled(true);
@@ -185,26 +184,26 @@ public class RepositoryResourceTest extends ResourceTest {
         repository.setType(RepositoryType.MAVEN);
         Response response = jersey.target(V1_REPOSITORY).request().header(X_API_KEY, apiKey)
                 .put(Entity.entity(repository, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus());
+        Assertions.assertEquals(201, response.getStatus());
 
 
         response = jersey.target(V1_REPOSITORY).request().header(X_API_KEY, apiKey).get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(18), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(18), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(18, json.size());
-        Assert.assertEquals("MAVEN", json.getJsonObject(13).getString("type"));
-        Assert.assertEquals("test", json.getJsonObject(13).getString("identifier"));
-        Assert.assertEquals("www.foobar.com", json.getJsonObject(13).getString("url"));
-        Assert.assertTrue(json.getJsonObject(13).getInt("resolutionOrder") > 0);
-        Assert.assertTrue(json.getJsonObject(13).getBoolean("authenticationRequired"));
-        Assert.assertEquals("testuser", json.getJsonObject(13).getString("username"));
-        Assert.assertTrue(json.getJsonObject(13).getBoolean("enabled"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(18, json.size());
+        Assertions.assertEquals("MAVEN", json.getJsonObject(13).getString("type"));
+        Assertions.assertEquals("test", json.getJsonObject(13).getString("identifier"));
+        Assertions.assertEquals("www.foobar.com", json.getJsonObject(13).getString("url"));
+        Assertions.assertTrue(json.getJsonObject(13).getInt("resolutionOrder") > 0);
+        Assertions.assertTrue(json.getJsonObject(13).getBoolean("authenticationRequired"));
+        Assertions.assertEquals("testuser", json.getJsonObject(13).getString("username"));
+        Assertions.assertTrue(json.getJsonObject(13).getBoolean("enabled"));
     }
 
     @Test
-    public void createNonInternalRepositoryTest() {
+    void createNonInternalRepositoryTest() {
         Repository repository = new Repository();
         repository.setAuthenticationRequired(true);
         repository.setEnabled(true);
@@ -217,27 +216,27 @@ public class RepositoryResourceTest extends ResourceTest {
         RepositoryResource repositoryResource = new RepositoryResource();
         Response response = jersey.target(V1_REPOSITORY).request().header(X_API_KEY, apiKey)
                 .put(Entity.entity(repository, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus());
+        Assertions.assertEquals(201, response.getStatus());
 
 
         response = jersey.target(V1_REPOSITORY).request().header(X_API_KEY, apiKey).get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(18), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(18), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(18, json.size());
-        Assert.assertEquals("MAVEN", json.getJsonObject(13).getString("type"));
-        Assert.assertEquals("test", json.getJsonObject(13).getString("identifier"));
-        Assert.assertEquals("www.foobar.com", json.getJsonObject(13).getString("url"));
-        Assert.assertTrue(json.getJsonObject(13).getInt("resolutionOrder") > 0);
-        Assert.assertTrue(json.getJsonObject(13).getBoolean("authenticationRequired"));
-        Assert.assertFalse(json.getJsonObject(13).getBoolean("internal"));
-        Assert.assertEquals("testuser", json.getJsonObject(13).getString("username"));
-        Assert.assertTrue(json.getJsonObject(13).getBoolean("enabled"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(18, json.size());
+        Assertions.assertEquals("MAVEN", json.getJsonObject(13).getString("type"));
+        Assertions.assertEquals("test", json.getJsonObject(13).getString("identifier"));
+        Assertions.assertEquals("www.foobar.com", json.getJsonObject(13).getString("url"));
+        Assertions.assertTrue(json.getJsonObject(13).getInt("resolutionOrder") > 0);
+        Assertions.assertTrue(json.getJsonObject(13).getBoolean("authenticationRequired"));
+        Assertions.assertFalse(json.getJsonObject(13).getBoolean("internal"));
+        Assertions.assertEquals("testuser", json.getJsonObject(13).getString("username"));
+        Assertions.assertTrue(json.getJsonObject(13).getBoolean("enabled"));
     }
 
     @Test
-    public void createRepositoryAuthFalseTest() {
+    void createRepositoryAuthFalseTest() {
         Repository repository = new Repository();
         repository.setAuthenticationRequired(false);
         repository.setEnabled(true);
@@ -247,26 +246,26 @@ public class RepositoryResourceTest extends ResourceTest {
         repository.setType(RepositoryType.MAVEN);
         Response response = jersey.target(V1_REPOSITORY).request().header(X_API_KEY, apiKey)
                 .put(Entity.entity(repository, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus());
+        Assertions.assertEquals(201, response.getStatus());
 
 
         response = jersey.target(V1_REPOSITORY).request().header(X_API_KEY, apiKey).get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(18), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(18), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(18, json.size());
-        Assert.assertEquals("MAVEN", json.getJsonObject(13).getString("type"));
-        Assert.assertEquals("test", json.getJsonObject(13).getString("identifier"));
-        Assert.assertEquals("www.foobar.com", json.getJsonObject(13).getString("url"));
-        Assert.assertTrue(json.getJsonObject(13).getInt("resolutionOrder") > 0);
-        Assert.assertFalse(json.getJsonObject(13).getBoolean("authenticationRequired"));
-        Assert.assertTrue(json.getJsonObject(13).getBoolean("enabled"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(18, json.size());
+        Assertions.assertEquals("MAVEN", json.getJsonObject(13).getString("type"));
+        Assertions.assertEquals("test", json.getJsonObject(13).getString("identifier"));
+        Assertions.assertEquals("www.foobar.com", json.getJsonObject(13).getString("url"));
+        Assertions.assertTrue(json.getJsonObject(13).getInt("resolutionOrder") > 0);
+        Assertions.assertFalse(json.getJsonObject(13).getBoolean("authenticationRequired"));
+        Assertions.assertTrue(json.getJsonObject(13).getBoolean("enabled"));
 
     }
 
     @Test
-    public void updateRepositoryTest() throws Exception {
+    void updateRepositoryTest() throws Exception {
         Repository repository = new Repository();
         repository.setAuthenticationRequired(true);
         repository.setEnabled(true);
@@ -278,7 +277,7 @@ public class RepositoryResourceTest extends ResourceTest {
         repository.setType(RepositoryType.MAVEN);
         Response response = jersey.target(V1_REPOSITORY).request().header(X_API_KEY, apiKey)
                 .put(Entity.entity(repository, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus());
+        Assertions.assertEquals(201, response.getStatus());
         try (QueryManager qm = new QueryManager()) {
             List<Repository> repositoryList = qm.getRepositories(RepositoryType.MAVEN).getList(Repository.class);
             for (Repository repository1 : repositoryList) {
@@ -286,14 +285,14 @@ public class RepositoryResourceTest extends ResourceTest {
                     repository1.setAuthenticationRequired(false);
                     response = jersey.target(V1_REPOSITORY).request().header(X_API_KEY, apiKey)
                             .post(Entity.entity(repository1, MediaType.APPLICATION_JSON));
-                    Assert.assertEquals(200, response.getStatus());
+                    Assertions.assertEquals(200, response.getStatus());
                     break;
                 }
             }
             repositoryList = qm.getRepositories(RepositoryType.MAVEN).getList(Repository.class);
             for (Repository repository1 : repositoryList) {
                 if (repository1.getIdentifier().equals("test")) {
-                    Assert.assertEquals(false, repository1.isAuthenticationRequired());
+                    Assertions.assertEquals(false, repository1.isAuthenticationRequired());
                     break;
                 }
             }

--- a/src/test/java/org/dependencytrack/resources/v1/SearchResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/SearchResourceTest.java
@@ -23,32 +23,32 @@ import alpine.event.framework.SingleThreadedEventService;
 import alpine.event.framework.Subscriber;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import org.dependencytrack.JerseyTestRule;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.event.IndexEvent;
 import org.dependencytrack.model.License;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.search.IndexManager;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import jakarta.json.JsonObject;
-import jakarta.ws.rs.core.Response;
 import java.time.Duration;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-public class SearchResourceTest extends ResourceTest {
+class SearchResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(SearchResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(SearchResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
@@ -63,109 +63,104 @@ public class SearchResourceTest extends ResourceTest {
 
     }
 
-    @Before
-    @Override
+    @BeforeEach
     public void before() throws Exception {
-        super.before();
-
         SingleThreadedEventService.getInstance().subscribe(IndexEvent.class, EventSubscriber.class);
     }
 
-    @After
-    @Override
-    public void after() throws Exception {
+    @AfterEach
+    public void after() {
         SingleThreadedEventService.getInstance().unsubscribe(EventSubscriber.class);
         EVENTS.clear();
-        super.after();
     }
 
     @Test
-    public void searchTest() {
+    void searchTest() {
         Response response = jersey.target(V1_SEARCH).queryParam("query", "tomcat").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
+        Assertions.assertNotNull(json);
     }
 
     @Test
-    public void searchProjectTest() {
+    void searchProjectTest() {
         Response response = jersey.target(V1_SEARCH + "/project").queryParam("query", "acme").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
+        Assertions.assertNotNull(json);
     }
 
     @Test
-    public void searchComponentTest() {
+    void searchComponentTest() {
         Response response = jersey.target(V1_SEARCH + "/component").queryParam("query", "bootstrap").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
+        Assertions.assertNotNull(json);
     }
 
     @Test
-    public void searchServiceComponentTest() {
+    void searchServiceComponentTest() {
         Response response = jersey.target(V1_SEARCH + "/service").queryParam("query", "stock-ticker").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
+        Assertions.assertNotNull(json);
     }
 
     @Test
-    public void searchLicenseTest() {
+    void searchLicenseTest() {
         Response response = jersey.target(V1_SEARCH + "/license").queryParam("query", "Apache").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
+        Assertions.assertNotNull(json);
     }
 
     @Test
-    public void searchVulnerabilityTest() {
+    void searchVulnerabilityTest() {
         Response response = jersey.target(V1_SEARCH + "/vulnerability").queryParam("query", "CVE-2020").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
+        Assertions.assertNotNull(json);
     }
 
     @Test
-    public void reindexWithBadIndexTypes() {
+    void reindexWithBadIndexTypes() {
         Response response = jersey.target(V1_SEARCH + "/reindex").queryParam("type", "BAD_TYPE_1", "BAD_TYPE_2").request()
                 .header(X_API_KEY, apiKey)
                 .post(null, Response.class);
-        Assert.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertEquals(400, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("No valid index type was provided", body);
+        Assertions.assertEquals("No valid index type was provided", body);
         assertThat(EVENTS).isEmpty();
     }
 
     @Test
-    public void reindexWithMixedIndexTypes() {
+    void reindexWithMixedIndexTypes() {
         Response response = jersey.target(V1_SEARCH + "/reindex").queryParam("type", "BAD_TYPE_1", IndexManager.IndexType.VULNERABILITY.name(), IndexManager.IndexType.LICENSE).request()
                 .header(X_API_KEY, apiKey)
                 .post(null, Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
+        Assertions.assertNotNull(json);
         String token = json.getString("token");
-        Assert.assertNotNull(token);
+        Assertions.assertNotNull(token);
 
         await("Index event dispatch")
                 .atMost(Duration.ofSeconds(5))

--- a/src/test/java/org/dependencytrack/resources/v1/SearchResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/SearchResourceTest.java
@@ -47,7 +47,7 @@ import static org.awaitility.Awaitility.await;
 class SearchResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(SearchResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
@@ -3,7 +3,11 @@ package org.dependencytrack.resources.v1;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import alpine.server.filters.AuthorizationFilter;
-import org.dependencytrack.JerseyTestRule;
+import jakarta.json.JsonArray;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.NotificationRule;
@@ -17,14 +21,11 @@ import org.dependencytrack.resources.v1.exception.NoSuchElementExceptionMapper;
 import org.dependencytrack.resources.v1.exception.TagOperationFailedExceptionMapper;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import jakarta.json.JsonArray;
-import jakarta.ws.rs.HttpMethod;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -35,11 +36,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.model.ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED;
 import static org.hamcrest.CoreMatchers.equalTo;
 
-public class TagResourceTest extends ResourceTest {
+class TagResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(TagResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(TagResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class)
                     .register(AuthorizationFilter.class)
@@ -48,7 +49,7 @@ public class TagResourceTest extends ResourceTest {
                     .register(TagOperationFailedExceptionMapper.class));
 
     @Test
-    public void getTagsTest() {
+    void getTagsTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 
         qm.createConfigProperty(
@@ -130,7 +131,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTagsWithPaginationTest() {
+    void getTagsWithPaginationTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 
         for (int i = 0; i < 5; i++) {
@@ -195,7 +196,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTagsWithFilterTest() {
+    void getTagsWithFilterTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 
         qm.createTag("foo");
@@ -221,7 +222,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTagsSortByProjectCountTest() {
+    void getTagsSortByProjectCountTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 
         final var projectA = new Project();
@@ -265,7 +266,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void deleteTagsTest() {
+    void deleteTagsTest() {
         initializeWithPermissions(Permissions.TAG_MANAGEMENT);
 
         qm.createTag("foo");
@@ -282,7 +283,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void deleteTagsWhenNotExistsTest() {
+    void deleteTagsWhenNotExistsTest() {
         initializeWithPermissions(Permissions.TAG_MANAGEMENT);
 
         final Response response = jersey.target(V1_TAG)
@@ -305,7 +306,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void deleteTagsWhenAssignedToProjectTest() {
+    void deleteTagsWhenAssignedToProjectTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT, Permissions.TAG_MANAGEMENT);
 
         final Tag unusedTag = qm.createTag("foo");
@@ -329,7 +330,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void deleteTagsWhenAssignedToProjectWithoutPortfolioManagementPermissionTest() {
+    void deleteTagsWhenAssignedToProjectWithoutPortfolioManagementPermissionTest() {
         initializeWithPermissions(Permissions.TAG_MANAGEMENT);
 
         final Tag unusedTag = qm.createTag("foo");
@@ -364,7 +365,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void deleteTagsWhenAssignedToInaccessibleProjectTest() {
+    void deleteTagsWhenAssignedToInaccessibleProjectTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT, Permissions.TAG_MANAGEMENT);
 
         qm.createConfigProperty(
@@ -415,7 +416,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void deleteTagsWhenAssignedToPolicyTest() {
+    void deleteTagsWhenAssignedToPolicyTest() {
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT, Permissions.TAG_MANAGEMENT);
 
         final Tag unusedTag = qm.createTag("foo");
@@ -442,7 +443,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void deleteTagsWhenAssignedToPolicyWithoutPolicyManagementPermissionTest() {
+    void deleteTagsWhenAssignedToPolicyWithoutPolicyManagementPermissionTest() {
         initializeWithPermissions(Permissions.TAG_MANAGEMENT);
 
         final Tag unusedTag = qm.createTag("foo");
@@ -480,7 +481,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void deleteTagsWhenAssignedToNotificationRuleTest() {
+    void deleteTagsWhenAssignedToNotificationRuleTest() {
         initializeWithPermissions(Permissions.TAG_MANAGEMENT, Permissions.SYSTEM_CONFIGURATION);
 
         final Tag unusedTag = qm.createTag("foo");
@@ -507,7 +508,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void deleteTagsWhenAssignedToNotificationRuleWithoutSystemConfigurationPermissionTest() {
+    void deleteTagsWhenAssignedToNotificationRuleWithoutSystemConfigurationPermissionTest() {
         initializeWithPermissions(Permissions.TAG_MANAGEMENT);
 
         final Tag unusedTag = qm.createTag("foo");
@@ -545,7 +546,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createTagsTest() {
+    void createTagsTest() {
         initializeWithPermissions(Permissions.TAG_MANAGEMENT);
 
         final Response response = jersey.target(V1_TAG)
@@ -559,7 +560,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createTagsWithExistingTest() {
+    void createTagsWithExistingTest() {
         initializeWithPermissions(Permissions.TAG_MANAGEMENT);
 
         qm.createTag("foo");
@@ -576,7 +577,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTaggedProjectsTest() {
+    void getTaggedProjectsTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 
         qm.createConfigProperty(
@@ -634,7 +635,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTaggedProjectsWithPaginationTest() {
+    void getTaggedProjectsWithPaginationTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 
         final Tag tag = qm.createTag("foo");
@@ -695,7 +696,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTaggedProjectsWithTagNotExistsTest() {
+    void getTaggedProjectsWithTagNotExistsTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 
         final Response response = jersey.target(V1_TAG + "/foo/project")
@@ -708,7 +709,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTaggedProjectsWithNonLowerCaseTagNameTest() {
+    void getTaggedProjectsWithNonLowerCaseTagNameTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 
         qm.createTag("foo");
@@ -723,7 +724,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void tagProjectsTest() {
+    void tagProjectsTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
 
         final var projectA = new Project();
@@ -757,7 +758,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void tagProjectsWithTagNotExistsTest() {
+    void tagProjectsWithTagNotExistsTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
 
         final var project = new Project();
@@ -780,7 +781,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void tagProjectsWithNoProjectUuidsTest() {
+    void tagProjectsWithNoProjectUuidsTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
 
         qm.createTag("foo");
@@ -803,7 +804,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void tagProjectsWithAclTest() {
+    void tagProjectsWithAclTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
 
         qm.createConfigProperty(
@@ -838,7 +839,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void tagProjectsWhenAlreadyTaggedTest() {
+    void tagProjectsWhenAlreadyTaggedTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
 
         final var project = new Project();
@@ -859,7 +860,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void untagProjectsTest() {
+    void untagProjectsTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
 
         final var projectA = new Project();
@@ -887,7 +888,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void untagProjectsWithAclTest() {
+    void untagProjectsWithAclTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
 
         qm.createConfigProperty(
@@ -925,7 +926,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void untagProjectsWithTagNotExistsTest() {
+    void untagProjectsWithTagNotExistsTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
 
         final var project = new Project();
@@ -949,7 +950,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void untagProjectsWithNoProjectUuidsTest() {
+    void untagProjectsWithNoProjectUuidsTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
 
         qm.createTag("foo");
@@ -973,7 +974,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void untagProjectsWithTooManyProjectUuidsTest() {
+    void untagProjectsWithTooManyProjectUuidsTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
 
         qm.createTag("foo");
@@ -1002,7 +1003,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void untagProjectsWhenNotTaggedTest() {
+    void untagProjectsWhenNotTaggedTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
 
         final var project = new Project();
@@ -1023,7 +1024,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTaggedPoliciesTest() {
+    void getTaggedPoliciesTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 
         final Tag tagFoo = qm.createTag("foo");
@@ -1063,7 +1064,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTaggedPoliciesWithPaginationTest() {
+    void getTaggedPoliciesWithPaginationTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 
         final Tag tag = qm.createTag("foo");
@@ -1126,7 +1127,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTaggedPoliciesWithTagNotExistsTest() {
+    void getTaggedPoliciesWithTagNotExistsTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 
         final Response response = jersey.target(V1_TAG + "/foo/policy")
@@ -1139,7 +1140,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTaggedPoliciesWithNonLowerCaseTagNameTest() {
+    void getTaggedPoliciesWithNonLowerCaseTagNameTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 
         qm.createTag("foo");
@@ -1154,7 +1155,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void tagPoliciesTest() {
+    void tagPoliciesTest() {
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
 
         final var policyA = new Policy();
@@ -1194,7 +1195,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void tagPoliciesWithTagNotExistsTest() {
+    void tagPoliciesWithTagNotExistsTest() {
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
 
         final var policy = new Policy();
@@ -1219,7 +1220,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void tagPoliciesWithNoPolicyUuidsTest() {
+    void tagPoliciesWithNoPolicyUuidsTest() {
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
 
         qm.createTag("foo");
@@ -1242,7 +1243,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void untagPoliciesTest() {
+    void untagPoliciesTest() {
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
 
         final var policyA = new Policy();
@@ -1274,7 +1275,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void untagPoliciesWithTagNotExistsTest() {
+    void untagPoliciesWithTagNotExistsTest() {
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
 
         final var policy = new Policy();
@@ -1300,7 +1301,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void untagPoliciesWithNoProjectUuidsTest() {
+    void untagPoliciesWithNoProjectUuidsTest() {
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
 
         qm.createTag("foo");
@@ -1324,7 +1325,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void untagPoliciesWithTooManyPolicyUuidsTest() {
+    void untagPoliciesWithTooManyPolicyUuidsTest() {
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
 
         qm.createTag("foo");
@@ -1353,7 +1354,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void untagPoliciesWhenNotTaggedTest() {
+    void untagPoliciesWhenNotTaggedTest() {
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
 
         final var policy = new Policy();
@@ -1376,7 +1377,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTagsForPolicyWithOrderingTest() {
+    void getTagsForPolicyWithOrderingTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 
         for (int i = 1; i < 5; i++) {
@@ -1391,16 +1392,16 @@ public class TagResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .get();
 
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals(String.valueOf(4), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals(String.valueOf(4), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(4, json.size());
-        Assert.assertEquals("tag 2", json.getJsonObject(0).getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(4, json.size());
+        Assertions.assertEquals("tag 2", json.getJsonObject(0).getString("name"));
     }
 
     @Test
-    public void getTagsForPolicyWithPolicyProjectsFilterTest() {
+    void getTagsForPolicyWithPolicyProjectsFilterTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 
         for (int i = 1; i < 5; i++) {
@@ -1418,16 +1419,16 @@ public class TagResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .get();
 
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(3, json.size());
-        Assert.assertEquals("tag 1", json.getJsonObject(0).getString("name"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(3, json.size());
+        Assertions.assertEquals("tag 1", json.getJsonObject(0).getString("name"));
     }
 
     @Test
-    public void getTaggedNotificationRulesTest() {
+    void getTaggedNotificationRulesTest() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION);
 
         final Tag tagFoo = qm.createTag("foo");
@@ -1467,7 +1468,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTaggedNotificationRulesWithPaginationTest() {
+    void getTaggedNotificationRulesWithPaginationTest() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION);
 
         final Tag tag = qm.createTag("foo");
@@ -1530,7 +1531,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTaggedNotificationRulesWithTagNotExistsTest() {
+    void getTaggedNotificationRulesWithTagNotExistsTest() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION);
 
         final Response response = jersey.target(V1_TAG + "/foo/notificationRule")
@@ -1543,7 +1544,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTaggedNotificationRulesWithNonLowerCaseTagNameTest() {
+    void getTaggedNotificationRulesWithNonLowerCaseTagNameTest() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION);
 
         qm.createTag("foo");
@@ -1558,7 +1559,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void tagNotificationRulesTest() {
+    void tagNotificationRulesTest() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION);
 
         final var notificationRuleA = new NotificationRule();
@@ -1598,7 +1599,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void tagNotificationRulesWithTagNotExistsTest() {
+    void tagNotificationRulesWithTagNotExistsTest() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION);
 
         final var notificationRule = new NotificationRule();
@@ -1623,7 +1624,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void tagNotificationRulesWithNoRuleUuidsTest() {
+    void tagNotificationRulesWithNoRuleUuidsTest() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION);
 
         qm.createTag("foo");
@@ -1646,7 +1647,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void untagNotificationRulesTest() {
+    void untagNotificationRulesTest() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION);
 
         final var notificationRuleA = new NotificationRule();
@@ -1678,7 +1679,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void untagNotificationRulesWithTagNotExistsTest() {
+    void untagNotificationRulesWithTagNotExistsTest() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION);
 
         final var notificationRule = new NotificationRule();
@@ -1704,7 +1705,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void untagNotificationRulesWithNoProjectUuidsTest() {
+    void untagNotificationRulesWithNoProjectUuidsTest() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION);
 
         qm.createTag("foo");
@@ -1728,7 +1729,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void untagNotificationRulesWithTooManyRuleUuidsTest() {
+    void untagNotificationRulesWithTooManyRuleUuidsTest() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION);
 
         qm.createTag("foo");
@@ -1757,7 +1758,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void untagNotificationRulesWhenNotTaggedTest() {
+    void untagNotificationRulesWhenNotTaggedTest() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION);
 
         final var notificationRule = new NotificationRule();
@@ -1780,7 +1781,7 @@ public class TagResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getTagWithNonUuidNameTest() {
+    void getTagWithNonUuidNameTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 
         // NB: This is just to ensure that requests to /api/v1/tag/<value>

--- a/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 import java.util.Collections;
 import java.util.List;
@@ -36,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.model.ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED;
 import static org.hamcrest.CoreMatchers.equalTo;
 
+@DefaultLocale("en-US")
 class TagResourceTest extends ResourceTest {
 
     @RegisterExtension

--- a/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
@@ -21,9 +21,8 @@ import org.dependencytrack.resources.v1.exception.NoSuchElementExceptionMapper;
 import org.dependencytrack.resources.v1.exception.TagOperationFailedExceptionMapper;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.jupiter.api.Test;
-
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junitpioneer.jupiter.DefaultLocale;
 
@@ -41,7 +40,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 class TagResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(TagResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class)

--- a/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
@@ -57,7 +57,7 @@ class TeamResourceTest extends ResourceTest {
     private Team userNotPartof;
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(TeamResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/UserResourceAuthenticatedTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/UserResourceAuthenticatedTest.java
@@ -25,96 +25,101 @@ import alpine.model.Team;
 import alpine.server.auth.JsonWebToken;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import org.dependencytrack.JerseyTestRule;
-import org.dependencytrack.ResourceTest;
-import org.dependencytrack.model.IdentifiableObject;
-import org.glassfish.jersey.client.ClientProperties;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.model.IdentifiableObject;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import java.util.UUID;
 
-public class UserResourceAuthenticatedTest extends ResourceTest {
+class UserResourceAuthenticatedTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(UserResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(UserResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
     private ManagedUser testUser;
     private String jwt;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
-        super.before();
         testUser = qm.createManagedUser("testuser", TEST_USER_PASSWORD_HASH);
         this.jwt = new JsonWebToken().createToken(testUser);
         qm.addUserToTeam(testUser, team);
     }
 
+    @AfterEach
+    public void after() {
+        qm.delete(testUser);
+    }
+
     @Test
-    public void getManagedUsersTest() {
+    void getManagedUsersTest() {
         for (int i=0; i<1000; i++) {
             qm.createManagedUser("managed-user-" + i, TEST_USER_PASSWORD_HASH);
         }
         Response response = jersey.target(V1_USER + "/managed").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(1001), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(1001), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(1001, json.size()); // There's already a built-in managed user in ResourceTest
-        Assert.assertEquals("managed-user-0", json.getJsonObject(0).getString("username"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(1001, json.size()); // There's already a built-in managed user in ResourceTest
+        Assertions.assertEquals("managed-user-0", json.getJsonObject(0).getString("username"));
     }
 
     @Test
-    public void getLdapUsersTest() {
+    void getLdapUsersTest() {
         for (int i=0; i<1000; i++) {
             qm.createLdapUser("ldap-user-" + i);
         }
         Response response = jersey.target(V1_USER + "/ldap").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(1000), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(1000), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(1000, json.size());
-        Assert.assertEquals("ldap-user-0", json.getJsonObject(0).getString("username"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(1000, json.size());
+        Assertions.assertEquals("ldap-user-0", json.getJsonObject(0).getString("username"));
     }
 
     @Test
-    public void getSelfTest() {
+    void getSelfTest() {
         Response response = jersey.target(V1_USER + "/self").request()
                 .header("Authorization", "Bearer " + jwt)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("testuser", json.getString("username"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("testuser", json.getString("username"));
     }
 
     @Test
-    public void getSelfNonUserTest() {
+    void getSelfNonUserTest() {
         Response response = jersey.target(V1_USER + "/self").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(401, response.getStatus(), 0);
+        Assertions.assertEquals(401, response.getStatus(), 0);
     }
 
     @Test
-    public void updateSelfTest() {
+    void updateSelfTest() {
         ManagedUser user = new ManagedUser();
         user.setUsername(testUser.getUsername());
         user.setFullname("Captain BlackBeard");
@@ -122,16 +127,16 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/self").request()
                 .header("Authorization", "Bearer " + jwt)
                 .post(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Captain BlackBeard", json.getString("fullname"));
-        Assert.assertEquals("blackbeard@example.com", json.getString("email"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Captain BlackBeard", json.getString("fullname"));
+        Assertions.assertEquals("blackbeard@example.com", json.getString("email"));
     }
 
     @Test
-    public void updateSelfInvalidFullnameTest() {
+    void updateSelfInvalidFullnameTest() {
         ManagedUser user = new ManagedUser();
         user.setUsername(testUser.getUsername());
         user.setFullname("");
@@ -139,13 +144,13 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/self").request()
                 .header("Authorization", "Bearer " + jwt)
                 .post(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertEquals(400, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("Full name is required.", body);
+        Assertions.assertEquals("Full name is required.", body);
     }
 
     @Test
-    public void updateSelfInvalidEmailTest() {
+    void updateSelfInvalidEmailTest() {
         ManagedUser user = new ManagedUser();
         user.setUsername(testUser.getUsername());
         user.setFullname("Captain BlackBeard");
@@ -153,23 +158,23 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/self").request()
                 .header("Authorization", "Bearer " + jwt)
                 .post(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertEquals(400, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("Email address is required.", body);
+        Assertions.assertEquals("Email address is required.", body);
     }
 
     @Test
-    public void updateSelfUnauthorizedTest() {
+    void updateSelfUnauthorizedTest() {
         ManagedUser user = new ManagedUser();
         user.setUsername(testUser.getUsername());
         Response response = jersey.target(V1_USER + "/self").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(401, response.getStatus(), 0);
+        Assertions.assertEquals(401, response.getStatus(), 0);
     }
 
     @Test
-    public void updateSelfPasswordsTest() {
+    void updateSelfPasswordsTest() {
         ManagedUser user = new ManagedUser();
         user.setUsername(testUser.getUsername());
         user.setFullname("Captain BlackBeard");
@@ -179,16 +184,16 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/self").request()
                 .header("Authorization", "Bearer " + jwt)
                 .post(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Captain BlackBeard", json.getString("fullname"));
-        Assert.assertEquals("blackbeard@example.com", json.getString("email"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Captain BlackBeard", json.getString("fullname"));
+        Assertions.assertEquals("blackbeard@example.com", json.getString("email"));
     }
 
     @Test
-    public void updateSelfPasswordMismatchTest() {
+    void updateSelfPasswordMismatchTest() {
         ManagedUser user = new ManagedUser();
         user.setUsername(testUser.getUsername());
         user.setFullname("Captain BlackBeard");
@@ -198,52 +203,52 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/self").request()
                 .header("Authorization", "Bearer " + jwt)
                 .post(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertEquals(400, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("Passwords do not match.", body);
+        Assertions.assertEquals("Passwords do not match.", body);
     }
 
     @Test
-    public void createLdapUserTest() {
+    void createLdapUserTest() {
         LdapUser user = new LdapUser();
         user.setUsername("blackbeard");
         Response response = jersey.target(V1_USER + "/ldap").request()
                 .header("Authorization", "Bearer " + jwt)
                 .put(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("blackbeard", json.getString("username"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("blackbeard", json.getString("username"));
     }
 
     @Test
-    public void createLdapUserInvalidUsernameTest() {
+    void createLdapUserInvalidUsernameTest() {
         LdapUser user = new LdapUser();
         user.setUsername("");
         Response response = jersey.target(V1_USER + "/ldap").request()
                 .header("Authorization", "Bearer " + jwt)
                 .put(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertEquals(400, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("Username cannot be null or blank.", body);
+        Assertions.assertEquals("Username cannot be null or blank.", body);
     }
 
     @Test
-    public void createLdapUserDuplicateUsernameTest() {
+    void createLdapUserDuplicateUsernameTest() {
         qm.createLdapUser("blackbeard");
         LdapUser user = new LdapUser();
         user.setUsername("blackbeard");
         Response response = jersey.target(V1_USER + "/ldap").request()
                 .header("Authorization", "Bearer " + jwt)
                 .put(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(409, response.getStatus(), 0);
+        Assertions.assertEquals(409, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("A user with the same username already exists. Cannot create new user.", body);
+        Assertions.assertEquals("A user with the same username already exists. Cannot create new user.", body);
     }
 
     @Test
-    public void deleteLdapUserTest() {
+    void deleteLdapUserTest() {
         qm.createLdapUser("blackbeard");
         LdapUser user = new LdapUser();
         user.setUsername("blackbeard");
@@ -252,11 +257,11 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true) // HACK
                 .method("DELETE", Entity.entity(user, MediaType.APPLICATION_JSON)); // HACK
         // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
-        Assert.assertEquals(204, response.getStatus(), 0);
+        Assertions.assertEquals(204, response.getStatus(), 0);
     }
 
     @Test
-    public void createManagedUserTest() {
+    void createManagedUserTest() {
         ManagedUser user = new ManagedUser();
         user.setFullname("Captain BlackBeard");
         user.setEmail("blackbeard@example.com");
@@ -266,17 +271,17 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/managed").request()
                 .header("Authorization", "Bearer " + jwt)
                 .put(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Captain BlackBeard", json.getString("fullname"));
-        Assert.assertEquals("blackbeard@example.com", json.getString("email"));
-        Assert.assertEquals("blackbeard", json.getString("username"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Captain BlackBeard", json.getString("fullname"));
+        Assertions.assertEquals("blackbeard@example.com", json.getString("email"));
+        Assertions.assertEquals("blackbeard", json.getString("username"));
     }
 
     @Test
-    public void createManagedUserInvalidUsernameTest() {
+    void createManagedUserInvalidUsernameTest() {
         ManagedUser user = new ManagedUser();
         user.setFullname("Captain BlackBeard");
         user.setEmail("blackbeard@example.com");
@@ -286,14 +291,14 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/managed").request()
                 .header("Authorization", "Bearer " + jwt)
                 .put(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("Username cannot be null or blank.", body);
+        Assertions.assertEquals("Username cannot be null or blank.", body);
     }
 
     @Test
-    public void createManagedUserInvalidFullnameTest() {
+    void createManagedUserInvalidFullnameTest() {
         ManagedUser user = new ManagedUser();
         user.setFullname("");
         user.setEmail("blackbeard@example.com");
@@ -303,14 +308,14 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/managed").request()
                 .header("Authorization", "Bearer " + jwt)
                 .put(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The users full name is missing.", body);
+        Assertions.assertEquals("The users full name is missing.", body);
     }
 
     @Test
-    public void createManagedUserInvalidEmailTest() {
+    void createManagedUserInvalidEmailTest() {
         ManagedUser user = new ManagedUser();
         user.setFullname("Captain BlackBeard");
         user.setEmail("");
@@ -320,14 +325,14 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/managed").request()
                 .header("Authorization", "Bearer " + jwt)
                 .put(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The users email address is missing.", body);
+        Assertions.assertEquals("The users email address is missing.", body);
     }
 
     @Test
-    public void createManagedUserInvalidPasswordTest() {
+    void createManagedUserInvalidPasswordTest() {
         ManagedUser user = new ManagedUser();
         user.setFullname("Captain BlackBeard");
         user.setEmail("blackbeard@example.com");
@@ -337,14 +342,14 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/managed").request()
                 .header("Authorization", "Bearer " + jwt)
                 .put(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("A password must be set.", body);
+        Assertions.assertEquals("A password must be set.", body);
     }
 
     @Test
-    public void createManagedUserPasswordMismatchTest() {
+    void createManagedUserPasswordMismatchTest() {
         ManagedUser user = new ManagedUser();
         user.setFullname("Captain BlackBeard");
         user.setEmail("blackbeard@example.com");
@@ -354,14 +359,14 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/managed").request()
                 .header("Authorization", "Bearer " + jwt)
                 .put(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The passwords do not match.", body);
+        Assertions.assertEquals("The passwords do not match.", body);
     }
 
     @Test
-    public void createManagedUserDuplicateUsernameTest() {
+    void createManagedUserDuplicateUsernameTest() {
         qm.createManagedUser("blackbeard", TEST_USER_PASSWORD_HASH);
         ManagedUser user = new ManagedUser();
         user.setFullname("Captain BlackBeard");
@@ -372,14 +377,14 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/managed").request()
                 .header("Authorization", "Bearer " + jwt)
                 .put(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(409, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(409, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("A user with the same username already exists. Cannot create new user.", body);
+        Assertions.assertEquals("A user with the same username already exists. Cannot create new user.", body);
     }
 
     @Test
-    public void updateManagedUserTest() {
+    void updateManagedUserTest() {
         qm.createManagedUser("blackbeard", "Captain BlackBeard", "blackbeard@example.com", TEST_USER_PASSWORD_HASH, false, false, false);
         ManagedUser user = new ManagedUser();
         user.setUsername("blackbeard");
@@ -391,19 +396,19 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/managed").request()
                 .header("Authorization", "Bearer " + jwt)
                 .post(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Dr BlackBeard, Ph.D.", json.getString("fullname"));
-        Assert.assertEquals("blackbeard@example.com", json.getString("email"));
-        Assert.assertTrue(json.getBoolean("forcePasswordChange"));
-        Assert.assertTrue(json.getBoolean("nonExpiryPassword"));
-        Assert.assertTrue(json.getBoolean("suspended"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Dr BlackBeard, Ph.D.", json.getString("fullname"));
+        Assertions.assertEquals("blackbeard@example.com", json.getString("email"));
+        Assertions.assertTrue(json.getBoolean("forcePasswordChange"));
+        Assertions.assertTrue(json.getBoolean("nonExpiryPassword"));
+        Assertions.assertTrue(json.getBoolean("suspended"));
     }
 
     @Test
-    public void updateManagedUserInvalidFullnameTest() {
+    void updateManagedUserInvalidFullnameTest() {
         qm.createManagedUser("blackbeard", "Captain BlackBeard", "blackbeard@example.com", TEST_USER_PASSWORD_HASH, false, false, false);
         ManagedUser user = new ManagedUser();
         user.setUsername("blackbeard");
@@ -415,14 +420,14 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/managed").request()
                 .header("Authorization", "Bearer " + jwt)
                 .post(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The users full name is missing.", body);
+        Assertions.assertEquals("The users full name is missing.", body);
     }
 
     @Test
-    public void updateManagedUserInvalidEmailTest() {
+    void updateManagedUserInvalidEmailTest() {
         qm.createManagedUser("blackbeard", "Captain BlackBeard", "blackbeard@example.com", TEST_USER_PASSWORD_HASH, false, false, false);
         ManagedUser user = new ManagedUser();
         user.setUsername("blackbeard");
@@ -434,14 +439,14 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/managed").request()
                 .header("Authorization", "Bearer " + jwt)
                 .post(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The users email address is missing.", body);
+        Assertions.assertEquals("The users email address is missing.", body);
     }
 
     @Test
-    public void updateManagedUserInvalidUsernameTest() {
+    void updateManagedUserInvalidUsernameTest() {
         qm.createManagedUser("blackbeard", "Captain BlackBeard", "blackbeard@example.com", TEST_USER_PASSWORD_HASH, false, false, false);
         ManagedUser user = new ManagedUser();
         user.setUsername("");
@@ -453,14 +458,14 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/managed").request()
                 .header("Authorization", "Bearer " + jwt)
                 .post(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The user could not be found.", body);
+        Assertions.assertEquals("The user could not be found.", body);
     }
 
     @Test
-    public void deleteManagedUserTest() {
+    void deleteManagedUserTest() {
         qm.createManagedUser("blackbeard", "Captain BlackBeard", "blackbeard@example.com", TEST_USER_PASSWORD_HASH, false, false, false);
         ManagedUser user = new ManagedUser();
         user.setUsername("blackbeard");
@@ -469,38 +474,38 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true) // HACK
                 .method("DELETE", Entity.entity(user, MediaType.APPLICATION_JSON)); // HACK
         // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
-        Assert.assertEquals(204, response.getStatus(), 0);
+        Assertions.assertEquals(204, response.getStatus(), 0);
     }
 
     @Test
-    public void createOidcUserTest() {
+    void createOidcUserTest() {
         final OidcUser user = new OidcUser();
         user.setUsername("blackbeard");
         Response response = jersey.target(V1_USER + "/oidc").request()
                 .header("Authorization", "Bearer " + jwt)
                 .put(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(201, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("blackbeard", json.getString("username"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("blackbeard", json.getString("username"));
     }
 
     @Test
-    public void createOidcUserDuplicateUsernameTest() {
+    void createOidcUserDuplicateUsernameTest() {
         qm.createOidcUser("blackbeard");
         final OidcUser user = new OidcUser();
         user.setUsername("blackbeard");
         Response response = jersey.target(V1_USER + "/oidc").request()
                 .header("Authorization", "Bearer " + jwt)
                 .put(Entity.entity(user, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(409, response.getStatus(), 0);
+        Assertions.assertEquals(409, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("A user with the same username already exists. Cannot create new user.", body);
+        Assertions.assertEquals("A user with the same username already exists. Cannot create new user.", body);
     }
 
     @Test
-    public void deleteOidcUserTest() {
+    void deleteOidcUserTest() {
         qm.createOidcUser("blackbeard");
         OidcUser user = new OidcUser();
         user.setUsername("blackbeard");
@@ -509,11 +514,11 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true) // HACK
                 .method("DELETE", Entity.entity(user, MediaType.APPLICATION_JSON)); // HACK
         // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
-        Assert.assertEquals(204, response.getStatus(), 0);
+        Assertions.assertEquals(204, response.getStatus(), 0);
     }
 
     @Test
-    public void addTeamToUserTest() {
+    void addTeamToUserTest() {
         qm.createManagedUser("blackbeard", "Captain BlackBeard", "blackbeard@example.com", TEST_USER_PASSWORD_HASH, false, false, false);
         Team team = qm.createTeam("Pirates");
         IdentifiableObject ido = new IdentifiableObject();
@@ -523,19 +528,19 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/blackbeard/membership").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(ido, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Captain BlackBeard", json.getString("fullname"));
-        Assert.assertEquals("blackbeard@example.com", json.getString("email"));
-        Assert.assertFalse(json.getBoolean("forcePasswordChange"));
-        Assert.assertFalse(json.getBoolean("nonExpiryPassword"));
-        Assert.assertFalse(json.getBoolean("suspended"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Captain BlackBeard", json.getString("fullname"));
+        Assertions.assertEquals("blackbeard@example.com", json.getString("email"));
+        Assertions.assertFalse(json.getBoolean("forcePasswordChange"));
+        Assertions.assertFalse(json.getBoolean("nonExpiryPassword"));
+        Assertions.assertFalse(json.getBoolean("suspended"));
     }
 
     @Test
-    public void addTeamToUserInvalidTeamTest() {
+    void addTeamToUserInvalidTeamTest() {
         qm.createManagedUser("blackbeard", "Captain BlackBeard", "blackbeard@example.com", TEST_USER_PASSWORD_HASH, false, false, false);
         IdentifiableObject ido = new IdentifiableObject();
         ido.setUuid(UUID.randomUUID().toString());
@@ -544,14 +549,14 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/blackbeard/membership").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(ido, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The team could not be found.", body);
+        Assertions.assertEquals("The team could not be found.", body);
     }
 
     @Test
-    public void addTeamToUserInvalidUserTest() {
+    void addTeamToUserInvalidUserTest() {
         Team team = qm.createTeam("Pirates");
         IdentifiableObject ido = new IdentifiableObject();
         ido.setUuid(team.getUuid().toString());
@@ -560,14 +565,14 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/blackbeard/membership").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(ido, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The user could not be found.", body);
+        Assertions.assertEquals("The user could not be found.", body);
     }
 
     @Test
-    public void addTeamToUserDuplicateMembershipTest() {
+    void addTeamToUserDuplicateMembershipTest() {
         Team team = qm.createTeam("Pirates");
         ManagedUser user = qm.createManagedUser("blackbeard", "Captain BlackBeard", "blackbeard@example.com", TEST_USER_PASSWORD_HASH, false, false, false);
         qm.addUserToTeam(user, team);
@@ -576,15 +581,15 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/blackbeard/membership").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(ido, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(304, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(304, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
         // TODO: Possible bug in Jersey? The response entity is set in the resource, but blank in the actual response.
-        //Assert.assertEquals("The user is already a member of the specified team.", body);
+        //Assertions.assertEquals("The user is already a member of the specified team.", body);
     }
 
     @Test
-    public void removeTeamFromUserTest() {
+    void removeTeamFromUserTest() {
         Team team = qm.createTeam("Pirates");
         ManagedUser user = qm.createManagedUser("blackbeard", "Captain BlackBeard", "blackbeard@example.com", TEST_USER_PASSWORD_HASH, false, false, false);
         qm.addUserToTeam(user, team);
@@ -595,6 +600,6 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true) // HACK
                 .method("DELETE", Entity.entity(ido, MediaType.APPLICATION_JSON)); // HACK
         // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/UserResourceAuthenticatedTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/UserResourceAuthenticatedTest.java
@@ -46,7 +46,7 @@ import java.util.UUID;
 class UserResourceAuthenticatedTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(UserResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/UserResourceUnauthenticatedTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/UserResourceUnauthenticatedTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class UserResourceUnauthenticatedTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(UserResource.class)
                     .register(ApiFilter.class));
 

--- a/src/test/java/org/dependencytrack/resources/v1/UserResourceUnauthenticatedTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/UserResourceUnauthenticatedTest.java
@@ -21,51 +21,49 @@ package org.dependencytrack.resources.v1;
 import alpine.model.ManagedUser;
 import alpine.server.auth.PasswordService;
 import alpine.server.filters.ApiFilter;
-import org.dependencytrack.JerseyTestRule;
-import org.dependencytrack.ResourceTest;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Form;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class UserResourceUnauthenticatedTest extends ResourceTest {
+class UserResourceUnauthenticatedTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(UserResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(UserResource.class)
                     .register(ApiFilter.class));
 
     private ManagedUser testUser;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
-        super.before();
         testUser = qm.createManagedUser("testuser", TEST_USER_PASSWORD_HASH);
         qm.addUserToTeam(testUser, team);
     }
 
     @Test
-    public void validateCredentialsTest() {
+    void validateCredentialsTest() {
         Form form = new Form();
         form.param("username", "testuser");
         form.param("password", "testuser");
         Response response = jersey.target(V1_USER + "/login").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         String token = getPlainTextBody(response);
-        Assert.assertNotNull(token);
-        //Assert.assertEquals(token, response.getCookies().get("Authorization-Token").getValue());
+        Assertions.assertNotNull(token);
+        //Assertions.assertEquals(token, response.getCookies().get("Authorization-Token").getValue());
     }
 
     @Test
-    public void validateCredentialsSuspendedTest() {
+    void validateCredentialsSuspendedTest() {
         ManagedUser user = qm.getManagedUser("testuser");
         user.setSuspended(true);
         qm.persist(user);
@@ -75,22 +73,22 @@ public class UserResourceUnauthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/login").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
-        Assert.assertEquals(403, response.getStatus(), 0);
+        Assertions.assertEquals(403, response.getStatus(), 0);
     }
 
     @Test
-    public void validateCredentialsUnauthorizedTest() {
+    void validateCredentialsUnauthorizedTest() {
         Form form = new Form();
         form.param("username", "testuser");
         form.param("password", "wrong");
         Response response = jersey.target(V1_USER + "/login").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
-        Assert.assertEquals(401, response.getStatus(), 0);
+        Assertions.assertEquals(401, response.getStatus(), 0);
     }
 
     @Test
-    public void validateOidcAccessTokenOidcNotAvailableTest() {
+    void validateOidcAccessTokenOidcNotAvailableTest() {
         final Form form = new Form();
         form.param("accessToken", "accessToken");
 
@@ -98,48 +96,48 @@ public class UserResourceUnauthenticatedTest extends ResourceTest {
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
 
         // OIDC is disabled by default
-        Assert.assertEquals(204, response.getStatus());
+        Assertions.assertEquals(204, response.getStatus());
     }
 
     @Test
-    public void forceChangePasswordTest() {
+    void forceChangePasswordTest() {
         Form form = new Form();
         form.param("username", "testuser");
         form.param("password", "testuser");
         form.param("newPassword", "Password1!");
         form.param("confirmPassword", "Password1!");
-        Assert.assertTrue(PasswordService.matches("testuser".toCharArray(), testUser));
+        Assertions.assertTrue(PasswordService.matches("testuser".toCharArray(), testUser));
         Response response = jersey.target(V1_USER + "/forceChangePassword").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         qm.getPersistenceManager().refresh(testUser);
-        Assert.assertTrue(PasswordService.matches("Password1!".toCharArray(), testUser));
+        Assertions.assertTrue(PasswordService.matches("Password1!".toCharArray(), testUser));
     }
 
     @Test
-    public void forceChangePasswordFlagResetTest() {
+    void forceChangePasswordFlagResetTest() {
         testUser.setForcePasswordChange(true);
         qm.persist(testUser);
         qm.getPersistenceManager().refresh(testUser);
-        Assert.assertTrue(testUser.isForcePasswordChange());
+        Assertions.assertTrue(testUser.isForcePasswordChange());
         Form form = new Form();
         form.param("username", "testuser");
         form.param("password", "testuser");
         form.param("newPassword", "Password1!");
         form.param("confirmPassword", "Password1!");
-        Assert.assertTrue(PasswordService.matches("testuser".toCharArray(), testUser));
+        Assertions.assertTrue(PasswordService.matches("testuser".toCharArray(), testUser));
         Response response = jersey.target(V1_USER + "/forceChangePassword").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         qm.getPersistenceManager().refresh(testUser);
-        Assert.assertTrue(PasswordService.matches("Password1!".toCharArray(), testUser));
-        Assert.assertFalse(testUser.isForcePasswordChange());
+        Assertions.assertTrue(PasswordService.matches("Password1!".toCharArray(), testUser));
+        Assertions.assertFalse(testUser.isForcePasswordChange());
     }
 
     @Test
-    public void forceChangePasswordMismatchTest() {
+    void forceChangePasswordMismatchTest() {
         Form form = new Form();
         form.param("username", "testuser");
         form.param("password", "testuser");
@@ -148,14 +146,14 @@ public class UserResourceUnauthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/forceChangePassword").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
-        Assert.assertEquals(406, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(406, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The passwords do not match. Password not changed.", body);
+        Assertions.assertEquals("The passwords do not match. Password not changed.", body);
     }
 
     @Test
-    public void forceChangePasswordUnchangedTest() {
+    void forceChangePasswordUnchangedTest() {
         Form form = new Form();
         form.param("username", "testuser");
         form.param("password", "testuser");
@@ -164,14 +162,14 @@ public class UserResourceUnauthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/forceChangePassword").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
-        Assert.assertEquals(406, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(406, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("Existing password is the same as new password. Password not changed.", body);
+        Assertions.assertEquals("Existing password is the same as new password. Password not changed.", body);
     }
 
     @Test
-    public void forceChangePasswordSuspendedTest() {
+    void forceChangePasswordSuspendedTest() {
         testUser.setSuspended(true);
         qm.persist(testUser);
         Form form = new Form();
@@ -182,14 +180,14 @@ public class UserResourceUnauthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/forceChangePassword").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
-        Assert.assertEquals(403, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(403, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("SUSPENDED", body);
+        Assertions.assertEquals("SUSPENDED", body);
     }
 
     @Test
-    public void forceChangePasswordInvalidCredsTest() {
+    void forceChangePasswordInvalidCredsTest() {
         Form form = new Form();
         form.param("username", "testuser");
         form.param("password", "blah");
@@ -198,9 +196,9 @@ public class UserResourceUnauthenticatedTest extends ResourceTest {
         Response response = jersey.target(V1_USER + "/forceChangePassword").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
-        Assert.assertEquals(401, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(401, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("INVALID_CREDENTIALS", body);
+        Assertions.assertEquals("INVALID_CREDENTIALS", body);
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
@@ -21,7 +21,10 @@ package org.dependencytrack.resources.v1;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import com.fasterxml.jackson.core.StreamReadConstraints;
-import org.dependencytrack.JerseyTestRule;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.AnalysisResponse;
@@ -38,13 +41,11 @@ import org.dependencytrack.resources.v1.exception.JsonMappingExceptionMapper;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
@@ -57,18 +58,18 @@ import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_T
 import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE;
 import static org.hamcrest.CoreMatchers.equalTo;
 
-public class VexResourceTest extends ResourceTest {
+class VexResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(VexResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(VexResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class)
                     .register(MultiPartFeature.class)
                     .register(JsonMappingExceptionMapper.class));
 
     @Test
-    public void exportProjectAsCycloneDxTest() {
+    void exportProjectAsCycloneDxTest() {
         var vulnA = new Vulnerability();
         vulnA.setVulnId("INT-001");
         vulnA.setSource(Vulnerability.Source.INTERNAL);
@@ -220,7 +221,7 @@ public class VexResourceTest extends ResourceTest {
     }
 
     @Test
-    public void exportVexWithSameVulnAnalysisValidJsonTest() {
+    void exportVexWithSameVulnAnalysisValidJsonTest() {
         var project = new Project();
         project.setName("acme-app");
         project.setVersion("1.0.0");
@@ -317,7 +318,7 @@ public class VexResourceTest extends ResourceTest {
     }
 
     @Test
-    public void exportVexWithDifferentVulnAnalysisValidJsonTest() {
+    void exportVexWithDifferentVulnAnalysisValidJsonTest() {
         var project = new Project();
         project.setName("acme-app");
         project.setVersion("1.0.0");
@@ -441,7 +442,7 @@ public class VexResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadVexInvalidJsonTest() {
+    void uploadVexInvalidJsonTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
 
         qm.createConfigProperty(
@@ -497,7 +498,7 @@ public class VexResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadVexInvalidXmlTest() {
+    void uploadVexInvalidXmlTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
 
         qm.createConfigProperty(
@@ -550,7 +551,7 @@ public class VexResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadVexWithValidationModeDisabledTest() {
+    void uploadVexWithValidationModeDisabledTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
 
         qm.createConfigProperty(
@@ -595,7 +596,7 @@ public class VexResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadVexWithValidationModeEnabledForTagsTest() {
+    void uploadVexWithValidationModeEnabledForTagsTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
 
         qm.createConfigProperty(
@@ -662,7 +663,7 @@ public class VexResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadVexWithValidationModeDisabledForTagsTest() {
+    void uploadVexWithValidationModeDisabledForTagsTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
 
         qm.createConfigProperty(
@@ -729,7 +730,7 @@ public class VexResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadVexTooLargeViaPutTest() {
+    void uploadVexTooLargeViaPutTest() {
         final var project = new Project();
         project.setName("acme-app");
         project.setVersion("1.0.0");
@@ -758,7 +759,7 @@ public class VexResourceTest extends ResourceTest {
     }
 
     @Test
-    public void uploadVexCollectionProjectTest() {
+    void uploadVexCollectionProjectTest() {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
@@ -791,10 +792,10 @@ public class VexResourceTest extends ResourceTest {
                           "vex": "%s"
                         }
                         """.formatted(encodedVex), MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("VEX cannot be uploaded to collection project.", body);
+        Assertions.assertEquals("VEX cannot be uploaded to collection project.", body);
     }
 
 }

--- a/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Test;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 import java.util.Base64;
 import java.util.Collections;
@@ -58,6 +59,7 @@ import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_T
 import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE;
 import static org.hamcrest.CoreMatchers.equalTo;
 
+@DefaultLocale("en-US")
 class VexResourceTest extends ResourceTest {
 
     @RegisterExtension

--- a/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
@@ -41,9 +41,8 @@ import org.dependencytrack.resources.v1.exception.JsonMappingExceptionMapper;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.jupiter.api.Test;
-
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junitpioneer.jupiter.DefaultLocale;
 
@@ -63,7 +62,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 class VexResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(VexResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class)

--- a/src/test/java/org/dependencytrack/resources/v1/ViolationAnalysisResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ViolationAnalysisResourceTest.java
@@ -26,8 +26,14 @@ import alpine.notification.Subscription;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import alpine.server.filters.AuthorizationFilter;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import net.jcip.annotations.NotThreadSafe;
-import org.dependencytrack.JerseyTestRule;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Component;
@@ -46,18 +52,12 @@ import org.dependencytrack.notification.NotificationScope;
 import org.dependencytrack.resources.v1.vo.ViolationAnalysisRequest;
 import org.dependencytrack.util.NotificationUtil;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.time.Duration;
 import java.util.Date;
 import java.util.UUID;
@@ -67,11 +67,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.assertion.Assertions.assertConditionWithTimeout;
 
 @NotThreadSafe
-public class ViolationAnalysisResourceTest extends ResourceTest {
+class ViolationAnalysisResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(ViolationAnalysisResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(ViolationAnalysisResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class)
                     .register(AuthorizationFilter.class));
@@ -87,25 +87,23 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
 
     private static final ConcurrentLinkedQueue<Notification> NOTIFICATIONS = new ConcurrentLinkedQueue<>();
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() {
         NotificationService.getInstance().subscribe(new Subscription(NotificationSubscriber.class));
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() {
         NotificationService.getInstance().unsubscribe(new Subscription(NotificationSubscriber.class));
     }
 
-    @After
-    @Override
-    public void after() throws Exception {
+    @AfterEach
+    public void after() {
         NOTIFICATIONS.clear();
-        super.after();
     }
 
     @Test
-    public void retrieveAnalysisTest() {
+    void retrieveAnalysisTest() {
         initializeWithPermissions(Permissions.VIEW_POLICY_VIOLATION);
 
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
@@ -153,7 +151,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
     }
 
     @Test
-    public void retrieveAnalysisUnauthorizedTest() {
+    void retrieveAnalysisUnauthorizedTest() {
         final Response response = jersey.target(V1_VIOLATION_ANALYSIS)
                 .queryParam("component", UUID.randomUUID())
                 .queryParam("policyViolation", UUID.randomUUID())
@@ -165,7 +163,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
     }
 
     @Test
-    public void retrieveAnalysisComponentNotFoundTest() {
+    void retrieveAnalysisComponentNotFoundTest() {
         initializeWithPermissions(Permissions.VIEW_POLICY_VIOLATION);
 
         final Response response = jersey.target(V1_VIOLATION_ANALYSIS)
@@ -180,7 +178,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
     }
 
     @Test
-    public void retrieveAnalysisViolationNotFoundTest() {
+    void retrieveAnalysisViolationNotFoundTest() {
         initializeWithPermissions(Permissions.VIEW_POLICY_VIOLATION);
 
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
@@ -203,7 +201,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
     }
 
     @Test
-    public void updateAnalysisCreateNewTest() throws Exception {
+    void updateAnalysisCreateNewTest() throws Exception {
         initializeWithPermissions(Permissions.POLICY_VIOLATION_ANALYSIS);
 
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
@@ -260,7 +258,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
     }
 
     @Test
-    public void updateAnalysisCreateNewWithEmptyRequestTest() throws Exception {
+    void updateAnalysisCreateNewWithEmptyRequestTest() throws Exception {
         initializeWithPermissions(Permissions.POLICY_VIOLATION_ANALYSIS);
 
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
@@ -310,7 +308,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
     }
 
     @Test
-    public void updateAnalysisUpdateExistingTest() throws Exception {
+    void updateAnalysisUpdateExistingTest() throws Exception {
         initializeWithPermissions(Permissions.POLICY_VIOLATION_ANALYSIS);
 
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
@@ -378,7 +376,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
     }
 
     @Test
-    public void updateAnalysisUpdateExistingNoChangesTest() throws Exception{
+    void updateAnalysisUpdateExistingNoChangesTest() throws Exception{
         initializeWithPermissions(Permissions.POLICY_VIOLATION_ANALYSIS);
 
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
@@ -426,7 +424,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
     }
 
     @Test
-    public void updateAnalysisUpdateExistingWithEmptyRequestTest() throws Exception {
+    void updateAnalysisUpdateExistingWithEmptyRequestTest() throws Exception {
         initializeWithPermissions(Permissions.POLICY_VIOLATION_ANALYSIS);
 
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
@@ -486,7 +484,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
     }
 
     @Test
-    public void updateAnalysisUnauthorizedTest() {
+    void updateAnalysisUnauthorizedTest() {
         final var request = new ViolationAnalysisRequest(UUID.randomUUID().toString(),
                 UUID.randomUUID().toString(), ViolationAnalysisState.REJECTED, "Some comment", false);
 
@@ -499,7 +497,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
     }
 
     @Test
-    public void updateAnalysisComponentNotFoundTest() {
+    void updateAnalysisComponentNotFoundTest() {
         initializeWithPermissions(Permissions.POLICY_VIOLATION_ANALYSIS);
 
         final var request = new ViolationAnalysisRequest(UUID.randomUUID().toString(),
@@ -515,7 +513,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
     }
 
     @Test
-    public void updateAnalysisViolationNotFoundTest() {
+    void updateAnalysisViolationNotFoundTest() {
         initializeWithPermissions(Permissions.POLICY_VIOLATION_ANALYSIS);
 
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);

--- a/src/test/java/org/dependencytrack/resources/v1/ViolationAnalysisResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ViolationAnalysisResourceTest.java
@@ -70,7 +70,7 @@ import static org.dependencytrack.assertion.Assertions.assertConditionWithTimeou
 class ViolationAnalysisResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(ViolationAnalysisResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class)

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -56,7 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class VulnerabilityResourceTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(VulnerabilityResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -21,8 +21,15 @@ package org.dependencytrack.resources.v1;
 import alpine.common.util.UuidUtil;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import net.javacrumbs.jsonunit.core.Option;
-import org.dependencytrack.JerseyTestRule;
+import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.AffectedVersionAttribution;
 import org.dependencytrack.model.AnalysisJustification;
@@ -36,224 +43,217 @@ import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.UUID;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class VulnerabilityResourceTest extends ResourceTest {
+class VulnerabilityResourceTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(VulnerabilityResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(VulnerabilityResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class));
 
     @Test
-    public void getVulnerabilitiesByComponentUuidTest() {
+    void getVulnerabilitiesByComponentUuidTest() {
         SampleData sampleData = new SampleData();
         Response response = jersey.target(V1_VULNERABILITY + "/component/" + sampleData.c1.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(3, json.size());
-        Assert.assertEquals("INT-1", json.getJsonObject(0).getString("vulnId"));
-        Assert.assertEquals("INTERNAL", json.getJsonObject(0).getString("source"));
-        Assert.assertEquals("Description 1", json.getJsonObject(0).getString("description"));
-        Assert.assertEquals("CRITICAL", json.getJsonObject(0).getString("severity"));
-        Assert.assertNull(json.getJsonObject(0).getJsonObject("cwe"));
-        Assert.assertNull(json.getJsonObject(0).getJsonArray("cwes"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(0).getString("uuid")));
-        Assert.assertEquals("INT-2", json.getJsonObject(1).getString("vulnId"));
-        Assert.assertEquals("INTERNAL", json.getJsonObject(1).getString("source"));
-        Assert.assertEquals("Description 2", json.getJsonObject(1).getString("description"));
-        Assert.assertEquals("HIGH", json.getJsonObject(1).getString("severity"));
-        Assert.assertNull(json.getJsonObject(1).getJsonObject("cwe"));
-        Assert.assertNull(json.getJsonObject(1).getJsonArray("cwes"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(1).getString("uuid")));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(3, json.size());
+        Assertions.assertEquals("INT-1", json.getJsonObject(0).getString("vulnId"));
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(0).getString("source"));
+        Assertions.assertEquals("Description 1", json.getJsonObject(0).getString("description"));
+        Assertions.assertEquals("CRITICAL", json.getJsonObject(0).getString("severity"));
+        Assertions.assertNull(json.getJsonObject(0).getJsonObject("cwe"));
+        Assertions.assertNull(json.getJsonObject(0).getJsonArray("cwes"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(0).getString("uuid")));
+        Assertions.assertEquals("INT-2", json.getJsonObject(1).getString("vulnId"));
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(1).getString("source"));
+        Assertions.assertEquals("Description 2", json.getJsonObject(1).getString("description"));
+        Assertions.assertEquals("HIGH", json.getJsonObject(1).getString("severity"));
+        Assertions.assertNull(json.getJsonObject(1).getJsonObject("cwe"));
+        Assertions.assertNull(json.getJsonObject(1).getJsonArray("cwes"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(1).getString("uuid")));
     }
 
     @Test
-    public void getVulnerabilitiesByComponentInvalidTest() {
+    void getVulnerabilitiesByComponentInvalidTest() {
         new SampleData();
         Response response = jersey.target(V1_VULNERABILITY + "/component/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The component could not be found.", body);
+        Assertions.assertEquals("The component could not be found.", body);
     }
 
     @Test
-    public void getVulnerabilitiesByComponentUuidIncludeSuppressedTest() {
+    void getVulnerabilitiesByComponentUuidIncludeSuppressedTest() {
         SampleData sampleData = new SampleData();
         Response response = jersey.target(V1_VULNERABILITY + "/component/" + sampleData.c1.getUuid().toString())
                 .queryParam("suppressed", "true")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(4), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(4), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(4, json.size());
-        Assert.assertEquals("INT-1", json.getJsonObject(0).getString("vulnId"));
-        Assert.assertEquals("INTERNAL", json.getJsonObject(0).getString("source"));
-        Assert.assertEquals("Description 1", json.getJsonObject(0).getString("description"));
-        Assert.assertEquals("CRITICAL", json.getJsonObject(0).getString("severity"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(0).getString("uuid")));
-        Assert.assertEquals("INT-2", json.getJsonObject(1).getString("vulnId"));
-        Assert.assertEquals("INTERNAL", json.getJsonObject(1).getString("source"));
-        Assert.assertEquals("Description 2", json.getJsonObject(1).getString("description"));
-        Assert.assertEquals("HIGH", json.getJsonObject(1).getString("severity"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(1).getString("uuid")));
-        Assert.assertEquals("INT-3", json.getJsonObject(2).getString("vulnId"));
-        Assert.assertEquals("INTERNAL", json.getJsonObject(2).getString("source"));
-        Assert.assertEquals("Description 3", json.getJsonObject(2).getString("description"));
-        Assert.assertEquals("MEDIUM", json.getJsonObject(2).getString("severity"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(2).getString("uuid")));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(4, json.size());
+        Assertions.assertEquals("INT-1", json.getJsonObject(0).getString("vulnId"));
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(0).getString("source"));
+        Assertions.assertEquals("Description 1", json.getJsonObject(0).getString("description"));
+        Assertions.assertEquals("CRITICAL", json.getJsonObject(0).getString("severity"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(0).getString("uuid")));
+        Assertions.assertEquals("INT-2", json.getJsonObject(1).getString("vulnId"));
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(1).getString("source"));
+        Assertions.assertEquals("Description 2", json.getJsonObject(1).getString("description"));
+        Assertions.assertEquals("HIGH", json.getJsonObject(1).getString("severity"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(1).getString("uuid")));
+        Assertions.assertEquals("INT-3", json.getJsonObject(2).getString("vulnId"));
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(2).getString("source"));
+        Assertions.assertEquals("Description 3", json.getJsonObject(2).getString("description"));
+        Assertions.assertEquals("MEDIUM", json.getJsonObject(2).getString("severity"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(2).getString("uuid")));
     }
 
     @Test
-    public void getVulnerabilitiesByProjectTest() {
+    void getVulnerabilitiesByProjectTest() {
         SampleData sampleData = new SampleData();
         Response response = jersey.target(V1_VULNERABILITY + "/project/" + sampleData.p1.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(5), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(5), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(5, json.size());
-        Assert.assertEquals("INT-1", json.getJsonObject(0).getString("vulnId"));
-        Assert.assertEquals("INTERNAL", json.getJsonObject(0).getString("source"));
-        Assert.assertEquals("Description 1", json.getJsonObject(0).getString("description"));
-        Assert.assertEquals("CRITICAL", json.getJsonObject(0).getString("severity"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(0).getString("uuid")));
-        Assert.assertEquals("INT-2", json.getJsonObject(1).getString("vulnId"));
-        Assert.assertEquals("INTERNAL", json.getJsonObject(1).getString("source"));
-        Assert.assertEquals("Description 2", json.getJsonObject(1).getString("description"));
-        Assert.assertEquals("HIGH", json.getJsonObject(1).getString("severity"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(1).getString("uuid")));
-        Assert.assertEquals("INT-6", json.getJsonObject(2).getString("vulnId"));
-        Assert.assertEquals("INTERNAL", json.getJsonObject(2).getString("source"));
-        Assert.assertEquals("Description 6", json.getJsonObject(2).getString("description"));
-        Assert.assertEquals("CRITICAL", json.getJsonObject(2).getString("severity"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(2).getString("uuid")));
-        Assert.assertEquals("INT-4", json.getJsonObject(3).getString("vulnId"));
-        Assert.assertEquals("INTERNAL", json.getJsonObject(3).getString("source"));
-        Assert.assertEquals("Description 4", json.getJsonObject(3).getString("description"));
-        Assert.assertEquals("LOW", json.getJsonObject(3).getString("severity"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(3).getString("uuid")));
-        Assert.assertEquals("INT-5", json.getJsonObject(4).getString("vulnId"));
-        Assert.assertEquals("INTERNAL", json.getJsonObject(4).getString("source"));
-        Assert.assertEquals("Description 5", json.getJsonObject(4).getString("description"));
-        Assert.assertEquals("CRITICAL", json.getJsonObject(4).getString("severity"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(4).getString("uuid")));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(5, json.size());
+        Assertions.assertEquals("INT-1", json.getJsonObject(0).getString("vulnId"));
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(0).getString("source"));
+        Assertions.assertEquals("Description 1", json.getJsonObject(0).getString("description"));
+        Assertions.assertEquals("CRITICAL", json.getJsonObject(0).getString("severity"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(0).getString("uuid")));
+        Assertions.assertEquals("INT-2", json.getJsonObject(1).getString("vulnId"));
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(1).getString("source"));
+        Assertions.assertEquals("Description 2", json.getJsonObject(1).getString("description"));
+        Assertions.assertEquals("HIGH", json.getJsonObject(1).getString("severity"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(1).getString("uuid")));
+        Assertions.assertEquals("INT-6", json.getJsonObject(2).getString("vulnId"));
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(2).getString("source"));
+        Assertions.assertEquals("Description 6", json.getJsonObject(2).getString("description"));
+        Assertions.assertEquals("CRITICAL", json.getJsonObject(2).getString("severity"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(2).getString("uuid")));
+        Assertions.assertEquals("INT-4", json.getJsonObject(3).getString("vulnId"));
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(3).getString("source"));
+        Assertions.assertEquals("Description 4", json.getJsonObject(3).getString("description"));
+        Assertions.assertEquals("LOW", json.getJsonObject(3).getString("severity"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(3).getString("uuid")));
+        Assertions.assertEquals("INT-5", json.getJsonObject(4).getString("vulnId"));
+        Assertions.assertEquals("INTERNAL", json.getJsonObject(4).getString("source"));
+        Assertions.assertEquals("Description 5", json.getJsonObject(4).getString("description"));
+        Assertions.assertEquals("CRITICAL", json.getJsonObject(4).getString("severity"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getJsonObject(4).getString("uuid")));
     }
 
     @Test
-    public void getVulnerabilitiesByProjectIncludeProjectSuppressedTest() {
+    void getVulnerabilitiesByProjectIncludeProjectSuppressedTest() {
         SampleData sampleData = new SampleData();
         Response response = jersey.target(V1_VULNERABILITY + "/project/" + sampleData.p2.getUuid().toString())
                 .queryParam("suppressed", "true")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(3, json.size());
-        Assert.assertEquals("INT-4", json.getJsonObject(0).getString("vulnId"));
-        Assert.assertEquals("INT-5", json.getJsonObject(1).getString("vulnId"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(3, json.size());
+        Assertions.assertEquals("INT-4", json.getJsonObject(0).getString("vulnId"));
+        Assertions.assertEquals("INT-5", json.getJsonObject(1).getString("vulnId"));
     }
 
     @Test
-    public void getVulnerabilitiesByProjectInvalidTest() {
+    void getVulnerabilitiesByProjectInvalidTest() {
         new SampleData();
         Response response = jersey.target(V1_VULNERABILITY + "/project/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The project could not be found.", body);
+        Assertions.assertEquals("The project could not be found.", body);
     }
 
     @Test
-    public void getVulnerabilityByUuidTest() {
+    void getVulnerabilityByUuidTest() {
         SampleData sampleData = new SampleData();
         Response response = jersey.target(V1_VULNERABILITY + "/" + sampleData.v1.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("INT-1", json.getString("vulnId"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("INT-1", json.getString("vulnId"));
     }
 
     @Test
-    public void getVulnerabilityByUuidInvalidTest() {
+    void getVulnerabilityByUuidInvalidTest() {
         new SampleData();
         Response response = jersey.target(V1_VULNERABILITY + "/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The vulnerability could not be found.", body);
+        Assertions.assertEquals("The vulnerability could not be found.", body);
     }
 
     @Test
-    public void getVulnerabilityByVulnIdTest() {
+    void getVulnerabilityByVulnIdTest() {
         SampleData sampleData = new SampleData();
         Response response = jersey.target(V1_VULNERABILITY + "/source/" + sampleData.v1.getSource() + "/vuln/" + sampleData.v1.getVulnId()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("INT-1", json.getString("vulnId"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("INT-1", json.getString("vulnId"));
         JsonArray affectedComponents = json.getJsonArray("affectedComponents");
-        Assert.assertNotNull(affectedComponents);
+        Assertions.assertNotNull(affectedComponents);
         JsonArray affectedVersionAttributions = affectedComponents.getJsonObject(0).getJsonArray("affectedVersionAttributions");
-        Assert.assertNotNull(affectedVersionAttributions);
-        Assert.assertEquals(affectedVersionAttributions.getJsonObject(0).getString("source"), "INTERNAL");
+        Assertions.assertNotNull(affectedVersionAttributions);
+        Assertions.assertEquals(affectedVersionAttributions.getJsonObject(0).getString("source"), "INTERNAL");
     }
 
     @Test
-    public void getVulnerabilityByVulnIdInvalidTest() {
+    void getVulnerabilityByVulnIdInvalidTest() {
         new SampleData();
         Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/blah").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The vulnerability could not be found.", body);
+        Assertions.assertEquals("The vulnerability could not be found.", body);
     }
 
     @Test
-    public void getVulnerabilityByVulnIdACLEnabledTest() {
+    void getVulnerabilityByVulnIdACLEnabledTest() {
         SampleData sampleData = new SampleData();
         qm.createConfigProperty(
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
@@ -264,18 +264,18 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY + "/source/" + sampleData.v6.getSource() + "/vuln/" + sampleData.v6.getVulnId()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("INT-6", json.getString("vulnId"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("INT-6", json.getString("vulnId"));
         JsonArray components = json.getJsonArray("components");
-        Assert.assertNotNull(components);
-        Assert.assertEquals(1, components.size());
+        Assertions.assertNotNull(components);
+        Assertions.assertEquals(1, components.size());
     }
 
     @Test
-    public void getVulnerabilityByVulnIdACLDisabledTest() {
+    void getVulnerabilityByVulnIdACLDisabledTest() {
         SampleData sampleData = new SampleData();
         qm.createConfigProperty(
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
@@ -286,45 +286,45 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY + "/source/" + sampleData.v6.getSource() + "/vuln/" + sampleData.v6.getVulnId()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("INT-6", json.getString("vulnId"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("INT-6", json.getString("vulnId"));
         JsonArray components = json.getJsonArray("components");
-        Assert.assertNotNull(components);
-        Assert.assertEquals(2, components.size());
+        Assertions.assertNotNull(components);
+        Assertions.assertEquals(2, components.size());
     }
 
     @Test
-    public void getAffectedProjectTest() {
+    void getAffectedProjectTest() {
         SampleData sampleData = new SampleData();
         Response response = jersey.target(V1_VULNERABILITY + "/source/" + sampleData.v1.getSource() + "/vuln/" + sampleData.v1.getVulnId() + "/projects").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Project 1", json.getJsonObject(0).getString("name"));
-        Assert.assertEquals(sampleData.p1.getUuid().toString(), json.getJsonObject(0).getString("uuid"));
-        Assert.assertEquals(sampleData.c1.getUuid().toString(), json.getJsonObject(0).getJsonArray("affectedComponentUuids").getJsonString(0).getString());
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("Project 1", json.getJsonObject(0).getString("name"));
+        Assertions.assertEquals(sampleData.p1.getUuid().toString(), json.getJsonObject(0).getString("uuid"));
+        Assertions.assertEquals(sampleData.c1.getUuid().toString(), json.getJsonObject(0).getJsonArray("affectedComponentUuids").getJsonString(0).getString());
     }
 
     @Test
-    public void getAffectedProjectInvalidTest() {
+    void getAffectedProjectInvalidTest() {
         new SampleData();
         Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/blah/projects").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The vulnerability could not be found.", body);
+        Assertions.assertEquals("The vulnerability could not be found.", body);
     }
 
     @Test
-    public void getAffectedProjectACLEnabledTest() {
+    void getAffectedProjectACLEnabledTest() {
         SampleData sampleData = new SampleData();
         qm.createConfigProperty(
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
@@ -335,16 +335,16 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY + "/source/" + sampleData.v6.getSource() + "/vuln/" + sampleData.v6.getVulnId() + "/projects").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(1, json.size());
-        Assert.assertEquals("Project 1", json.getJsonObject(0).getString("name"));
-        Assert.assertEquals(sampleData.p1.getUuid().toString(), json.getJsonObject(0).getString("uuid"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(1, json.size());
+        Assertions.assertEquals("Project 1", json.getJsonObject(0).getString("name"));
+        Assertions.assertEquals(sampleData.p1.getUuid().toString(), json.getJsonObject(0).getString("uuid"));
     }
 
     @Test
-    public void getAffectedProjectACLDisabledTest() {
+    void getAffectedProjectACLDisabledTest() {
         SampleData sampleData = new SampleData();
         qm.createConfigProperty(
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
@@ -355,10 +355,10 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY + "/source/" + sampleData.v6.getSource() + "/vuln/" + sampleData.v6.getVulnId() + "/projects").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(2, json.size());
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(2, json.size());
         assertThat(json).satisfiesExactlyInAnyOrder(
                 jsonValue -> {
                     final JsonObject projectObject = jsonValue.asJsonObject();
@@ -373,26 +373,26 @@ public class VulnerabilityResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getAllVulnerabilitiesTest() {
+    void getAllVulnerabilitiesTest() {
         new SampleData();
         Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(6), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(6), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals(6, json.size());
-        Assert.assertEquals("INT-1", json.getJsonObject(0).getString("vulnId"));
-        Assert.assertEquals("INT-2", json.getJsonObject(1).getString("vulnId"));
-        Assert.assertEquals("INT-3", json.getJsonObject(2).getString("vulnId"));
-        Assert.assertEquals("INT-4", json.getJsonObject(3).getString("vulnId"));
-        Assert.assertEquals("INT-5", json.getJsonObject(4).getString("vulnId"));
-        Assert.assertEquals("INT-6", json.getJsonObject(5).getString("vulnId"));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(6, json.size());
+        Assertions.assertEquals("INT-1", json.getJsonObject(0).getString("vulnId"));
+        Assertions.assertEquals("INT-2", json.getJsonObject(1).getString("vulnId"));
+        Assertions.assertEquals("INT-3", json.getJsonObject(2).getString("vulnId"));
+        Assertions.assertEquals("INT-4", json.getJsonObject(3).getString("vulnId"));
+        Assertions.assertEquals("INT-5", json.getJsonObject(4).getString("vulnId"));
+        Assertions.assertEquals("INT-6", json.getJsonObject(5).getString("vulnId"));
     }
 
     @Test
-    public void getAllVulnerabilitiesACLEnabledTest() {
+    void getAllVulnerabilitiesACLEnabledTest() {
         new SampleData();
         qm.createConfigProperty(
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
@@ -403,20 +403,20 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(6), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(6), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray jsons = parseJsonArray(response);
-        Assert.assertNotNull(jsons);
-        Assert.assertEquals(6, jsons.size());
+        Assertions.assertNotNull(jsons);
+        Assertions.assertEquals(6, jsons.size());
         for (JsonValue json : jsons) {
             JsonArray components = json.asJsonObject().getJsonArray("components");
-            Assert.assertNotNull(components);
-            Assert.assertEquals(1, components.size());
+            Assertions.assertNotNull(components);
+            Assertions.assertEquals(1, components.size());
         }
     }
 
     @Test
-    public void getAllVulnerabilitiesACLDisabledTest() {
+    void getAllVulnerabilitiesACLDisabledTest() {
         new SampleData();
         qm.createConfigProperty(
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
@@ -427,30 +427,30 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(6), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(String.valueOf(6), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray jsons = parseJsonArray(response);
-        Assert.assertNotNull(jsons);
-        Assert.assertEquals(6, jsons.size());
+        Assertions.assertNotNull(jsons);
+        Assertions.assertEquals(6, jsons.size());
         for (int i = 0; i < 3; i++) {
             JsonArray components = jsons.get(i).asJsonObject().getJsonArray("components");
-            Assert.assertNotNull(components);
-            Assert.assertEquals(1, components.size());
+            Assertions.assertNotNull(components);
+            Assertions.assertEquals(1, components.size());
         }
         JsonArray components = jsons.get(3).asJsonObject().getJsonArray("components");
-        Assert.assertNotNull(components);
-        Assert.assertEquals(2, components.size());
+        Assertions.assertNotNull(components);
+        Assertions.assertEquals(2, components.size());
         components = jsons.get(4).asJsonObject().getJsonArray("components");
-        Assert.assertNotNull(components);
-        Assert.assertEquals(2, components.size());
+        Assertions.assertNotNull(components);
+        Assertions.assertEquals(2, components.size());
         components = jsons.get(5).asJsonObject().getJsonArray("components");
-        Assert.assertNotNull(components);
-        Assert.assertEquals(2, components.size());
+        Assertions.assertNotNull(components);
+        Assertions.assertEquals(2, components.size());
     }
 
 
     @Test
-    public void createVulnerabilityTest() {
+    void createVulnerabilityTest() {
         JsonObject payload = Json.createObjectBuilder()
                 .add("vulnId", "ACME-1")
                 .add("description", "Something is vulnerable")
@@ -468,43 +468,43 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.json(payload.toString()));
-        Assert.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertEquals(201, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("ACME-1", json.getString("vulnId"));
-        Assert.assertEquals("INTERNAL", json.getString("source"));
-        Assert.assertEquals("Something is vulnerable", json.getString("description"));
-        Assert.assertEquals(6.0, json.getJsonNumber("cvssV2BaseScore").doubleValue(), 0);
-        Assert.assertEquals(6.4, json.getJsonNumber("cvssV2ImpactSubScore").doubleValue(), 0);
-        Assert.assertEquals(6.8, json.getJsonNumber("cvssV2ExploitabilitySubScore").doubleValue(), 0);
-        Assert.assertEquals("(AV:N/AC:M/Au:S/C:P/I:P/A:P)", json.getString("cvssV2Vector"));
-        Assert.assertEquals(6.3, json.getJsonNumber("cvssV3BaseScore").doubleValue(), 0);
-        Assert.assertEquals(3.4, json.getJsonNumber("cvssV3ImpactSubScore").doubleValue(), 0);
-        Assert.assertEquals(2.8, json.getJsonNumber("cvssV3ExploitabilitySubScore").doubleValue(), 0);
-        Assert.assertEquals("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L", json.getString("cvssV3Vector"));
-        Assert.assertEquals(1.0, json.getJsonNumber("owaspRRLikelihoodScore").doubleValue(), 0);
-        Assert.assertEquals(1.25, json.getJsonNumber("owaspRRTechnicalImpactScore").doubleValue(), 0);
-        Assert.assertEquals(1.75, json.getJsonNumber("owaspRRBusinessImpactScore").doubleValue(), 0);
-        Assert.assertEquals("SL:1/M:1/O:0/S:2/ED:1/EE:1/A:1/ID:1/LC:2/LI:1/LAV:1/LAC:1/FD:1/RD:1/NC:2/PV:3", json.getString("owaspRRVector"));
-        Assert.assertEquals("MEDIUM", json.getString("severity"));
-        Assert.assertNotNull(json.getJsonObject("cwe"));
-        Assert.assertEquals(80, json.getJsonObject("cwe").getInt("cweId"));
-        Assert.assertEquals(1, json.getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonArray("cwes").getJsonObject(0).getString("name"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("ACME-1", json.getString("vulnId"));
+        Assertions.assertEquals("INTERNAL", json.getString("source"));
+        Assertions.assertEquals("Something is vulnerable", json.getString("description"));
+        Assertions.assertEquals(6.0, json.getJsonNumber("cvssV2BaseScore").doubleValue(), 0);
+        Assertions.assertEquals(6.4, json.getJsonNumber("cvssV2ImpactSubScore").doubleValue(), 0);
+        Assertions.assertEquals(6.8, json.getJsonNumber("cvssV2ExploitabilitySubScore").doubleValue(), 0);
+        Assertions.assertEquals("(AV:N/AC:M/Au:S/C:P/I:P/A:P)", json.getString("cvssV2Vector"));
+        Assertions.assertEquals(6.3, json.getJsonNumber("cvssV3BaseScore").doubleValue(), 0);
+        Assertions.assertEquals(3.4, json.getJsonNumber("cvssV3ImpactSubScore").doubleValue(), 0);
+        Assertions.assertEquals(2.8, json.getJsonNumber("cvssV3ExploitabilitySubScore").doubleValue(), 0);
+        Assertions.assertEquals("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L", json.getString("cvssV3Vector"));
+        Assertions.assertEquals(1.0, json.getJsonNumber("owaspRRLikelihoodScore").doubleValue(), 0);
+        Assertions.assertEquals(1.25, json.getJsonNumber("owaspRRTechnicalImpactScore").doubleValue(), 0);
+        Assertions.assertEquals(1.75, json.getJsonNumber("owaspRRBusinessImpactScore").doubleValue(), 0);
+        Assertions.assertEquals("SL:1/M:1/O:0/S:2/ED:1/EE:1/A:1/ID:1/LC:2/LI:1/LAV:1/LAC:1/FD:1/RD:1/NC:2/PV:3", json.getString("owaspRRVector"));
+        Assertions.assertEquals("MEDIUM", json.getString("severity"));
+        Assertions.assertNotNull(json.getJsonObject("cwe"));
+        Assertions.assertEquals(80, json.getJsonObject("cwe").getInt("cweId"));
+        Assertions.assertEquals(1, json.getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonArray("cwes").getJsonObject(0).getString("name"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
 
         // Verify that VulnerableSoftware records and attributions thereof have been created correctly
         final Vulnerability vuln = qm.getVulnerabilityByVulnId(Vulnerability.Source.INTERNAL, "ACME-1");
-        Assert.assertNotNull(vuln);
-        Assert.assertEquals(1, vuln.getVulnerableSoftware().size());
+        Assertions.assertNotNull(vuln);
+        Assertions.assertEquals(1, vuln.getVulnerableSoftware().size());
         final List<AffectedVersionAttribution> attributions = qm.getAffectedVersionAttributions(vuln, vuln.getVulnerableSoftware().get(0));
-        Assert.assertEquals(1, attributions.size());
-        Assert.assertEquals(Vulnerability.Source.INTERNAL, attributions.get(0).getSource());
+        Assertions.assertEquals(1, attributions.size());
+        Assertions.assertEquals(Vulnerability.Source.INTERNAL, attributions.get(0).getSource());
     }
 
     @Test
-    public void createVulnerabilityWithBadOwaspVectorTest() {
+    void createVulnerabilityWithBadOwaspVectorTest() {
         JsonObject payload = Json.createObjectBuilder()
                 .add("vulnId", "ACME-1")
                 .add("description", "Something is vulnerable")
@@ -522,10 +522,10 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.json(payload.toString()));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertEquals(400, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertNotNull(body);
-        Assert.assertEquals("Provided vector SL:1/M:1/O:a/S:2/ED:1/EE:1/A:1/ID:1/LC:2/LI:1/LAV:1/LAC:1/FD:1/RD:1/NC:2/PV:3 does not match OWASP RR Vector pattern SL:\\d/M:\\d/O:\\d/S:\\d/ED:\\d/EE:\\d/A:\\d/ID:\\d/LC:\\d/LI:\\d/LAV:\\d/LAC:\\d/FD:\\d/RD:\\d/NC:\\d/PV:\\d", body);
+        Assertions.assertNotNull(body);
+        Assertions.assertEquals("Provided vector SL:1/M:1/O:a/S:2/ED:1/EE:1/A:1/ID:1/LC:2/LI:1/LAV:1/LAC:1/FD:1/RD:1/NC:2/PV:3 does not match OWASP RR Vector pattern SL:\\d/M:\\d/O:\\d/S:\\d/ED:\\d/EE:\\d/A:\\d/ID:\\d/LC:\\d/LI:\\d/LAV:\\d/LAC:\\d/FD:\\d/RD:\\d/NC:\\d/PV:\\d", body);
     }
 
     /**
@@ -533,7 +533,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
      * still works, and both "cwe" and "cwes" fields are returned in the response.
      */
     @Test
-    public void createVulnerabilityCwePreV450CompatTest() {
+    void createVulnerabilityCwePreV450CompatTest() {
         JsonObject payload = Json.createObjectBuilder()
                 .add("vulnId", "ACME-1")
                 .add("cwe", Json.createObjectBuilder().add("cweId", 80))
@@ -541,22 +541,22 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.json(payload.toString()));
-        Assert.assertEquals(201, response.getStatus(), 0);
+        Assertions.assertEquals(201, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("ACME-1", json.getString("vulnId"));
-        Assert.assertEquals("INTERNAL", json.getString("source"));
-        Assert.assertNotNull(json.getJsonObject("cwe"));
-        Assert.assertEquals(80, json.getJsonObject("cwe").getInt("cweId"));
-        Assert.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonObject("cwe").getString("name"));
-        Assert.assertEquals(1, json.getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonArray("cwes").getJsonObject(0).getString("name"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("ACME-1", json.getString("vulnId"));
+        Assertions.assertEquals("INTERNAL", json.getString("source"));
+        Assertions.assertNotNull(json.getJsonObject("cwe"));
+        Assertions.assertEquals(80, json.getJsonObject("cwe").getInt("cweId"));
+        Assertions.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonObject("cwe").getString("name"));
+        Assertions.assertEquals(1, json.getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonArray("cwes").getJsonObject(0).getString("name"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
     }
 
     @Test
-    public void createVulnerabilityDuplicateTest() {
+    void createVulnerabilityDuplicateTest() {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
@@ -572,14 +572,14 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.json(payload.toString()));
-        Assert.assertEquals(409, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(409, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("A vulnerability with the specified vulnId already exists.", body);
+        Assertions.assertEquals("A vulnerability with the specified vulnId already exists.", body);
     }
 
     @Test
-    public void updateVulnerabilityTest() {
+    void updateVulnerabilityTest() {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
@@ -597,33 +597,33 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(payload.toString()));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("ACME-1", json.getString("vulnId"));
-        Assert.assertEquals("INTERNAL", json.getString("source"));
-        Assert.assertEquals("Something is vulnerable", json.getString("description"));
-        Assert.assertEquals(6.0, json.getJsonNumber("cvssV2BaseScore").doubleValue(), 0);
-        Assert.assertEquals(6.4, json.getJsonNumber("cvssV2ImpactSubScore").doubleValue(), 0);
-        Assert.assertEquals(6.8, json.getJsonNumber("cvssV2ExploitabilitySubScore").doubleValue(), 0);
-        Assert.assertEquals("(AV:N/AC:M/Au:S/C:P/I:P/A:P)", json.getString("cvssV2Vector"));
-        Assert.assertEquals(6.3, json.getJsonNumber("cvssV3BaseScore").doubleValue(), 0);
-        Assert.assertEquals(3.4, json.getJsonNumber("cvssV3ImpactSubScore").doubleValue(), 0);
-        Assert.assertEquals(2.8, json.getJsonNumber("cvssV3ExploitabilitySubScore").doubleValue(), 0);
-        Assert.assertEquals(1.0, json.getJsonNumber("owaspRRLikelihoodScore").doubleValue(), 0);
-        Assert.assertEquals(1.25, json.getJsonNumber("owaspRRTechnicalImpactScore").doubleValue(), 0);
-        Assert.assertEquals(1.75, json.getJsonNumber("owaspRRBusinessImpactScore").doubleValue(), 0);
-        Assert.assertEquals("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L", json.getString("cvssV3Vector"));
-        Assert.assertEquals("SL:1/M:1/O:0/S:2/ED:1/EE:1/A:1/ID:1/LC:2/LI:1/LAV:1/LAC:1/FD:1/RD:1/NC:2/PV:3", json.getString("owaspRRVector"));
-        Assert.assertEquals("MEDIUM", json.getString("severity"));
-        Assert.assertEquals(1, json.getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonArray("cwes").getJsonObject(0).getString("name"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals("ACME-1", json.getString("vulnId"));
+        Assertions.assertEquals("INTERNAL", json.getString("source"));
+        Assertions.assertEquals("Something is vulnerable", json.getString("description"));
+        Assertions.assertEquals(6.0, json.getJsonNumber("cvssV2BaseScore").doubleValue(), 0);
+        Assertions.assertEquals(6.4, json.getJsonNumber("cvssV2ImpactSubScore").doubleValue(), 0);
+        Assertions.assertEquals(6.8, json.getJsonNumber("cvssV2ExploitabilitySubScore").doubleValue(), 0);
+        Assertions.assertEquals("(AV:N/AC:M/Au:S/C:P/I:P/A:P)", json.getString("cvssV2Vector"));
+        Assertions.assertEquals(6.3, json.getJsonNumber("cvssV3BaseScore").doubleValue(), 0);
+        Assertions.assertEquals(3.4, json.getJsonNumber("cvssV3ImpactSubScore").doubleValue(), 0);
+        Assertions.assertEquals(2.8, json.getJsonNumber("cvssV3ExploitabilitySubScore").doubleValue(), 0);
+        Assertions.assertEquals(1.0, json.getJsonNumber("owaspRRLikelihoodScore").doubleValue(), 0);
+        Assertions.assertEquals(1.25, json.getJsonNumber("owaspRRTechnicalImpactScore").doubleValue(), 0);
+        Assertions.assertEquals(1.75, json.getJsonNumber("owaspRRBusinessImpactScore").doubleValue(), 0);
+        Assertions.assertEquals("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L", json.getString("cvssV3Vector"));
+        Assertions.assertEquals("SL:1/M:1/O:0/S:2/ED:1/EE:1/A:1/ID:1/LC:2/LI:1/LAV:1/LAC:1/FD:1/RD:1/NC:2/PV:3", json.getString("owaspRRVector"));
+        Assertions.assertEquals("MEDIUM", json.getString("severity"));
+        Assertions.assertEquals(1, json.getJsonArray("cwes").size());
+        Assertions.assertEquals(80, json.getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assertions.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonArray("cwes").getJsonObject(0).getString("name"));
+        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
     }
 
     @Test
-    public void updateVulnerabilityInvalidTest() {
+    void updateVulnerabilityInvalidTest() {
         JsonObject payload = Json.createObjectBuilder()
                 .add("vulnId", "ACME-1")
                 .add("description", "Something is vulnerable")
@@ -636,14 +636,14 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(payload.toString()));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The vulnerability could not be found.", body);
+        Assertions.assertEquals("The vulnerability could not be found.", body);
     }
 
     @Test
-    public void updateVulnerabilityUnchangableTest() {
+    void updateVulnerabilityUnchangableTest() {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
@@ -660,14 +660,14 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(payload.toString()));
-        Assert.assertEquals(406, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(406, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The vulnId may not be changed.", body);
+        Assertions.assertEquals("The vulnId may not be changed.", body);
     }
 
     @Test
-    public void testReconcileVulnerableSoftwareWithInternalSource() {
+    void testReconcileVulnerableSoftwareWithInternalSource() {
         Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.json(/* language=JSON */ """
@@ -865,7 +865,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
     }
 
     @Test
-    public void deleteVulnerabilityTest() {
+    void deleteVulnerabilityTest() {
         final VulnerableSoftware vs = qm.persist(new VulnerableSoftware());
         var vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
@@ -877,16 +877,16 @@ public class VulnerabilityResourceTest extends ResourceTest {
         final Response response = jersey.target(V1_VULNERABILITY + "/" + vuln.getUuid()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(204, response.getStatus());
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(204, response.getStatus());
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
 
-        Assert.assertNull(qm.getObjectByUuid(AffectedVersionAttribution.class, attribution.getUuid()));
-        Assert.assertNotNull(qm.getObjectByUuid(VulnerableSoftware.class, vs.getUuid()));
-        Assert.assertNull(qm.getObjectByUuid(Vulnerability.class, vuln.getUuid()));
+        Assertions.assertNull(qm.getObjectByUuid(AffectedVersionAttribution.class, attribution.getUuid()));
+        Assertions.assertNotNull(qm.getObjectByUuid(VulnerableSoftware.class, vs.getUuid()));
+        Assertions.assertNull(qm.getObjectByUuid(Vulnerability.class, vuln.getUuid()));
     }
 
     @Test
-    public void assignVulnerabilityTest() {
+    void assignVulnerabilityTest() {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
@@ -899,12 +899,12 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/ACME-1/component/" + comp.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void assignVulnerabilityInvalidVulnerabilityTest() {
+    void assignVulnerabilityInvalidVulnerabilityTest() {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, false, false);
         Component comp = new Component();
         comp.setProject(project);
@@ -913,14 +913,14 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/BLAH/component/" + comp.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The vulnerability could not be found.", body);
+        Assertions.assertEquals("The vulnerability could not be found.", body);
     }
 
     @Test
-    public void assignVulnerabilityInvalidComponentTest() {
+    void assignVulnerabilityInvalidComponentTest() {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
@@ -928,14 +928,14 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/ACME-1/component/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The component could not be found.", body);
+        Assertions.assertEquals("The component could not be found.", body);
     }
 
     @Test
-    public void assignVulnerabilityByUuidTest() {
+    void assignVulnerabilityByUuidTest() {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
@@ -948,12 +948,12 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/component/" + comp.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void assignVulnerabilityByUuidInvalidVulnerabilityTest() {
+    void assignVulnerabilityByUuidInvalidVulnerabilityTest() {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, false, false);
         Component comp = new Component();
         comp.setProject(project);
@@ -962,14 +962,14 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY + "/" + UUID.randomUUID().toString() + "/component/" + comp.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The vulnerability could not be found.", body);
+        Assertions.assertEquals("The vulnerability could not be found.", body);
     }
 
     @Test
-    public void assignVulnerabilityByUuidInvalidComponentTest() {
+    void assignVulnerabilityByUuidInvalidComponentTest() {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
@@ -977,14 +977,14 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/component/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The component could not be found.", body);
+        Assertions.assertEquals("The component could not be found.", body);
     }
 
     @Test
-    public void unassignVulnerabilityTest() {
+    void unassignVulnerabilityTest() {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
@@ -997,12 +997,12 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/ACME-1/component/" + comp.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void unassignVulnerabilityInvalidVulnerabilityTest() {
+    void unassignVulnerabilityInvalidVulnerabilityTest() {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, false, false);
         Component comp = new Component();
         comp.setProject(project);
@@ -1011,14 +1011,14 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/BLAH/component/" + comp.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The vulnerability could not be found.", body);
+        Assertions.assertEquals("The vulnerability could not be found.", body);
     }
 
     @Test
-    public void unassignVulnerabilityInvalidComponentTest() {
+    void unassignVulnerabilityInvalidComponentTest() {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
@@ -1026,14 +1026,14 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/ACME-1/component/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The component could not be found.", body);
+        Assertions.assertEquals("The component could not be found.", body);
     }
 
     @Test
-    public void unassignVulnerabilityByUuidTest() {
+    void unassignVulnerabilityByUuidTest() {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
@@ -1046,12 +1046,12 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/component/" + comp.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
-    public void unassignVulnerabilityByUuidInvalidVulnerabilityTest() {
+    void unassignVulnerabilityByUuidInvalidVulnerabilityTest() {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, false, false);
         Component comp = new Component();
         comp.setProject(project);
@@ -1060,14 +1060,14 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY + "/" + UUID.randomUUID().toString() + "/component/" + comp.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The vulnerability could not be found.", body);
+        Assertions.assertEquals("The vulnerability could not be found.", body);
     }
 
     @Test
-    public void unassignVulnerabilityByUuidInvalidComponentTest() {
+    void unassignVulnerabilityByUuidInvalidComponentTest() {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
@@ -1075,10 +1075,10 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Response response = jersey.target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/component/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(404, response.getStatus(), 0);
+        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
-        Assert.assertEquals("The component could not be found.", body);
+        Assertions.assertEquals("The component could not be found.", body);
     }
 
     private class SampleData {

--- a/src/test/java/org/dependencytrack/resources/v1/exception/ClientErrorExceptionMapperTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/exception/ClientErrorExceptionMapperTest.java
@@ -18,27 +18,26 @@
  */
 package org.dependencytrack.resources.v1.exception;
 
-import org.dependencytrack.JerseyTestRule;
-import org.dependencytrack.ResourceTest;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ClientErrorExceptionMapperTest extends ResourceTest {
+class ClientErrorExceptionMapperTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(TestResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(TestResource.class)
                     .register(ClientErrorExceptionMapper.class));
 
     @Test
-    public void testNotFound() {
+    void testNotFound() {
         final Response response = jersey.target("/does/not/exist")
                 .request()
                 .get();
@@ -47,7 +46,7 @@ public class ClientErrorExceptionMapperTest extends ResourceTest {
     }
 
     @Test
-    public void testMethodNotAllowed() {
+    void testMethodNotAllowed() {
         final Response response = jersey.target("/test/foo")
                 .request()
                 .delete();

--- a/src/test/java/org/dependencytrack/resources/v1/exception/ClientErrorExceptionMapperTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/exception/ClientErrorExceptionMapperTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ClientErrorExceptionMapperTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(TestResource.class)
                     .register(ClientErrorExceptionMapper.class));
 

--- a/src/test/java/org/dependencytrack/resources/v1/exception/ConstraintViolationExceptionMapperTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/exception/ConstraintViolationExceptionMapperTest.java
@@ -34,10 +34,12 @@ import jakarta.ws.rs.core.Response;
 import org.dependencytrack.JerseyTestExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@DefaultLocale("en-US")
 class ConstraintViolationExceptionMapperTest extends ResourceTest {
 
     @RegisterExtension

--- a/src/test/java/org/dependencytrack/resources/v1/exception/ConstraintViolationExceptionMapperTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/exception/ConstraintViolationExceptionMapperTest.java
@@ -18,11 +18,6 @@
  */
 package org.dependencytrack.resources.v1.exception;
 
-import net.javacrumbs.jsonunit.core.Option;
-import org.dependencytrack.ResourceTest;
-import org.dependencytrack.model.validation.ValidUuid;
-import org.glassfish.jersey.server.ResourceConfig;
-
 import jakarta.validation.constraints.Pattern;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -31,7 +26,11 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import net.javacrumbs.jsonunit.core.Option;
 import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.model.validation.ValidUuid;
+import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junitpioneer.jupiter.DefaultLocale;
@@ -43,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ConstraintViolationExceptionMapperTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(TestResource.class)
                     .register(ConstraintViolationExceptionMapper.class));
 

--- a/src/test/java/org/dependencytrack/resources/v1/exception/ConstraintViolationExceptionMapperTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/exception/ConstraintViolationExceptionMapperTest.java
@@ -19,12 +19,9 @@
 package org.dependencytrack.resources.v1.exception;
 
 import net.javacrumbs.jsonunit.core.Option;
-import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.validation.ValidUuid;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.ClassRule;
-import org.junit.Test;
 
 import jakarta.validation.constraints.Pattern;
 import jakarta.ws.rs.GET;
@@ -34,19 +31,22 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ConstraintViolationExceptionMapperTest extends ResourceTest {
+class ConstraintViolationExceptionMapperTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(TestResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(TestResource.class)
                     .register(ConstraintViolationExceptionMapper.class));
 
     @Test
-    public void test() {
+    void test() {
         final Response response = jersey.target("/not-a-uuid")
                 .queryParam("foo", "666")
                 .request()

--- a/src/test/java/org/dependencytrack/resources/v1/exception/NotSortableExceptionMapperTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/exception/NotSortableExceptionMapperTest.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class NotSortableExceptionMapperTest extends ResourceTest {
 
     @RegisterExtension
-    public JerseyTestExtension jersey = new JerseyTestExtension(
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
             () -> new ResourceConfig(TestResource.class)
                     .register(ApiFilter.class)
                     .register(NotSortableExceptionMapper.class));

--- a/src/test/java/org/dependencytrack/resources/v1/exception/NotSortableExceptionMapperTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/exception/NotSortableExceptionMapperTest.java
@@ -22,32 +22,31 @@ import alpine.persistence.PaginatedResult;
 import alpine.server.auth.AuthenticationNotRequired;
 import alpine.server.filters.ApiFilter;
 import alpine.server.resources.AlpineResource;
-import org.dependencytrack.JerseyTestRule;
-import org.dependencytrack.ResourceTest;
-import org.dependencytrack.persistence.QueryManager;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.persistence.QueryManager;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class NotSortableExceptionMapperTest extends ResourceTest {
+class NotSortableExceptionMapperTest extends ResourceTest {
 
-    @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(TestResource.class)
+    @RegisterExtension
+    public JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(TestResource.class)
                     .register(ApiFilter.class)
                     .register(NotSortableExceptionMapper.class));
 
     @Test
-    public void testFieldDoesNotExist() {
+    void testFieldDoesNotExist() {
         final Response response = jersey.target("/")
                 .queryParam("sortName", "foo")
                 .queryParam("sortOrder", "asc")
@@ -66,7 +65,7 @@ public class NotSortableExceptionMapperTest extends ResourceTest {
     }
 
     @Test
-    public void testTransientField() {
+    void testTransientField() {
         final Response response = jersey.target("/")
                 .queryParam("sortName", "bomRef")
                 .queryParam("sortOrder", "asc")
@@ -85,7 +84,7 @@ public class NotSortableExceptionMapperTest extends ResourceTest {
     }
 
     @Test
-    public void testPersistentField() {
+    void testPersistentField() {
         final Response response = jersey.target("/")
                 .queryParam("sortName", "name")
                 .queryParam("sortOrder", "asc")

--- a/src/test/java/org/dependencytrack/resources/v1/misc/BadgerTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/misc/BadgerTest.java
@@ -20,34 +20,34 @@ package org.dependencytrack.resources.v1.misc;
 
 import org.apache.commons.io.FileUtils;
 import org.dependencytrack.model.ProjectMetrics;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
-public class BadgerTest {
+class BadgerTest {
 
     @Test
-    public void generateVulnerabilitiesWithoutMetricsGenerateExpectedSvg() throws Exception {
+    void generateVulnerabilitiesWithoutMetricsGenerateExpectedSvg() throws Exception {
         Badger badger = new Badger();
         String svg = badger.generateVulnerabilities(null);
-        Assert.assertEquals(strip(svg), strip(expectedSvg("project-vulns-nometrics.svg")));
+        Assertions.assertEquals(strip(svg), strip(expectedSvg("project-vulns-nometrics.svg")));
     }
 
     @Test
-    public void generateVulnerabilitiesWithoutVulnerabilitiesGenerateExpectedSvg() throws Exception {
+    void generateVulnerabilitiesWithoutVulnerabilitiesGenerateExpectedSvg() throws Exception {
         ProjectMetrics metrics = new ProjectMetrics();
         metrics.setVulnerabilities(0);
         Badger badger = new Badger();
         String svg = badger.generateVulnerabilities(metrics);
-        Assert.assertEquals(strip(svg), strip(expectedSvg("project-vulns-none.svg")));
+        Assertions.assertEquals(strip(svg), strip(expectedSvg("project-vulns-none.svg")));
     }
 
     @Test
-    public void generateVulnerabilitiesWithVulnerabilitiesGenerateExpectedSvg() throws Exception {
+    void generateVulnerabilitiesWithVulnerabilitiesGenerateExpectedSvg() throws Exception {
         ProjectMetrics metrics = new ProjectMetrics();
         metrics.setVulnerabilities(1 + 2 + 3 + 4 + 5);
         metrics.setCritical(1);
@@ -57,27 +57,27 @@ public class BadgerTest {
         metrics.setUnassigned(5);
         Badger badger = new Badger();
         String svg = badger.generateVulnerabilities(metrics);
-        Assert.assertEquals(strip(svg), strip(expectedSvg("project-vulns.svg")));
+        Assertions.assertEquals(strip(svg), strip(expectedSvg("project-vulns.svg")));
     }
 
     @Test
-    public void generateViolationsWithoutMetricsGenerateExpectedSvg() throws Exception {
+    void generateViolationsWithoutMetricsGenerateExpectedSvg() throws Exception {
         Badger badger = new Badger();
         String svg = badger.generateViolations(null);
-        Assert.assertEquals(strip(svg), strip(expectedSvg("project-violations-nometrics.svg")));
+        Assertions.assertEquals(strip(svg), strip(expectedSvg("project-violations-nometrics.svg")));
     }
 
     @Test
-    public void generateViolationsWithoutViolationsGenerateExpectedSvg() throws Exception {
+    void generateViolationsWithoutViolationsGenerateExpectedSvg() throws Exception {
         ProjectMetrics metrics = new ProjectMetrics();
         metrics.setPolicyViolationsTotal(0);
         Badger badger = new Badger();
         String svg = badger.generateViolations(metrics);
-        Assert.assertEquals(strip(svg), strip(expectedSvg("project-violations-none.svg")));
+        Assertions.assertEquals(strip(svg), strip(expectedSvg("project-violations-none.svg")));
     }
 
     @Test
-    public void generateViolationsWithViolationsGenerateExpectedSvg() throws Exception {
+    void generateViolationsWithViolationsGenerateExpectedSvg() throws Exception {
         ProjectMetrics metrics = new ProjectMetrics();
         metrics.setPolicyViolationsTotal(1 + 2 + 3);
         metrics.setPolicyViolationsFail(1);
@@ -85,7 +85,7 @@ public class BadgerTest {
         metrics.setPolicyViolationsInfo(3);
         Badger badger = new Badger();
         String svg = badger.generateViolations(metrics);
-        Assert.assertEquals(strip(svg), strip(expectedSvg("project-violations.svg")));
+        Assertions.assertEquals(strip(svg), strip(expectedSvg("project-violations.svg")));
     }
 
     private String expectedSvg(String filename) throws Exception {

--- a/src/test/java/org/dependencytrack/resources/v1/vo/AffectedComponentTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/vo/AffectedComponentTest.java
@@ -1,14 +1,11 @@
 package org.dependencytrack.resources.v1.vo;
 
-
 import com.github.packageurl.PackageURL;
 import org.dependencytrack.model.AffectedVersionAttribution;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerableSoftware;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import java.sql.Date;
 import java.time.Instant;
@@ -16,17 +13,13 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Suite.class)
-@SuiteClasses(value = {
-        AffectedComponentTest.FromVulnerableSoftwareTest.class,
-        AffectedComponentTest.ToVulnerableSoftwareTest.class
-})
 public class AffectedComponentTest {
 
-    public static class FromVulnerableSoftwareTest {
+    @Nested
+    class FromVulnerableSoftwareTest {
 
         @Test
-        public void shouldMapCpe22ToCpeIdentity() {
+        void shouldMapCpe22ToCpeIdentity() {
             final var vs = new VulnerableSoftware();
             vs.setCpe22("cpe:/a:apache:tomcat:7.0.27");
 
@@ -41,7 +34,7 @@ public class AffectedComponentTest {
         }
 
         @Test
-        public void shouldMapCpe23ToCpeIdentity() {
+        void shouldMapCpe23ToCpeIdentity() {
             final var vs = new VulnerableSoftware();
             vs.setCpe23("cpe:2.3:a:apache:tomcat:7.0.27:*:*:*:*:*:*:*");
 
@@ -56,7 +49,7 @@ public class AffectedComponentTest {
         }
 
         @Test
-        public void shouldMapPurlToPurlIdentity() {
+        void shouldMapPurlToPurlIdentity() {
             final var vs = new VulnerableSoftware();
             vs.setPurl("pkg:golang/foo/bar@baz?ping=pong#1/2/3");
 
@@ -71,7 +64,7 @@ public class AffectedComponentTest {
         }
 
         @Test
-        public void shouldMapPurlToPurlIdentityEvenWhenNoNamespace() {
+        void shouldMapPurlToPurlIdentityEvenWhenNoNamespace() {
             final var vs = new VulnerableSoftware();
             vs.setPurlType(PackageURL.StandardTypes.GOLANG);
             vs.setPurlName("bar");
@@ -85,7 +78,7 @@ public class AffectedComponentTest {
         }
 
         @Test
-        public void shouldMapPurlFragmentsToPurlIdentity() {
+        void shouldMapPurlFragmentsToPurlIdentity() {
             final var vs = new VulnerableSoftware();
             vs.setPurlType(PackageURL.StandardTypes.GOLANG);
             vs.setPurlNamespace("foo");
@@ -105,7 +98,7 @@ public class AffectedComponentTest {
         }
 
         @Test
-        public void shouldMapMinimalPurlPartsToPurlIdentity() {
+        void shouldMapMinimalPurlPartsToPurlIdentity() {
             final var vs = new VulnerableSoftware();
             vs.setPurlType(PackageURL.StandardTypes.GOLANG);
             vs.setPurlNamespace("foo");
@@ -122,7 +115,7 @@ public class AffectedComponentTest {
         }
 
         @Test
-        public void shouldIgnorePurlQualifiersWhenInvalid() {
+        void shouldIgnorePurlQualifiersWhenInvalid() {
             final var vs = new VulnerableSoftware();
             vs.setPurlType(PackageURL.StandardTypes.GOLANG);
             vs.setPurlNamespace("foo");
@@ -142,7 +135,7 @@ public class AffectedComponentTest {
         }
 
         @Test
-        public void shouldUseExactVersionWhenAvailable() {
+        void shouldUseExactVersionWhenAvailable() {
             final var vs = new VulnerableSoftware();
             vs.setVersion("foo");
 
@@ -156,7 +149,7 @@ public class AffectedComponentTest {
         }
 
         @Test
-        public void shouldUseVersionRangeWhenAvailable() {
+        void shouldUseVersionRangeWhenAvailable() {
             final var vs = new VulnerableSoftware();
             vs.setVersionStartIncluding("foo");
             vs.setVersionStartExcluding("bar");
@@ -173,7 +166,7 @@ public class AffectedComponentTest {
         }
 
         @Test
-        public void shouldUseVersionRangeWhenBothRangeAndExactVersionAreAvailable() {
+        void shouldUseVersionRangeWhenBothRangeAndExactVersionAreAvailable() {
             final var vs = new VulnerableSoftware();
             vs.setVersion("*"); // CPEs will have a version wildcard when ranges are defined
             vs.setVersionStartIncluding("foo");
@@ -191,7 +184,7 @@ public class AffectedComponentTest {
         }
 
         @Test
-        public void shouldMapAffectedPackageAttribution() {
+        void shouldMapAffectedPackageAttribution() {
             final var vs = new VulnerableSoftware();
             AffectedVersionAttribution ava = new AffectedVersionAttribution();
             ava.setVulnerableSoftware(vs);
@@ -203,7 +196,8 @@ public class AffectedComponentTest {
         }
     }
 
-    public static class ToVulnerableSoftwareTest {
+    @Nested
+    class ToVulnerableSoftwareTest {
 
         @Test
         public void shouldMapCpe22Fields() {

--- a/src/test/java/org/dependencytrack/search/ComponentIndexerTest.java
+++ b/src/test/java/org/dependencytrack/search/ComponentIndexerTest.java
@@ -21,32 +21,32 @@ package org.dependencytrack.search;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.search.document.ComponentDocument;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-public class ComponentIndexerTest extends PersistenceCapableTest {
+class ComponentIndexerTest extends PersistenceCapableTest {
 
     @Test
-    public void getSearchFieldsTest() {
+    void getSearchFieldsTest() {
         String[] fields = ComponentIndexer.getInstance().getSearchFields();
-        Assert.assertEquals(6, fields.length);
-        Assert.assertEquals("uuid", fields[0]);
-        Assert.assertEquals("name", fields[1]);
-        Assert.assertEquals("group", fields[2]);
-        Assert.assertEquals("version", fields[3]);
-        Assert.assertEquals("sha1", fields[4]);
-        Assert.assertEquals("description", fields[5]);
+        Assertions.assertEquals(6, fields.length);
+        Assertions.assertEquals("uuid", fields[0]);
+        Assertions.assertEquals("name", fields[1]);
+        Assertions.assertEquals("group", fields[2]);
+        Assertions.assertEquals("version", fields[3]);
+        Assertions.assertEquals("sha1", fields[4]);
+        Assertions.assertEquals("description", fields[5]);
     }
 
     @Test
-    public void getIndexTypeTest() {
-        Assert.assertEquals(IndexManager.IndexType.COMPONENT, ComponentIndexer.getInstance().getIndexType());
+    void getIndexTypeTest() {
+        Assertions.assertEquals(IndexManager.IndexType.COMPONENT, ComponentIndexer.getInstance().getIndexType());
     }
 
     @Test
-    public void addTest() {
+    void addTest() {
         Component c = new Component();
         c.setUuid(UUID.randomUUID());
         c.setGroup("acme");
@@ -56,12 +56,12 @@ public class ComponentIndexerTest extends PersistenceCapableTest {
         ComponentIndexer.getInstance().commit();
         SearchManager searchManager = new SearchManager();
         SearchResult result = searchManager.searchIndex(ComponentIndexer.getInstance(), c.getUuid().toString(), 10);
-        Assert.assertEquals(1, result.getResults().size());
-        Assert.assertEquals(1, result.getResults().get("component").size());
+        Assertions.assertEquals(1, result.getResults().size());
+        Assertions.assertEquals(1, result.getResults().get("component").size());
     }
 
     @Test
-    public void removeTest() {
+    void removeTest() {
         Component c = new Component();
         c.setUuid(UUID.randomUUID());
         c.setGroup("acme");
@@ -73,12 +73,12 @@ public class ComponentIndexerTest extends PersistenceCapableTest {
         ComponentIndexer.getInstance().remove(new ComponentDocument(c));
         ComponentIndexer.getInstance().commit();
         SearchResult result = searchManager.searchIndex(ComponentIndexer.getInstance(), c.getUuid().toString(), 10);
-        Assert.assertEquals(1, result.getResults().size());
-        Assert.assertEquals(0, result.getResults().get("component").size());
+        Assertions.assertEquals(1, result.getResults().size());
+        Assertions.assertEquals(0, result.getResults().get("component").size());
     }
 
     @Test
-    public void reindexTest() {
+    void reindexTest() {
         ComponentIndexer.getInstance().reindex();
     }
 }

--- a/src/test/java/org/dependencytrack/search/FuzzyVulnerableSoftwareSearchManagerTest.java
+++ b/src/test/java/org/dependencytrack/search/FuzzyVulnerableSoftwareSearchManagerTest.java
@@ -6,11 +6,12 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.search.document.VulnerableSoftwareDocument;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.CpeParser;
 import us.springett.parsers.cpe.exceptions.CpeEncodingException;
@@ -24,16 +25,12 @@ import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class FuzzyVulnerableSoftwareSearchManagerTest {
+class FuzzyVulnerableSoftwareSearchManagerTest {
     private static final File INDEX_DIRECTORY;
     private static final File INDEX_TEMP_DIRECTORY;
     private FuzzyVulnerableSoftwareSearchManager toTest = new FuzzyVulnerableSoftwareSearchManager(true);
@@ -46,7 +43,7 @@ public class FuzzyVulnerableSoftwareSearchManagerTest {
         INDEX_TEMP_DIRECTORY = new File(INDEX_DIRECTORY.getAbsolutePath() + "_tmp");
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void saveVsIndex() throws IOException {
         VulnerableSoftwareIndexer.getInstance().close();
         if (INDEX_TEMP_DIRECTORY.exists()) {
@@ -62,61 +59,61 @@ public class FuzzyVulnerableSoftwareSearchManagerTest {
         VulnerableSoftwareIndexer.getInstance().add(new VulnerableSoftwareDocument(vs));
         VulnerableSoftwareIndexer.getInstance().commit();
     }
-    @AfterClass
+    @AfterAll
     public static void restoreVsIndex() throws IOException {
         VulnerableSoftwareIndexer.getInstance().close();
         if (INDEX_DIRECTORY.exists()) {
             FileUtils.deleteDirectory(INDEX_DIRECTORY);
         }
         if (INDEX_TEMP_DIRECTORY.exists()) {
-            assertTrue(INDEX_TEMP_DIRECTORY.renameTo(INDEX_DIRECTORY));
+            Assertions.assertTrue(INDEX_TEMP_DIRECTORY.renameTo(INDEX_DIRECTORY));
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         qm = mock(QueryManager.class);
         when(qm.getObjectByUuid(any(), anyString())).thenReturn(VALUE_TO_MATCH);
     }
 
     @Test
-    public void fuzzyAnalysis() throws CpeParsingException, CpeValidationException {
+    void fuzzyAnalysis() throws CpeParsingException, CpeValidationException {
         us.springett.parsers.cpe.Cpe justThePart = new us.springett.parsers.cpe.Cpe(Part.APPLICATION, "*", "*", "*", "*", "*", "*", "*", "*", "*", "*");
         // wildcard all components after part to constrain fuzzing to components of same type e.g. application, operating-system
         String fuzzyTerm = FuzzyVulnerableSoftwareSearchManager.getLuceneCpeRegexp(justThePart.toCpe23FS());
         SearchResult searchResult = toTest.searchIndex("product:libexpat1~0.88 AND " + fuzzyTerm);
         // Oddly validating lucene first cuz can't decouple from that.
-        assertEquals(1, searchResult.getResults().size());
-        assertEquals(1, searchResult.getResults().values().iterator().next().size());
+        Assertions.assertEquals(1, searchResult.getResults().size());
+        Assertions.assertEquals(1, searchResult.getResults().values().iterator().next().size());
 
         Component component = new Component();
         component.setName("libexpat1");
         component.setCpe("cpe:2.3:a:libexpat_project:libexpat1:2.0.0:*:*:*:*:*:*:*");
         Cpe cpe = CpeParser.parse(component.getCpe());
         List<VulnerableSoftware> vs = toTest.fuzzyAnalysis(qm, component, cpe);
-        assertFalse(vs.isEmpty());
-        assertSame(VALUE_TO_MATCH, vs.get(0));
+        Assertions.assertFalse(vs.isEmpty());
+        Assertions.assertSame(VALUE_TO_MATCH, vs.get(0));
 
     }
 
     @Test
-    public void getLuceneCpeRegexp() throws CpeValidationException, CpeEncodingException {
+    void getLuceneCpeRegexp() throws CpeValidationException, CpeEncodingException {
         us.springett.parsers.cpe.Cpe os = new us.springett.parsers.cpe.Cpe( Part.OPERATING_SYSTEM, "vendor", "product", "1\\.0", "2", "33","en", "inside", "Vista", "x86", "other");
 
-        assertEquals("cpe23:/cpe\\:2\\.3\\:a\\:.*\\:.*\\:.*\\:.*\\:.*\\:.*\\:.*\\:.*\\:.*\\:.*/", FuzzyVulnerableSoftwareSearchManager.getLuceneCpeRegexp("cpe:2.3:a:*:*:*:*:*:*:*:*:*:*"));
-        assertEquals("cpe23:/cpe\\:2\\.3\\:o\\:vendor\\:product\\:1.0\\:2\\:33\\:en\\:inside\\:Vista\\:x86\\:other/", FuzzyVulnerableSoftwareSearchManager.getLuceneCpeRegexp(os.toCpe23FS()));
-        assertEquals("cpe22:/cpe\\:\\/o\\:vendor\\:product\\:1.0\\:2\\:33\\:en/", FuzzyVulnerableSoftwareSearchManager.getLuceneCpeRegexp(os.toCpe22Uri()));
+        Assertions.assertEquals("cpe23:/cpe\\:2\\.3\\:a\\:.*\\:.*\\:.*\\:.*\\:.*\\:.*\\:.*\\:.*\\:.*\\:.*/", FuzzyVulnerableSoftwareSearchManager.getLuceneCpeRegexp("cpe:2.3:a:*:*:*:*:*:*:*:*:*:*"));
+        Assertions.assertEquals("cpe23:/cpe\\:2\\.3\\:o\\:vendor\\:product\\:1.0\\:2\\:33\\:en\\:inside\\:Vista\\:x86\\:other/", FuzzyVulnerableSoftwareSearchManager.getLuceneCpeRegexp(os.toCpe23FS()));
+        Assertions.assertEquals("cpe22:/cpe\\:\\/o\\:vendor\\:product\\:1.0\\:2\\:33\\:en/", FuzzyVulnerableSoftwareSearchManager.getLuceneCpeRegexp(os.toCpe22Uri()));
     }
 
     @Test
-    @Ignore ("This demonstrates assumptions about CPE matching but does not exercise code")
-    public void cpeMatching() {
+    @Disabled("This demonstrates assumptions about CPE matching but does not exercise code")
+    void cpeMatching() {
         String lucene = FuzzyVulnerableSoftwareSearchManager.getLuceneCpeRegexp("cpe:2.3:a:*:file:*:*:*:*:*:*:*:*");
         String regex = lucene.substring(7, lucene.length()-1);
         Pattern pattern = Pattern.compile(regex);
-        assertFalse(pattern.matcher(
+        Assertions.assertFalse(pattern.matcher(
         "cpe:2.3:a:dell:emc_vnx2_operating_environment:*:*:*:*:*:file:*:*").matches());
-        assertTrue(pattern.matcher(
+        Assertions.assertTrue(pattern.matcher(
                 "cpe:2.3:a:*:file:*:*:*:*:*:file:*:*").matches());
     }
 }

--- a/src/test/java/org/dependencytrack/search/LicenseIndexerTest.java
+++ b/src/test/java/org/dependencytrack/search/LicenseIndexerTest.java
@@ -21,29 +21,29 @@ package org.dependencytrack.search;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.License;
 import org.dependencytrack.search.document.LicenseDocument;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-public class LicenseIndexerTest extends PersistenceCapableTest {
+class LicenseIndexerTest extends PersistenceCapableTest {
 
     @Test
-    public void getSearchFieldsTest() {
+    void getSearchFieldsTest() {
         String[] fields = LicenseIndexer.getInstance().getSearchFields();
-        Assert.assertEquals(3, fields.length);
-        Assert.assertEquals("uuid", fields[0]);
-        Assert.assertEquals("licenseId", fields[1]);
-        Assert.assertEquals("name", fields[2]);
+        Assertions.assertEquals(3, fields.length);
+        Assertions.assertEquals("uuid", fields[0]);
+        Assertions.assertEquals("licenseId", fields[1]);
+        Assertions.assertEquals("name", fields[2]);
     }
 
     @Test
-    public void getIndexTypeTest() {
-        Assert.assertEquals(IndexManager.IndexType.LICENSE, LicenseIndexer.getInstance().getIndexType());
+    void getIndexTypeTest() {
+        Assertions.assertEquals(IndexManager.IndexType.LICENSE, LicenseIndexer.getInstance().getIndexType());
     }
 
     @Test
-    public void addTest() {
+    void addTest() {
         License l = new License();
         l.setUuid(UUID.randomUUID());
         l.setName("Acme License");
@@ -52,12 +52,12 @@ public class LicenseIndexerTest extends PersistenceCapableTest {
         LicenseIndexer.getInstance().commit();
         SearchManager searchManager = new SearchManager();
         SearchResult result = searchManager.searchIndex(LicenseIndexer.getInstance(), l.getUuid().toString(), 10);
-        Assert.assertEquals(1, result.getResults().size());
-        Assert.assertEquals(1, result.getResults().get("license").size());
+        Assertions.assertEquals(1, result.getResults().size());
+        Assertions.assertEquals(1, result.getResults().get("license").size());
     }
 
     @Test
-    public void removeTest() {
+    void removeTest() {
         License l = new License();
         l.setUuid(UUID.randomUUID());
         l.setName("Acme License");
@@ -68,12 +68,12 @@ public class LicenseIndexerTest extends PersistenceCapableTest {
         LicenseIndexer.getInstance().remove(new LicenseDocument(l));
         LicenseIndexer.getInstance().commit();
         SearchResult result = searchManager.searchIndex(LicenseIndexer.getInstance(), l.getUuid().toString(), 10);
-        Assert.assertEquals(1, result.getResults().size());
-        Assert.assertEquals(0, result.getResults().get("license").size());
+        Assertions.assertEquals(1, result.getResults().size());
+        Assertions.assertEquals(0, result.getResults().get("license").size());
     }
 
     @Test
-    public void reindexTest() {
+    void reindexTest() {
         LicenseIndexer.getInstance().reindex();
     }
 }

--- a/src/test/java/org/dependencytrack/search/ProjectIndexerTest.java
+++ b/src/test/java/org/dependencytrack/search/ProjectIndexerTest.java
@@ -21,31 +21,31 @@ package org.dependencytrack.search;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.search.document.ProjectDocument;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-public class ProjectIndexerTest extends PersistenceCapableTest {
+class ProjectIndexerTest extends PersistenceCapableTest {
 
     @Test
-    public void getSearchFieldsTest() {
+    void getSearchFieldsTest() {
         String[] fields = ProjectIndexer.getInstance().getSearchFields();
-        Assert.assertEquals(5, fields.length);
-        Assert.assertEquals("uuid", fields[0]);
-        Assert.assertEquals("name", fields[1]);
-        Assert.assertEquals("version", fields[2]);
-        Assert.assertEquals("properties", fields[3]);
-        Assert.assertEquals("description", fields[4]);
+        Assertions.assertEquals(5, fields.length);
+        Assertions.assertEquals("uuid", fields[0]);
+        Assertions.assertEquals("name", fields[1]);
+        Assertions.assertEquals("version", fields[2]);
+        Assertions.assertEquals("properties", fields[3]);
+        Assertions.assertEquals("description", fields[4]);
     }
 
     @Test
-    public void getIndexTypeTest() {
-        Assert.assertEquals(IndexManager.IndexType.PROJECT, ProjectIndexer.getInstance().getIndexType());
+    void getIndexTypeTest() {
+        Assertions.assertEquals(IndexManager.IndexType.PROJECT, ProjectIndexer.getInstance().getIndexType());
     }
 
     @Test
-    public void addTest() {
+    void addTest() {
         Project p = new Project();
         p.setUuid(UUID.randomUUID());
         p.setName("Acme Application");
@@ -54,12 +54,12 @@ public class ProjectIndexerTest extends PersistenceCapableTest {
         ProjectIndexer.getInstance().commit();
         SearchManager searchManager = new SearchManager();
         SearchResult result = searchManager.searchIndex(ProjectIndexer.getInstance(), p.getUuid().toString(), 10);
-        Assert.assertEquals(1, result.getResults().size());
-        Assert.assertEquals(1, result.getResults().get("project").size());
+        Assertions.assertEquals(1, result.getResults().size());
+        Assertions.assertEquals(1, result.getResults().get("project").size());
     }
 
     @Test
-    public void removeTest() {
+    void removeTest() {
         Project p = new Project();
         p.setUuid(UUID.randomUUID());
         p.setName("Acme Application");
@@ -70,12 +70,12 @@ public class ProjectIndexerTest extends PersistenceCapableTest {
         ProjectIndexer.getInstance().remove(new ProjectDocument(p));
         ProjectIndexer.getInstance().commit();
         SearchResult result = searchManager.searchIndex(ProjectIndexer.getInstance(), p.getUuid().toString(), 10);
-        Assert.assertEquals(1, result.getResults().size());
-        Assert.assertEquals(0, result.getResults().get("project").size());
+        Assertions.assertEquals(1, result.getResults().size());
+        Assertions.assertEquals(0, result.getResults().get("project").size());
     }
 
     @Test
-    public void reindexTest() {
+    void reindexTest() {
         ProjectIndexer.getInstance().reindex();
     }
 }

--- a/src/test/java/org/dependencytrack/search/ServiceComponentIndexerTest.java
+++ b/src/test/java/org/dependencytrack/search/ServiceComponentIndexerTest.java
@@ -21,32 +21,32 @@ package org.dependencytrack.search;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.ServiceComponent;
 import org.dependencytrack.search.document.ServiceComponentDocument;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-public class ServiceComponentIndexerTest extends PersistenceCapableTest {
+class ServiceComponentIndexerTest extends PersistenceCapableTest {
 
     @Test
-    public void getSearchFieldsTest() {
+    void getSearchFieldsTest() {
         String[] fields = ServiceComponentIndexer.getInstance().getSearchFields();
-        Assert.assertEquals(6, fields.length);
-        Assert.assertEquals("uuid", fields[0]);
-        Assert.assertEquals("name", fields[1]);
-        Assert.assertEquals("group", fields[2]);
-        Assert.assertEquals("version", fields[3]);
-        Assert.assertEquals("url", fields[4]);
-        Assert.assertEquals("description", fields[5]);
+        Assertions.assertEquals(6, fields.length);
+        Assertions.assertEquals("uuid", fields[0]);
+        Assertions.assertEquals("name", fields[1]);
+        Assertions.assertEquals("group", fields[2]);
+        Assertions.assertEquals("version", fields[3]);
+        Assertions.assertEquals("url", fields[4]);
+        Assertions.assertEquals("description", fields[5]);
     }
 
     @Test
-    public void getIndexTypeTest() {
-        Assert.assertEquals(IndexManager.IndexType.SERVICECOMPONENT, ServiceComponentIndexer.getInstance().getIndexType());
+    void getIndexTypeTest() {
+        Assertions.assertEquals(IndexManager.IndexType.SERVICECOMPONENT, ServiceComponentIndexer.getInstance().getIndexType());
     }
 
     @Test
-    public void addTest() {
+    void addTest() {
         ServiceComponent s = new ServiceComponent();
         s.setUuid(UUID.randomUUID());
         s.setGroup("acme");
@@ -56,12 +56,12 @@ public class ServiceComponentIndexerTest extends PersistenceCapableTest {
         ServiceComponentIndexer.getInstance().commit();
         SearchManager searchManager = new SearchManager();
         SearchResult result = searchManager.searchIndex(ServiceComponentIndexer.getInstance(), s.getUuid().toString(), 10);
-        Assert.assertEquals(1, result.getResults().size());
-        Assert.assertEquals(1, result.getResults().get("servicecomponent").size());
+        Assertions.assertEquals(1, result.getResults().size());
+        Assertions.assertEquals(1, result.getResults().get("servicecomponent").size());
     }
 
     @Test
-    public void removeTest() {
+    void removeTest() {
         ServiceComponent s = new ServiceComponent();
         s.setUuid(UUID.randomUUID());
         s.setGroup("acme");
@@ -73,12 +73,12 @@ public class ServiceComponentIndexerTest extends PersistenceCapableTest {
         ServiceComponentIndexer.getInstance().remove(new ServiceComponentDocument(s));
         ServiceComponentIndexer.getInstance().commit();
         SearchResult result = searchManager.searchIndex(ServiceComponentIndexer.getInstance(), s.getUuid().toString(), 10);
-        Assert.assertEquals(1, result.getResults().size());
-        Assert.assertEquals(0, result.getResults().get("servicecomponent").size());
+        Assertions.assertEquals(1, result.getResults().size());
+        Assertions.assertEquals(0, result.getResults().get("servicecomponent").size());
     }
 
     @Test
-    public void reindexTest() {
+    void reindexTest() {
         ServiceComponentIndexer.getInstance().reindex();
     }
 }

--- a/src/test/java/org/dependencytrack/search/VulnerabilityIndexerTest.java
+++ b/src/test/java/org/dependencytrack/search/VulnerabilityIndexerTest.java
@@ -21,29 +21,29 @@ package org.dependencytrack.search;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.search.document.VulnerabilityDocument;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-public class VulnerabilityIndexerTest extends PersistenceCapableTest {
+class VulnerabilityIndexerTest extends PersistenceCapableTest {
 
     @Test
-    public void getSearchFieldsTest() {
+    void getSearchFieldsTest() {
         String[] fields = VulnerabilityIndexer.getInstance().getSearchFields();
-        Assert.assertEquals(3, fields.length);
-        Assert.assertEquals("uuid", fields[0]);
-        Assert.assertEquals("vulnId", fields[1]);
-        Assert.assertEquals("description", fields[2]);
+        Assertions.assertEquals(3, fields.length);
+        Assertions.assertEquals("uuid", fields[0]);
+        Assertions.assertEquals("vulnId", fields[1]);
+        Assertions.assertEquals("description", fields[2]);
     }
 
     @Test
-    public void getIndexTypeTest() {
-        Assert.assertEquals(IndexManager.IndexType.VULNERABILITY, VulnerabilityIndexer.getInstance().getIndexType());
+    void getIndexTypeTest() {
+        Assertions.assertEquals(IndexManager.IndexType.VULNERABILITY, VulnerabilityIndexer.getInstance().getIndexType());
     }
 
     @Test
-    public void addTest() {
+    void addTest() {
         Vulnerability v = new Vulnerability();
         v.setUuid(UUID.randomUUID());
         v.setVulnId("INT-1");
@@ -53,12 +53,12 @@ public class VulnerabilityIndexerTest extends PersistenceCapableTest {
         VulnerabilityIndexer.getInstance().commit();
         SearchManager searchManager = new SearchManager();
         SearchResult result = searchManager.searchIndex(VulnerabilityIndexer.getInstance(), v.getUuid().toString(), 10);
-        Assert.assertEquals(1, result.getResults().size());
-        Assert.assertEquals(1, result.getResults().get("vulnerability").size());
+        Assertions.assertEquals(1, result.getResults().size());
+        Assertions.assertEquals(1, result.getResults().get("vulnerability").size());
     }
 
     @Test
-    public void removeTest() {
+    void removeTest() {
         Vulnerability v = new Vulnerability();
         v.setUuid(UUID.randomUUID());
         v.setVulnId("INT-1");
@@ -70,12 +70,12 @@ public class VulnerabilityIndexerTest extends PersistenceCapableTest {
         VulnerabilityIndexer.getInstance().remove(new VulnerabilityDocument(v));
         VulnerabilityIndexer.getInstance().commit();
         SearchResult result = searchManager.searchIndex(VulnerabilityIndexer.getInstance(), v.getUuid().toString(), 10);
-        Assert.assertEquals(1, result.getResults().size());
-        Assert.assertEquals(0, result.getResults().get("vulnerability").size());
+        Assertions.assertEquals(1, result.getResults().size());
+        Assertions.assertEquals(0, result.getResults().get("vulnerability").size());
     }
 
     @Test
-    public void reindexTest() {
+    void reindexTest() {
         VulnerabilityIndexer.getInstance().reindex();
     }
 }

--- a/src/test/java/org/dependencytrack/search/VulnerableSoftwareIndexerTest.java
+++ b/src/test/java/org/dependencytrack/search/VulnerableSoftwareIndexerTest.java
@@ -21,32 +21,32 @@ package org.dependencytrack.search;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.search.document.VulnerableSoftwareDocument;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-public class VulnerableSoftwareIndexerTest extends PersistenceCapableTest {
+class VulnerableSoftwareIndexerTest extends PersistenceCapableTest {
 
     @Test
-    public void getSearchFieldsTest() {
+    void getSearchFieldsTest() {
         String[] fields = VulnerableSoftwareIndexer.getInstance().getSearchFields();
-        Assert.assertEquals(6, fields.length);
-        Assert.assertEquals("uuid", fields[0]);
-        Assert.assertEquals("cpe22", fields[1]);
-        Assert.assertEquals("cpe23", fields[2]);
-        Assert.assertEquals("vendor", fields[3]);
-        Assert.assertEquals("product", fields[4]);
-        Assert.assertEquals("version", fields[5]);
+        Assertions.assertEquals(6, fields.length);
+        Assertions.assertEquals("uuid", fields[0]);
+        Assertions.assertEquals("cpe22", fields[1]);
+        Assertions.assertEquals("cpe23", fields[2]);
+        Assertions.assertEquals("vendor", fields[3]);
+        Assertions.assertEquals("product", fields[4]);
+        Assertions.assertEquals("version", fields[5]);
     }
 
     @Test
-    public void getIndexTypeTest() {
-        Assert.assertEquals(IndexManager.IndexType.VULNERABLESOFTWARE, VulnerableSoftwareIndexer.getInstance().getIndexType());
+    void getIndexTypeTest() {
+        Assertions.assertEquals(IndexManager.IndexType.VULNERABLESOFTWARE, VulnerableSoftwareIndexer.getInstance().getIndexType());
     }
 
     @Test
-    public void addTest() {
+    void addTest() {
         VulnerableSoftware vulnerableSoftware = new VulnerableSoftware();
         vulnerableSoftware.setUuid(UUID.randomUUID());
         vulnerableSoftware.setCpe22("cpe22");
@@ -58,12 +58,12 @@ public class VulnerableSoftwareIndexerTest extends PersistenceCapableTest {
         VulnerableSoftwareIndexer.getInstance().commit();
         SearchManager searchManager = new SearchManager();
         SearchResult result = searchManager.searchIndex(VulnerableSoftwareIndexer.getInstance(), vulnerableSoftware.getCpe23(), 10);
-        Assert.assertEquals(1, result.getResults().size());
-        Assert.assertEquals(1, result.getResults().get(VulnerableSoftwareIndexer.getInstance().getIndexType().name().toLowerCase()).size());
+        Assertions.assertEquals(1, result.getResults().size());
+        Assertions.assertEquals(1, result.getResults().get(VulnerableSoftwareIndexer.getInstance().getIndexType().name().toLowerCase()).size());
     }
 
     @Test
-    public void removeTest() {
+    void removeTest() {
         VulnerableSoftware vulnerableSoftware = new VulnerableSoftware();
         vulnerableSoftware.setUuid(UUID.randomUUID());
         vulnerableSoftware.setCpe22("cpe22");
@@ -77,12 +77,12 @@ public class VulnerableSoftwareIndexerTest extends PersistenceCapableTest {
         VulnerableSoftwareIndexer.getInstance().remove(new VulnerableSoftwareDocument(vulnerableSoftware));
         VulnerableSoftwareIndexer.getInstance().commit();
         SearchResult result = searchManager.searchIndex(VulnerableSoftwareIndexer.getInstance(), vulnerableSoftware.getUuid().toString(), 10);
-        Assert.assertEquals(1, result.getResults().size());
-        Assert.assertEquals(0, result.getResults().get(VulnerableSoftwareIndexer.getInstance().getIndexType().name().toLowerCase()).size());
+        Assertions.assertEquals(1, result.getResults().size());
+        Assertions.assertEquals(0, result.getResults().get(VulnerableSoftwareIndexer.getInstance().getIndexType().name().toLowerCase()).size());
     }
 
     @Test
-    public void reindexTest() {
+    void reindexTest() {
         VulnerableSoftwareIndexer.getInstance().reindex();
     }
 }

--- a/src/test/java/org/dependencytrack/servlet/NvdMirrorServletTest.java
+++ b/src/test/java/org/dependencytrack/servlet/NvdMirrorServletTest.java
@@ -19,8 +19,8 @@
 package org.dependencytrack.servlet;
 
 import org.dependencytrack.servlets.NvdMirrorServlet;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletContext;
@@ -31,11 +31,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class NvdMirrorServletTest {
+class NvdMirrorServletTest {
 
     private NvdMirrorServlet servlet;
 
-    @Before
+    @BeforeEach
     public void before() throws ServletException {
         final ServletConfig servletConfig = mock(ServletConfig.class);
         final ServletContext servletContext = mock(ServletContext.class);
@@ -45,7 +45,7 @@ public class NvdMirrorServletTest {
     }
 
     @Test
-    public void doGet() throws Exception {
+    void doGet() throws Exception {
         final HttpServletRequest request =  mock(HttpServletRequest.class);
         HttpServletResponse response =  mock(HttpServletResponse.class);
         when(request.getMethod()).thenReturn("http");

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -49,15 +49,16 @@ import org.dependencytrack.notification.vo.BomProcessingFailed;
 import org.dependencytrack.notification.vo.NewVulnerabilityIdentified;
 import org.dependencytrack.parser.spdx.json.SpdxLicenseDetailParser;
 import org.dependencytrack.search.document.ComponentDocument;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
+
 import javax.jdo.JDOObjectNotFoundException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
@@ -79,7 +80,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
 import static org.dependencytrack.assertion.Assertions.assertConditionWithTimeout;
 
-public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
+class BomUploadProcessingTaskTest extends PersistenceCapableTest {
 
     public static class EventSubscriber implements alpine.event.framework.Subscriber {
 
@@ -102,7 +103,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     private static final ConcurrentLinkedQueue<Event> EVENTS = new ConcurrentLinkedQueue<>();
     private static final ConcurrentLinkedQueue<Notification> NOTIFICATIONS = new ConcurrentLinkedQueue<>();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         EventService.getInstance().subscribe(IndexEvent.class, EventSubscriber.class);
         EventService.getInstance().subscribe(RepositoryMetaEvent.class, EventSubscriber.class);
@@ -122,7 +123,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
                 ConfigPropertyConstants.SCANNER_INTERNAL_ENABLED.getDescription());
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         EventService.getInstance().unsubscribe(EventSubscriber.class);
         EventService.getInstance().unsubscribe(VulnerabilityAnalysisTask.class);
@@ -134,7 +135,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informTest() throws Exception {
+    void informTest() throws Exception {
         EventService.getInstance().subscribe(ProjectVulnerabilityAnalysisEvent.class, VulnerabilityAnalysisTask.class);
         EventService.getInstance().subscribe(NewVulnerableDependencyAnalysisEvent.class, NewVulnerableDependencyAnalysisTask.class);
 
@@ -285,7 +286,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithEmptyBomTest() throws Exception {
+    void informWithEmptyBomTest() throws Exception {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
         final var bomUploadEvent = new BomUploadEvent(qm.detach(Project.class, project.getId()),
@@ -302,7 +303,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithInvalidCycloneDxBomTest() throws Exception {
+    void informWithInvalidCycloneDxBomTest() throws Exception {
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
         final byte[] bomBytes = """
@@ -337,7 +338,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithNonExistentProjectTest() throws Exception {
+    void informWithNonExistentProjectTest() throws Exception {
         final Project project = new Project();
         project.setId(1);
         project.setUuid(UUID.randomUUID());
@@ -356,7 +357,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithComponentsUnderMetadataBomTest() throws Exception {
+    void informWithComponentsUnderMetadataBomTest() throws Exception {
         final var project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
         final var bomUploadEvent = new BomUploadEvent(qm.detach(Project.class, project.getId()),
@@ -387,7 +388,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithExistingDuplicateComponentsTest() {
+    void informWithExistingDuplicateComponentsTest() {
         final var project = new Project();
         project.setName("acme-app");
         project.setVersion("1.0.0");
@@ -471,7 +472,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithBloatedBomTest() throws Exception {
+    void informWithBloatedBomTest() throws Exception {
         final var project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
         final var bomUploadEvent = new BomUploadEvent(qm.detach(Project.class, project.getId()),
@@ -522,7 +523,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithCustomLicenseResolutionTest() throws Exception {
+    void informWithCustomLicenseResolutionTest() throws Exception {
         final var customLicense = new License();
         customLicense.setName("custom license foobar");
         qm.createCustomLicense(customLicense, false);
@@ -555,7 +556,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithBomContainingLicenseExpressionTest() {
+    void informWithBomContainingLicenseExpressionTest() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -595,7 +596,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithBomContainingLicenseExpressionWithSingleIdTest() {
+    void informWithBomContainingLicenseExpressionWithSingleIdTest() {
         final var license = new License();
         license.setLicenseId("EPL-2.0");
         license.setName("Eclipse Public License 2.0");
@@ -641,7 +642,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithBomContainingInvalidLicenseExpressionTest() {
+    void informWithBomContainingInvalidLicenseExpressionTest() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -681,7 +682,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test // https://github.com/DependencyTrack/dependency-track/issues/3433
-    public void informIssue3433Test() {
+    void informIssue3433Test() {
         final var license = new License();
         license.setLicenseId("GPL-3.0-or-later");
         license.setName("GPL-3.0-or-later");
@@ -723,8 +724,9 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
         });
     }
 
-    @Test // https://github.com/DependencyTrack/dependency-track/issues/3498
-    public void informUpdateExistingLicenseTest() {
+    @Test
+        // https://github.com/DependencyTrack/dependency-track/issues/3498
+    void informUpdateExistingLicenseTest() {
         final var existingLicense = new License();
         existingLicense.setLicenseId("GPL-3.0-or-later");
         existingLicense.setName("GPL-3.0-or-later");
@@ -811,7 +813,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test // https://github.com/DependencyTrack/dependency-track/issues/3498
-    public void informDeleteExistingLicenseTest() {
+    void informDeleteExistingLicenseTest() {
         final var existingLicense = new License();
         existingLicense.setLicenseId("GPL-3.0-or-later");
         existingLicense.setName("GPL-3.0-or-later");
@@ -888,7 +890,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithBomContainingServiceTest() throws Exception {
+    void informWithBomContainingServiceTest() throws Exception {
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
         final var bomUploadEvent = new BomUploadEvent(qm.detach(Project.class, project.getId()),
@@ -901,7 +903,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithExistingComponentPropertiesAndBomWithoutComponentProperties() {
+    void informWithExistingComponentPropertiesAndBomWithoutComponentProperties() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -941,7 +943,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithExistingComponentPropertiesAndBomWithComponentProperties() {
+    void informWithExistingComponentPropertiesAndBomWithComponentProperties() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -992,7 +994,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithExistingDuplicateComponentPropertiesAndBomWithDuplicateComponentProperties() {
+    void informWithExistingDuplicateComponentPropertiesAndBomWithDuplicateComponentProperties() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -1058,7 +1060,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithLicenseResolutionByNameTest() {
+    void informWithLicenseResolutionByNameTest() {
         final var license = new License();
         license.setLicenseId("MIT");
         license.setName("MIT License");
@@ -1101,7 +1103,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithLicenseResolutionByIdOrNameTest() {
+    void informWithLicenseResolutionByIdOrNameTest() {
         final var license = new License();
         license.setLicenseId("MIT");
         license.setName("MIT License");
@@ -1144,7 +1146,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informWithEmptyComponentAndServiceNameTest() {
+    void informWithEmptyComponentAndServiceNameTest() {
         final var project = new Project();
         project.setName("acme-license-app");
         qm.persist(project);
@@ -1183,7 +1185,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test // https://github.com/DependencyTrack/dependency-track/issues/1905
-    public void informIssue1905Test() throws Exception {
+    void informIssue1905Test() throws Exception {
         final var project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
         for (int i = 0; i < 3; i++) {
@@ -1217,7 +1219,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test // https://github.com/DependencyTrack/dependency-track/issues/2519
-    public void informIssue2519Test() throws Exception {
+    void informIssue2519Test() throws Exception {
         final var project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
         // Upload the same BOM again a few times.
@@ -1237,7 +1239,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test // https://github.com/DependencyTrack/dependency-track/issues/2859
-    public void informIssue2859Test() throws Exception {
+    void informIssue2859Test() throws Exception {
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
         final byte[] bomBytes = resourceToByteArray("/unit/bom-issue2859.xml");
@@ -1247,7 +1249,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test // https://github.com/DependencyTrack/dependency-track/issues/3309
-    public void informIssue3309Test() {
+    void informIssue3309Test() {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -1290,7 +1292,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test // https://github.com/DependencyTrack/dependency-track/issues/3371
-    public void informIssue3371Test() throws Exception {
+    void informIssue3371Test() throws Exception {
         final var project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
         // Upload the same BOM again a few times.
@@ -1320,8 +1322,9 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
         }
     }
 
-    @Test // https://github.com/DependencyTrack/dependency-track/issues/3957
-    public void informIssue3957Test() {
+    @Test
+        // https://github.com/DependencyTrack/dependency-track/issues/3957
+    void informIssue3957Test() {
         final var licenseA = new License();
         licenseA.setLicenseId("GPL-1.0");
         licenseA.setName("GNU General Public License v1.0 only");
@@ -1370,7 +1373,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informIssue3981Test() {
+    void informIssue3981Test() {
         final var project = new Project();
         project.setName("acme-license-app");
         project.setVersion("1.2.3");
@@ -1447,7 +1450,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informIssue3936Test() throws Exception {
+    void informIssue3936Test() throws Exception {
         final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         List<String> boms = new ArrayList<>(Arrays.asList("/unit/bom-issue3936-authors.json", "/unit/bom-issue3936-author.json", "/unit/bom-issue3936-both.json"));
         for (String bom : boms) {
@@ -1465,7 +1468,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informIssue4455Test() throws Exception {
+    void informIssue4455Test() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         project.setVersion("1.2.3");
@@ -1487,7 +1490,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
                 final JsonObject directDependencyObject = directDependenciesArray.getJsonObject(i);
                 final String directDependencyUuid = directDependencyObject.getString("uuid");
                 if (!uuidsSeen.add(directDependencyUuid)) {
-                    Assert.fail("Duplicate UUID %s in project's directDependencies: %s".formatted(
+                    Assertions.fail("Duplicate UUID %s in project's directDependencies: %s".formatted(
                             directDependencyUuid, directDependenciesJson));
                 }
             }
@@ -1508,7 +1511,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
                 final JsonObject directDependencyObject = directDependenciesArray.getJsonObject(i);
                 final String directDependencyUuid = directDependencyObject.getString("uuid");
                 if (!uuidsSeen.add(directDependencyUuid)) {
-                    Assert.fail("Duplicate UUID %s in component's directDependencies: %s".formatted(
+                    Assertions.fail("Duplicate UUID %s in component's directDependencies: %s".formatted(
                             directDependencyUuid, component.getDirectDependencies()));
                 }
             }

--- a/src/test/java/org/dependencytrack/tasks/DefectDojoUploadTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/DefectDojoUploadTaskTest.java
@@ -19,7 +19,9 @@
 package org.dependencytrack.tasks;
 
 import alpine.model.IConfigProperty;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import jakarta.ws.rs.core.MediaType;
 import org.apache.http.HttpHeaders;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.event.DefectDojoUploadEventAbstract;
@@ -28,11 +30,9 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-
-import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aMultipart;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -46,19 +46,22 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.dependencytrack.model.ConfigPropertyConstants.DEFECTDOJO_API_KEY;
 import static org.dependencytrack.model.ConfigPropertyConstants.DEFECTDOJO_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.DEFECTDOJO_REIMPORT_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.DEFECTDOJO_URL;
 
-public class DefectDojoUploadTaskTest extends PersistenceCapableTest {
+@WireMockTest
+class DefectDojoUploadTaskTest extends PersistenceCapableTest {
+    private WireMockRuntimeInfo wmRuntimeInfo;
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        this.wmRuntimeInfo = wmRuntimeInfo;
+    }
 
     @Test
-    public void testUpload() {
+    void testUpload() {
         qm.createConfigProperty(
                 DEFECTDOJO_ENABLED.getGroupName(),
                 DEFECTDOJO_ENABLED.getPropertyName(),
@@ -69,7 +72,7 @@ public class DefectDojoUploadTaskTest extends PersistenceCapableTest {
         qm.createConfigProperty(
                 DEFECTDOJO_URL.getGroupName(),
                 DEFECTDOJO_URL.getPropertyName(),
-                wireMockRule.baseUrl(),
+                wmRuntimeInfo.getHttpBaseUrl(),
                 DEFECTDOJO_URL.getPropertyType(),
                 null
         );
@@ -185,7 +188,7 @@ public class DefectDojoUploadTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testUploadWithTestName() {
+    void testUploadWithTestName() {
         qm.createConfigProperty(
                 DEFECTDOJO_ENABLED.getGroupName(),
                 DEFECTDOJO_ENABLED.getPropertyName(),
@@ -196,7 +199,7 @@ public class DefectDojoUploadTaskTest extends PersistenceCapableTest {
         qm.createConfigProperty(
                 DEFECTDOJO_URL.getGroupName(),
                 DEFECTDOJO_URL.getPropertyName(),
-                wireMockRule.baseUrl(),
+                wmRuntimeInfo.getHttpBaseUrl(),
                 DEFECTDOJO_URL.getPropertyType(),
                 null
         );
@@ -317,7 +320,7 @@ public class DefectDojoUploadTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testUploadWithGlobalReimport() {
+    void testUploadWithGlobalReimport() {
         qm.createConfigProperty(
                 DEFECTDOJO_ENABLED.getGroupName(),
                 DEFECTDOJO_ENABLED.getPropertyName(),
@@ -328,7 +331,7 @@ public class DefectDojoUploadTaskTest extends PersistenceCapableTest {
         qm.createConfigProperty(
                 DEFECTDOJO_URL.getGroupName(),
                 DEFECTDOJO_URL.getPropertyName(),
-                wireMockRule.baseUrl(),
+                wmRuntimeInfo.getHttpBaseUrl(),
                 DEFECTDOJO_URL.getPropertyType(),
                 null
         );
@@ -416,7 +419,7 @@ public class DefectDojoUploadTaskTest extends PersistenceCapableTest {
                                   ],
                                   "prefetch": {}
                                 }
-                                """.formatted(wireMockRule.baseUrl()))));
+                                """.formatted(wmRuntimeInfo.getHttpBaseUrl()))));
 
         stubFor(get(urlPathEqualTo("/api/v2/tests/"))
                 .withQueryParam("engagement", equalTo("666"))
@@ -461,7 +464,7 @@ public class DefectDojoUploadTaskTest extends PersistenceCapableTest {
                                    ],
                                    "prefetch": {}
                                  }
-                                """.formatted(wireMockRule.baseUrl()))));
+                                """.formatted(wmRuntimeInfo.getHttpBaseUrl()))));
 
         stubFor(post(urlPathEqualTo("/api/v2/reimport-scan/"))
                 .willReturn(aResponse()
@@ -565,7 +568,7 @@ public class DefectDojoUploadTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testUploadWithProjectLevelReimport() {
+    void testUploadWithProjectLevelReimport() {
         qm.createConfigProperty(
                 DEFECTDOJO_ENABLED.getGroupName(),
                 DEFECTDOJO_ENABLED.getPropertyName(),
@@ -576,7 +579,7 @@ public class DefectDojoUploadTaskTest extends PersistenceCapableTest {
         qm.createConfigProperty(
                 DEFECTDOJO_URL.getGroupName(),
                 DEFECTDOJO_URL.getPropertyName(),
-                wireMockRule.baseUrl(),
+                wmRuntimeInfo.getHttpBaseUrl(),
                 DEFECTDOJO_URL.getPropertyType(),
                 null
         );
@@ -687,7 +690,7 @@ public class DefectDojoUploadTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testUploadWithProjectLevelReimportAndTestName() {
+    void testUploadWithProjectLevelReimportAndTestName() {
         qm.createConfigProperty(
                 DEFECTDOJO_ENABLED.getGroupName(),
                 DEFECTDOJO_ENABLED.getPropertyName(),
@@ -698,7 +701,7 @@ public class DefectDojoUploadTaskTest extends PersistenceCapableTest {
         qm.createConfigProperty(
                 DEFECTDOJO_URL.getGroupName(),
                 DEFECTDOJO_URL.getPropertyName(),
-                wireMockRule.baseUrl(),
+                wmRuntimeInfo.getHttpBaseUrl(),
                 DEFECTDOJO_URL.getPropertyType(),
                 null
         );
@@ -814,7 +817,7 @@ public class DefectDojoUploadTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testUploadWithReimportAndNoExistingTest() {
+    void testUploadWithReimportAndNoExistingTest() {
         qm.createConfigProperty(
                 DEFECTDOJO_ENABLED.getGroupName(),
                 DEFECTDOJO_ENABLED.getPropertyName(),
@@ -825,7 +828,7 @@ public class DefectDojoUploadTaskTest extends PersistenceCapableTest {
         qm.createConfigProperty(
                 DEFECTDOJO_URL.getGroupName(),
                 DEFECTDOJO_URL.getPropertyName(),
-                wireMockRule.baseUrl(),
+                wmRuntimeInfo.getHttpBaseUrl(),
                 DEFECTDOJO_URL.getPropertyType(),
                 null
         );
@@ -912,8 +915,8 @@ public class DefectDojoUploadTaskTest extends PersistenceCapableTest {
      * for instructions on how to set it up.
      */
     @Test
-    @Ignore
-    public void testUploadIntegration() {
+    @Disabled
+    void testUploadIntegration() {
         final var baseUrl = "http://localhost:8080";
         final var apiKey = "";
         final var engagementId = "";

--- a/src/test/java/org/dependencytrack/tasks/GitHubAdvisoryMirrorTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/GitHubAdvisoryMirrorTaskTest.java
@@ -33,8 +33,8 @@ import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.Vulnerability.Source;
 import org.dependencytrack.model.VulnerabilityAlias;
 import org.dependencytrack.model.VulnerableSoftware;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.List;
@@ -45,12 +45,12 @@ import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SO
 import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_API_URL;
 import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED;
 
-public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
+class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
 
     private final ObjectMapper jsonMapper = new JsonMapper()
             .registerModule(new JavaTimeModule());
 
-    @Before
+    @BeforeEach
     public void beforeEach() {
         qm.createConfigProperty(
                 VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED.getGroupName(),
@@ -73,7 +73,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testProcessAdvisory() throws Exception {
+    void testProcessAdvisory() throws Exception {
         qm.createConfigProperty(
                 VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ALIAS_SYNC_ENABLED.getGroupName(),
                 VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ALIAS_SYNC_ENABLED.getPropertyName(),
@@ -142,7 +142,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testProcessAdvisoryWithAliasSyncDisabled() throws Exception {
+    void testProcessAdvisoryWithAliasSyncDisabled() throws Exception {
         qm.createConfigProperty(
                 VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ALIAS_SYNC_ENABLED.getGroupName(),
                 VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ALIAS_SYNC_ENABLED.getPropertyName(),
@@ -199,7 +199,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testProcessAdvisoryVulnerableVersionRanges() throws Exception {
+    void testProcessAdvisoryVulnerableVersionRanges() throws Exception {
         var vs1 = new VulnerableSoftware();
         vs1.setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind");
         vs1.setPurlType("maven");
@@ -348,7 +348,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldNotRetryOnResponseWithCode403() {
+    void shouldNotRetryOnResponseWithCode403() {
         final var httpResponse = new BasicHttpResponse(403);
         final var httpContext = HttpClientContext.create();
 
@@ -358,7 +358,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldRetryOnResponseWithCode429() {
+    void shouldRetryOnResponseWithCode429() {
         final var httpResponse = new BasicHttpResponse(429);
         final var httpContext = HttpClientContext.create();
 
@@ -368,7 +368,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldRetryOnResponseWithCode503() {
+    void shouldRetryOnResponseWithCode503() {
         final var httpResponse = new BasicHttpResponse(503);
         final var httpContext = HttpClientContext.create();
 
@@ -378,7 +378,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldRetryUpToSixAttempts() {
+    void shouldRetryUpToSixAttempts() {
         final var httpResponse = new BasicHttpResponse(503);
         final var httpContext = HttpClientContext.create();
 
@@ -392,7 +392,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldRetryOnResponseWithCode403AndRetryAfterHeader() {
+    void shouldRetryOnResponseWithCode403AndRetryAfterHeader() {
         final var httpResponse = new BasicHttpResponse(403);
         httpResponse.addHeader("retry-after", /* 1min */ 60);
         final var httpContext = HttpClientContext.create();
@@ -403,7 +403,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldRetryOnResponseWithCode429AndRetryAfterHeader() {
+    void shouldRetryOnResponseWithCode429AndRetryAfterHeader() {
         final var httpResponse = new BasicHttpResponse(429);
         httpResponse.addHeader("retry-after", /* 1min */ 60);
         final var httpContext = HttpClientContext.create();
@@ -414,7 +414,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldNotRetryWhenRetryAfterExceedsMaxDelay() {
+    void shouldNotRetryWhenRetryAfterExceedsMaxDelay() {
         final var httpResponse = new BasicHttpResponse(403);
         httpResponse.addHeader("retry-after", /* 3min */ 180);
         final var httpContext = HttpClientContext.create();
@@ -429,7 +429,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldRetryOnResponseWithCode403AndRateLimitHeaders() {
+    void shouldRetryOnResponseWithCode403AndRateLimitHeaders() {
         final var httpResponse = new BasicHttpResponse(403);
         httpResponse.addHeader("x-ratelimit-remaining", 6);
         httpResponse.addHeader("x-ratelimit-limit", 666);
@@ -442,7 +442,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldRetryOnResponseWithCode429AndRateLimitHeaders() {
+    void shouldRetryOnResponseWithCode429AndRateLimitHeaders() {
         final var httpResponse = new BasicHttpResponse(429);
         httpResponse.addHeader("x-ratelimit-remaining", 6);
         httpResponse.addHeader("x-ratelimit-limit", 666);
@@ -455,7 +455,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldRetryWhenLimitResetIsShorterThanMaxDelay() {
+    void shouldRetryWhenLimitResetIsShorterThanMaxDelay() {
         final var httpResponse = new BasicHttpResponse(429);
         httpResponse.addHeader("x-ratelimit-remaining", 0);
         httpResponse.addHeader("x-ratelimit-limit", 666);
@@ -468,7 +468,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldNotRetryWhenLimitResetExceedsMaxDelay() {
+    void shouldNotRetryWhenLimitResetExceedsMaxDelay() {
         final var httpResponse = new BasicHttpResponse(429);
         httpResponse.addHeader("x-ratelimit-remaining", 0);
         httpResponse.addHeader("x-ratelimit-limit", 666);
@@ -481,7 +481,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldUseRetryAfterHeaderForRetryDelay() {
+    void shouldUseRetryAfterHeaderForRetryDelay() {
         final var httpResponse = new BasicHttpResponse(429);
         httpResponse.addHeader("retry-after", /* 1min 6sec */ 66);
         final var httpContext = HttpClientContext.create();
@@ -492,7 +492,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldUseLimitResetHeaderForRetryDelay() {
+    void shouldUseLimitResetHeaderForRetryDelay() {
         final var httpResponse = new BasicHttpResponse(429);
         httpResponse.addHeader("x-ratelimit-remaining", 0);
         httpResponse.addHeader("x-ratelimit-limit", 666);
@@ -505,7 +505,7 @@ public class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldUseOneSecondAsDefaultRetryDelay() {
+    void shouldUseOneSecondAsDefaultRetryDelay() {
         final var httpResponse = new BasicHttpResponse(503);
         final var httpContext = HttpClientContext.create();
 

--- a/src/test/java/org/dependencytrack/tasks/InternalComponentIdentificationTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/InternalComponentIdentificationTaskTest.java
@@ -24,17 +24,17 @@ import org.dependencytrack.event.InternalComponentIdentificationEvent;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.Project;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.jdo.Query;
 import javax.jdo.Transaction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class InternalComponentIdentificationTaskTest extends PersistenceCapableTest {
+class InternalComponentIdentificationTaskTest extends PersistenceCapableTest {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         // Configure internal components to be identified by group "org.acme"
         // and names starting with "foobar-".
@@ -64,7 +64,7 @@ public class InternalComponentIdentificationTaskTest extends PersistenceCapableT
     }
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         new InternalComponentIdentificationTask().inform(new InternalComponentIdentificationEvent());
         assertThat(getInternalComponentCount()).isEqualTo(30);
     }

--- a/src/test/java/org/dependencytrack/tasks/KennaSecurityUploadTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/KennaSecurityUploadTaskTest.java
@@ -20,7 +20,8 @@ package org.dependencytrack.tasks;
 
 import alpine.model.IConfigProperty;
 import alpine.security.crypto.DataEncryption;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.event.KennaSecurityUploadEventAbstract;
 import org.dependencytrack.model.Component;
@@ -28,8 +29,7 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aMultipart;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -40,19 +40,15 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.dependencytrack.model.ConfigPropertyConstants.KENNA_API_URL;
 import static org.dependencytrack.model.ConfigPropertyConstants.KENNA_CONNECTOR_ID;
 import static org.dependencytrack.model.ConfigPropertyConstants.KENNA_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.KENNA_TOKEN;
 
-public class KennaSecurityUploadTaskTest extends PersistenceCapableTest {
-
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
-
+@WireMockTest
+class KennaSecurityUploadTaskTest extends PersistenceCapableTest {
     @Test
-    public void test() throws Exception {
+    void test(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         qm.createConfigProperty(
                 KENNA_ENABLED.getGroupName(),
                 KENNA_ENABLED.getPropertyName(),
@@ -62,7 +58,7 @@ public class KennaSecurityUploadTaskTest extends PersistenceCapableTest {
         qm.createConfigProperty(
                 KENNA_API_URL.getGroupName(),
                 KENNA_API_URL.getPropertyName(),
-                wireMockRule.baseUrl(),
+                wmRuntimeInfo.getHttpBaseUrl(),
                 KENNA_API_URL.getPropertyType(),
                 KENNA_API_URL.getDescription());
         qm.createConfigProperty(

--- a/src/test/java/org/dependencytrack/tasks/NistApiMirrorTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/NistApiMirrorTaskTest.java
@@ -19,7 +19,8 @@
 package org.dependencytrack.tasks;
 
 import alpine.model.ConfigProperty;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.event.NistApiMirrorEvent;
 import org.dependencytrack.model.AffectedVersionAttribution;
@@ -27,9 +28,8 @@ import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.Vulnerability.Source;
 import org.dependencytrack.model.VulnerableSoftware;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -39,20 +39,18 @@ import java.util.List;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.apache.commons.io.IOUtils.resourceToByteArray;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_NVD_API_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_NVD_API_LAST_MODIFIED_EPOCH_SECONDS;
 import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_NVD_API_URL;
 
-public class NistApiMirrorTaskTest extends PersistenceCapableTest {
+@WireMockTest
+class NistApiMirrorTaskTest extends PersistenceCapableTest {
 
-    @Rule
-    public WireMockRule wireMock = new WireMockRule(options().dynamicPort());
-
-    @Before
-    public void setUp() {
+    @BeforeEach
+    public void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
         qm.createConfigProperty(
                 VULNERABILITY_SOURCE_NVD_API_ENABLED.getGroupName(),
                 VULNERABILITY_SOURCE_NVD_API_ENABLED.getPropertyName(),
@@ -63,7 +61,7 @@ public class NistApiMirrorTaskTest extends PersistenceCapableTest {
         qm.createConfigProperty(
                 VULNERABILITY_SOURCE_NVD_API_URL.getGroupName(),
                 VULNERABILITY_SOURCE_NVD_API_URL.getPropertyName(),
-                wireMock.baseUrl(),
+                wmRuntimeInfo.getHttpBaseUrl(),
                 VULNERABILITY_SOURCE_NVD_API_URL.getPropertyType(),
                 VULNERABILITY_SOURCE_NVD_API_URL.getDescription()
         );
@@ -77,8 +75,8 @@ public class NistApiMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testInformWithNewVulnerability() throws Exception {
-        wireMock.stubFor(get(anyUrl())
+    void testInformWithNewVulnerability() throws Exception {
+        stubFor(get(anyUrl())
                 .willReturn(aResponse()
                         .withBody(resourceToByteArray("/unit/nvd/api/jsons/cve-2022-1954.json"))));
 
@@ -247,7 +245,7 @@ public class NistApiMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testInformWithUpdatedVulnerability() throws Exception {
+    void testInformWithUpdatedVulnerability() throws Exception {
         final var vuln = new Vulnerability();
         vuln.setVulnId("CVE-2022-1954");
         vuln.setSource(Source.NVD);
@@ -261,7 +259,7 @@ public class NistApiMirrorTaskTest extends PersistenceCapableTest {
         vuln.setEpssPercentile(BigDecimal.valueOf(0.6));
         qm.persist(vuln);
 
-        wireMock.stubFor(get(anyUrl())
+        stubFor(get(anyUrl())
                 .willReturn(aResponse()
                         .withBody(resourceToByteArray("/unit/nvd/api/jsons/cve-2022-1954.json"))));
 
@@ -283,7 +281,7 @@ public class NistApiMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testInformWithUpdatedVulnerableSoftware() throws Exception {
+    void testInformWithUpdatedVulnerableSoftware() throws Exception {
         final var vuln = new Vulnerability();
         vuln.setVulnId("CVE-2022-1954");
         vuln.setSource(Source.NVD);
@@ -346,7 +344,7 @@ public class NistApiMirrorTaskTest extends PersistenceCapableTest {
         vuln.setVulnerableSoftware(List.of(oldVsReportedByNvd, vsReportedByNvd, vsReportedByOsv));
         qm.persist(vuln);
 
-        wireMock.stubFor(get(anyUrl())
+        stubFor(get(anyUrl())
                 .willReturn(aResponse()
                         .withBody(resourceToByteArray("/unit/nvd/api/jsons/cve-2022-1954.json"))));
 
@@ -404,8 +402,8 @@ public class NistApiMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testInformWithIgnoringAmbiguousRunningOnCpeMatches() throws Exception {
-        wireMock.stubFor(get(anyUrl())
+    void testInformWithIgnoringAmbiguousRunningOnCpeMatches() throws Exception {
+        stubFor(get(anyUrl())
                 .willReturn(aResponse()
                         .withBody(resourceToByteArray("/unit/nvd/api/jsons/cve-2015-0312.json"))));
 
@@ -440,8 +438,8 @@ public class NistApiMirrorTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-public void testInformWithIgnoringAmbiguousRunningOnCpeMatchesAlt() throws Exception {
-        wireMock.stubFor(get(anyUrl())
+    void testInformWithIgnoringAmbiguousRunningOnCpeMatchesAlt() throws Exception {
+        stubFor(get(anyUrl())
                 .willReturn(aResponse()
                         .withBody(resourceToByteArray("/unit/nvd/api/jsons/cve-2024-23113.json"))));
 

--- a/src/test/java/org/dependencytrack/tasks/OsvDownloadTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/OsvDownloadTaskTest.java
@@ -29,9 +29,9 @@ import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.parser.osv.OsvAdvisoryParser;
 import org.dependencytrack.parser.osv.model.OsvAdvisory;
 import org.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -47,11 +47,11 @@ import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SO
 import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_NVD_ENABLED;
 
-public class OsvDownloadTaskTest extends PersistenceCapableTest {
+class OsvDownloadTaskTest extends PersistenceCapableTest {
     private JSONObject jsonObject;
     private final OsvAdvisoryParser parser = new OsvAdvisoryParser();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         qm.createConfigProperty(VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getGroupName(),
                 VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED.getPropertyName(),
@@ -76,7 +76,7 @@ public class OsvDownloadTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testParseOSVJsonToAdvisoryAndSave() throws Exception {
+    void testParseOSVJsonToAdvisoryAndSave() throws Exception {
         // Enable alias synchronization
         qm.createConfigProperty(
                 ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ALIAS_SYNC_ENABLED.getGroupName(),
@@ -88,47 +88,47 @@ public class OsvDownloadTaskTest extends PersistenceCapableTest {
 
         prepareJsonObject("src/test/resources/unit/osv.jsons/osv-GHSA-77rv-6vfw-x4gc.json");
         OsvAdvisory advisory = parser.parse(jsonObject);
-        Assert.assertNotNull(advisory);
-        Assert.assertEquals(8, advisory.getAffectedPackages().size());
+        Assertions.assertNotNull(advisory);
+        Assertions.assertEquals(8, advisory.getAffectedPackages().size());
 
         // pass the mapped advisory to OSV task to update the database
         final var task = new OsvDownloadTask();
         task.updateDatasource(advisory);
 
         final Consumer<Vulnerability> assertVulnerability = (vulnerability) -> {
-            Assert.assertNotNull(vulnerability);
-            Assert.assertFalse(StringUtils.isEmpty(vulnerability.getTitle()));
-            Assert.assertFalse(StringUtils.isEmpty(vulnerability.getDescription()));
-            Assert.assertNotNull(vulnerability.getCwes());
-            Assert.assertEquals(1, vulnerability.getCwes().size());
-            Assert.assertEquals(601, vulnerability.getCwes().get(0).intValue());
-            Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H", vulnerability.getCvssV3Vector());
-            Assert.assertEquals(Severity.CRITICAL, vulnerability.getSeverity());
-            Assert.assertNull(vulnerability.getCreated());
-            Assert.assertNotNull(vulnerability.getPublished());
-            Assert.assertEquals(LocalDateTime.of(2019, 3, 14, 15, 39, 30).toInstant(ZoneOffset.UTC), vulnerability.getPublished().toInstant());
-            Assert.assertNotNull(vulnerability.getUpdated());
-            Assert.assertEquals(LocalDateTime.of(2022, 6, 9, 7, 1, 32, 587000000).toInstant(ZoneOffset.UTC), vulnerability.getUpdated().toInstant());
-            Assert.assertEquals("Skywalker, Solo", vulnerability.getCredits());
+            Assertions.assertNotNull(vulnerability);
+            Assertions.assertFalse(StringUtils.isEmpty(vulnerability.getTitle()));
+            Assertions.assertFalse(StringUtils.isEmpty(vulnerability.getDescription()));
+            Assertions.assertNotNull(vulnerability.getCwes());
+            Assertions.assertEquals(1, vulnerability.getCwes().size());
+            Assertions.assertEquals(601, vulnerability.getCwes().get(0).intValue());
+            Assertions.assertEquals("CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H", vulnerability.getCvssV3Vector());
+            Assertions.assertEquals(Severity.CRITICAL, vulnerability.getSeverity());
+            Assertions.assertNull(vulnerability.getCreated());
+            Assertions.assertNotNull(vulnerability.getPublished());
+            Assertions.assertEquals(LocalDateTime.of(2019, 3, 14, 15, 39, 30).toInstant(ZoneOffset.UTC), vulnerability.getPublished().toInstant());
+            Assertions.assertNotNull(vulnerability.getUpdated());
+            Assertions.assertEquals(LocalDateTime.of(2022, 6, 9, 7, 1, 32, 587000000).toInstant(ZoneOffset.UTC), vulnerability.getUpdated().toInstant());
+            Assertions.assertEquals("Skywalker, Solo", vulnerability.getCredits());
         };
 
         Vulnerability vulnerability = qm.getVulnerabilityByVulnId("GITHUB", "GHSA-77rv-6vfw-x4gc", true);
         assertVulnerability.accept(vulnerability);
 
         List<VulnerableSoftware> vulnerableSoftware = qm.getAllVulnerableSoftwareByPurl(new PackageURL("pkg:maven/org.springframework.security.oauth/spring-security-oauth"));
-        Assert.assertEquals(4, vulnerableSoftware.size());
-        Assert.assertNull(vulnerableSoftware.get(0).getVersionStartIncluding());
-        Assert.assertEquals("2.0.17", vulnerableSoftware.get(0).getVersionEndExcluding());
-        Assert.assertEquals("2.1.0", vulnerableSoftware.get(1).getVersionStartIncluding());
-        Assert.assertEquals("2.1.4", vulnerableSoftware.get(1).getVersionEndExcluding());
-        Assert.assertEquals("2.2.0", vulnerableSoftware.get(2).getVersionStartIncluding());
-        Assert.assertEquals("2.2.4", vulnerableSoftware.get(2).getVersionEndExcluding());
-        Assert.assertEquals("2.3.0", vulnerableSoftware.get(3).getVersionStartIncluding());
-        Assert.assertEquals("2.3.5", vulnerableSoftware.get(3).getVersionEndExcluding());
+        Assertions.assertEquals(4, vulnerableSoftware.size());
+        Assertions.assertNull(vulnerableSoftware.get(0).getVersionStartIncluding());
+        Assertions.assertEquals("2.0.17", vulnerableSoftware.get(0).getVersionEndExcluding());
+        Assertions.assertEquals("2.1.0", vulnerableSoftware.get(1).getVersionStartIncluding());
+        Assertions.assertEquals("2.1.4", vulnerableSoftware.get(1).getVersionEndExcluding());
+        Assertions.assertEquals("2.2.0", vulnerableSoftware.get(2).getVersionStartIncluding());
+        Assertions.assertEquals("2.2.4", vulnerableSoftware.get(2).getVersionEndExcluding());
+        Assertions.assertEquals("2.3.0", vulnerableSoftware.get(3).getVersionStartIncluding());
+        Assertions.assertEquals("2.3.5", vulnerableSoftware.get(3).getVersionEndExcluding());
 
         // The advisory reports both spring-security-oauth and spring-security-oauth2 as affected
         vulnerableSoftware = qm.getAllVulnerableSoftwareByPurl(new PackageURL("pkg:maven/org.springframework.security.oauth/spring-security-oauth2"));
-        Assert.assertEquals(4, vulnerableSoftware.size());
+        Assertions.assertEquals(4, vulnerableSoftware.size());
 
         final List<VulnerabilityAlias> aliases = qm.getVulnerabilityAliases(vulnerability);
         assertThat(aliases).satisfiesExactly(
@@ -141,18 +141,18 @@ public class OsvDownloadTaskTest extends PersistenceCapableTest {
         // incoming vulnerability when vulnerability with same ID already exists
         prepareJsonObject("src/test/resources/unit/osv.jsons/new-GHSA-77rv-6vfw-x4gc.json");
         advisory = parser.parse(jsonObject);
-        Assert.assertNotNull(advisory);
+        Assertions.assertNotNull(advisory);
         task.updateDatasource(advisory);
         vulnerability = qm.getVulnerabilityByVulnId("GITHUB", "GHSA-77rv-6vfw-x4gc", true);
-        Assert.assertNotNull(vulnerability);
+        Assertions.assertNotNull(vulnerability);
         assertVulnerability.accept(vulnerability); // Ensure that the vulnerability was not modified
-        Assert.assertEquals(1, vulnerability.getVulnerableSoftware().size());
-        Assert.assertEquals("3.1.0", vulnerability.getVulnerableSoftware().get(0).getVersionStartIncluding());
-        Assert.assertEquals("3.3.0", vulnerability.getVulnerableSoftware().get(0).getVersionEndExcluding());
+        Assertions.assertEquals(1, vulnerability.getVulnerableSoftware().size());
+        Assertions.assertEquals("3.1.0", vulnerability.getVulnerableSoftware().get(0).getVersionStartIncluding());
+        Assertions.assertEquals("3.3.0", vulnerability.getVulnerableSoftware().get(0).getVersionEndExcluding());
     }
 
     @Test
-    public void testUpdateDatasourceWithAliasSyncDisabled() throws Exception {
+    void testUpdateDatasourceWithAliasSyncDisabled() throws Exception {
         // Disable alias synchronization
         qm.createConfigProperty(
                 ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ALIAS_SYNC_ENABLED.getGroupName(),
@@ -164,8 +164,8 @@ public class OsvDownloadTaskTest extends PersistenceCapableTest {
 
         prepareJsonObject("src/test/resources/unit/osv.jsons/osv-GHSA-77rv-6vfw-x4gc.json");
         OsvAdvisory advisory = parser.parse(jsonObject);
-        Assert.assertNotNull(advisory);
-        Assert.assertEquals(8, advisory.getAffectedPackages().size());
+        Assertions.assertNotNull(advisory);
+        Assertions.assertEquals(8, advisory.getAffectedPackages().size());
 
         // pass the mapped advisory to OSV task to update the database
         final var task = new OsvDownloadTask();
@@ -178,7 +178,7 @@ public class OsvDownloadTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testUpdateDatasourceVulnerableVersionRanges() {
+    void testUpdateDatasourceVulnerableVersionRanges() {
         var vs1 = new VulnerableSoftware();
         vs1.setPurlType("maven");
         vs1.setPurlNamespace("com.fasterxml.jackson.core");
@@ -349,95 +349,95 @@ public class OsvDownloadTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testParseAdvisoryToVulnerability() throws IOException {
+    void testParseAdvisoryToVulnerability() throws IOException {
 
         prepareJsonObject("src/test/resources/unit/osv.jsons/osv-GHSA-77rv-6vfw-x4gc.json");
         OsvAdvisory advisory = parser.parse(jsonObject);
-        Assert.assertNotNull(advisory);
+        Assertions.assertNotNull(advisory);
         final var task = new OsvDownloadTask();
         Vulnerability vuln = task.mapAdvisoryToVulnerability(qm, advisory);
-        Assert.assertNotNull(vuln);
-        Assert.assertEquals("Skywalker, Solo", vuln.getCredits());
-        Assert.assertEquals("GITHUB", vuln.getSource());
-        Assert.assertEquals(Severity.CRITICAL, vuln.getSeverity());
-        Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H", vuln.getCvssV3Vector());
+        Assertions.assertNotNull(vuln);
+        Assertions.assertEquals("Skywalker, Solo", vuln.getCredits());
+        Assertions.assertEquals("GITHUB", vuln.getSource());
+        Assertions.assertEquals(Severity.CRITICAL, vuln.getSeverity());
+        Assertions.assertEquals("CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H", vuln.getCvssV3Vector());
     }
 
     @Test
-    public void testParseAdvisoryToVulnerabilityWithInvalidPurl() throws IOException {
+    void testParseAdvisoryToVulnerabilityWithInvalidPurl() throws IOException {
         final var task = new OsvDownloadTask();
         prepareJsonObject("src/test/resources/unit/osv.jsons/osv-invalid-purl.json");
         OsvAdvisory advisory = parser.parse(jsonObject);
         task.updateDatasource(advisory);
-        Assert.assertNotNull(advisory);
+        Assertions.assertNotNull(advisory);
         Vulnerability vuln = qm.getVulnerabilityByVulnId("OSV", "OSV-2021-60", true);
-        Assert.assertNotNull(vuln);
-        Assert.assertEquals(Severity.MEDIUM, vuln.getSeverity());
-        Assert.assertEquals(1, vuln.getVulnerableSoftware().size());
+        Assertions.assertNotNull(vuln);
+        Assertions.assertEquals(Severity.MEDIUM, vuln.getSeverity());
+        Assertions.assertEquals(1, vuln.getVulnerableSoftware().size());
     }
 
     @Test
-    public void testWithdrawnAdvisory() throws Exception {
+    void testWithdrawnAdvisory() throws Exception {
 
         prepareJsonObject("src/test/resources/unit/osv.jsons/osv-withdrawn.json");
         OsvAdvisory advisory = parser.parse(jsonObject);
-        Assert.assertNull(advisory);
+        Assertions.assertNull(advisory);
     }
 
     @Test
-    public void testSourceOfVulnerability() {
+    void testSourceOfVulnerability() {
         final var task = new OsvDownloadTask();
 
         String sourceTestId = "GHSA-77rv-6vfw-x4gc";
         Vulnerability.Source source = task.extractSource(sourceTestId);
-        Assert.assertNotNull(source);
-        Assert.assertEquals(Vulnerability.Source.GITHUB, source);
+        Assertions.assertNotNull(source);
+        Assertions.assertEquals(Vulnerability.Source.GITHUB, source);
 
         sourceTestId = "CVE-2022-tyhg";
         source = task.extractSource(sourceTestId);
-        Assert.assertNotNull(source);
-        Assert.assertEquals(Vulnerability.Source.NVD, source);
+        Assertions.assertNotNull(source);
+        Assertions.assertEquals(Vulnerability.Source.NVD, source);
 
         sourceTestId = "anyOther-2022-tyhg";
         source = task.extractSource(sourceTestId);
-        Assert.assertNotNull(source);
-        Assert.assertEquals(Vulnerability.Source.OSV, source);
+        Assertions.assertNotNull(source);
+        Assertions.assertEquals(Vulnerability.Source.OSV, source);
     }
 
     @Test
-    public void testCalculateOSVSeverity() throws IOException {
+    void testCalculateOSVSeverity() throws IOException {
         final var task = new OsvDownloadTask();
         prepareJsonObject("src/test/resources/unit/osv.jsons/osv-GHSA-77rv-6vfw-x4gc.json");
         OsvAdvisory advisory = parser.parse(jsonObject);
-        Assert.assertNotNull(advisory);
+        Assertions.assertNotNull(advisory);
         Severity severity = task.calculateOSVSeverity(advisory);
-        Assert.assertEquals(Severity.CRITICAL, severity);
+        Assertions.assertEquals(Severity.CRITICAL, severity);
 
         prepareJsonObject("src/test/resources/unit/osv.jsons/osv-severity-test-ecosystem-cvss.json");
         advisory = parser.parse(jsonObject);
         severity = task.calculateOSVSeverity(advisory);
-        Assert.assertEquals(Severity.CRITICAL, severity);
+        Assertions.assertEquals(Severity.CRITICAL, severity);
 
         prepareJsonObject("src/test/resources/unit/osv.jsons/osv-severity-test-ecosystem.json");
         advisory = parser.parse(jsonObject);
         severity = task.calculateOSVSeverity(advisory);
-        Assert.assertEquals(Severity.MEDIUM, severity);
+        Assertions.assertEquals(Severity.MEDIUM, severity);
 
         prepareJsonObject("src/test/resources/unit/osv.jsons/osv-vulnerability-no-range.json");
         advisory = parser.parse(jsonObject);
-        Assert.assertNotNull(advisory);
+        Assertions.assertNotNull(advisory);
         severity = task.calculateOSVSeverity(advisory);
-        Assert.assertEquals(Severity.UNASSIGNED, severity);
+        Assertions.assertEquals(Severity.UNASSIGNED, severity);
 
         prepareJsonObject("src/test/resources/unit/osv.jsons/osv-CURL-CVE-2009-0037.json");
         advisory = parser.parse(jsonObject);
-        Assert.assertNotNull(advisory);
+        Assertions.assertNotNull(advisory);
         severity = task.calculateOSVSeverity(advisory);
-        Assert.assertEquals(Severity.UNASSIGNED, severity);
+        Assertions.assertEquals(Severity.UNASSIGNED, severity);
     }
 
     @Test
-    public void testCommitHashRangesAndVersions() throws IOException {
+    void testCommitHashRangesAndVersions() throws IOException {
         final var task = new OsvDownloadTask();
 
         // insert a vulnerability in database
@@ -446,21 +446,21 @@ public class OsvDownloadTaskTest extends PersistenceCapableTest {
         task.updateDatasource(advisory);
 
         Vulnerability vulnerability = qm.getVulnerabilityByVulnId("OSV", "OSV-2021-1820", true);
-        Assert.assertNotNull(vulnerability);
-        Assert.assertEquals(22, vulnerability.getVulnerableSoftware().size());
-        Assert.assertEquals(Severity.MEDIUM, vulnerability.getSeverity());
+        Assertions.assertNotNull(vulnerability);
+        Assertions.assertEquals(22, vulnerability.getVulnerableSoftware().size());
+        Assertions.assertEquals(Severity.MEDIUM, vulnerability.getSeverity());
     }
 
     @Test
-    public void testGetEcosystems() {
+    void testGetEcosystems() {
         final var task = new OsvDownloadTask();
         List<String> ecosystems = task.getEcosystems();
-        Assert.assertNotNull(ecosystems);
-        Assert.assertTrue(ecosystems.contains("Maven"));
+        Assertions.assertNotNull(ecosystems);
+        Assertions.assertTrue(ecosystems.contains("Maven"));
     }
 
     @Test
-    public void testUpdateDatasourceWithAdvisoryAlreadyMirroredFromEnabledNvdSource() throws IOException {
+    void testUpdateDatasourceWithAdvisoryAlreadyMirroredFromEnabledNvdSource() throws IOException {
 
         prepareJsonObject("src/test/resources/unit/osv.jsons/osv-existing-nvd-vuln-CVE-2021-34552.json");
 
@@ -488,9 +488,9 @@ public class OsvDownloadTaskTest extends PersistenceCapableTest {
         // Reload from database to bypass first level cache
         qm.getPersistenceManager().refreshAll();
         Vulnerability vulnerability = qm.getVulnerabilityByVulnId("NVD", "CVE-2021-34552", false);
-        Assert.assertNotNull(vulnerability);
-        Assert.assertEquals(Severity.CRITICAL, vulnerability.getSeverity());
-        Assert.assertEquals(existingVuln.getDescription(), vulnerability.getDescription());
+        Assertions.assertNotNull(vulnerability);
+        Assertions.assertEquals(Severity.CRITICAL, vulnerability.getSeverity());
+        Assertions.assertEquals(existingVuln.getDescription(), vulnerability.getDescription());
 
         final List<VulnerableSoftware> vsList = vulnerability.getVulnerableSoftware();
         assertThat(vsList).satisfiesExactlyInAnyOrder(
@@ -531,7 +531,7 @@ public class OsvDownloadTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testUpdateDatasourceWithAdvisoryAlreadyMirroredFromDisabledNvdSource() throws IOException {
+    void testUpdateDatasourceWithAdvisoryAlreadyMirroredFromDisabledNvdSource() throws IOException {
 
         ConfigProperty property = qm.getConfigProperty(VULNERABILITY_SOURCE_NVD_ENABLED.getGroupName(),
                 VULNERABILITY_SOURCE_NVD_ENABLED.getPropertyName());
@@ -564,9 +564,9 @@ public class OsvDownloadTaskTest extends PersistenceCapableTest {
         // Reload from database to bypass first level cache
         qm.getPersistenceManager().refreshAll();
         Vulnerability vulnerability = qm.getVulnerabilityByVulnId("NVD", "CVE-2021-34552", false);
-        Assert.assertNotNull(vulnerability);
-        Assert.assertEquals(Severity.UNASSIGNED, vulnerability.getSeverity());
-        Assert.assertEquals(jsonObject.getString("details"), vulnerability.getDescription());
+        Assertions.assertNotNull(vulnerability);
+        Assertions.assertEquals(Severity.UNASSIGNED, vulnerability.getSeverity());
+        Assertions.assertEquals(jsonObject.getString("details"), vulnerability.getDescription());
 
         final List<VulnerableSoftware> vsList = vulnerability.getVulnerableSoftware();
         assertThat(vsList).satisfiesExactlyInAnyOrder(
@@ -607,7 +607,7 @@ public class OsvDownloadTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testUpdateDatasourceWithAdvisoryAlreadyMirroredFromEnabledGithubSource() throws IOException {
+    void testUpdateDatasourceWithAdvisoryAlreadyMirroredFromEnabledGithubSource() throws IOException {
 
         prepareJsonObject("src/test/resources/unit/osv.jsons/osv-GHSA-77rv-6vfw-x4gc.json");
 
@@ -624,12 +624,12 @@ public class OsvDownloadTaskTest extends PersistenceCapableTest {
         // Reload from database to bypass first level cache
         qm.getPersistenceManager().refreshAll();
         Vulnerability vulnerability = qm.getVulnerabilityByVulnId("GITHUB", "GHSA-77rv-6vfw-x4gc", false);
-        Assert.assertNotNull(vulnerability);
-        Assert.assertEquals(Severity.LOW, vulnerability.getSeverity());
+        Assertions.assertNotNull(vulnerability);
+        Assertions.assertEquals(Severity.LOW, vulnerability.getSeverity());
     }
 
     @Test
-    public void testUpdateDatasourceWithAdvisoryAlreadyMirroredFromDisabledGithubSource() throws IOException {
+    void testUpdateDatasourceWithAdvisoryAlreadyMirroredFromDisabledGithubSource() throws IOException {
 
         ConfigProperty property = qm.getConfigProperty(VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED.getGroupName(),
                 VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED.getPropertyName());
@@ -651,8 +651,8 @@ public class OsvDownloadTaskTest extends PersistenceCapableTest {
         // Reload from database to bypass first level cache
         qm.getPersistenceManager().refreshAll();
         Vulnerability vulnerability = qm.getVulnerabilityByVulnId("GITHUB", "GHSA-77rv-6vfw-x4gc", false);
-        Assert.assertNotNull(vulnerability);
-        Assert.assertEquals(Severity.CRITICAL, vulnerability.getSeverity());
+        Assertions.assertNotNull(vulnerability);
+        Assertions.assertEquals(Severity.CRITICAL, vulnerability.getSeverity());
     }
 
     private void prepareJsonObject(String filePath) throws IOException {

--- a/src/test/java/org/dependencytrack/tasks/PolicyEvaluationTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/PolicyEvaluationTaskTest.java
@@ -7,16 +7,16 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
 import org.dependencytrack.model.Project;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PolicyEvaluationTaskTest extends PersistenceCapableTest {
+class PolicyEvaluationTaskTest extends PersistenceCapableTest {
 
     @Test
-    public void testPolicyEvaluationForSingleComponent() {
+    void testPolicyEvaluationForSingleComponent() {
         Project project = new Project();
         project.setName("my-project");
         project.setGroup("com.example");

--- a/src/test/java/org/dependencytrack/tasks/RepoMetaAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/RepoMetaAnalysisTaskTest.java
@@ -5,7 +5,9 @@ import com.github.packageurl.PackageURL;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.http.Body;
 import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import jakarta.ws.rs.core.MediaType;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.event.RepositoryMetaEvent;
 import org.dependencytrack.model.Component;
@@ -14,40 +16,35 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.tasks.repositories.RepositoryMetaAnalyzerTask;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import jakarta.ws.rs.core.MediaType;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RepoMetaAnalysisTaskTest extends PersistenceCapableTest {
+@WireMockTest
+class RepoMetaAnalysisTaskTest extends PersistenceCapableTest {
+    private WireMockRuntimeInfo wmRuntimeInfo;
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(options().port(2345));
-
-    @Before
-    public void setUp() {
+    @BeforeEach
+    public void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
+        this.wmRuntimeInfo = wmRuntimeInfo;
         qm.createConfigProperty(ConfigPropertyConstants.SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD.getGroupName(),
                 ConfigPropertyConstants.SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD.getPropertyName(), "43200000",
                 ConfigPropertyConstants.SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD.getPropertyType(),
                 ConfigPropertyConstants.SCANNER_ANALYSIS_CACHE_VALIDITY_PERIOD.getDescription());
-        wireMockRule.start();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         EventService.getInstance().unsubscribe(RepositoryMetaAnalyzerTask.class);
-        wireMockRule.stop();
     }
 
     @Test
-    public void informTestNullPassword() throws Exception {
+    void informTestNullPassword() throws Exception {
         WireMock.stubFor(WireMock.get(WireMock.anyUrl()).withHeader("Authorization", containing("Basic"))
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)
@@ -85,7 +82,7 @@ public class RepoMetaAnalysisTaskTest extends PersistenceCapableTest {
         component.setName("junit");
         component.setPurl(new PackageURL("pkg:maven/junit/junit@4.12"));
         qm.createComponent(component, false);
-        qm.createRepository(RepositoryType.MAVEN, "test", wireMockRule.baseUrl(), true, false, true, "testuser", null);
+        qm.createRepository(RepositoryType.MAVEN, "test", wmRuntimeInfo.getHttpBaseUrl(), true, false, true, "testuser", null);
         new RepositoryMetaAnalyzerTask().inform(new RepositoryMetaEvent(List.of(component)));
         RepositoryMetaComponent metaComponent = qm.getRepositoryMetaComponent(RepositoryType.MAVEN, "junit", "junit");
         qm.getPersistenceManager().refresh(metaComponent);
@@ -93,7 +90,7 @@ public class RepoMetaAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informTestNullUserName() throws Exception {
+    void informTestNullUserName() throws Exception {
         WireMock.stubFor(WireMock.get(WireMock.anyUrl()).withHeader("Authorization", containing("Basic"))
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)
@@ -131,7 +128,7 @@ public class RepoMetaAnalysisTaskTest extends PersistenceCapableTest {
         component.setName("test1");
         component.setPurl(new PackageURL("pkg:maven/test1/test1@1.2.0"));
         qm.createComponent(component, false);
-        qm.createRepository(RepositoryType.MAVEN, "test", wireMockRule.baseUrl(), true, false, true, null, "testPassword");
+        qm.createRepository(RepositoryType.MAVEN, "test", wmRuntimeInfo.getHttpBaseUrl(), true, false, true, null, "testPassword");
         new RepositoryMetaAnalyzerTask().inform(new RepositoryMetaEvent(List.of(component)));
         RepositoryMetaComponent metaComponent = qm.getRepositoryMetaComponent(RepositoryType.MAVEN, "test1", "test1");
         qm.getPersistenceManager().refresh(metaComponent);
@@ -139,7 +136,7 @@ public class RepoMetaAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informTestNullUserNameAndPassword() throws Exception {
+    void informTestNullUserNameAndPassword() throws Exception {
         WireMock.stubFor(WireMock.get(WireMock.anyUrl())
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)
@@ -177,7 +174,7 @@ public class RepoMetaAnalysisTaskTest extends PersistenceCapableTest {
         component.setName("junit");
         component.setPurl(new PackageURL("pkg:maven/test2/test2@4.12"));
         qm.createComponent(component, false);
-        qm.createRepository(RepositoryType.MAVEN, "test", wireMockRule.baseUrl(), true, false, false, null, null);
+        qm.createRepository(RepositoryType.MAVEN, "test", wmRuntimeInfo.getHttpBaseUrl(), true, false, false, null, null);
         new RepositoryMetaAnalyzerTask().inform(new RepositoryMetaEvent(List.of(component)));
         RepositoryMetaComponent metaComponent = qm.getRepositoryMetaComponent(RepositoryType.MAVEN, "test2", "test2");
         qm.getPersistenceManager().refresh(metaComponent);
@@ -185,7 +182,7 @@ public class RepoMetaAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void informTestUserNameAndPassword() throws Exception {
+    void informTestUserNameAndPassword() throws Exception {
         WireMock.stubFor(WireMock.get(WireMock.anyUrl())
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)
@@ -223,7 +220,7 @@ public class RepoMetaAnalysisTaskTest extends PersistenceCapableTest {
         component.setName("test3");
         component.setPurl(new PackageURL("pkg:maven/test3/test3@4.12"));
         qm.createComponent(component, false);
-        qm.createRepository(RepositoryType.MAVEN, "test", wireMockRule.baseUrl(), true, false, true, "testUser", "testPassword");
+        qm.createRepository(RepositoryType.MAVEN, "test", wmRuntimeInfo.getHttpBaseUrl(), true, false, true, "testUser", "testPassword");
         new RepositoryMetaAnalyzerTask().inform(new RepositoryMetaEvent(List.of(component)));
         RepositoryMetaComponent metaComponent = qm.getRepositoryMetaComponent(RepositoryType.MAVEN, "test3", "test3");
         qm.getPersistenceManager().refresh(metaComponent);

--- a/src/test/java/org/dependencytrack/tasks/ScheduledNotificationDispatchTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/ScheduledNotificationDispatchTaskTest.java
@@ -42,9 +42,9 @@ import org.dependencytrack.notification.publisher.WebhookPublisher;
 import org.dependencytrack.notification.vo.NewPolicyViolationsSummary;
 import org.dependencytrack.notification.vo.NewVulnerabilitiesSummary;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -61,7 +61,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 
-public class ScheduledNotificationDispatchTaskTest extends PersistenceCapableTest {
+class ScheduledNotificationDispatchTaskTest extends PersistenceCapableTest {
 
     public static class NotificationSubscriber implements Subscriber {
 
@@ -75,25 +75,19 @@ public class ScheduledNotificationDispatchTaskTest extends PersistenceCapableTes
     private static final Queue<Notification> NOTIFICATIONS = new ConcurrentLinkedQueue<>();
     private static final Subscription SUBSCRIPTION = new Subscription(NotificationSubscriber.class);
 
-    @Before
-    @Override
+    @BeforeEach
     public void before() throws Exception {
-        super.before();
-
         NotificationService.getInstance().subscribe(SUBSCRIPTION);
     }
 
-    @After
-    @Override
+    @AfterEach
     public void after() {
         NotificationService.getInstance().unsubscribe(SUBSCRIPTION);
         NOTIFICATIONS.clear();
-
-        super.after();
     }
 
     @Test
-    public void shouldDispatchNewVulnNotification() {
+    void shouldDispatchNewVulnNotification() {
         final Instant ruleLastFiredAt = Instant.now().minus(10, ChronoUnit.MINUTES);
         final Instant beforeRuleLastFiredAt = ruleLastFiredAt.minus(5, ChronoUnit.MINUTES);
         final Instant afterRuleLastFiredAt = ruleLastFiredAt.plus(5, ChronoUnit.MINUTES);
@@ -307,7 +301,7 @@ public class ScheduledNotificationDispatchTaskTest extends PersistenceCapableTes
     }
 
     @Test
-    public void shouldDispatchPolicyViolationNotificationWhenNotLimitedToProjects() {
+    void shouldDispatchPolicyViolationNotificationWhenNotLimitedToProjects() {
         final Instant ruleLastFiredAt = Instant.now().minus(10, ChronoUnit.MINUTES);
         final Instant beforeRuleLastFiredAt = ruleLastFiredAt.minus(5, ChronoUnit.MINUTES);
         final Instant afterRuleLastFiredAt = ruleLastFiredAt.plus(5, ChronoUnit.MINUTES);

--- a/src/test/java/org/dependencytrack/tasks/VulnerabilityAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/VulnerabilityAnalysisTaskTest.java
@@ -32,9 +32,9 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAnalysisLevel;
 import org.dependencytrack.model.VulnerableSoftware;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.List;
@@ -47,7 +47,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.awaitility.Awaitility.await;
 import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_INTERNAL_ENABLED;
 
-public class VulnerabilityAnalysisTaskTest extends PersistenceCapableTest {
+class VulnerabilityAnalysisTaskTest extends PersistenceCapableTest {
 
     private static final ConcurrentLinkedQueue<Event> EVENTS = new ConcurrentLinkedQueue<>();
 
@@ -60,26 +60,20 @@ public class VulnerabilityAnalysisTaskTest extends PersistenceCapableTest {
 
     }
 
-    @Before
-    @Override
+    @BeforeEach
     public void before() throws Exception {
-        super.before();
-
         EventService.getInstance().subscribe(ComponentMetricsUpdateEvent.class, EventSubscriber.class);
         EventService.getInstance().subscribe(ProjectMetricsUpdateEvent.class, EventSubscriber.class);
     }
 
-    @After
-    @Override
+    @AfterEach
     public void after() {
         EventService.getInstance().unsubscribe(EventSubscriber.class);
         EVENTS.clear();
-
-        super.after();
     }
 
     @Test
-    public void shouldAnalyzeComponent() {
+    void shouldAnalyzeComponent() {
         qm.createConfigProperty(
                 SCANNER_INTERNAL_ENABLED.getGroupName(),
                 SCANNER_INTERNAL_ENABLED.getPropertyName(),
@@ -119,7 +113,7 @@ public class VulnerabilityAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldAnalyzeProject() {
+    void shouldAnalyzeProject() {
         qm.createConfigProperty(
                 SCANNER_INTERNAL_ENABLED.getGroupName(),
                 SCANNER_INTERNAL_ENABLED.getPropertyName(),
@@ -166,7 +160,7 @@ public class VulnerabilityAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldAnalyzePortfolio() {
+    void shouldAnalyzePortfolio() {
         qm.createConfigProperty(
                 SCANNER_INTERNAL_ENABLED.getGroupName(),
                 SCANNER_INTERNAL_ENABLED.getPropertyName(),
@@ -231,13 +225,13 @@ public class VulnerabilityAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void shouldThrowWhenInformedAboutUnexpectedEvent() {
+    void shouldThrowWhenInformedAboutUnexpectedEvent() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new VulnerabilityAnalysisTask().inform(new GitHubAdvisoryMirrorEvent()));
     }
 
     @Test
-    public void shouldNotThrowWhenProjectDoesNotExist() {
+    void shouldNotThrowWhenProjectDoesNotExist() {
         final var dummyProject = new Project();
         dummyProject.setUuid(UUID.randomUUID());
 

--- a/src/test/java/org/dependencytrack/tasks/metrics/ComponentMetricsUpdateTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/metrics/ComponentMetricsUpdateTaskTest.java
@@ -30,17 +30,17 @@ import org.dependencytrack.model.ViolationAnalysisState;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ComponentMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest {
+class ComponentMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest {
 
     @Test
-    public void testUpdateCMetricsEmpty() {
+    void testUpdateCMetricsEmpty() {
         var project = new Project();
         project.setName("acme-app");
         project = qm.createProject(project, List.of(), false);
@@ -85,7 +85,7 @@ public class ComponentMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTes
     }
 
     @Test
-    public void testUpdateMetricsUnchanged() {
+    void testUpdateMetricsUnchanged() {
         var project = new Project();
         project.setName("acme-app");
         project = qm.createProject(project, List.of(), false);
@@ -111,7 +111,7 @@ public class ComponentMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTes
     }
 
     @Test
-    public void testUpdateMetricsVulnerabilities() {
+    void testUpdateMetricsVulnerabilities() {
         var project = new Project();
         project.setName("acme-app");
         project = qm.createProject(project, List.of(), false);
@@ -182,7 +182,7 @@ public class ComponentMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTes
     }
 
     @Test
-    public void testUpdateMetricsPolicyViolations() {
+    void testUpdateMetricsPolicyViolations() {
         var project = new Project();
         project.setName("acme-app");
         project = qm.createProject(project, List.of(), false);
@@ -238,7 +238,7 @@ public class ComponentMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTes
     }
 
     @Test
-    public void testUpdateMetricsWithDuplicateAliases() {
+    void testUpdateMetricsWithDuplicateAliases() {
         var project = new Project();
         project.setName("acme-app");
         project = qm.createProject(project, List.of(), false);

--- a/src/test/java/org/dependencytrack/tasks/metrics/PortfolioMetricsUpdateTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/metrics/PortfolioMetricsUpdateTaskTest.java
@@ -34,9 +34,9 @@ import org.dependencytrack.model.ViolationAnalysisState;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.tasks.CallbackTask;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 import java.util.List;
@@ -44,22 +44,22 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
-public class PortfolioMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest {
+class PortfolioMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() {
         EventService.getInstance().subscribe(ProjectMetricsUpdateEvent.class, ProjectMetricsUpdateTask.class);
         EventService.getInstance().subscribe(CallbackEvent.class, CallbackTask.class);
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() {
         EventService.getInstance().unsubscribe(ProjectMetricsUpdateTask.class);
         EventService.getInstance().unsubscribe(CallbackTask.class);
     }
 
     @Test
-    public void testUpdateMetricsEmpty() {
+    void testUpdateMetricsEmpty() {
         new PortfolioMetricsUpdateTask().inform(new PortfolioMetricsUpdateEvent());
 
         final PortfolioMetrics metrics = qm.getMostRecentPortfolioMetrics();
@@ -96,7 +96,7 @@ public class PortfolioMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTes
     }
 
     @Test
-    public void testUpdateMetricsUnchanged() {
+    void testUpdateMetricsUnchanged() {
         // Record initial portfolio metrics
         new PortfolioMetricsUpdateTask().inform(new PortfolioMetricsUpdateEvent());
         final PortfolioMetrics metrics = qm.getMostRecentPortfolioMetrics();
@@ -113,7 +113,7 @@ public class PortfolioMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTes
     }
 
     @Test
-    public void testUpdateMetricsVulnerabilities() {
+    void testUpdateMetricsVulnerabilities() {
         var vuln = new Vulnerability();
         vuln.setVulnId("INTERNAL-001");
         vuln.setSource(Vulnerability.Source.INTERNAL);
@@ -197,7 +197,7 @@ public class PortfolioMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTes
     }
 
     @Test
-    public void testUpdateMetricsPolicyViolations() {
+    void testUpdateMetricsPolicyViolations() {
         // Create a project with an unaudited violation.
         var projectUnaudited = new Project();
         projectUnaudited.setName("acme-app-a");

--- a/src/test/java/org/dependencytrack/tasks/metrics/ProjectMetricsUpdateTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/metrics/ProjectMetricsUpdateTaskTest.java
@@ -21,17 +21,17 @@ package org.dependencytrack.tasks.metrics;
 import org.dependencytrack.event.ProjectMetricsUpdateEvent;
 import org.dependencytrack.model.*;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProjectMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest {
+class ProjectMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest {
 
     @Test
-    public void testUpdateMetricsEmpty() {
+    void testUpdateMetricsEmpty() {
         var project = new Project();
         project.setName("acme-app");
         project = qm.createProject(project, List.of(), false);
@@ -75,7 +75,7 @@ public class ProjectMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest 
     }
 
     @Test
-    public void testUpdateMetricsUnchanged() {
+    void testUpdateMetricsUnchanged() {
         var project = new Project();
         project.setName("acme-app");
         project = qm.createProject(project, List.of(), false);
@@ -96,7 +96,7 @@ public class ProjectMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest 
     }
 
     @Test
-    public void testUpdateMetricsVulnerabilities() {
+    void testUpdateMetricsVulnerabilities() {
         var project = new Project();
         project.setName("acme-app");
         project = qm.createProject(project, List.of(), false);
@@ -154,7 +154,7 @@ public class ProjectMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest 
     }
 
     @Test
-    public void testUpdateMetricsPolicyViolations() {
+    void testUpdateMetricsPolicyViolations() {
         var project = new Project();
         project.setName("acme-app");
         project = qm.createProject(project, List.of(), false);
@@ -222,7 +222,7 @@ public class ProjectMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest 
     }
 
     @Test
-    public void testCollectionLogicChanged() {
+    void testCollectionLogicChanged() {
         var project = new Project();
         project.setName("acme-app");
         project = qm.createProject(project, List.of(), false);
@@ -249,7 +249,7 @@ public class ProjectMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest 
     }
 
     @Test
-    public void testCollectionProjectMetricsAggregatingAllChildren() {
+    void testCollectionProjectMetricsAggregatingAllChildren() {
         var project = new Project();
         project.setActive(true);
         project.setName("testCollectionProjectMetricsAggregatingAllChildren");
@@ -285,7 +285,7 @@ public class ProjectMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest 
     }
 
     @Test
-    public void testCollectionProjectMetricsAggregatingTaggedChildren() {
+    void testCollectionProjectMetricsAggregatingTaggedChildren() {
         Tag tag = qm.createTag("prod");
         var project = new Project();
         project.setActive(true);
@@ -328,7 +328,7 @@ public class ProjectMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest 
     }
 
     @Test
-    public void testCollectionProjectMetricsAggregatingLatestChildren() {
+    void testCollectionProjectMetricsAggregatingLatestChildren() {
         var project = new Project();
         project.setActive(true);
         project.setName("testCollectionProjectMetricsAggregatingAllChildren");

--- a/src/test/java/org/dependencytrack/tasks/metrics/VulnerabilityMetricsUpdateTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/metrics/VulnerabilityMetricsUpdateTaskTest.java
@@ -24,7 +24,7 @@ import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityMetrics;
 import org.dependencytrack.persistence.QueryManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -33,10 +33,10 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class VulnerabilityMetricsUpdateTaskTest extends PersistenceCapableTest {
+class VulnerabilityMetricsUpdateTaskTest extends PersistenceCapableTest {
 
     @Test
-    public void testUpdateMetricsEmpty() {
+    void testUpdateMetricsEmpty() {
         new VulnerabilityMetricsUpdateTask().inform(new VulnerabilityMetricsUpdateEvent());
 
         try (final var qm = new QueryManager()) {
@@ -46,7 +46,7 @@ public class VulnerabilityMetricsUpdateTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testUpdateMetrics() {
+    void testUpdateMetrics() {
         try (final var qm = new QueryManager()) {
             // Test that paging works by creating more vulnerabilities
             // than fit on a single page (of size 500).
@@ -82,7 +82,7 @@ public class VulnerabilityMetricsUpdateTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testUpdateMetricsPublishedCreated() {
+    void testUpdateMetricsPublishedCreated() {
         try (final var qm = new QueryManager()) {
             // Test that paging works by creating more vulnerabilities
             // than fit on a single page (of size 500).
@@ -119,7 +119,7 @@ public class VulnerabilityMetricsUpdateTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testUpdateMetricsPublished() {
+    void testUpdateMetricsPublished() {
         try (final var qm = new QueryManager()) {
             // Test that paging works by creating more vulnerabilities
             // than fit on a single page (of size 500).

--- a/src/test/java/org/dependencytrack/tasks/repositories/CargoMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/CargoMetaAnalyzerTest.java
@@ -21,21 +21,21 @@ package org.dependencytrack.tasks.repositories;
 import com.github.packageurl.PackageURL;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class CargoMetaAnalyzerTest {
+class CargoMetaAnalyzerTest {
 
     @Test
-    public void testAnalyzer() throws Exception {
+    void testAnalyzer() throws Exception {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:cargo/rand@0.7.2"));
 
         CargoMetaAnalyzer analyzer = new CargoMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.CARGO, analyzer.supportedRepositoryType());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.CARGO, analyzer.supportedRepositoryType());
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertNotNull(metaModel.getLatestVersion());
-        Assert.assertNotNull(metaModel.getPublishedTimestamp());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertNotNull(metaModel.getPublishedTimestamp());
     }
 }

--- a/src/test/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzerTest.java
@@ -28,50 +28,50 @@ import java.text.SimpleDateFormat;
 import org.apache.http.HttpHeaders;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 
 import com.github.packageurl.PackageURL;
 
-public class ComposerMetaAnalyzerTest {
+class ComposerMetaAnalyzerTest {
 
         private static ClientAndServer mockServer;
 
-        @BeforeClass
+        @BeforeAll
         public static void beforeClass() {
                 mockServer = ClientAndServer.startClientAndServer(1080);
         }
 
-        @AfterClass
+        @AfterAll
         public static void afterClass() {
                 mockServer.stop();
         }
 
-        @Before
+        @BeforeEach
         public void setUp() {
                 mockServer.reset();
         }
 
         @Test
-        public void testAnalyzer() throws Exception {
+        void testAnalyzer() throws Exception {
                 Component component = new Component();
                 component.setPurl(new PackageURL("pkg:composer/phpunit/phpunit@1.0.0"));
 
                 ComposerMetaAnalyzer analyzer = new ComposerMetaAnalyzer();
-                Assert.assertTrue(analyzer.isApplicable(component));
-                Assert.assertEquals(RepositoryType.COMPOSER, analyzer.supportedRepositoryType());
+                Assertions.assertTrue(analyzer.isApplicable(component));
+                Assertions.assertEquals(RepositoryType.COMPOSER, analyzer.supportedRepositoryType());
                 MetaModel metaModel = analyzer.analyze(component);
-                Assert.assertNotNull(metaModel.getLatestVersion());
-                Assert.assertNotNull(metaModel.getPublishedTimestamp());
+                Assertions.assertNotNull(metaModel.getLatestVersion());
+                Assertions.assertNotNull(metaModel.getPublishedTimestamp());
         }
 
         @Test
-        public void testAnalyzerV1() throws Exception {
+        void testAnalyzerV1() throws Exception {
                 Component component = new Component();
                 ComposerMetaAnalyzer analyzer = new ComposerMetaAnalyzer();
 
@@ -107,14 +107,12 @@ public class ComposerMetaAnalyzerTest {
 
                 MetaModel metaModel = analyzer.analyze(component);
 
-                Assert.assertEquals("3.8.1", metaModel.getLatestVersion());
-                Assert.assertEquals(
-                                new SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX").parse("2024-12-05 17:15:07 Z"),
-                                metaModel.getPublishedTimestamp());
+                Assertions.assertEquals("3.8.1", metaModel.getLatestVersion());
+                Assertions.assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX").parse("2024-12-05 17:15:07 Z"), metaModel.getPublishedTimestamp());
         }
 
         @Test
-        public void testAnalyzerFindsVersionWithLeadingVV2() throws Exception {
+        void testAnalyzerFindsVersionWithLeadingVV2() throws Exception {
                 Component component = new Component();
                 ComposerMetaAnalyzer analyzer = new ComposerMetaAnalyzer();
 
@@ -150,14 +148,12 @@ public class ComposerMetaAnalyzerTest {
 
                 MetaModel metaModel = analyzer.analyze(component);
 
-                Assert.assertEquals("v1.2.0", metaModel.getLatestVersion());
-                Assert.assertEquals(
-                                new SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX").parse("2024-10-11 08:11:39 Z"),
-                                metaModel.getPublishedTimestamp());
+                Assertions.assertEquals("v1.2.0", metaModel.getLatestVersion());
+                Assertions.assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX").parse("2024-10-11 08:11:39 Z"), metaModel.getPublishedTimestamp());
         }
 
         @Test
-        public void testAnalyzerInlinePackageAndRepoPath() throws Exception {
+        void testAnalyzerInlinePackageAndRepoPath() throws Exception {
                 Component component = new Component();
                 ComposerMetaAnalyzer analyzer = new ComposerMetaAnalyzer();
 
@@ -191,8 +187,8 @@ public class ComposerMetaAnalyzerTest {
 
                 MetaModel metaModel = analyzer.analyze(component);
 
-                Assert.assertEquals("1.18.0", metaModel.getLatestVersion());
-                Assert.assertNull(metaModel.getPublishedTimestamp());
+                Assertions.assertEquals("1.18.0", metaModel.getLatestVersion());
+                Assertions.assertNull(metaModel.getPublishedTimestamp());
 
                 mockClient.verify(
                                 request()
@@ -213,8 +209,8 @@ public class ComposerMetaAnalyzerTest {
                 component.setPurl(new PackageURL("pkg:composer/something/something@v1.1.0"));
                 MetaModel metaModel2 = analyzer.analyze(component);
 
-                Assert.assertNull(metaModel2.getLatestVersion());
-                Assert.assertNull(metaModel2.getPublishedTimestamp());
+                Assertions.assertNull(metaModel2.getLatestVersion());
+                Assertions.assertNull(metaModel2.getPublishedTimestamp());
 
                 // no extra calls should have been made
                 mockClient.verify(
@@ -235,7 +231,7 @@ public class ComposerMetaAnalyzerTest {
         }
 
         @Test
-        public void testAnalyzerIncludesAndRepoPath() throws Exception {
+        void testAnalyzerIncludesAndRepoPath() throws Exception {
                 Component component = new Component();
                 ComposerMetaAnalyzer analyzer = new ComposerMetaAnalyzer();
 
@@ -274,9 +270,9 @@ public class ComposerMetaAnalyzerTest {
 
                 MetaModel metaModel = analyzer.analyze(component);
 
-                Assert.assertEquals("2.3.8", metaModel.getLatestVersion());
+                Assertions.assertEquals("2.3.8", metaModel.getLatestVersion());
                 // Timestamps are in invalid format for this repo
-                Assert.assertNull(metaModel.getPublishedTimestamp());
+                Assertions.assertNull(metaModel.getPublishedTimestamp());
 
                 mockClient.verify(
                                 request()
@@ -297,8 +293,8 @@ public class ComposerMetaAnalyzerTest {
                 component.setPurl(new PackageURL("pkg:composer/something/something@v1.1.0"));
                 MetaModel metaModel2 = analyzer.analyze(component);
 
-                Assert.assertNull(metaModel2.getLatestVersion());
-                Assert.assertNull(metaModel2.getPublishedTimestamp());
+                Assertions.assertNull(metaModel2.getLatestVersion());
+                Assertions.assertNull(metaModel2.getPublishedTimestamp());
 
                 // no extra calls should have been made
                 mockClient.verify(
@@ -319,7 +315,7 @@ public class ComposerMetaAnalyzerTest {
         }
 
         @Test
-        public void testAnalyzerIncludesWithMetadataUrl() throws Exception {
+        void testAnalyzerIncludesWithMetadataUrl() throws Exception {
                 Component component = new Component();
                 ComposerMetaAnalyzer analyzer = new ComposerMetaAnalyzer();
 
@@ -365,8 +361,8 @@ public class ComposerMetaAnalyzerTest {
 
                 MetaModel metaModel = analyzer.analyze(component);
 
-                Assert.assertEquals("6.6.6", metaModel.getLatestVersion());
-                Assert.assertNull(metaModel.getPublishedTimestamp());
+                Assertions.assertEquals("6.6.6", metaModel.getLatestVersion());
+                Assertions.assertNull(metaModel.getPublishedTimestamp());
 
                 mockClient.verify(
                                 request()
@@ -393,8 +389,8 @@ public class ComposerMetaAnalyzerTest {
                 component.setPurl(new PackageURL("pkg:composer/something/something@v1.1.0"));
                 MetaModel metaModel2 = analyzer.analyze(component);
 
-                Assert.assertNull(metaModel2.getLatestVersion());
-                Assert.assertNull(metaModel2.getPublishedTimestamp());
+                Assertions.assertNull(metaModel2.getLatestVersion());
+                Assertions.assertNull(metaModel2.getPublishedTimestamp());
 
                 // no extra calls should have been made, only a metadata call as those are not
                 // cached
@@ -422,7 +418,7 @@ public class ComposerMetaAnalyzerTest {
         }
 
         @Test
-        public void testAnalyzerCacheOfRoot() throws Exception {
+        void testAnalyzerCacheOfRoot() throws Exception {
                 Component component = new Component();
                 ComposerMetaAnalyzer analyzer = new ComposerMetaAnalyzer();
 
@@ -458,10 +454,8 @@ public class ComposerMetaAnalyzerTest {
 
                 MetaModel metaModel = analyzer.analyze(component);
 
-                Assert.assertEquals("v1.2.0", metaModel.getLatestVersion());
-                Assert.assertEquals(
-                                new SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX").parse("2024-10-11 08:11:39 Z"),
-                                metaModel.getPublishedTimestamp());
+                Assertions.assertEquals("v1.2.0", metaModel.getLatestVersion());
+                Assertions.assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX").parse("2024-10-11 08:11:39 Z"), metaModel.getPublishedTimestamp());
                 mockClient.verify(
                                 request()
                                                 .withMethod("GET")
@@ -490,7 +484,7 @@ public class ComposerMetaAnalyzerTest {
         }
 
         @Test
-        public void testAnalyzerEmptyRoot() throws Exception {
+        void testAnalyzerEmptyRoot() throws Exception {
                 Component component = new Component();
                 ComposerMetaAnalyzer analyzer = new ComposerMetaAnalyzer();
 
@@ -513,8 +507,8 @@ public class ComposerMetaAnalyzerTest {
                                                                 .withBody(getTestData(packagistRepoRootFile)));
 
                 MetaModel metaModel = analyzer.analyze(component);
-                Assert.assertNull(metaModel.getLatestVersion());
-                Assert.assertNull(metaModel.getPublishedTimestamp());
+                Assertions.assertNull(metaModel.getLatestVersion());
+                Assertions.assertNull(metaModel.getPublishedTimestamp());
 
                 mockClient.verify(
                                 request()
@@ -523,8 +517,8 @@ public class ComposerMetaAnalyzerTest {
                                 org.mockserver.verify.VerificationTimes.exactly(1));
 
                 MetaModel metaModel2 = analyzer.analyze(component);
-                Assert.assertNull(metaModel2.getLatestVersion());
-                Assert.assertNull(metaModel2.getPublishedTimestamp());
+                Assertions.assertNull(metaModel2.getLatestVersion());
+                Assertions.assertNull(metaModel2.getPublishedTimestamp());
                 mockClient.verify(
                                 request()
                                                 .withMethod("GET")
@@ -534,7 +528,7 @@ public class ComposerMetaAnalyzerTest {
         }
 
         @Test
-        public void testAnalyzerDrupalV2NoTimeWithAvailablePackagePatterns() throws Exception {
+        void testAnalyzerDrupalV2NoTimeWithAvailablePackagePatterns() throws Exception {
                 Component component = new Component();
                 ComposerMetaAnalyzer analyzer = new ComposerMetaAnalyzer();
 
@@ -570,14 +564,14 @@ public class ComposerMetaAnalyzerTest {
 
                 MetaModel metaModel = analyzer.analyze(component);
 
-                Assert.assertEquals("2.2.1", metaModel.getLatestVersion());
-                Assert.assertEquals(null, metaModel.getPublishedTimestamp());
+                Assertions.assertEquals("2.2.1", metaModel.getLatestVersion());
+                Assertions.assertEquals(null, metaModel.getPublishedTimestamp());
 
                 component.setPurl(new PackageURL("pkg:composer/phpunit/phpunit@v2.0.0"));
                 MetaModel metaModel2 = analyzer.analyze(component);
 
-                Assert.assertNull(metaModel2.getLatestVersion());
-                Assert.assertNull(metaModel2.getPublishedTimestamp());
+                Assertions.assertNull(metaModel2.getLatestVersion());
+                Assertions.assertNull(metaModel2.getPublishedTimestamp());
 
                 // no calls should have been made for non-matching package
                 mockClient.verify(
@@ -587,7 +581,7 @@ public class ComposerMetaAnalyzerTest {
         }
 
         @Test
-        public void testAnalyzerAvailablePackages() throws Exception {
+        void testAnalyzerAvailablePackages() throws Exception {
                 Component component = new Component();
                 ComposerMetaAnalyzer analyzer = new ComposerMetaAnalyzer();
 
@@ -623,16 +617,14 @@ public class ComposerMetaAnalyzerTest {
 
                 MetaModel metaModel = analyzer.analyze(component);
 
-                Assert.assertEquals("v1.2.0", metaModel.getLatestVersion());
-                Assert.assertEquals(
-                                new SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX").parse("2024-10-11 08:11:39 Z"),
-                                metaModel.getPublishedTimestamp());
+                Assertions.assertEquals("v1.2.0", metaModel.getLatestVersion());
+                Assertions.assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX").parse("2024-10-11 08:11:39 Z"), metaModel.getPublishedTimestamp());
 
                 component.setPurl(new PackageURL("pkg:composer/phpunit/phpunit@v0.0.0"));
                 MetaModel metaModel2 = analyzer.analyze(component);
 
-                Assert.assertNull(metaModel2.getLatestVersion());
-                Assert.assertNull(metaModel2.getPublishedTimestamp());
+                Assertions.assertNull(metaModel2.getLatestVersion());
+                Assertions.assertNull(metaModel2.getPublishedTimestamp());
 
                 // no calls should have been made for non-matching package
                 mockClient.verify(
@@ -642,7 +634,7 @@ public class ComposerMetaAnalyzerTest {
         }
 
         @Test
-        public void testAnalyzerNotInAvailablePackagesAndMatchingLogic() throws Exception {
+        void testAnalyzerNotInAvailablePackagesAndMatchingLogic() throws Exception {
                 Component component = new Component();
                 ComposerMetaAnalyzer analyzer = new ComposerMetaAnalyzer();
 
@@ -678,16 +670,14 @@ public class ComposerMetaAnalyzerTest {
 
                 MetaModel metaModel = analyzer.analyze(component);
 
-                Assert.assertEquals("v1.2.0", metaModel.getLatestVersion());
-                Assert.assertEquals(
-                                new SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX").parse("2024-10-11 08:11:39 Z"),
-                                metaModel.getPublishedTimestamp());
+                Assertions.assertEquals("v1.2.0", metaModel.getLatestVersion());
+                Assertions.assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX").parse("2024-10-11 08:11:39 Z"), metaModel.getPublishedTimestamp());
 
                 component.setPurl(new PackageURL("pkg:composer/io2/phpunit@v0.0.0"));
                 MetaModel metaModel2 = analyzer.analyze(component);
 
-                Assert.assertNull(metaModel2.getLatestVersion());
-                Assert.assertNull(metaModel2.getPublishedTimestamp());
+                Assertions.assertNull(metaModel2.getLatestVersion());
+                Assertions.assertNull(metaModel2.getPublishedTimestamp());
 
                 // no calls should have been made for non-matching package
                 mockClient.verify(
@@ -708,7 +698,7 @@ public class ComposerMetaAnalyzerTest {
          * behaviour.
          */
         @Test
-        public void testAnalyzerGetsUnexpectedResponseContentCausingLatestVersionBeingNull() throws Exception {
+        void testAnalyzerGetsUnexpectedResponseContentCausingLatestVersionBeingNull() throws Exception {
                 Component component = new Component();
                 ComposerMetaAnalyzer analyzer = new ComposerMetaAnalyzer();
 
@@ -745,11 +735,11 @@ public class ComposerMetaAnalyzerTest {
                 analyzer.analyze(component);
                 MetaModel metaModel = analyzer.analyze(component);
 
-                Assert.assertNull(metaModel.getLatestVersion());
+                Assertions.assertNull(metaModel.getLatestVersion());
         }
 
         @Test
-        public void testAnalyzerGetsUnexpectedResponseContent404() throws Exception {
+        void testAnalyzerGetsUnexpectedResponseContent404() throws Exception {
                 Component component = new Component();
                 ComposerMetaAnalyzer analyzer = new ComposerMetaAnalyzer();
 
@@ -771,7 +761,7 @@ public class ComposerMetaAnalyzerTest {
                 analyzer.analyze(component);
                 MetaModel metaModel = analyzer.analyze(component);
 
-                Assert.assertNull(metaModel.getLatestVersion());
+                Assertions.assertNull(metaModel.getLatestVersion());
         }
 
         private static File getRepoResourceFile(String repo, String filename) throws Exception {

--- a/src/test/java/org/dependencytrack/tasks/repositories/CpanMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/CpanMetaAnalyzerTest.java
@@ -22,35 +22,35 @@ import java.util.Date;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.util.ComponentVersion;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import com.github.packageurl.PackageURL;
 
-public class CpanMetaAnalyzerTest {
+class CpanMetaAnalyzerTest {
 
     @Test
-    public void testAnalyzerMoose() throws Exception {
+    void testAnalyzerMoose() throws Exception {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:cpan/Moose@2.2200"));
 
         CpanMetaAnalyzer analyzer = new CpanMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.CPAN, analyzer.supportedRepositoryType());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.CPAN, analyzer.supportedRepositoryType());
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertTrue(new ComponentVersion("2.2200").compareTo(new ComponentVersion(metaModel.getLatestVersion())) < 0);
-        Assert.assertTrue(new Date().compareTo(metaModel.getPublishedTimestamp()) > 0);
+        Assertions.assertTrue(new ComponentVersion("2.2200").compareTo(new ComponentVersion(metaModel.getLatestVersion())) < 0);
+        Assertions.assertTrue(new Date().compareTo(metaModel.getPublishedTimestamp()) > 0);
     }
 
     @Test
-    public void testAnalyzerFutureQ() throws Exception {
+    void testAnalyzerFutureQ() throws Exception {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:cpan/Future::Q@0.27"));
 
         CpanMetaAnalyzer analyzer = new CpanMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.CPAN, analyzer.supportedRepositoryType());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.CPAN, analyzer.supportedRepositoryType());
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertTrue(new ComponentVersion("0.27").compareTo(new ComponentVersion(metaModel.getLatestVersion())) < 0);
-        Assert.assertTrue(new Date().compareTo(metaModel.getPublishedTimestamp()) > 0);
+        Assertions.assertTrue(new ComponentVersion("0.27").compareTo(new ComponentVersion(metaModel.getLatestVersion())) < 0);
+        Assertions.assertTrue(new Date().compareTo(metaModel.getPublishedTimestamp()) > 0);
     }
 }

--- a/src/test/java/org/dependencytrack/tasks/repositories/GemMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/GemMetaAnalyzerTest.java
@@ -21,21 +21,21 @@ package org.dependencytrack.tasks.repositories;
 import com.github.packageurl.PackageURL;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class GemMetaAnalyzerTest {
+class GemMetaAnalyzerTest {
 
     @Test
-    public void testAnalyzer() throws Exception {
+    void testAnalyzer() throws Exception {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:gem/test-unit@3.2.0"));
 
         GemMetaAnalyzer analyzer = new GemMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.GEM, analyzer.supportedRepositoryType());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.GEM, analyzer.supportedRepositoryType());
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertNotNull(metaModel.getLatestVersion());
-        //Assert.assertNotNull(metaModel.getPublishedTimestamp()); // todo: not yet supported
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        //Assertions.assertNotNull(metaModel.getPublishedTimestamp()); // todo: not yet supported
     }
 }

--- a/src/test/java/org/dependencytrack/tasks/repositories/GitHubMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/GitHubMetaAnalyzerTest.java
@@ -21,99 +21,104 @@ package org.dependencytrack.tasks.repositories;
 import com.github.packageurl.PackageURL;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-public class GitHubMetaAnalyzerTest {
+// TODO this depends on an external API and will fail if that API doesn't respond fast enough; this especially
+//      happens rather fast when executing tests locally repeatedly
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
+class GitHubMetaAnalyzerTest {
 
     private static final String VERSION_TYPE_PATTERN = "[a-f,0-9]{6,40}";
     @Test
-    public void testAnalyzerRelease() throws Exception {
+    void testAnalyzerRelease() throws Exception {
         final var component = new Component();
         component.setPurl(new PackageURL("pkg:github/CycloneDX/cdxgen@v9.8.9"));
 
         final var analyzer = new GithubMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
 
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertNotNull(metaModel.getLatestVersion());
-        Assert.assertTrue(metaModel.getLatestVersion().startsWith("v"));
-        Assert.assertNotNull(metaModel.getPublishedTimestamp());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertTrue(metaModel.getLatestVersion().startsWith("v"));
+        Assertions.assertNotNull(metaModel.getPublishedTimestamp());
     }
     @Test
-    public void testAnalyzerLongCommit() throws Exception{
+    void testAnalyzerLongCommit() throws Exception{
         final var component = new Component();
         component.setPurl(new PackageURL("pkg:github/CycloneDX/cdxgen@4359dee1b7bd29ee25bc78e358a1254a0277ee96"));
         Pattern version_pattern = Pattern.compile(VERSION_TYPE_PATTERN);
 
         final var analyzer = new GithubMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
 
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertNotNull(metaModel.getLatestVersion());
-        Assert.assertTrue(version_pattern.matcher(metaModel.getLatestVersion()).find());
-        Assert.assertNotNull(metaModel.getPublishedTimestamp());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertTrue(version_pattern.matcher(metaModel.getLatestVersion()).find());
+        Assertions.assertNotNull(metaModel.getPublishedTimestamp());
     }
 
     @Test
-    public void testAnalyzerShortCommit() throws Exception{
+    void testAnalyzerShortCommit() throws Exception{
         final var component = new Component();
         component.setPurl(new PackageURL("pkg:github/CycloneDX/cdxgen@4359dee"));
         Pattern version_pattern = Pattern.compile(VERSION_TYPE_PATTERN);
 
         final var analyzer = new GithubMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
 
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertNotNull(metaModel.getLatestVersion());
-        Assert.assertTrue(version_pattern.matcher(metaModel.getLatestVersion()).find());
-        Assert.assertNotNull(metaModel.getPublishedTimestamp());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertTrue(version_pattern.matcher(metaModel.getLatestVersion()).find());
+        Assertions.assertNotNull(metaModel.getPublishedTimestamp());
     }
 
     @Test
-    public void testAnalyzerNoVersion() throws Exception{
+    void testAnalyzerNoVersion() throws Exception{
         final var component = new Component();
         component.setPurl(new PackageURL("pkg:github/CycloneDX/cdxgen"));
 
         final var analyzer = new GithubMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
 
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertNotNull(metaModel.getLatestVersion());
-        Assert.assertTrue(metaModel.getLatestVersion().startsWith("v"));
-        Assert.assertNull(metaModel.getPublishedTimestamp());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertTrue(metaModel.getLatestVersion().startsWith("v"));
+        Assertions.assertNull(metaModel.getPublishedTimestamp());
     }
     @Test
-    public void testAnalyzerInvalidCommit() throws Exception{
+    void testAnalyzerInvalidCommit() throws Exception{
         final var component = new Component();
         component.setPurl(new PackageURL("pkg:github/CycloneDX/cdxgen@0000000"));
 
         final var analyzer = new GithubMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
 
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertNotNull(metaModel.getLatestVersion());
-        Assert.assertNull(metaModel.getPublishedTimestamp());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertNull(metaModel.getPublishedTimestamp());
     }
 
-        @Test
-    public void testAnalyzerInvalidRelease() throws Exception{
+    @Test
+    void testAnalyzerInvalidRelease() throws Exception {
         final var component = new Component();
         component.setPurl(new PackageURL("pkg:github/CycloneDX/cdxgen@invalid-release"));
 
         final var analyzer = new GithubMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
 
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertNotNull(metaModel.getLatestVersion());
-        Assert.assertNull(metaModel.getPublishedTimestamp());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertNull(metaModel.getPublishedTimestamp());
     }
 }

--- a/src/test/java/org/dependencytrack/tasks/repositories/GoModulesMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/GoModulesMetaAnalyzerTest.java
@@ -21,38 +21,38 @@ package org.dependencytrack.tasks.repositories;
 import com.github.packageurl.PackageURL;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class GoModulesMetaAnalyzerTest {
+class GoModulesMetaAnalyzerTest {
 
     @Test
-    public void testAnalyzer() throws Exception {
+    void testAnalyzer() throws Exception {
         final var component = new Component();
         component.setVersion("v0.1.0");
         component.setPurl(new PackageURL("pkg:golang/github.com/CycloneDX/cyclonedx-go@v0.3.0"));
 
         final var analyzer = new GoModulesMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.GO_MODULES, analyzer.supportedRepositoryType());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.GO_MODULES, analyzer.supportedRepositoryType());
 
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertNotNull(metaModel.getLatestVersion());
-        Assert.assertTrue(metaModel.getLatestVersion().startsWith("v"));
-        Assert.assertNotNull(metaModel.getPublishedTimestamp());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertTrue(metaModel.getLatestVersion().startsWith("v"));
+        Assertions.assertNotNull(metaModel.getPublishedTimestamp());
 
         component.setVersion("0.1.0");
         metaModel = analyzer.analyze(component);
-        Assert.assertNotNull(metaModel.getLatestVersion());
-        Assert.assertFalse(metaModel.getLatestVersion().startsWith("v"));
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertFalse(metaModel.getLatestVersion().startsWith("v"));
     }
 
     @Test
-    public void testCaseEncode() {
+    void testCaseEncode() {
         final var analyzer = new GoModulesMetaAnalyzer();
 
-        Assert.assertEquals("!cyclone!d!x", analyzer.caseEncode("CycloneDX"));
-        Assert.assertEquals("cyclonedx", analyzer.caseEncode("cyclonedx"));
+        Assertions.assertEquals("!cyclone!d!x", analyzer.caseEncode("CycloneDX"));
+        Assertions.assertEquals("cyclonedx", analyzer.caseEncode("cyclonedx"));
     }
 
 }

--- a/src/test/java/org/dependencytrack/tasks/repositories/HackageMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/HackageMetaAnalyzerTest.java
@@ -3,19 +3,19 @@ package org.dependencytrack.tasks.repositories;
 import com.github.packageurl.PackageURL;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class HackageMetaAnalyzerTest {
+class HackageMetaAnalyzerTest {
     @Test
-    public void testAnalyzer() throws Exception {
+    void testAnalyzer() throws Exception {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:hackage/singletons-th@3.1"));
 
         HackageMetaAnalyzer analyzer = new HackageMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.HACKAGE, analyzer.supportedRepositoryType());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.HACKAGE, analyzer.supportedRepositoryType());
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
     }
 }

--- a/src/test/java/org/dependencytrack/tasks/repositories/HexMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/HexMetaAnalyzerTest.java
@@ -21,21 +21,21 @@ package org.dependencytrack.tasks.repositories;
 import com.github.packageurl.PackageURL;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class HexMetaAnalyzerTest {
+class HexMetaAnalyzerTest {
 
     @Test
-    public void testAnalyzer() throws Exception {
+    void testAnalyzer() throws Exception {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:hex/phoenix@1.4.10"));
 
         HexMetaAnalyzer analyzer = new HexMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.HEX, analyzer.supportedRepositoryType());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.HEX, analyzer.supportedRepositoryType());
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertNotNull(metaModel.getLatestVersion());
-        Assert.assertNotNull(metaModel.getPublishedTimestamp());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertNotNull(metaModel.getPublishedTimestamp());
     }
 }

--- a/src/test/java/org/dependencytrack/tasks/repositories/MavenMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/MavenMetaAnalyzerTest.java
@@ -21,26 +21,26 @@ package org.dependencytrack.tasks.repositories;
 import com.github.packageurl.PackageURL;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class MavenMetaAnalyzerTest {
+class MavenMetaAnalyzerTest {
 
     @Test
-    public void testAnalyzer() throws Exception {
+    void testAnalyzer() throws Exception {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:maven/junit/junit@4.12"));
 
         MavenMetaAnalyzer analyzer = new MavenMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.MAVEN, analyzer.supportedRepositoryType());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.MAVEN, analyzer.supportedRepositoryType());
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertNotNull(metaModel.getLatestVersion());
-        Assert.assertNotNull(metaModel.getPublishedTimestamp());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertNotNull(metaModel.getPublishedTimestamp());
     }
 
     @Test
-    public void testAnalyzerForScalaComponent() throws Exception {
+    void testAnalyzerForScalaComponent() throws Exception {
         Component component = new Component();
 
         // Scala packages differ from others in that their name always includes the version of
@@ -48,11 +48,11 @@ public class MavenMetaAnalyzerTest {
         component.setPurl(new PackageURL("pkg:maven/com.typesafe.akka/akka-actor_2.13@2.5.23"));
 
         MavenMetaAnalyzer analyzer = new MavenMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.MAVEN, analyzer.supportedRepositoryType());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.MAVEN, analyzer.supportedRepositoryType());
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertNotNull(metaModel.getLatestVersion());
-        Assert.assertNotNull(metaModel.getPublishedTimestamp());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertNotNull(metaModel.getPublishedTimestamp());
     }
 
 }

--- a/src/test/java/org/dependencytrack/tasks/repositories/NixpkgsMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/NixpkgsMetaAnalyzerTest.java
@@ -3,21 +3,21 @@ package org.dependencytrack.tasks.repositories;
 import com.github.packageurl.PackageURL;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class NixpkgsMetaAnalyzerTest {
+class NixpkgsMetaAnalyzerTest {
     @Test
-    public void testAnalyzer() throws Exception {
+    void testAnalyzer() throws Exception {
         final var component1 = new Component();
         final var component2 = new Component();
         component1.setPurl(new PackageURL("pkg:nixpkgs/SDL_sound@1.0.3"));
         component2.setPurl(new PackageURL("pkg:nixpkgs/amarok@2.9.71"));
         final var analyzer = new NixpkgsMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component1));
-        Assert.assertTrue(analyzer.isApplicable(component2));
-        Assert.assertEquals(RepositoryType.NIXPKGS, analyzer.supportedRepositoryType());
-        Assert.assertNotNull(analyzer.analyze(component1).getLatestVersion());
-        Assert.assertNotNull(analyzer.analyze(component2).getLatestVersion());
+        Assertions.assertTrue(analyzer.isApplicable(component1));
+        Assertions.assertTrue(analyzer.isApplicable(component2));
+        Assertions.assertEquals(RepositoryType.NIXPKGS, analyzer.supportedRepositoryType());
+        Assertions.assertNotNull(analyzer.analyze(component1).getLatestVersion());
+        Assertions.assertNotNull(analyzer.analyze(component2).getLatestVersion());
     }
 }

--- a/src/test/java/org/dependencytrack/tasks/repositories/NugetMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/NugetMetaAnalyzerTest.java
@@ -22,10 +22,10 @@ import com.github.packageurl.PackageURL;
 import org.apache.http.HttpHeaders;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 
@@ -40,22 +40,22 @@ import static org.dependencytrack.tasks.repositories.NugetMetaAnalyzer.SUPPORTED
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
-public class NugetMetaAnalyzerTest {
+class NugetMetaAnalyzerTest {
 
     private static ClientAndServer mockServer;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         mockServer = ClientAndServer.startClientAndServer(1080);
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         mockServer.stop();
     }
 
     @Test
-    public void testAnalyzer() throws Exception {
+    void testAnalyzer() throws Exception {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:nuget/CycloneDX.Core@5.4.0"));
         NugetMetaAnalyzer analyzer = new NugetMetaAnalyzer();
@@ -63,10 +63,10 @@ public class NugetMetaAnalyzerTest {
         analyzer.setRepositoryBaseUrl("https://api.nuget.org");
         MetaModel metaModel = analyzer.analyze(component);
 
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.NUGET, analyzer.supportedRepositoryType());
-        Assert.assertNotNull(metaModel.getLatestVersion());
-        Assert.assertNotNull(metaModel.getPublishedTimestamp());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.NUGET, analyzer.supportedRepositoryType());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertNotNull(metaModel.getPublishedTimestamp());
     }
 
 
@@ -75,7 +75,7 @@ public class NugetMetaAnalyzerTest {
     // retrieved from the repository at the time of running. 
     // When it was created, the latest release version was 9.0.0-preview.1.24080.9
     @Test
-    public void testAnalyzerExcludingPreRelease() throws Exception {
+    void testAnalyzerExcludingPreRelease() throws Exception {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:nuget/Microsoft.Extensions.DependencyInjection@8.0.0"));
         NugetMetaAnalyzer analyzer = new NugetMetaAnalyzer();
@@ -83,11 +83,11 @@ public class NugetMetaAnalyzerTest {
         analyzer.setRepositoryBaseUrl("https://api.nuget.org");
         MetaModel metaModel = analyzer.analyze(component);
 
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.NUGET, analyzer.supportedRepositoryType());
-        Assert.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.NUGET, analyzer.supportedRepositoryType());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
 
-        Assert.assertFalse(metaModel.getLatestVersion().contains("-"));
+        Assertions.assertFalse(metaModel.getLatestVersion().contains("-"));
     }
 
     // This test is to check if the analyzer is including pre-release versions
@@ -95,7 +95,7 @@ public class NugetMetaAnalyzerTest {
     // retrieved from the repository at the time of running. 
     // When it was created, the latest release version was 9.0.0-preview.1.24080.9
     @Test
-    public void testAnalyzerIncludingPreRelease() throws Exception {
+    void testAnalyzerIncludingPreRelease() throws Exception {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:nuget/Microsoft.Extensions.DependencyInjection@8.0.0-beta.21301.5"));
         NugetMetaAnalyzer analyzer = new NugetMetaAnalyzer();
@@ -103,15 +103,15 @@ public class NugetMetaAnalyzerTest {
         analyzer.setRepositoryBaseUrl("https://api.nuget.org");
         MetaModel metaModel = analyzer.analyze(component);
 
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.NUGET, analyzer.supportedRepositoryType());
-        Assert.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.NUGET, analyzer.supportedRepositoryType());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
 
-        Assert.assertFalse(metaModel.getLatestVersion().contains("-"));
+        Assertions.assertFalse(metaModel.getLatestVersion().contains("-"));
     }
 
     @Test
-    public void testAnalyzerWithPrivatePackageRepository() throws Exception {
+    void testAnalyzerWithPrivatePackageRepository() throws Exception {
         String mockIndexResponse = readResourceFileToString("/unit/tasks/repositories/https---localhost-1080-v3-index.json");
         new MockServerClient("localhost", mockServer.getPort())
                 .when(
@@ -164,12 +164,12 @@ public class NugetMetaAnalyzerTest {
         analyzer.setRepositoryUsernameAndPassword(null, "password");
         analyzer.setRepositoryBaseUrl("http://localhost:1080");
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertEquals("5.0.2", metaModel.getLatestVersion());
-        Assert.assertNotNull(metaModel.getPublishedTimestamp());
+        Assertions.assertEquals("5.0.2", metaModel.getLatestVersion());
+        Assertions.assertNotNull(metaModel.getPublishedTimestamp());
     }
 
     @Test
-    public void testPublishedDateTimeFormat() throws ParseException {
+    void testPublishedDateTimeFormat() throws ParseException {
         Date dateParsed = null;
         for (DateFormat dateFormat : SUPPORTED_DATE_FORMATS) {
             try {
@@ -177,7 +177,7 @@ public class NugetMetaAnalyzerTest {
             } catch (ParseException e) {}
         }
         DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-        Assert.assertEquals(dateFormat.parse("1900-01-01T00:00:00+00:00"), dateParsed);
+        Assertions.assertEquals(dateFormat.parse("1900-01-01T00:00:00+00:00"), dateParsed);
     }
 
     private String readResourceFileToString(String fileName) throws Exception {

--- a/src/test/java/org/dependencytrack/tasks/repositories/PypiMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/PypiMetaAnalyzerTest.java
@@ -21,21 +21,21 @@ package org.dependencytrack.tasks.repositories;
 import com.github.packageurl.PackageURL;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.RepositoryType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class PypiMetaAnalyzerTest {
+class PypiMetaAnalyzerTest {
 
     @Test
-    public void testAnalyzer() throws Exception {
+    void testAnalyzer() throws Exception {
         Component component = new Component();
         component.setPurl(new PackageURL("pkg:pypi/Flask@1.0.0"));
 
         PypiMetaAnalyzer analyzer = new PypiMetaAnalyzer();
-        Assert.assertTrue(analyzer.isApplicable(component));
-        Assert.assertEquals(RepositoryType.PYPI, analyzer.supportedRepositoryType());
+        Assertions.assertTrue(analyzer.isApplicable(component));
+        Assertions.assertEquals(RepositoryType.PYPI, analyzer.supportedRepositoryType());
         MetaModel metaModel = analyzer.analyze(component);
-        Assert.assertNotNull(metaModel.getLatestVersion());
-        Assert.assertNotNull(metaModel.getPublishedTimestamp());
+        Assertions.assertNotNull(metaModel.getLatestVersion());
+        Assertions.assertNotNull(metaModel.getPublishedTimestamp());
     }
 }

--- a/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskCpeMatchingTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskCpeMatchingTest.java
@@ -26,11 +26,10 @@ import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAnalysisLevel;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.parser.nvd.ModelConverter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -41,283 +40,281 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_INTERNAL_ENABLED;
 import static org.dependencytrack.tasks.scanners.InternalAnalysisTaskCpeMatchingTest.Range.withRange;
 
-@RunWith(Parameterized.class)
-public class InternalAnalysisTaskCpeMatchingTest extends PersistenceCapableTest {
+class InternalAnalysisTaskCpeMatchingTest extends PersistenceCapableTest {
 
-    @Parameters(name = "{index} source={0}, target={3}, range={1}, expectMatch={2}")
-    public static Collection<Object[]> parameters() {
-        return Arrays.asList(new Object[][]{
+    public static Collection<Arguments> parameters() {
+        return Arrays.asList(
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 1   | ANY        | ANY        | EQUAL    |
-                {"cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*"},
+                Arguments.of("cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*"),
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 2   | ANY        | NA         | SUPERSET |
-                {"cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-"},
+                Arguments.of("cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-"),
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 3   | ANY        | i          | SUPERSET |
-                {"cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
+                Arguments.of("cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
                 // | No. | Source A-V | Target A-V     | Relation   |
                 // | :-- | :--------- | :------------- | :--------- |
                 // | 4   | ANY        | m + wild cards | undefined  |
-                // {"cpe:2.3:*:vendor:product:1.0.0:*:*:*:*:*:*:*", MATCHES, "cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*"},
+                // {"cpe:2.3:*:vendor:product:1.0.0:*:*:*:*:*:*:*", MATCHES, "cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*"),
                 //   cpe-parser library does not allow wildcards for the part attribute.
-                {"cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*"},
+                Arguments.of("cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*"),
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 5   | NA         | ANY        | SUBSET   |
-                {"cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*"},
+                Arguments.of("cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*"),
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 6   | NA         | NA         | EQUAL    |
-                {"cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-"},
+                Arguments.of("cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-"),
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 7   | NA         | i          | DISJOINT |
-                {"cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
+                Arguments.of("cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
                 // | No. | Source A-V | Target A-V      | Relation   |
                 // | :-- | :--------- | :-------------- | :--------- |
                 // | 8   | NA         | m + wild cards  | undefined  |
-                // {"cpe:2.3:-:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*"},
+                // {"cpe:2.3:-:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*"),
                 //   cpe-parser library does not allow wildcards for the part attribute.
-                {"cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*"},
+                Arguments.of("cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*"),
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 9   | i          | i          | EQUAL    |
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 10  | i          | k          | DISJOINT |
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:o:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:rodnev:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:tcudorp:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:0.0.1:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:etadpu:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:noitide:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:gnal:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:noitidEws:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:wStegrat:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:wHtegrat:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:rehto"},
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:o:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:rodnev:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:tcudorp:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:0.0.1:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:etadpu:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:noitide:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:gnal:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:noitidEws:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:wStegrat:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:wHtegrat:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:rehto"),
                 // | No. | Source A-V | Target A-V      | Relation   |
                 // | :-- | :--------- | :-------------- | :--------- |
                 // | 11  | i          | m + wild cards  | undefined  |
-                // {"cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*"},
+                // {"cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*"),
                 //   cpe-parser library does not allow wildcards for the part attribute.
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*"},
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*"),
                 // | No. | Source A-V | Target A-V | Relation |
                 // | :-- | :--------- | :--------- | :------- |
                 // | 12  | i          | NA         | DISJOINT |
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-"},
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:-:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-"),
                 // | No. | Source A-V     | Target A-V | Relation |
                 // | :-- | :------------- | :--------- | :------- |
                 // | 13  | i              | ANY        | SUPERSET |
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*"},
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:*:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*"),
                 // | No. | Source A-V      | Target A-V | Relation             |
                 // | :-- | :-------------- | :--------- | :------------------- |
                 // | 14  | m1 + wild cards | m2         | SUPERSET or DISJOINT |
-                // {"cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"},
+                // {"cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
                 //   cpe-parser library does not allow wildcards for the part attribute.
-                {"cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
+                Arguments.of("cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
                 //   wildcard expansion in source vendor is currently not supported; *should* be SUPERSET.
-                {"cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
+                Arguments.of("cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
                 //   wildcard expansion in source product is currently not supported; *should* be SUPERSET.
-                {"cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
+                Arguments.of("cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
                 // | No. | Source A-V     | Target A-V | Relation |
                 // | :-- | :------------- | :--------- | :------- |
                 // | 15  | m + wild cards | ANY        | SUPERSET |
-                // {"cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:*:vendor:product:1.0.0:*:*:*:*:*:*:*"},
+                // {"cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:*:vendor:product:1.0.0:*:*:*:*:*:*:*"),
                 //   cpe-parser library does not allow wildcards for the part attribute.
-                {"cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*"},
+                Arguments.of("cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:*:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:*:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:*:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:*:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:*:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:*"),
                 // | No. | Source A-V     | Target A-V | Relation |
                 // | :-- | :------------- | :--------- | :------- |
                 // | 16  | m + wild cards | NA         | DISJOINT |
-                // {"cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:-:vendor:product:1.0.0:*:*:*:*:*:*:*"},
+                // {"cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:-:vendor:product:1.0.0:*:*:*:*:*:*:*"),
                 //   cpe-parser library does not allow wildcards for the part attribute.
-                {"cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-"},
+                Arguments.of("cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:-:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:-:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:-:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:-:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:-:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:-:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:-:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:-:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:-"),
                 // | No. | Source A-V      | Target A-V      | Relation   |
                 // | :-- | :-------------- | :-------------- | :--------- |
                 // | 17  | m1 + wild cards | m2 + wild cards | undefined  |
-                // {"cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*"},
+                // {"cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*", DOES_NOT_MATCH, "cpe:2.3:?:vendor:product:1.0.0:*:*:*:*:*:*:*"),
                 //   cpe-parser library does not allow wildcards for the part attribute.
-                {"cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*"},
-                {"cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:v*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:p*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1*:update:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:u*:edition:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:e*:lang:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:l*:swEdition:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:s*:targetSw:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:t*:targetHw:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:t*:other"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:o*"},
+                Arguments.of("cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*"),
+                Arguments.of("cpe:2.3:a:ven*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:v*:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:pro*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:p*:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.*:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1*:update:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:upd*:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:u*:edition:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edi*:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:e*:lang:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:la*:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:l*:swEdition:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdi*:targetSw:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:s*:targetSw:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:tar*:targetHw:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:t*:targetHw:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:tar*:other", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:t*:other"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:oth*", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:o*"),
                 // ---
                 // Version range evaluation
                 // ---
-                {"cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingStartIncluding("1.0.0"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"},
-                {"cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingStartExcluding("1.0.0"), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"},
-                {"cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingStartIncluding("0.9.9"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"},
-                {"cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingStartExcluding("0.9.9"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"},
-                {"cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingStartIncluding("1.0.0"), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"},
-                {"cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingEndIncluding("1.0.0"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"},
-                {"cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingEndExcluding("1.0.0"), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"},
-                {"cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingEndIncluding("1.0.1"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"},
-                {"cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingEndExcluding("1.0.1"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"},
-                {"cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingEndIncluding("1.0.0"), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingStartIncluding("1.0.0"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                Arguments.of("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingStartExcluding("1.0.0"), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                Arguments.of("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingStartIncluding("0.9.9"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                Arguments.of("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingStartExcluding("0.9.9"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                Arguments.of("cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingStartIncluding("1.0.0"), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                Arguments.of("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingEndIncluding("1.0.0"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                Arguments.of("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingEndExcluding("1.0.0"), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                Arguments.of("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingEndIncluding("1.0.1"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                Arguments.of("cpe:2.3:a:vendor:product:*:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingEndExcluding("1.0.1"), MATCHES, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
+                Arguments.of("cpe:2.3:a:vendor:product:-:update:edition:lang:swEdition:targetSw:targetHw:other", withRange().havingEndIncluding("1.0.0"), DOES_NOT_MATCH, "cpe:2.3:a:vendor:product:1.0.0:*:*:*:*:*:*:*"),
                 // ---
                 // Required CPE name comparison relations (as per table 6-4 in the spec)
                 // ---
                 // Scenario:  All attributes are EQUAL
-                {"cpe:2.3:*:*:*:*:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*"},
-                {"cpe:2.3:-:-:-:-:-:-:-:-:-:-:-", WITHOUT_RANGE, MATCHES, "cpe:2.3:-:-:-:-:-:-:-:-:-:-:-"},
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
+                Arguments.of("cpe:2.3:*:*:*:*:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*"),
+                Arguments.of("cpe:2.3:-:-:-:-:-:-:-:-:-:-:-", WITHOUT_RANGE, MATCHES, "cpe:2.3:-:-:-:-:-:-:-:-:-:-:-"),
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
                 // Scenario:  All attributes of source are SUPERSET of target
-                {"cpe:2.3:*:*:*:*:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"},
+                Arguments.of("cpe:2.3:*:*:*:*:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other"),
                 // Scenario:  All attributes of source are SUBSET of target
-                {"cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:a:vendor:product:1.0.0:update:edition:lang:swEdition:targetSw:targetHw:other", WITHOUT_RANGE, MATCHES, "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*"),
                 // ---
                 // Regression tests
                 // ---
@@ -325,30 +322,30 @@ public class InternalAnalysisTaskCpeMatchingTest extends PersistenceCapableTest 
                 // Scenario:  "product" of source is "2000e_firmware", "version" of target is "2000e_firmware" -> EQUAL.
                 //            "version" of source is NA, "version" of target is NA -> EQUAL.
                 // Table No.: 6, 9
-                {"cpe:2.3:o:intel:2000e_firmware:-:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:o:intel:2000e_firmware:-:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:o:intel:2000e_firmware:-:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:o:intel:2000e_firmware:-:*:*:*:*:*:*:*"),
                 // Scenario:  "version" of source is ANY, "version" of target is "2000e" -> SUPERSET.
                 //            "update" of source is ANY, "update" of target is NA -> SUPERSET.
                 // Table No.: 3, 2
-                {"cpe:2.3:h:intel:*:*:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:h:intel:2000e:-:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:h:intel:*:*:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:h:intel:2000e:-:*:*:*:*:*:*:*"),
                 // ---
                 // Issue:     https://github.com/DependencyTrack/dependency-track/issues/1832
                 // Scenario:  "version" of source is NA, "version" of target is "2.4.54" -> DISJOINT.
                 // Table No.: 7
-                {"cpe:2.3:a:apache:http_server:-:*:*:*:*:*:*:*", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:apache:http_server:2.4.53:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:a:apache:http_server:-:*:*:*:*:*:*:*", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:apache:http_server:2.4.53:*:*:*:*:*:*:*"),
                 // Scenario:  "version" of source is NA, "version" of target is ANY -> SUBSET.
                 // Table No.: 5
-                {"cpe:2.3:a:apache:http_server:-:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:a:apache:http_server:-:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*"),
                 // ---
                 // Issue:     https://github.com/DependencyTrack/dependency-track/issues/2188
                 // Scenario:  "update" of source is NA, "update" of target is ANY -> SUBSET.
                 // Table No.: 5
-                {"cpe:2.3:a:xiph:speex:1.2:-:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:xiph:speex:1.2:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:a:xiph:speex:1.2:-:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:a:xiph:speex:1.2:*:*:*:*:*:*:*"),
                 // ---
                 // Issue:     https://github.com/DependencyTrack/dependency-track/issues/2580
                 // Scenario:  "vendor" of source is "linux", "vendor" of target ANY -> SUBSET.
                 // Table No.: 13
-                {"cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:o:*:linux_kernel:*:*:*:*:*:*:*:*"},
-                {"cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:o:*:linux_kernel:4.19.139:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:o:*:linux_kernel:*:*:*:*:*:*:*:*"),
+                Arguments.of("cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:o:*:linux_kernel:4.19.139:*:*:*:*:*:*:*"),
                 // ---
                 // Issue:     https://github.com/DependencyTrack/dependency-track/issues/2894
                 // Scenario:  "vendor" and "product" with different casing -> EQUAL.
@@ -356,49 +353,49 @@ public class InternalAnalysisTaskCpeMatchingTest extends PersistenceCapableTest 
                 // Note:      CPEs with uppercase "part" are considered invalid by the cpe-parser library.
                 // TODO:      This should match, but can't currently support this as it would require an function index on UPPER("PART"),
                 //            UPPER("VENDOR"), and UPPER("PRODUCT"), which we cannot add through JDO annotations.
-                {"cpe:2.3:o:lInUx:lInUx_KeRnEl:5.15.37:*:*:*:*:*:*:*", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:o:LiNuX:LiNuX_kErNeL:5.15.37:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:o:lInUx:lInUx_KeRnEl:5.15.37:*:*:*:*:*:*:*", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:o:LiNuX:LiNuX_kErNeL:5.15.37:*:*:*:*:*:*:*"),
                 // ---
                 // Issue:     https://github.com/DependencyTrack/dependency-track/issues/2988
                 // Scenario:  "other" attribute of source is NA, "other" attribute of target is ANY -> SUBSET.
                 // Table No.: 5
-                {"cpe:2.3:o:linux:linux_kernel:5.15.37:*:*:*:*:*:*:NA", WITHOUT_RANGE, MATCHES, "cpe:2.3:o:linux:linux_kernel:5.15.37:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:o:linux:linux_kernel:5.15.37:*:*:*:*:*:*:NA", WITHOUT_RANGE, MATCHES, "cpe:2.3:o:linux:linux_kernel:5.15.37:*:*:*:*:*:*:*"),
                 // Scenario:  "target_hw" of source if x64, "target_hw" of target is ANY -> SUBSET.
                 // Table No.: 13
-                {"cpe:2.3:o:linux:linux_kernel:5.15.37:*:*:*:*:*:x86:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:o:linux:linux_kernel:5.15.37:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:o:linux:linux_kernel:5.15.37:*:*:*:*:*:x86:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:o:linux:linux_kernel:5.15.37:*:*:*:*:*:*:*"),
                 // Scenario:  "vendor" of source contains wildcard, "vendor" of target is ANY -> SUBSET.
                 // Table No.: 15
-                {"cpe:2.3:o:linu*:linux_kernel:5.15.37:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:o:*:linux_kernel:5.15.37:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:o:linu*:linux_kernel:5.15.37:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:o:*:linux_kernel:5.15.37:*:*:*:*:*:*:*"),
                 // ---
                 // Issue:     https://github.com/DependencyTrack/dependency-track/issues/2994
                 // Scenario:  "part" of source is "a", "part" of target is ANY -> SUBSET.
                 // Table No.: 13
-                {"cpe:2.3:a:busybox:busybox:1.34.1:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:*:busybox:busybox:1.34.1:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:a:busybox:busybox:1.34.1:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:*:busybox:busybox:1.34.1:*:*:*:*:*:*:*"),
                 // ---
                 // Issue:     https://github.com/DependencyTrack/dependency-track/pull/1929#issuecomment-1759411976
                 // Scenario:  "part" and "vendor" of source are i, "part" and "vendor" of target are ANY -> SUBSET
                 // Table No.: 13
-                {"cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:*:*:nginx:*:*:*:*:*:*:*:*"},
-                {"cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*", withRange().havingEndExcluding("1.21.0"), MATCHES, "cpe:2.3:*:*:nginx:*:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:*:*:nginx:*:*:*:*:*:*:*:*"),
+                Arguments.of("cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*", withRange().havingEndExcluding("1.21.0"), MATCHES, "cpe:2.3:*:*:nginx:*:*:*:*:*:*:*:*"),
                 // Scenario:  Same as above, but "version" of target is i, which evaluates to SUPERSET for the "version" attribute
                 // Table No.: 3, 13
-                {"cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:*:*:nginx:1.20.1:*:*:*:*:*:*:*"},
-                {"cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*", withRange().havingEndExcluding("1.21.0"), MATCHES, "cpe:2.3:*:*:nginx:1.20.1:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*", WITHOUT_RANGE, MATCHES, "cpe:2.3:*:*:nginx:1.20.1:*:*:*:*:*:*:*"),
+                Arguments.of("cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*", withRange().havingEndExcluding("1.21.0"), MATCHES, "cpe:2.3:*:*:nginx:1.20.1:*:*:*:*:*:*:*"),
                 // ---
                 // Issue:     https://github.com/DependencyTrack/dependency-track/issues/3178#issuecomment-1812809295
                 // Scenario:  "vendor" of source is i, "product" of source is ANY, "vendor" of target is ANY, "product" of target is i
                 //            We consider mixed SUBSET and SUPERSET relations in "vendor" and "product" attributes to be ambiguous and treat them as no-match
                 // Table No.: 3, 13
-                {"cpe:2.3:a:pascom_cloud_phone_system:*:*:*:*:*:*:*:*:*", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:*:util-linux-setarch:2.37.4:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:a:pascom_cloud_phone_system:*:*:*:*:*:*:*:*:*", WITHOUT_RANGE, DOES_NOT_MATCH, "cpe:2.3:a:*:util-linux-setarch:2.37.4:*:*:*:*:*:*:*"),
                 // ---
                 // Issue:     https://github.com/DependencyTrack/dependency-track/issues/4609
                 // Scenario:  "version" of source and target are ANY -> EQUAL.
                 //            A version range is available but doesn't make sense to use since the target version is already ANY.
                 // Table No.: 1
-                {"cpe:2.3:a:zlib:zlib:*:*:*:*:*:*:*:*", withRange().havingStartIncluding("1.2.0").havingEndExcluding("1.2.9"), MATCHES, "cpe:2.3:a:zlib:zlib:*:*:*:*:*:*:*:*"},
+                Arguments.of("cpe:2.3:a:zlib:zlib:*:*:*:*:*:*:*:*", Range.withRange().havingStartIncluding("1.2.0").havingEndExcluding("1.2.9"), MATCHES, "cpe:2.3:a:zlib:zlib:*:*:*:*:*:*:*:*"),
                 // Scenario:  Same as above, but "version" of target is NA -> SUPERSET.
                 // Table No.: 2
-                {"cpe:2.3:a:zlib:zlib:*:*:*:*:*:*:*:*", withRange().havingStartIncluding("1.2.0").havingEndExcluding("1.2.9"), MATCHES, "cpe:2.3:a:zlib:zlib:-:*:*:*:*:*:*:*"}
-        });
+                Arguments.of("cpe:2.3:a:zlib:zlib:*:*:*:*:*:*:*:*", Range.withRange().havingStartIncluding("1.2.0").havingEndExcluding("1.2.9"), MATCHES, "cpe:2.3:a:zlib:zlib:-:*:*:*:*:*:*:*")
+        );
     }
 
     public record Range(String startIncluding, String startExcluding, String endIncluding, String endExcluding) {
@@ -429,21 +426,8 @@ public class InternalAnalysisTaskCpeMatchingTest extends PersistenceCapableTest 
     private static final boolean DOES_NOT_MATCH = false;
     private static final Range WITHOUT_RANGE = null;
 
-    private final String sourceCpe;
-    private final Range sourceRange;
-    private final boolean expectMatch;
-    private final String targetCpe;
-
-    public InternalAnalysisTaskCpeMatchingTest(final String sourceCpe, final Range sourceRange,
-                                               final boolean expectMatch, final String targetCpe) {
-        this.sourceCpe = sourceCpe;
-        this.sourceRange = sourceRange;
-        this.expectMatch = expectMatch;
-        this.targetCpe = targetCpe;
-    }
-
-    @Before
-    public void setUp() {
+    @BeforeEach
+    public void setUp() throws Exception {
         qm.createConfigProperty(
                 SCANNER_INTERNAL_ENABLED.getGroupName(),
                 SCANNER_INTERNAL_ENABLED.getPropertyName(),
@@ -453,8 +437,12 @@ public class InternalAnalysisTaskCpeMatchingTest extends PersistenceCapableTest 
         );
     }
 
-    @Test
-    public void test() throws Exception {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void test(final String sourceCpe,
+              final Range sourceRange,
+              final boolean expectMatch,
+              final String targetCpe) throws Exception {
         final VulnerableSoftware vs = ModelConverter.convertCpe23UriToVulnerableSoftware(sourceCpe);
         if (sourceRange != null) {
             Optional.ofNullable(sourceRange.startIncluding).ifPresent(vs::setVersionStartIncluding);

--- a/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskTest.java
@@ -7,7 +7,7 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.parser.nvd.ModelConverter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import us.springett.parsers.cpe.exceptions.CpeEncodingException;
 import us.springett.parsers.cpe.exceptions.CpeParsingException;
 
@@ -16,10 +16,10 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class InternalAnalysisTaskTest extends PersistenceCapableTest {
+class InternalAnalysisTaskTest extends PersistenceCapableTest {
 
     @Test
-    public void testIssue1574() {
+    void testIssue1574() {
         var project = new Project();
         project.setName("acme-app");
         project = qm.createProject(project, Collections.emptyList(), false);
@@ -52,7 +52,7 @@ public class InternalAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testExactMatchWithNAUpdate() throws CpeParsingException, CpeEncodingException {
+    void testExactMatchWithNAUpdate() throws CpeParsingException, CpeEncodingException {
         var project = new Project();
         project.setName("acme-app");
         project = qm.createProject(project, Collections.emptyList(), false);

--- a/src/test/java/org/dependencytrack/tasks/scanners/SnykAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/SnykAnalysisTaskTest.java
@@ -41,11 +41,11 @@ import org.dependencytrack.model.VulnerabilityAnalysisLevel;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationScope;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.matchers.Times;
 import org.mockserver.verify.VerificationTimes;
@@ -73,17 +73,17 @@ import static org.mockserver.model.HttpError.error;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
-public class SnykAnalysisTaskTest extends PersistenceCapableTest {
+class SnykAnalysisTaskTest extends PersistenceCapableTest {
 
     private static ClientAndServer mockServer;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         NotificationService.getInstance().subscribe(new Subscription(NotificationSubscriber.class));
         mockServer = ClientAndServer.startClientAndServer(1080);
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         qm.createConfigProperty(SCANNER_SNYK_ENABLED.getGroupName(),
                 SCANNER_SNYK_ENABLED.getPropertyName(),
@@ -122,20 +122,20 @@ public class SnykAnalysisTaskTest extends PersistenceCapableTest {
                 "url");
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         mockServer.reset();
         NOTIFICATIONS.clear();
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         mockServer.stop();
         NotificationService.getInstance().unsubscribe(new Subscription(NotificationSubscriber.class));
     }
 
     @Test
-    public void testIsCapable() {
+    void testIsCapable() {
         final var asserts = new SoftAssertions();
 
         for (final Map.Entry<String, Boolean> test : Map.of(
@@ -153,7 +153,7 @@ public class SnykAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testShouldAnalyzeWhenCacheIsCurrent() throws Exception {
+    void testShouldAnalyzeWhenCacheIsCurrent() throws Exception {
         qm.updateComponentAnalysisCache(ComponentAnalysisCache.CacheType.VULNERABILITY, "http://localhost:1080",
                 Vulnerability.Source.SNYK.name(), "pkg:maven/com.fasterxml.woodstox/woodstox-core@5.0.0", new Date(),
                 Json.createObjectBuilder()
@@ -164,12 +164,12 @@ public class SnykAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testShouldAnalyzeWhenCacheIsNotCurrent() throws Exception {
+    void testShouldAnalyzeWhenCacheIsNotCurrent() throws Exception {
         assertThat(new SnykAnalysisTask().shouldAnalyze(new PackageURL("pkg:maven/com.fasterxml.woodstox/woodstox-core@5.0.0?foo=bar#baz"))).isTrue();
     }
 
     @Test
-    public void testAnalyzeWithRateLimiting() {
+    void testAnalyzeWithRateLimiting() {
         mockServer
                 .when(request(), Times.exactly(2))
                 .respond(response().withStatusCode(429));
@@ -348,7 +348,7 @@ public class SnykAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAnalyzeWithAliasSyncDisabled() {
+    void testAnalyzeWithAliasSyncDisabled() {
         final ConfigProperty aliasSyncProperty = qm.getConfigProperty(
                 SCANNER_SNYK_ALIAS_SYNC_ENABLED.getGroupName(),
                 SCANNER_SNYK_ALIAS_SYNC_ENABLED.getPropertyName()
@@ -487,7 +487,7 @@ public class SnykAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAnalyzeWithNoIssues() {
+    void testAnalyzeWithNoIssues() {
         mockServer
                 .when(request()
                         .withMethod("GET")
@@ -545,7 +545,7 @@ public class SnykAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAnalyzeWithError() {
+    void testAnalyzeWithError() {
         mockServer
                 .when(request()
                         .withMethod("GET")
@@ -605,7 +605,7 @@ public class SnykAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAnalyzeWithUnspecifiedError() {
+    void testAnalyzeWithUnspecifiedError() {
         mockServer
                 .when(request()
                         .withMethod("GET")
@@ -638,7 +638,7 @@ public class SnykAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAnalyzeWithConnectionError() {
+    void testAnalyzeWithConnectionError() {
         mockServer
                 .when(request().withPath("/rest/.+"))
                 .error(error().withDropConnection(true));
@@ -666,7 +666,7 @@ public class SnykAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAnalyzeWithCurrentCache() {
+    void testAnalyzeWithCurrentCache() {
         var vuln = new Vulnerability();
         vuln.setVulnId("SNYK-001");
         vuln.setSource(Vulnerability.Source.SNYK);
@@ -701,7 +701,7 @@ public class SnykAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAnalyzeWithDeprecatedApiVersion() throws Exception {
+    void testAnalyzeWithDeprecatedApiVersion() throws Exception {
         mockServer
                 .when(request()
                         .withMethod("GET")
@@ -757,7 +757,7 @@ public class SnykAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAnalyzeWithMultipleTokens() throws Exception {
+    void testAnalyzeWithMultipleTokens() throws Exception {
         final ConfigProperty configProperty = qm.getConfigProperty(
                 SCANNER_SNYK_API_TOKEN.getGroupName(),
                 SCANNER_SNYK_API_TOKEN.getPropertyName());
@@ -797,7 +797,7 @@ public class SnykAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testSendsUserAgent() throws Exception {
+    void testSendsUserAgent() throws Exception {
         mockServer
                 .when(request()
                         .withMethod("GET")

--- a/src/test/java/org/dependencytrack/tasks/scanners/VulnDBAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/VulnDBAnalysisTaskTest.java
@@ -34,11 +34,11 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAnalysisLevel;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
 
@@ -58,17 +58,17 @@ import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_VULNDB_O
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
-public class VulnDBAnalysisTaskTest extends PersistenceCapableTest {
+class VulnDBAnalysisTaskTest extends PersistenceCapableTest {
 
     private static ClientAndServer mockServer;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         NotificationService.getInstance().subscribe(new Subscription(NotificationSubscriber.class));
         mockServer = ClientAndServer.startClientAndServer(1080);
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         qm.createConfigProperty(SCANNER_VULNDB_ENABLED.getGroupName(),
                 SCANNER_VULNDB_ENABLED.getPropertyName(),
@@ -92,20 +92,20 @@ public class VulnDBAnalysisTaskTest extends PersistenceCapableTest {
                 "secret");
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         mockServer.reset();
         NOTIFICATIONS.clear();
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         mockServer.stop();
         NotificationService.getInstance().unsubscribe(new Subscription(NotificationSubscriber.class));
     }
 
     @Test
-    public void testIsCapable() {
+    void testIsCapable() {
         final var asserts = new SoftAssertions();
 
         for (final Map.Entry<String, Boolean> test : Map.of(
@@ -121,7 +121,7 @@ public class VulnDBAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAnalyzeWithOneIssue() {
+    void testAnalyzeWithOneIssue() {
         mockServer
                 .when(request()
                         .withMethod("GET")
@@ -246,7 +246,7 @@ public class VulnDBAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAnalyzeWithNoIssue() {
+    void testAnalyzeWithNoIssue() {
         mockServer
                 .when(request()
                         .withMethod("GET")
@@ -294,7 +294,7 @@ public class VulnDBAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAnalyzeWithCurrentCache() {
+    void testAnalyzeWithCurrentCache() {
         var vuln = new Vulnerability();
         vuln.setVulnId("VULNDB-001");
         vuln.setSource(Vulnerability.Source.VULNDB);

--- a/src/test/java/org/dependencytrack/util/AnalysisCommentUtilTest.java
+++ b/src/test/java/org/dependencytrack/util/AnalysisCommentUtilTest.java
@@ -3,7 +3,7 @@ package org.dependencytrack.util;
 import org.dependencytrack.model.Analysis;
 import org.dependencytrack.model.AnalysisResponse;
 import org.dependencytrack.persistence.QueryManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -12,9 +12,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-public class AnalysisCommentUtilTest {
+class AnalysisCommentUtilTest {
     @Test
-    public void makeCommentIfChangedNull() {
+    void makeCommentIfChangedNull() {
         final var qm = mock(QueryManager.class);
         final var analysis = mock(Analysis.class);
         assertFalse(AnalysisCommentUtil.makeCommentIfChanged("prefix", qm, analysis, AnalysisResponse.NOT_SET, null, "testuser"));
@@ -22,7 +22,7 @@ public class AnalysisCommentUtilTest {
     }
 
     @Test
-    public void makeCommentIfChangedWithChange() {
+    void makeCommentIfChangedWithChange() {
         final var qm = mock(QueryManager.class);
         final var analysis = mock(Analysis.class);
         assertTrue(AnalysisCommentUtil.makeCommentIfChanged("prefix", qm, analysis, AnalysisResponse.NOT_SET, AnalysisResponse.WILL_NOT_FIX, "testuser"));
@@ -30,7 +30,7 @@ public class AnalysisCommentUtilTest {
     }
 
     @Test
-    public void makeCommentIfChangedWithoutChanges() {
+    void makeCommentIfChangedWithoutChanges() {
         final var qm = mock(QueryManager.class);
         final var analysis = mock(Analysis.class);
         assertFalse(AnalysisCommentUtil.makeCommentIfChanged("prefix", qm, analysis, AnalysisResponse.WILL_NOT_FIX, AnalysisResponse.WILL_NOT_FIX, "testuser"));

--- a/src/test/java/org/dependencytrack/util/CacheStampedeBlockerTest.java
+++ b/src/test/java/org/dependencytrack/util/CacheStampedeBlockerTest.java
@@ -1,7 +1,7 @@
 package org.dependencytrack.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -15,12 +15,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class CacheStampedeBlockerTest {
+class CacheStampedeBlockerTest {
 
     private ExecutorService service = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 2);
 
     @Test
-    public void highConcurrencyScenarioWithSuccessfulCallable() throws ExecutionException, InterruptedException {
+    void highConcurrencyScenarioWithSuccessfulCallable() throws ExecutionException, InterruptedException {
         // Arrange
         CacheStampedeBlocker<String, Integer> cacheStampedeBlocker = new CacheStampedeBlocker<>("testCache", 10, true);
         Map<String, Integer> cache = new HashMap<>();
@@ -44,13 +44,13 @@ public class CacheStampedeBlockerTest {
         // Assert
         for (int i = 0; i < 10_000; i++) {
             Optional<Integer> result = results.get(i).get();
-            Assert.assertTrue(result.isPresent());
-            Assert.assertEquals("Iteration "+i+" failed", Integer.valueOf(1), result.get());
+            Assertions.assertTrue(result.isPresent());
+            Assertions.assertEquals(Integer.valueOf(1), result.get(), "Iteration "+i+" failed");
         }
     }
 
     @Test
-    public void highConcurrencyScenarioWithErroneousCallable() throws ExecutionException, InterruptedException {
+    void highConcurrencyScenarioWithErroneousCallable() throws ExecutionException, InterruptedException {
         // Arrange
         CacheStampedeBlocker<String, Integer> cacheStampedeBlocker = new CacheStampedeBlocker<>("testCache", 10, true);
         Map<String, Integer> cache = new HashMap<>();
@@ -71,12 +71,12 @@ public class CacheStampedeBlockerTest {
         // Assert
         for (int i = 0; i < 100; i++) {
             Optional<Integer> result = results.get(i).get();
-            Assert.assertTrue(result.isEmpty());
+            Assertions.assertTrue(result.isEmpty());
         }
     }
 
     @Test
-    public void retryScenarioWithNonRetryableException() {
+    void retryScenarioWithNonRetryableException() {
         // Arrange
         CacheStampedeBlocker<String, Integer> cacheStampedeBlocker = new CacheStampedeBlocker<>("testCache", 10, true, 3);
 
@@ -89,11 +89,11 @@ public class CacheStampedeBlockerTest {
         });
 
         // Assert
-        Assert.assertEquals(1, counter.get());
+        Assertions.assertEquals(1, counter.get());
     }
 
     @Test
-    public void retryScenarioWithRetryableException() {
+    void retryScenarioWithRetryableException() {
         // Arrange
         CacheStampedeBlocker<String, Integer> cacheStampedeBlocker = new CacheStampedeBlocker<>("testCache", 10, true, 3, Duration.ofMinutes(10).toMillis(), ArithmeticException.class);
 
@@ -106,6 +106,6 @@ public class CacheStampedeBlockerTest {
         });
 
         // Assert
-        Assert.assertEquals(3, counter.get());
+        Assertions.assertEquals(3, counter.get());
     }
 }

--- a/src/test/java/org/dependencytrack/util/DateUtilTest.java
+++ b/src/test/java/org/dependencytrack/util/DateUtilTest.java
@@ -18,8 +18,8 @@
  */
 package org.dependencytrack.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -28,41 +28,41 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Date;
 
-public class DateUtilTest {
+class DateUtilTest {
 
     @Test
-    public void testParseShortDate() throws Exception {
+    void testParseShortDate() throws Exception {
         Date date = DateUtil.parseShortDate("20191231");
         LocalDate localDate = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
-        Assert.assertEquals(Month.DECEMBER, localDate.getMonth());
-        Assert.assertEquals(31, localDate.getDayOfMonth());
-        Assert.assertEquals(2019, localDate.getYear());
+        Assertions.assertEquals(Month.DECEMBER, localDate.getMonth());
+        Assertions.assertEquals(31, localDate.getDayOfMonth());
+        Assertions.assertEquals(2019, localDate.getYear());
     }
 
     @Test
-    public void testParseDate() throws Exception {
+    void testParseDate() throws Exception {
         Date date = DateUtil.parseDate("20191231153012");
         LocalDateTime localDateTime = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
-        Assert.assertEquals(Month.DECEMBER, localDateTime.getMonth());
-        Assert.assertEquals(31, localDateTime.getDayOfMonth());
-        Assert.assertEquals(2019, localDateTime.getYear());
-        Assert.assertEquals(15, localDateTime.getHour());
-        Assert.assertEquals(30, localDateTime.getMinute());
-        Assert.assertEquals(12, localDateTime.getSecond());
+        Assertions.assertEquals(Month.DECEMBER, localDateTime.getMonth());
+        Assertions.assertEquals(31, localDateTime.getDayOfMonth());
+        Assertions.assertEquals(2019, localDateTime.getYear());
+        Assertions.assertEquals(15, localDateTime.getHour());
+        Assertions.assertEquals(30, localDateTime.getMinute());
+        Assertions.assertEquals(12, localDateTime.getSecond());
     }
 
     @Test
-    public void testDiff() {
+    void testDiff() {
         LocalDate d1 =  LocalDate.of(2019, Month.JANUARY, 1);
         LocalDate d2 =  LocalDate.of(2017, Month.JANUARY, 1);
         long diff = DateUtil.diff(java.sql.Date.valueOf(d2), java.sql.Date.valueOf(d1));
-        Assert.assertEquals(730, diff);
+        Assertions.assertEquals(730, diff);
     }
 
     @Test
-    public void testToISO8601() {
+    void testToISO8601() {
         Date date = Date.from(LocalDateTime.of(2019, Month.JANUARY, 31, 15, 30, 12).toInstant(ZoneOffset.UTC));
         String iso8601Date = DateUtil.toISO8601(date);
-        Assert.assertEquals("2019-01-31T15:30:12Z", iso8601Date);
+        Assertions.assertEquals("2019-01-31T15:30:12Z", iso8601Date);
     }
 }

--- a/src/test/java/org/dependencytrack/util/DebugDataEncryptionTest.java
+++ b/src/test/java/org/dependencytrack/util/DebugDataEncryptionTest.java
@@ -20,7 +20,7 @@ package org.dependencytrack.util;
 
 import alpine.security.crypto.DataEncryption;
 import alpine.security.crypto.KeyManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
@@ -29,10 +29,10 @@ import java.security.SecureRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DebugDataEncryptionTest {
+class DebugDataEncryptionTest {
 
     @Test
-    public void testReloadAndRetry() throws Exception {
+    void testReloadAndRetry() throws Exception {
         final Field secretKeyField = KeyManager.class.getDeclaredField("secretKey");
         secretKeyField.setAccessible(true);
 

--- a/src/test/java/org/dependencytrack/util/HashUtilTest.java
+++ b/src/test/java/org/dependencytrack/util/HashUtilTest.java
@@ -18,34 +18,34 @@
  */
 package org.dependencytrack.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-public class HashUtilTest {
+class HashUtilTest {
 
     @Test
-    public void testMd5() throws Exception {
+    void testMd5() throws Exception {
         File file = new File(Thread.currentThread().getContextClassLoader().getResource("textfile.txt").toURI());
-        Assert.assertEquals("6ccb8fac358fea58732ed8ffec85b9f5", HashUtil.md5(file));
+        Assertions.assertEquals("6ccb8fac358fea58732ed8ffec85b9f5", HashUtil.md5(file));
     }
 
     @Test
-    public void testSha1() throws Exception {
+    void testSha1() throws Exception {
         File file = new File(Thread.currentThread().getContextClassLoader().getResource("textfile.txt").toURI());
-        Assert.assertEquals("3f4b24f2a4da21774622417444436b193fe34764", HashUtil.sha1(file));
+        Assertions.assertEquals("3f4b24f2a4da21774622417444436b193fe34764", HashUtil.sha1(file));
     }
 
     @Test
-    public void testSha256() throws Exception {
+    void testSha256() throws Exception {
         File file = new File(Thread.currentThread().getContextClassLoader().getResource("textfile.txt").toURI());
-        Assert.assertEquals("958bf829329b84baef5136d99156f6703d0d95cffa9fc6cec6403ced7573eff3", HashUtil.sha256(file));
+        Assertions.assertEquals("958bf829329b84baef5136d99156f6703d0d95cffa9fc6cec6403ced7573eff3", HashUtil.sha256(file));
     }
 
     @Test
-    public void testSha512() throws Exception {
+    void testSha512() throws Exception {
         File file = new File(Thread.currentThread().getContextClassLoader().getResource("textfile.txt").toURI());
-        Assert.assertEquals("1e140d6171bf6377a749d7579034cf4879548d96e9d5299f02a5265e094168fd9812fda94fa5fa9ff45ac8454f19d18f612cb3204ad551e29baddbfa17636b59", HashUtil.sha512(file));
+        Assertions.assertEquals("1e140d6171bf6377a749d7579034cf4879548d96e9d5299f02a5265e094168fd9812fda94fa5fa9ff45ac8454f19d18f612cb3204ad551e29baddbfa17636b59", HashUtil.sha512(file));
     }
 }

--- a/src/test/java/org/dependencytrack/util/HttpUtilTest.java
+++ b/src/test/java/org/dependencytrack/util/HttpUtilTest.java
@@ -18,20 +18,20 @@
  */
 package org.dependencytrack.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class HttpUtilTest { 
+class HttpUtilTest {
 
     @Test
-    public void testBasicAuthHeader() throws Exception {
+    void testBasicAuthHeader() throws Exception {
         String header = HttpUtil.basicAuthHeader("username", "password");
-        Assert.assertEquals("Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=", header);
+        Assertions.assertEquals("Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=", header);
     } 
 
     @Test
-    public void testBasicAuthHeaderValue() throws Exception {
+    void testBasicAuthHeaderValue() throws Exception {
         String authvalue = HttpUtil.basicAuthHeaderValue("username", "password");
-        Assert.assertEquals("Basic dXNlcm5hbWU6cGFzc3dvcmQ=", authvalue);
+        Assertions.assertEquals("Basic dXNlcm5hbWU6cGFzc3dvcmQ=", authvalue);
     }
 } 

--- a/src/test/java/org/dependencytrack/util/InternalComponentIdentificationUtilTest.java
+++ b/src/test/java/org/dependencytrack/util/InternalComponentIdentificationUtilTest.java
@@ -2,67 +2,53 @@ package org.dependencytrack.util;
 
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Component;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
 
 import static org.dependencytrack.model.ConfigPropertyConstants.INTERNAL_COMPONENTS_GROUPS_REGEX;
 import static org.dependencytrack.model.ConfigPropertyConstants.INTERNAL_COMPONENTS_NAMES_REGEX;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@RunWith(Parameterized.class)
-public class InternalComponentIdentificationUtilTest extends PersistenceCapableTest {
+class InternalComponentIdentificationUtilTest extends PersistenceCapableTest {
 
-    private final String groupsRegexProperty;
-    private final String componentGroup;
-    private final String namesRegexProperty;
-    private final String componentName;
-    private final boolean shouldBeInternal;
-
-    @Parameterized.Parameters(name = "[{index}] groupsRegexProperty={0} componentGroup={1} " +
-            "namesRegexProperty={2} componentName={3} shouldBeInternal={4}")
-    public static Collection testParameters() {
-        return Arrays.asList(new Object[][]{
+    public static Collection<Arguments> testParameters() {
+        return Arrays.asList(
                 // neither regexes nor group / name provided
-                {"", "", "", "", false},
+                Arguments.of("", "", "", "", false),
                 // Neither group nor name provided
-                {".*", null, ".*", null, false},
+                Arguments.of(".*", null, ".*", null, false),
                 // group matches, name not provided
-                {".*", "a", ".*", null, true},
+                Arguments.of(".*", "a", ".*", null, true),
                 // group not provided, name matches
-                {".*", null, ".*", "a", true},
+                Arguments.of(".*", null, ".*", "a", true),
                 // both group and name match
-                {".*", "a", ".*", "b", true},
+                Arguments.of(".*", "a", ".*", "b", true),
                 // specific regex for group
-                {"^us\\.springett$", "us.springett", null, null, true},
+                Arguments.of("^us\\.springett$", "us.springett", null, null, true),
                 // specific regex for name
-                {null, null, "^dependency-track$", "dependency-track", true},
+                Arguments.of(null, null, "^dependency-track$", "dependency-track", true),
                 // generalized, case-insensitive regex for group
-                {"(?i)^(org\\.apache)(\\.[\\w.]+)?$", "Org.Apache.Logging.Log4J", null, "log4j-test", true},
+                Arguments.of("(?i)^(org\\.apache)(\\.[\\w.]+)?$", "Org.Apache.Logging.Log4J", null, "log4j-test", true),
                 // same as above, but with incomplete regex
-                {"(?i)^(org\\.apache)", "Org.Apache.Logging.Log4J", null, "log4j-test", false},
+                Arguments.of("(?i)^(org\\.apache)", "Org.Apache.Logging.Log4J", null, "log4j-test", false),
                 // generalized regex for names
-                {null, "org.apache.logging.log4j", "^(log4j-)([\\w-]+)$", "log4j-test", true},
+                Arguments.of(null, "org.apache.logging.log4j", "^(log4j-)([\\w-]+)$", "log4j-test", true),
                 // same as above, but with incomplete regex
-                {null, "org.apache.logging.log4j", "^(log4j-)", "log4j-test", false},
-        });
+                Arguments.of(null, "org.apache.logging.log4j", "^(log4j-)", "log4j-test", false)
+        );
     }
 
-    public InternalComponentIdentificationUtilTest(final String groupsRegexProperty, final String componentGroup,
-                                                   final String namesRegexProperty, final String componentName,
-                                                   final boolean shouldBeInternal) {
-        this.groupsRegexProperty = groupsRegexProperty;
-        this.componentGroup = componentGroup;
-        this.namesRegexProperty = namesRegexProperty;
-        this.componentName = componentName;
-        this.shouldBeInternal = shouldBeInternal;
-    }
-
-    @Test
-    public void testIsInternal() {
+    @ParameterizedTest
+    @MethodSource("testParameters")
+    void testIsInternal(final String groupsRegexProperty,
+                        final String componentGroup,
+                        final String namesRegexProperty,
+                        final String componentName,
+                        final boolean shouldBeInternal) {
         qm.createConfigProperty(
                 INTERNAL_COMPONENTS_GROUPS_REGEX.getGroupName(),
                 INTERNAL_COMPONENTS_GROUPS_REGEX.getPropertyName(),

--- a/src/test/java/org/dependencytrack/util/PersistenceUtilTest.java
+++ b/src/test/java/org/dependencytrack/util/PersistenceUtilTest.java
@@ -22,8 +22,8 @@ import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.util.PersistenceUtil.Diff;
 import org.dependencytrack.util.PersistenceUtil.Differ;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.jdo.PersistenceManager;
 import javax.jdo.Transaction;
@@ -35,17 +35,17 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.dependencytrack.util.PersistenceUtil.assertNonPersistent;
 import static org.dependencytrack.util.PersistenceUtil.assertPersistent;
 
-public class PersistenceUtilTest extends PersistenceCapableTest {
+class PersistenceUtilTest extends PersistenceCapableTest {
 
     private PersistenceManager pm;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         pm = qm.getPersistenceManager();
     }
 
     @Test
-    public void testAssertPersistentTx() {
+    void testAssertPersistentTx() {
         final Transaction trx = pm.currentTransaction();
         try {
             trx.begin();
@@ -62,7 +62,7 @@ public class PersistenceUtilTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAssertPersistentNonTx() {
+    void testAssertPersistentNonTx() {
         final var project = new Project();
         project.setName("foo");
         pm.makePersistent(project);
@@ -72,14 +72,14 @@ public class PersistenceUtilTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAssertPersistentWhenTransient() {
+    void testAssertPersistentWhenTransient() {
         final var project = new Project();
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> assertPersistent(project, null));
     }
 
     @Test
-    public void testAssertPersistentWhenDetached() {
+    void testAssertPersistentWhenDetached() {
         final var project = new Project();
         project.setName("foo");
         pm.makePersistent(project);
@@ -89,7 +89,7 @@ public class PersistenceUtilTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAssertNonPersistentTx() {
+    void testAssertNonPersistentTx() {
         final Transaction trx = pm.currentTransaction();
         try {
             trx.begin();
@@ -106,7 +106,7 @@ public class PersistenceUtilTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAssertNonPersistentNonTx() {
+    void testAssertNonPersistentNonTx() {
         final var project = new Project();
         project.setName("foo");
         pm.makePersistent(project);
@@ -116,14 +116,14 @@ public class PersistenceUtilTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testAssertNonPersistentWhenTransient() {
+    void testAssertNonPersistentWhenTransient() {
         final var project = new Project();
         assertThatNoException()
                 .isThrownBy(() -> assertNonPersistent(project, null));
     }
 
     @Test
-    public void testAssertNonPersistentWhenDetached() {
+    void testAssertNonPersistentWhenDetached() {
         final var project = new Project();
         project.setName("foo");
         pm.makePersistent(project);
@@ -134,7 +134,7 @@ public class PersistenceUtilTest extends PersistenceCapableTest {
 
 
     @Test
-    public void testDifferWithChanges() {
+    void testDifferWithChanges() {
         final var projectA = new Project();
         projectA.setName("acme-app-a");
         projectA.setVersion("1.0.0");
@@ -157,7 +157,7 @@ public class PersistenceUtilTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testDifferWithoutChanges() {
+    void testDifferWithoutChanges() {
         final var projectA = new Project();
         projectA.setName("acme-app-a");
         projectA.setVersion("1.0.0");

--- a/src/test/java/org/dependencytrack/util/RoundRobinAccessorTest.java
+++ b/src/test/java/org/dependencytrack/util/RoundRobinAccessorTest.java
@@ -18,7 +18,7 @@
  */
 package org.dependencytrack.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -28,10 +28,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RoundRobinAccessorTest {
+class RoundRobinAccessorTest {
 
     @Test
-    public void testGet() {
+    void testGet() {
         final var accessor = new RoundRobinAccessor<>(List.of("foo", "bar", "baz"));
 
         for (int i = 0; i < 3_000_000; i += 3) {
@@ -42,7 +42,7 @@ public class RoundRobinAccessorTest {
     }
 
     @Test
-    public void testGetConcurrently() throws Exception {
+    void testGetConcurrently() throws Exception {
         final var accessor = new RoundRobinAccessor<>(List.of("foo", "bar", "baz"));
 
         final var countDownLatch = new CountDownLatch(3_000_000);
@@ -78,7 +78,7 @@ public class RoundRobinAccessorTest {
     }
 
     @Test
-    public void testGetOnUnderflow() {
+    void testGetOnUnderflow() {
         final var accessor = new RoundRobinAccessor<>(List.of("foo", "bar", "baz"), new AtomicInteger(Integer.MAX_VALUE - 1));
 
         // The round-robin currently doesn't repeat cleanly when the underlying index exceeds Integer.MAX_VALUE.

--- a/src/test/java/org/dependencytrack/util/VersionDistanceTest.java
+++ b/src/test/java/org/dependencytrack/util/VersionDistanceTest.java
@@ -1,115 +1,115 @@
 package org.dependencytrack.util;
 
 import java.util.Arrays;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class VersionDistanceTest {
+class VersionDistanceTest {
 
     @Test
-    public void testVersionDistance() {
-        Assert.assertEquals("0:1.?.?", new VersionDistance("1").toString());
-        Assert.assertEquals("1:?.?.?", new VersionDistance("1:?").toString());
-        Assert.assertEquals("0:0.0.0", new VersionDistance().toString());
-        Assert.assertEquals("0:0.0.0", new VersionDistance(null).toString());
-        Assert.assertEquals("0:0.0.0", new VersionDistance(0,0,0).toString());
-        Assert.assertEquals("0:1.?.?", new VersionDistance(1, -1,-1).toString());
-        Assert.assertEquals("0:0.2.?", new VersionDistance(0, 2, -1).toString());
-        Assert.assertEquals("0:0.2.?", new VersionDistance("0:0.2").toString());
-        Assert.assertEquals("0:2.?.?", new VersionDistance("2").toString());
+    void testVersionDistance() {
+        Assertions.assertEquals("0:1.?.?", new VersionDistance("1").toString());
+        Assertions.assertEquals("1:?.?.?", new VersionDistance("1:?").toString());
+        Assertions.assertEquals("0:0.0.0", new VersionDistance().toString());
+        Assertions.assertEquals("0:0.0.0", new VersionDistance(null).toString());
+        Assertions.assertEquals("0:0.0.0", new VersionDistance(0,0,0).toString());
+        Assertions.assertEquals("0:1.?.?", new VersionDistance(1, -1,-1).toString());
+        Assertions.assertEquals("0:0.2.?", new VersionDistance(0, 2, -1).toString());
+        Assertions.assertEquals("0:0.2.?", new VersionDistance("0:0.2").toString());
+        Assertions.assertEquals("0:2.?.?", new VersionDistance("2").toString());
 
-        Assert.assertThrows(NumberFormatException.class, () -> new VersionDistance("ax").toString());
-        Assert.assertThrows(NumberFormatException.class, () -> new VersionDistance("1a").toString());
-        Assert.assertThrows(NumberFormatException.class, () -> new VersionDistance("1.2.3.4").toString());
-        Assert.assertThrows(NumberFormatException.class, () -> new VersionDistance("1a.2b.3c").toString());
-        Assert.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("1.0.0").toString());
-        Assert.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("1.1.0").toString());
-        Assert.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("?:1.0.0").toString());
-        Assert.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("0:?.0.0").toString());
-        Assert.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("?:1.0.0").toString());
-        Assert.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("0:?.1.0").toString());
+        Assertions.assertThrows(NumberFormatException.class, () -> new VersionDistance("ax").toString());
+        Assertions.assertThrows(NumberFormatException.class, () -> new VersionDistance("1a").toString());
+        Assertions.assertThrows(NumberFormatException.class, () -> new VersionDistance("1.2.3.4").toString());
+        Assertions.assertThrows(NumberFormatException.class, () -> new VersionDistance("1a.2b.3c").toString());
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("1.0.0").toString());
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("1.1.0").toString());
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("?:1.0.0").toString());
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("0:?.0.0").toString());
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("?:1.0.0").toString());
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new VersionDistance("0:?.1.0").toString());
     }
 
     @Test
-    public void testCompareTo() {
-        Assert.assertEquals(0, new VersionDistance(null).compareTo(new VersionDistance("0")));
-        Assert.assertTrue(new VersionDistance("2.?.?").compareTo(new VersionDistance("1.?.?")) > 0);
+    void testCompareTo() {
+        Assertions.assertEquals(0, new VersionDistance(null).compareTo(new VersionDistance("0")));
+        Assertions.assertTrue(new VersionDistance("2.?.?").compareTo(new VersionDistance("1.?.?")) > 0);
 
-        Assert.assertEquals(0, new VersionDistance().compareTo(new VersionDistance()));
-        Assert.assertEquals(0, new VersionDistance("0.0").compareTo(new VersionDistance("0")));
-        Assert.assertEquals(0, new VersionDistance("1.?.?").compareTo(new VersionDistance("1.?.?")));
+        Assertions.assertEquals(0, new VersionDistance().compareTo(new VersionDistance()));
+        Assertions.assertEquals(0, new VersionDistance("0.0").compareTo(new VersionDistance("0")));
+        Assertions.assertEquals(0, new VersionDistance("1.?.?").compareTo(new VersionDistance("1.?.?")));
 
-        Assert.assertTrue(new VersionDistance("1").compareTo(new VersionDistance()) > 0);
-        Assert.assertTrue(new VersionDistance("1").compareTo(new VersionDistance(null)) > 0);
-        Assert.assertTrue(new VersionDistance("1.?").compareTo(new VersionDistance("0")) > 0);
-        Assert.assertTrue(new VersionDistance("1.?.?").compareTo(new VersionDistance("0.0")) > 0);
-        Assert.assertTrue(new VersionDistance("1.?.?").compareTo(new VersionDistance("0.0.0")) > 0);
-        Assert.assertTrue(new VersionDistance("2.?.?").compareTo(new VersionDistance("1.?.?")) > 0);
-        Assert.assertTrue(new VersionDistance("1.?.?").compareTo(new VersionDistance("0.1.?")) > 0);
-        Assert.assertTrue(new VersionDistance("0.1.?").compareTo(new VersionDistance("0.0.1")) > 0);
+        Assertions.assertTrue(new VersionDistance("1").compareTo(new VersionDistance()) > 0);
+        Assertions.assertTrue(new VersionDistance("1").compareTo(new VersionDistance(null)) > 0);
+        Assertions.assertTrue(new VersionDistance("1.?").compareTo(new VersionDistance("0")) > 0);
+        Assertions.assertTrue(new VersionDistance("1.?.?").compareTo(new VersionDistance("0.0")) > 0);
+        Assertions.assertTrue(new VersionDistance("1.?.?").compareTo(new VersionDistance("0.0.0")) > 0);
+        Assertions.assertTrue(new VersionDistance("2.?.?").compareTo(new VersionDistance("1.?.?")) > 0);
+        Assertions.assertTrue(new VersionDistance("1.?.?").compareTo(new VersionDistance("0.1.?")) > 0);
+        Assertions.assertTrue(new VersionDistance("0.1.?").compareTo(new VersionDistance("0.0.1")) > 0);
 
-        Assert.assertTrue(new VersionDistance().compareTo(new VersionDistance("1")) < 0);
-        Assert.assertTrue(new VersionDistance(null).compareTo(new VersionDistance("1")) < 0);
-        Assert.assertTrue(new VersionDistance("0").compareTo(new VersionDistance("1.?")) < 0);
-        Assert.assertTrue(new VersionDistance("0.0").compareTo(new VersionDistance("0.0.1")) < 0);
-        Assert.assertTrue(new VersionDistance("0.1.?").compareTo(new VersionDistance("1.?.?")) < 0);
-        Assert.assertTrue(new VersionDistance("1.?.?").compareTo(new VersionDistance("2.?.?")) < 0);
-        Assert.assertTrue(new VersionDistance("1.?.?").compareTo(new VersionDistance("2.?.?")) < 0);
-        Assert.assertTrue(new VersionDistance("0.1.?").compareTo(new VersionDistance("0.2.?")) < 0);
-        Assert.assertTrue(new VersionDistance("0.0.1").compareTo(new VersionDistance("0.0.2")) < 0);
+        Assertions.assertTrue(new VersionDistance().compareTo(new VersionDistance("1")) < 0);
+        Assertions.assertTrue(new VersionDistance(null).compareTo(new VersionDistance("1")) < 0);
+        Assertions.assertTrue(new VersionDistance("0").compareTo(new VersionDistance("1.?")) < 0);
+        Assertions.assertTrue(new VersionDistance("0.0").compareTo(new VersionDistance("0.0.1")) < 0);
+        Assertions.assertTrue(new VersionDistance("0.1.?").compareTo(new VersionDistance("1.?.?")) < 0);
+        Assertions.assertTrue(new VersionDistance("1.?.?").compareTo(new VersionDistance("2.?.?")) < 0);
+        Assertions.assertTrue(new VersionDistance("1.?.?").compareTo(new VersionDistance("2.?.?")) < 0);
+        Assertions.assertTrue(new VersionDistance("0.1.?").compareTo(new VersionDistance("0.2.?")) < 0);
+        Assertions.assertTrue(new VersionDistance("0.0.1").compareTo(new VersionDistance("0.0.2")) < 0);
 
-        Assert.assertTrue(VersionDistance.getVersionDistance("1.0.0", "0.1.0").compareTo(new VersionDistance("1.?.?")) == 0);
-        Assert.assertTrue(VersionDistance.getVersionDistance("1.1.0", "1.0.0").compareTo(new VersionDistance("0.1.?")) == 0);
-        Assert.assertTrue(VersionDistance.getVersionDistance("1.0.0", "1.1.0").compareTo(new VersionDistance("0.1.?")) == 0);
-        Assert.assertTrue(VersionDistance.getVersionDistance("1.2.3", "2.1.0").compareTo(new VersionDistance("1.?.?")) == 0);
-        Assert.assertTrue(VersionDistance.getVersionDistance("2.2.2", "2.4.4").compareTo(new VersionDistance("0.1.?")) > 0);
-        Assert.assertTrue(VersionDistance.getVersionDistance("1.1.1", "1.1.3").compareTo(new VersionDistance("0.0.1")) > 0);
+        Assertions.assertTrue(VersionDistance.getVersionDistance("1.0.0", "0.1.0").compareTo(new VersionDistance("1.?.?")) == 0);
+        Assertions.assertTrue(VersionDistance.getVersionDistance("1.1.0", "1.0.0").compareTo(new VersionDistance("0.1.?")) == 0);
+        Assertions.assertTrue(VersionDistance.getVersionDistance("1.0.0", "1.1.0").compareTo(new VersionDistance("0.1.?")) == 0);
+        Assertions.assertTrue(VersionDistance.getVersionDistance("1.2.3", "2.1.0").compareTo(new VersionDistance("1.?.?")) == 0);
+        Assertions.assertTrue(VersionDistance.getVersionDistance("2.2.2", "2.4.4").compareTo(new VersionDistance("0.1.?")) > 0);
+        Assertions.assertTrue(VersionDistance.getVersionDistance("1.1.1", "1.1.3").compareTo(new VersionDistance("0.0.1")) > 0);
     }
 
     @Test
-    public void testEquals() {
-        Assert.assertEquals(new VersionDistance("0.0"), new VersionDistance(""));
-        Assert.assertEquals(new VersionDistance("0:0"), new VersionDistance(null));
-        Assert.assertEquals(new VersionDistance("4:?.?.?"), new VersionDistance("4:?"));
-        Assert.assertEquals(new VersionDistance("1.?.?"), new VersionDistance("1"));
-        Assert.assertEquals(new VersionDistance("0:1.?.?"), new VersionDistance("1.?"));
+    void testEquals() {
+        Assertions.assertEquals(new VersionDistance("0.0"), new VersionDistance(""));
+        Assertions.assertEquals(new VersionDistance("0:0"), new VersionDistance(null));
+        Assertions.assertEquals(new VersionDistance("4:?.?.?"), new VersionDistance("4:?"));
+        Assertions.assertEquals(new VersionDistance("1.?.?"), new VersionDistance("1"));
+        Assertions.assertEquals(new VersionDistance("0:1.?.?"), new VersionDistance("1.?"));
     }
 
     @Test
-    public void testGetVersionDistance() {
-        Assert.assertEquals(new VersionDistance("0.0.0"), VersionDistance.getVersionDistance("", null));
-        Assert.assertEquals(new VersionDistance("0.0.0"), VersionDistance.getVersionDistance(null, ""));
-        Assert.assertEquals(new VersionDistance("1.?.?"), VersionDistance.getVersionDistance("2", "1.0"));
-        Assert.assertEquals(new VersionDistance("0.1.?"), VersionDistance.getVersionDistance("1", "1.1.0"));
-        Assert.assertEquals(new VersionDistance("0.0.1"), VersionDistance.getVersionDistance("1", "1.0.1"));
-        Assert.assertEquals(new VersionDistance("2.?.?"), VersionDistance.getVersionDistance("1.2", "3.4.0"));
-        Assert.assertEquals(new VersionDistance("0:2.?"), VersionDistance.getVersionDistance("1.f", "3.4.0"));
-        Assert.assertEquals(new VersionDistance("2.?.?"), VersionDistance.getVersionDistance("1.", "3.4.0"));
-        Assert.assertEquals(new VersionDistance("2.?.?"), VersionDistance.getVersionDistance("1.2.3", "3.4.0"));
-        Assert.assertEquals(new VersionDistance("3.?.?"), VersionDistance.getVersionDistance("0.1.2", "3.4.0"));
-        Assert.assertEquals(new VersionDistance("0.2.?"), VersionDistance.getVersionDistance("3.2.2", "3.4.0"));
-        Assert.assertEquals(new VersionDistance("0.0.1"), VersionDistance.getVersionDistance("0.0.1", "0.0.2"));
-        Assert.assertEquals(new VersionDistance("2.?.?"), VersionDistance.getVersionDistance("3.4.0", "1.2.3"));
-        Assert.assertEquals(new VersionDistance("3.?.?"), VersionDistance.getVersionDistance("3.4.0", "0.1.2"));
-        Assert.assertEquals(new VersionDistance("0.2.?"), VersionDistance.getVersionDistance("3.4.0", "3.2.2"));
-        Assert.assertEquals(new VersionDistance("0.0.1"), VersionDistance.getVersionDistance("0.0.2", "0.0.1"));
+    void testGetVersionDistance() {
+        Assertions.assertEquals(new VersionDistance("0.0.0"), VersionDistance.getVersionDistance("", null));
+        Assertions.assertEquals(new VersionDistance("0.0.0"), VersionDistance.getVersionDistance(null, ""));
+        Assertions.assertEquals(new VersionDistance("1.?.?"), VersionDistance.getVersionDistance("2", "1.0"));
+        Assertions.assertEquals(new VersionDistance("0.1.?"), VersionDistance.getVersionDistance("1", "1.1.0"));
+        Assertions.assertEquals(new VersionDistance("0.0.1"), VersionDistance.getVersionDistance("1", "1.0.1"));
+        Assertions.assertEquals(new VersionDistance("2.?.?"), VersionDistance.getVersionDistance("1.2", "3.4.0"));
+        Assertions.assertEquals(new VersionDistance("0:2.?"), VersionDistance.getVersionDistance("1.f", "3.4.0"));
+        Assertions.assertEquals(new VersionDistance("2.?.?"), VersionDistance.getVersionDistance("1.", "3.4.0"));
+        Assertions.assertEquals(new VersionDistance("2.?.?"), VersionDistance.getVersionDistance("1.2.3", "3.4.0"));
+        Assertions.assertEquals(new VersionDistance("3.?.?"), VersionDistance.getVersionDistance("0.1.2", "3.4.0"));
+        Assertions.assertEquals(new VersionDistance("0.2.?"), VersionDistance.getVersionDistance("3.2.2", "3.4.0"));
+        Assertions.assertEquals(new VersionDistance("0.0.1"), VersionDistance.getVersionDistance("0.0.1", "0.0.2"));
+        Assertions.assertEquals(new VersionDistance("2.?.?"), VersionDistance.getVersionDistance("3.4.0", "1.2.3"));
+        Assertions.assertEquals(new VersionDistance("3.?.?"), VersionDistance.getVersionDistance("3.4.0", "0.1.2"));
+        Assertions.assertEquals(new VersionDistance("0.2.?"), VersionDistance.getVersionDistance("3.4.0", "3.2.2"));
+        Assertions.assertEquals(new VersionDistance("0.0.1"), VersionDistance.getVersionDistance("0.0.2", "0.0.1"));
         // optional build numbers are ignored:
-        Assert.assertEquals(new VersionDistance("0.0.0"), VersionDistance.getVersionDistance("0.0.0.1", "0.0.0.5"));
+        Assertions.assertEquals(new VersionDistance("0.0.0"), VersionDistance.getVersionDistance("0.0.0.1", "0.0.0.5"));
 
-        Assert.assertThrows(NumberFormatException.class, () -> VersionDistance.getVersionDistance("a:", "1"));
-        Assert.assertThrows(NumberFormatException.class, () -> VersionDistance.getVersionDistance("1a.2.3", "1"));
-        Assert.assertThrows(NumberFormatException.class, () -> VersionDistance.getVersionDistance("1.2a.3", "1"));
-        Assert.assertThrows(NumberFormatException.class, () -> VersionDistance.getVersionDistance("1.2.3a", "1"));
+        Assertions.assertThrows(NumberFormatException.class, () -> VersionDistance.getVersionDistance("a:", "1"));
+        Assertions.assertThrows(NumberFormatException.class, () -> VersionDistance.getVersionDistance("1a.2.3", "1"));
+        Assertions.assertThrows(NumberFormatException.class, () -> VersionDistance.getVersionDistance("1.2a.3", "1"));
+        Assertions.assertThrows(NumberFormatException.class, () -> VersionDistance.getVersionDistance("1.2.3a", "1"));
     }
 
     @Test
-    public void testParse() {
-        Assert.assertEquals(Arrays.asList(new VersionDistance(0,1,-1)), VersionDistance.parse("0.1.?"));
-        Assert.assertEquals(Arrays.asList(new VersionDistance(1,-1,-1), new VersionDistance(0,1,-1)), VersionDistance.parse("1.1.?"));
-        Assert.assertEquals(Arrays.asList(new VersionDistance(1, -1,-1,-1), new VersionDistance(1,-1, -1), new VersionDistance(0,1,-1)), VersionDistance.parse("1:1.1.?"));
-        Assert.assertEquals(Arrays.asList(), VersionDistance.parse("0:?.?.?"));
+    void testParse() {
+        Assertions.assertEquals(Arrays.asList(new VersionDistance(0,1,-1)), VersionDistance.parse("0.1.?"));
+        Assertions.assertEquals(Arrays.asList(new VersionDistance(1,-1,-1), new VersionDistance(0,1,-1)), VersionDistance.parse("1.1.?"));
+        Assertions.assertEquals(Arrays.asList(new VersionDistance(1, -1,-1,-1), new VersionDistance(1,-1, -1), new VersionDistance(0,1,-1)), VersionDistance.parse("1:1.1.?"));
+        Assertions.assertEquals(Arrays.asList(), VersionDistance.parse("0:?.?.?"));
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> VersionDistance.parse("1.2.3a.1"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> VersionDistance.parse("1.2.3a.1"));
     }
 
 }

--- a/src/test/java/org/dependencytrack/util/VulnerabilityUtilTest.java
+++ b/src/test/java/org/dependencytrack/util/VulnerabilityUtilTest.java
@@ -1,13 +1,12 @@
 package org.dependencytrack.util;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigDecimal;
 import java.util.AbstractMap;
@@ -18,11 +17,10 @@ import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(JUnitParamsRunner.class)
-public class VulnerabilityUtilTest {
+class VulnerabilityUtilTest {
 
     @Test
-    public void testGetUniqueAliases() {
+    void testGetUniqueAliases() {
         final var vuln = new Vulnerability();
         vuln.setVulnId("INTERNAL-001");
         vuln.setSource(Vulnerability.Source.INTERNAL);
@@ -47,71 +45,71 @@ public class VulnerabilityUtilTest {
     }
 
     @Test
-    public void testGetUniqueAliasesWhenVulnerabilityIsNull() {
+    void testGetUniqueAliasesWhenVulnerabilityIsNull() {
         assertThat(VulnerabilityUtil.getUniqueAliases(null)).isEmpty();
     }
 
     @Test
-    public void testGetUniqueAliasesWhenAliasesAreNull() {
+    void testGetUniqueAliasesWhenAliasesAreNull() {
         assertThat(VulnerabilityUtil.getUniqueAliases(new Vulnerability())).isEmpty();
     }
 
-    @Test
-    @Parameters(method = "cvss2ScoreSource")
-    public void testNormalizedCvssV2Score(double score, Severity severity) {
+    @ParameterizedTest
+    @MethodSource("cvss2ScoreSource")
+    void testNormalizedCvssV2Score(double score, Severity severity) {
         assertThat(VulnerabilityUtil.normalizedCvssV2Score(score)).isEqualTo(severity);
     }
 
-    @Test
-    @Parameters(method = "cvss3ScoreSource")
-    public void testNormalizedCvssV3Score(double score, Severity severity) {
+    @ParameterizedTest
+    @MethodSource("cvss3ScoreSource")
+    void testNormalizedCvssV3Score(double score, Severity severity) {
         assertThat(VulnerabilityUtil.normalizedCvssV3Score(score)).isEqualTo(severity);
     }
 
-    @Test
-    @Parameters(method = "owaspRRScoreSource")
-    public void testNormalizedOwaspRRScore(double score, Severity severity) {
+    @ParameterizedTest
+    @MethodSource("owaspRRScoreSource")
+    void testNormalizedOwaspRRScore(double score, Severity severity) {
         assertThat(VulnerabilityUtil.normalizedOwaspRRScore(score)).isEqualTo(severity);
     }
 
-    @Test
-    @Parameters(method = "detailedOwaspRRScoreSource")
-    public void testDetailedNormalizedOwaspRRScore(double likelihoodScore, double technicalImpactScore, double businessImpactScore, Severity severity) {
+    @ParameterizedTest
+    @MethodSource("detailedOwaspRRScoreSource")
+    void testDetailedNormalizedOwaspRRScore(double likelihoodScore, double technicalImpactScore, double businessImpactScore, Severity severity) {
         assertThat(VulnerabilityUtil.normalizedOwaspRRScore(likelihoodScore, technicalImpactScore, businessImpactScore)).isEqualTo(severity);
     }
 
-    @Test
-    @Parameters(method = "cvssAndOwaspRRSeverity")
-    public void testGetSeverity(BigDecimal cvssV2BaseScore, BigDecimal cvssV3BaseScore, BigDecimal owaspRRLikelihoodScore, BigDecimal owaspRRTechnicalImpactScore, BigDecimal owaspRRBusinessImpactScore, Severity severity) {
+    @ParameterizedTest
+    @MethodSource("cvssAndOwaspRRSeverity")
+    void testGetSeverity(BigDecimal cvssV2BaseScore, BigDecimal cvssV3BaseScore, BigDecimal owaspRRLikelihoodScore, BigDecimal owaspRRTechnicalImpactScore, BigDecimal owaspRRBusinessImpactScore, Severity severity) {
         assertThat(VulnerabilityUtil.getSeverity(cvssV2BaseScore, cvssV3BaseScore, owaspRRLikelihoodScore, owaspRRTechnicalImpactScore, owaspRRBusinessImpactScore)).isEqualTo(severity);
     }
 
     @Test
-    public void testPositiveResolutionByFullCveId() {
+    void testPositiveResolutionByFullCveId() {
         String cveId = VulnerabilityUtil.getValidCveId("CVE-2020-1234");
-        Assert.assertNotNull(cveId);
-        Assert.assertEquals("CVE-2020-1234", cveId);
+        Assertions.assertNotNull(cveId);
+        Assertions.assertEquals("CVE-2020-1234", cveId);
     }
 
     @Test
-    public void testPositiveResolutionByPartialCveId() {
+    void testPositiveResolutionByPartialCveId() {
         String cveId = VulnerabilityUtil.getValidCveId("2020-1234");
-        Assert.assertNotNull(cveId);
-        Assert.assertEquals("CVE-2020-1234", cveId);
+        Assertions.assertNotNull(cveId);
+        Assertions.assertEquals("CVE-2020-1234", cveId);
     }
 
     @Test
-    public void testNegativeResolutionByInvalidString() {
+    void testNegativeResolutionByInvalidString() {
         String cveId = VulnerabilityUtil.getValidCveId("20-1234");
-        Assert.assertNull(cveId);
-        Assert.assertNotEquals("CVE-2020-1234", cveId);
+        Assertions.assertNull(cveId);
+        Assertions.assertNotEquals("CVE-2020-1234", cveId);
     }
 
     @Test
-    public void testNegativeResolutionByInvalidCveId() {
+    void testNegativeResolutionByInvalidCveId() {
         String cveId = VulnerabilityUtil.getValidCveId("CVE-12345678");
-        Assert.assertNull(cveId);
-        Assert.assertNotEquals("CVE-1234-5678", cveId);
+        Assertions.assertNull(cveId);
+        Assertions.assertNotEquals("CVE-1234-5678", cveId);
     }
 
     private VulnerabilityAlias createAlias(final Consumer<VulnerabilityAlias> customizer) {
@@ -120,7 +118,7 @@ public class VulnerabilityUtilTest {
         return alias;
     }
 
-    private Object[] cvss2ScoreSource() {
+    private static Object[] cvss2ScoreSource() {
         return new Object[] {
             new Object[] { 8, Severity.HIGH },
             new Object[] { 5, Severity.MEDIUM },
@@ -130,7 +128,7 @@ public class VulnerabilityUtilTest {
         };
     }
 
-    private Object[] cvss3ScoreSource() {
+    private static Object[] cvss3ScoreSource() {
         return new Object[] {
             new Object[] { 9, Severity.CRITICAL },
             new Object[] { 8, Severity.HIGH },
@@ -141,7 +139,7 @@ public class VulnerabilityUtilTest {
         };
     }
 
-    private Object[] owaspRRScoreSource() {
+    private static Object[] owaspRRScoreSource() {
         return new Object[] {
             new Object[] { 10, Severity.HIGH },
             new Object[] { 7, Severity.HIGH },
@@ -152,7 +150,7 @@ public class VulnerabilityUtilTest {
         };
     }
 
-    private Object[] detailedOwaspRRScoreSource() {
+    private static Object[] detailedOwaspRRScoreSource() {
         return new Object[] {
             new Object[] { 0.875, 1.25, 1.75, Severity.INFO },
             new Object[] { 5, 2.3, 2, Severity.LOW },
@@ -162,7 +160,7 @@ public class VulnerabilityUtilTest {
         };
     }
 
-    private Object[] cvssAndOwaspRRSeverity() {
+    private static Object[] cvssAndOwaspRRSeverity() {
         return new Object[] {
             new Object[] { null, BigDecimal.valueOf(7.0), BigDecimal.valueOf(1.25), BigDecimal.valueOf(1.25), BigDecimal.valueOf(1.75), Severity.HIGH },
             new Object[] { null, BigDecimal.valueOf(7.0), null, null, null, Severity.HIGH },


### PR DESCRIPTION
### Description

Converts all tests from JUnit 4 to 5. From personal motivation, so that I can execute the tests from within IntelliJ more easily.

### Additional Details
This might break the GitHub workflows. Additionally, the tests run from within IntelliJ run 4x faster, and it seems that the tests sometimes fail because some resource is not properly closed/cleaned up, but I was unable to identify the underlying issue yet - this _might_ also explain the random errors I had with my past PRs, and I'd like to investigate this.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
