### PR TITLE
Align naming of isLatest parameter between PUT and POST endpoints for BOM upload

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -331,7 +331,7 @@ public class BomResource extends AlpineResource {
                             }
                         }
                         final String trimmedProjectName = StringUtils.trimToNull(request.getProjectName());
-                        if(request.isLatestProjectVersion()) {
+                        if(request.isLatest()) {
                             final Project oldLatest = qm.getLatestProjectVersion(trimmedProjectName);
                             if(oldLatest != null && !qm.hasAccess(super.getPrincipal(), oldLatest)) {
                                 return Response.status(Response.Status.FORBIDDEN)
@@ -343,7 +343,7 @@ public class BomResource extends AlpineResource {
 
                         project = qm.createProject(trimmedProjectName, null,
                                 StringUtils.trimToNull(request.getProjectVersion()), request.getProjectTags(), parent,
-                                null, true, request.isLatestProjectVersion(), true);
+                                null, true, request.isLatest(), true);
                         Principal principal = getPrincipal();
                         qm.updateNewProjectACL(project, principal);
                     } else {

--- a/src/main/java/org/dependencytrack/resources/v1/vo/BomSubmitRequest.java
+++ b/src/main/java/org/dependencytrack/resources/v1/vo/BomSubmitRequest.java
@@ -20,6 +20,7 @@ package org.dependencytrack.resources.v1.vo;
 
 import alpine.common.validation.RegexSequence;
 import alpine.server.json.TrimmedStringDeserializer;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -72,29 +73,30 @@ public final class BomSubmitRequest {
 
     private final boolean autoCreate;
 
-    private final boolean isLatestProjectVersion;
+    private final boolean isLatest;
 
     public BomSubmitRequest(String project,
                             String projectName,
                             String projectVersion,
                             List<Tag> projectTags,
                             boolean autoCreate,
-                            boolean isLatestProjectVersion,
+                            boolean isLatest,
                             String bom) {
-        this(project, projectName, projectVersion, projectTags, autoCreate, null, null, null, isLatestProjectVersion, bom);
+        this(project, projectName, projectVersion, projectTags, autoCreate, null, null, null, isLatest, bom);
     }
 
     @JsonCreator
-    public BomSubmitRequest(@JsonProperty(value = "project") String project,
-                            @JsonProperty(value = "projectName") String projectName,
-                            @JsonProperty(value = "projectVersion") String projectVersion,
-                            @JsonProperty(value = "projectTags") List<Tag> projectTags,
-                            @JsonProperty(value = "autoCreate") boolean autoCreate,
-                            @JsonProperty(value = "parentUUID") String parentUUID,
-                            @JsonProperty(value = "parentName") String parentName,
-                            @JsonProperty(value = "parentVersion") String parentVersion,
-                            @JsonProperty(value = "isLatestProjectVersion", defaultValue = "false") boolean isLatestProjectVersion,
-                            @JsonProperty(value = "bom", required = true) String bom) {
+    public BomSubmitRequest(
+            @JsonProperty(value = "project") String project,
+            @JsonProperty(value = "projectName") String projectName,
+            @JsonProperty(value = "projectVersion") String projectVersion,
+            @JsonProperty(value = "projectTags") List<Tag> projectTags,
+            @JsonProperty(value = "autoCreate") boolean autoCreate,
+            @JsonProperty(value = "parentUUID") String parentUUID,
+            @JsonProperty(value = "parentName") String parentName,
+            @JsonProperty(value = "parentVersion") String parentVersion,
+            @JsonProperty(value = "isLatest", defaultValue = "false") @JsonAlias("isLatestProjectVersion") boolean isLatest,
+            @JsonProperty(value = "bom", required = true) String bom) {
         this.project = project;
         this.projectName = projectName;
         this.projectVersion = projectVersion;
@@ -103,7 +105,7 @@ public final class BomSubmitRequest {
         this.parentUUID = parentUUID;
         this.parentName = parentName;
         this.parentVersion = parentVersion;
-        this.isLatestProjectVersion = isLatestProjectVersion;
+        this.isLatest = isLatest;
         this.bom = bom;
     }
 
@@ -148,8 +150,8 @@ public final class BomSubmitRequest {
         return autoCreate;
     }
 
-    @JsonProperty("isLatestProjectVersion")
-    public boolean isLatestProjectVersion() { return isLatestProjectVersion; }
+    @JsonProperty("isLatest")
+    public boolean isLatest() { return isLatest; }
 
     @Schema(
             description = "Base64 encoded BOM",


### PR DESCRIPTION
### Description
Align the naming of the `isLatest` parameter between the `PUT` and `POST` BOM upload endpoints(`/api/v1/bom`), while preserving backward compatibility to avoid breaking existing integrations.


### Addressed Issue

Closes [#4841]( https://github.com/DependencyTrack/dependency-track/issues/4841)

### Additional Details


### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
