### PR TITLE
Backport: Fix missing `NONE` value in classifier check constraint

### DIFF
--- a/src/main/java/org/dependencytrack/upgrade/v4131/v4131Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v4131/v4131Updater.java
@@ -22,10 +22,15 @@ import alpine.common.logging.Logger;
 import alpine.persistence.AlpineQueryManager;
 import alpine.server.upgrade.AbstractUpgradeItem;
 import alpine.server.util.DbUtil;
+import org.dependencytrack.model.Classifier;
 
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.StringJoiner;
 
 public class v4131Updater extends AbstractUpgradeItem {
 
@@ -39,6 +44,7 @@ public class v4131Updater extends AbstractUpgradeItem {
     @Override
     public void executeUpgrade(final AlpineQueryManager qm, final Connection connection) throws Exception {
         createTagJoinTablePrimaryKeys(connection);
+        maybeRecreateClassifierCheckConstraints(connection);
     }
 
     private void createTagJoinTablePrimaryKeys(final Connection connection) throws SQLException {
@@ -63,6 +69,210 @@ public class v4131Updater extends AbstractUpgradeItem {
                     PRIMARY KEY %s ("PROJECT_ID", "TAG_ID")
                     """.formatted(maybeClustered));
         }
+    }
+
+    private void maybeRecreateClassifierCheckConstraints(final Connection connection) throws SQLException {
+        if (DbUtil.isH2()) {
+            maybeRecreateClassifierCheckConstraintsForH2(connection);
+        } else if (DbUtil.isMssql()) {
+            maybeRecreateClassifierCheckConstraintsForMssql(connection);
+        } else if (DbUtil.isMysql()) {
+            // MySQL < 8 does not support check constraints.
+            // Since we never officially moved MySQL support past 5.7,
+            // there's nothing to do here.
+        } else if (DbUtil.isPostgreSQL()) {
+            maybeRecreateClassifierCheckConstraintsForPostgres(connection);
+        } else {
+            throw new IllegalStateException(
+                    "Unsupported database: " + connection.getMetaData().getDatabaseProductName());
+        }
+    }
+
+    private record ClassifierConstraint(String tableName, String columnName, String name, String definition) {
+
+        static ClassifierConstraint of(final ResultSet rs) throws SQLException {
+            return new ClassifierConstraint(
+                    rs.getString("TABLE_NAME"),
+                    rs.getString("COLUMN_NAME"),
+                    rs.getString("NAME"),
+                    rs.getString("DEFINITION"));
+        }
+
+        private ClassifierConstraint withoutName() {
+            return new ClassifierConstraint(tableName, columnName, null, definition);
+        }
+
+        private boolean isCurrent() {
+            final var missingClassifiers = new HashSet<Classifier>();
+            for (final Classifier classifier : Classifier.values()) {
+                if (!definition.contains(classifier.name())) {
+                    missingClassifiers.add(classifier);
+                }
+            }
+
+            if (!missingClassifiers.isEmpty()) {
+                LOGGER.info("Classifiers %s not found in check constraint %s; Current definition: %s".formatted(
+                        missingClassifiers, name, definition));
+                return false;
+            }
+
+            return true;
+        }
+
+    }
+
+    private void maybeRecreateClassifierCheckConstraintsForH2(final Connection connection) throws SQLException {
+        try (final Statement statement = connection.createStatement()) {
+            statement.execute("""
+                    SELECT CC.CONSTRAINT_NAME AS NAME
+                         , CC.CHECK_CLAUSE AS DEFINITION
+                         , CCU.TABLE_NAME AS TABLE_NAME
+                         , CCU.COLUMN_NAME AS COLUMN_NAME
+                      FROM INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE AS CCU
+                     INNER JOIN INFORMATION_SCHEMA.CHECK_CONSTRAINTS AS CC
+                        ON CC.CONSTRAINT_SCHEMA = CCU.CONSTRAINT_SCHEMA
+                       AND CC.CONSTRAINT_NAME = CCU.CONSTRAINT_NAME
+                     WHERE CCU.TABLE_NAME IN ('COMPONENT', 'PROJECT')
+                       AND CCU.COLUMN_NAME = 'CLASSIFIER';
+                    """);
+
+            final var constraints = new ArrayList<ClassifierConstraint>();
+
+            try (final ResultSet rs = statement.getResultSet()) {
+                while (rs.next()) {
+                    constraints.add(ClassifierConstraint.of(rs));
+                }
+            }
+
+            final var constraintsSeen = new HashSet<ClassifierConstraint>();
+            for (final ClassifierConstraint constraint : constraints) {
+                if (!constraintsSeen.add(constraint.withoutName())) {
+                    // DataNucleus may have created duplicate constraints before.
+                    // https://github.com/datanucleus/datanucleus-rdbms/issues/500
+                    LOGGER.warn("Detected duplicate constraint %s on table %s; Dropping".formatted(
+                            constraint.name(), constraint.tableName()));
+
+                    statement.execute("ALTER TABLE \"%s\" DROP CONSTRAINT \"%s\"".formatted(
+                            constraint.tableName(), constraint.name()));
+                    continue;
+                }
+
+                if (constraint.isCurrent()) {
+                    LOGGER.info("Constraint %s on table %s is already current; Will not re-create".formatted(
+                            constraint.name(), constraint.tableName()));
+                    continue;
+                }
+
+                LOGGER.info("Constraint %s on table %s is outdated; Recreating".formatted(
+                        constraint.name(), constraint.tableName()));
+
+                statement.execute("ALTER TABLE \"%s\" DROP CONSTRAINT \"%s\"".formatted(
+                        constraint.tableName(), constraint.name()));
+
+                statement.execute("ALTER TABLE \"%s\" ADD CONSTRAINT \"%s\" CHECK %s".formatted(
+                        constraint.tableName(), constraint.name(), classifierCheckConstraint()));
+            }
+        }
+    }
+
+    private void maybeRecreateClassifierCheckConstraintsForMssql(final Connection connection) throws SQLException {
+        try (final Statement statement = connection.createStatement()) {
+            statement.execute("""
+                    SELECT OBJ."NAME" AS TABLE_NAME
+                         , COL."NAME" AS COLUMN_NAME
+                         , CON."NAME" AS NAME
+                         , CON."DEFINITION" AS DEFINITION
+                      FROM SYS.CHECK_CONSTRAINTS AS CON
+                      LEFT JOIN SYS.OBJECTS AS OBJ
+                        ON OBJ.OBJECT_ID = CON.PARENT_OBJECT_ID
+                      LEFT JOIN SYS.ALL_COLUMNS AS COL
+                        ON COL.COLUMN_ID = CON.PARENT_COLUMN_ID
+                       AND COL.OBJECT_ID = CON.PARENT_OBJECT_ID
+                     WHERE OBJ."NAME" IN ('COMPONENT', 'PROJECT')
+                       AND COL."NAME" = 'CLASSIFIER'
+                    """);
+
+            final var constraints = new ArrayList<ClassifierConstraint>();
+
+            try (final ResultSet rs = statement.getResultSet()) {
+                while (rs.next()) {
+                    constraints.add(ClassifierConstraint.of(rs));
+                }
+            }
+
+            for (final ClassifierConstraint constraint : constraints) {
+                if (constraint.isCurrent()) {
+                    LOGGER.info("Constraint %s on table %s is already current; Will not re-create".formatted(
+                            constraint.name(), constraint.tableName()));
+                    continue;
+                }
+
+                LOGGER.info("Constraint %s on table %s is outdated; Recreating".formatted(
+                        constraint.name(), constraint.tableName()));
+
+                statement.execute("ALTER TABLE \"%s\" DROP CONSTRAINT \"%s\"".formatted(
+                        constraint.tableName(), constraint.name()));
+
+                statement.execute("ALTER TABLE \"%s\" ADD CONSTRAINT \"%s\" CHECK %s".formatted(
+                        constraint.tableName(), constraint.name(), classifierCheckConstraint()));
+            }
+        }
+    }
+
+    private void maybeRecreateClassifierCheckConstraintsForPostgres(final Connection connection) throws SQLException {
+        try (final Statement statement = connection.createStatement()) {
+            statement.execute("""
+                    SELECT CON.CONNAME AS "NAME"
+                         , PG_GET_CONSTRAINTDEF(CON.OID) AS "DEFINITION"
+                         , CCU.TABLE_NAME AS "TABLE_NAME"
+                         , CCU.COLUMN_NAME AS "COLUMN_NAME"
+                      FROM PG_CONSTRAINT AS CON
+                     INNER JOIN PG_NAMESPACE  AS NS
+                        ON NS.OID = CON.CONNAMESPACE
+                     INNER JOIN PG_CLASS AS CLS
+                        ON CLS.OID = CON.CONRELID
+                      LEFT JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE AS CCU
+                        ON CCU.CONSTRAINT_NAME = CON.CONNAME
+                       AND CCU.CONSTRAINT_SCHEMA = NS.NSPNAME
+                     WHERE CON.CONTYPE = 'c'
+                       AND CCU.TABLE_NAME IN ('COMPONENT', 'PROJECT')
+                       AND CCU.COLUMN_NAME = 'CLASSIFIER'
+                    """);
+
+            final var constraints = new ArrayList<ClassifierConstraint>();
+
+            try (final ResultSet rs = statement.getResultSet()) {
+                while (rs.next()) {
+                    constraints.add(ClassifierConstraint.of(rs));
+                }
+            }
+
+            for (final ClassifierConstraint constraint : constraints) {
+                if (constraint.isCurrent()) {
+                    LOGGER.info("Constraint %s on table %s is already current; Will not re-create".formatted(
+                            constraint.name(), constraint.tableName()));
+                    continue;
+                }
+
+                LOGGER.info("Constraint %s on table %s is outdated; Recreating".formatted(
+                        constraint.name(), constraint.tableName()));
+
+                statement.execute("ALTER TABLE \"%s\" DROP CONSTRAINT \"%s\"".formatted(
+                        constraint.tableName(), constraint.name()));
+
+                statement.execute("ALTER TABLE \"%s\" ADD CONSTRAINT \"%s\" CHECK %s".formatted(
+                        constraint.tableName(), constraint.name(), classifierCheckConstraint()));
+            }
+        }
+    }
+
+    private static String classifierCheckConstraint() {
+        final var classifierArrayLiteralJoiner = new StringJoiner(",", "(", ")");
+        for (final Classifier classifier : Classifier.values()) {
+            classifierArrayLiteralJoiner.add("'%s'".formatted(classifier.name()));
+        }
+
+        return "(\"CLASSIFIER\" IS NULL OR \"CLASSIFIER\" IN %s)".formatted(classifierArrayLiteralJoiner);
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->


Fixes missing `NONE` value in classifier check constraint.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #4844
Backports https://github.com/DependencyTrack/dependency-track/pull/4884

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [x] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
