### PR TITLE
Add mail notification severity options

### DIFF
--- a/src/main/java/org/dependencytrack/model/NotificationRule.java
+++ b/src/main/java/org/dependencytrack/model/NotificationRule.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.model;
 
+import alpine.common.logging.Logger;
 import alpine.common.validation.RegexSequence;
 import alpine.model.Team;
 import alpine.notification.NotificationLevel;
@@ -38,6 +39,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import org.dependencytrack.notification.publisher.SendMailPublisher;
+
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Element;
 import javax.jdo.annotations.Extension;
@@ -137,6 +140,10 @@ public class NotificationRule implements Serializable {
     @Persistent
     @Column(name = "NOTIFY_ON", length = 1024)
     private String notifyOn;
+
+    @Persistent
+    @Column(name = "NOTIFY_SEVERITIES", length = 1024)
+    private String notifySeverities;
 
     @Persistent
     @Column(name = "MESSAGE", length = 1024)
@@ -323,6 +330,37 @@ public class NotificationRule implements Serializable {
             }
         }
         this.notifyOn = sb.toString();
+    }
+
+    public List<Severity> getNotifySeverities(){
+        Logger LOGGER = Logger.getLogger(NotificationRule.class);
+        LOGGER.debug("S");
+
+        List<Severity> result = new ArrayList<>();
+        if (notifySeverities != null) {
+            String[] severities = notifySeverities.split(",");
+            for (String s: severities) {
+                result.add(Severity.valueOf(s.trim()));
+            }
+        } else {
+            Collections.addAll(result, Severity.values());
+        }
+        return result;
+    }
+
+    public void setNotifySeverities(List<Severity> notifySeverities){
+        if (notifySeverities.isEmpty()){
+            this.notifySeverities = null;
+            return;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i=0; i<notifySeverities.size(); i++) {
+            sb.append(notifySeverities.get(i));
+            if (i+1 < notifySeverities.size()) {
+                sb.append(",");
+            }
+        }
+        this.notifySeverities = sb.toString();
     }
 
     public NotificationPublisher getPublisher() {

--- a/src/main/java/org/dependencytrack/notification/NotificationRouter.java
+++ b/src/main/java/org/dependencytrack/notification/NotificationRouter.java
@@ -29,6 +29,7 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Tag;
 import org.dependencytrack.notification.publisher.PublishContext;
 import org.dependencytrack.notification.publisher.Publisher;
+import org.dependencytrack.notification.publisher.SendMailPublisher;
 import org.dependencytrack.notification.vo.AnalysisDecisionChange;
 import org.dependencytrack.notification.vo.BomConsumedOrProcessed;
 import org.dependencytrack.notification.vo.BomProcessingFailed;
@@ -90,7 +91,12 @@ public class NotificationRouter implements Subscriber {
                             .add(CONFIG_TEMPLATE_KEY, notificationPublisher.getTemplate())
                             .addAll(Json.createObjectBuilder(config))
                             .build();
-                    publisher.inform(ruleCtx, restrictNotificationToRuleProjects(notification, rule), notificationPublisherConfig);
+                    if (publisherClass == SendMailPublisher.class) {
+                        ((SendMailPublisher) publisher).inform(ruleCtx, restrictNotificationToRuleProjects(notification, rule), notificationPublisherConfig, rule.getTeams(), rule.getNotifySeverities());
+                    } else {
+                        publisher.inform(ruleCtx, restrictNotificationToRuleProjects(notification, rule), notificationPublisherConfig);
+                    }
+
                 } else {
                     LOGGER.error("The defined notification publisher is not assignable from " + Publisher.class.getCanonicalName() + " (%s)".formatted(ruleCtx));
                 }

--- a/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/SendMailPublisher.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.notification.publisher;
 
 import alpine.common.logging.Logger;
+import alpine.model.Team;
 import alpine.notification.Notification;
 import alpine.server.mail.SendMail;
 import alpine.server.mail.SendMailException;
@@ -26,6 +27,8 @@ import io.pebbletemplates.pebble.PebbleEngine;
 import io.pebbletemplates.pebble.extension.core.DisallowExtensionCustomizerBuilder;
 import io.pebbletemplates.pebble.template.PebbleTemplate;
 import org.apache.commons.text.StringEscapeUtils;
+import org.dependencytrack.model.Severity;
+import org.dependencytrack.notification.vo.NewVulnerabilityIdentified;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.DebugDataEncryption;
 
@@ -65,6 +68,22 @@ public class SendMailPublisher implements Publisher {
             LOGGER.warn("No configuration found; Skipping notification (%s)".formatted(ctx));
             return;
         }
+        final String[] destinations = getDestinations(config, ctx.ruleId());
+        sendNotification(ctx, notification, config, destinations);
+    }
+
+    public void inform(final PublishContext ctx, final Notification notification, final JsonObject config, List<Team> teams, List<Severity> notifySeverities) {
+        if (config == null) {
+            LOGGER.warn("No configuration found. Skipping notification. (%s)".formatted(ctx));
+            return;
+        }
+
+        if (notification.getSubject() instanceof final NewVulnerabilityIdentified subject) {
+            if(!notifySeverities.contains(subject.getVulnerability().getSeverity())) {
+                return;
+            }
+        }
+
         final String[] destinations = getDestinations(config, ctx.ruleId());
         sendNotification(ctx, notification, config, destinations);
     }

--- a/src/main/java/org/dependencytrack/persistence/NotificationQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/NotificationQueryManager.java
@@ -160,6 +160,7 @@ public class NotificationQueryManager extends QueryManager implements IQueryMana
             rule.setNotificationLevel(transientRule.getNotificationLevel());
             rule.setPublisherConfig(transientRule.getPublisherConfig());
             rule.setNotifyOn(transientRule.getNotifyOn());
+            rule.setNotifySeverities(transientRule.getNotifySeverities());
             bind(rule, resolveTags(transientRule.getTags()));
             return rule;
         });

--- a/src/test/java/org/dependencytrack/model/NotificationRuleTest.java
+++ b/src/test/java/org/dependencytrack/model/NotificationRuleTest.java
@@ -100,6 +100,16 @@ class NotificationRuleTest {
     }
 
     @Test
+    public void testAllowedSeverities() {
+        List<Severity> severities = new ArrayList<>();
+        severities.add(Severity.LOW);
+        severities.add(Severity.CRITICAL);
+        NotificationRule rule = new NotificationRule();
+        rule.setNotifySeverities(severities);
+        Assertions.assertEquals(2, rule.getNotifySeverities().size());
+    }
+
+    @Test
     void testPublisher() {
         NotificationPublisher publisher = new NotificationPublisher();
         NotificationRule rule = new NotificationRule();


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This PR adds support for configuring which CVE severities should trigger alert notifications.

#### Previously:
All NEW_VULNERABILITY_IDENTIFIED events triggered notifications, regardless of severity (e.g., low, medium, high).

#### Now:
Users can select which severities (e.g., only CRITICAL and HIGH) should trigger notifications. This helps reduce noise and makes it easier to focus on the most important vulnerabilities.

If no severity is selected, the system behaves as before (all severities trigger alerts).

### Addressed Issue

Closes #3767 

### Additional Details

As mentioned by users in the issue, teams managing many microservices currently receive too many alerts for low-priority issues. This change allows them to only receive notifications for critical or high-severity vulnerabilities, reducing email overload and improving focus. 

Also, see [frontend PR](https://github.com/DependencyTrack/frontend/pull/1235)

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
~- [] This PR fixes a defect, and I have provided tests to verify that the fix is effective~
~- [] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~

