### PR TITLE
PUT oidc/mapping should be idempotent

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/OidcResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/OidcResource.java
@@ -276,12 +276,13 @@ public class OidcResource extends AlpineResource {
                 return Response.status(Response.Status.NOT_FOUND).entity("A group with the specified UUID could not be found.").build();
             }
 
-            if (!qm.isOidcGroupMapped(team, group)) {
+            final MappedOidcGroup existingMapping = qm.getMappedOidcGroup(team, group);
+            if (existingMapping == null) {
                 final MappedOidcGroup mappedOidcGroup = qm.createMappedOidcGroup(team, group);
                 super.logSecurityEvent(LOGGER, SecurityMarkers.SECURITY_AUDIT, "Mapping created for group " + group.getName() + " and team " + team.getName());
                 return Response.ok(mappedOidcGroup).build();
             } else {
-                return Response.status(Response.Status.CONFLICT).entity("A mapping for the same team and group already exists.").build();
+                return Response.ok(existingMapping).build();
             }
         }
     }

--- a/src/test/java/org/dependencytrack/resources/v1/OidcResourceAuthenticatedTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/OidcResourceAuthenticatedTest.java
@@ -250,7 +250,7 @@ class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    void addMappingShouldIndicateConflictWhenMappingAlreadyExists() {
+    void putMappingShouldBeIdempotent() {
         final Team team = qm.createTeam("teamName");
         final OidcGroup group = qm.createOidcGroup("groupName");
         qm.createMappedOidcGroup(team, group);
@@ -262,7 +262,7 @@ class OidcResourceAuthenticatedTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
 
-        assertThat(response.getStatus()).isEqualTo(409);
+        assertThat(response.getStatus()).isEqualTo(200);
     }
 
     @Test


### PR DESCRIPTION
### Description

Make PUT `api/oidc/mapping` idempotent as it should be 

### Addressed Issue

#4950 

### Additional Details

### Checklist

- [ ] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
