### PR TITLE
switch cvss handling to metaeffekt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <lib.cpe-parser.version>3.0.0</lib.cpe-parser.version>
         <lib.commons-compress.version>1.27.1</lib.commons-compress.version>
         <lib.commons-text.version>1.13.1</lib.commons-text.version>
-        <lib.cvss-calculator.version>1.4.2</lib.cvss-calculator.version>
+        <lib.ae-security.version>0.138.0</lib.ae-security.version>
         <lib.owasp-rr-calculator.version>1.0.1</lib.owasp-rr-calculator.version>
         <lib.cyclonedx-java.version>10.2.1</lib.cyclonedx-java.version>
         <lib.jakarta-validation.version>3.0.2</lib.jakarta-validation.version>
@@ -175,11 +175,11 @@
             <artifactId>alpine-server</artifactId>
             <version>${lib.alpine.version}</version>
         </dependency>
-        <!-- CVSS Calculator -->
+        <!-- AE Security -->
         <dependency>
-            <groupId>us.springett</groupId>
-            <artifactId>cvss-calculator</artifactId>
-            <version>${lib.cvss-calculator.version}</version>
+            <groupId>org.metaeffekt.core</groupId>
+            <artifactId>ae-security</artifactId>
+            <version>${lib.ae-security.version}</version>
         </dependency>
         <!-- OWASP Risk Rating calculator -->
         <dependency>

--- a/src/main/java/org/dependencytrack/model/Vulnerability.java
+++ b/src/main/java/org/dependencytrack/model/Vulnerability.java
@@ -28,17 +28,18 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import org.dependencytrack.parser.common.resolver.CweResolver;
 import org.dependencytrack.persistence.CollectionIntegerConverter;
 import org.dependencytrack.resources.v1.serializers.CweDeserializer;
 import org.dependencytrack.resources.v1.serializers.CweSerializer;
 import org.dependencytrack.resources.v1.serializers.Iso8601DateSerializer;
 import org.dependencytrack.resources.v1.vo.AffectedComponent;
+import org.metaeffekt.core.security.cvss.CvssVector;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Convert;
 import javax.jdo.annotations.Extension;
@@ -594,6 +595,18 @@ public class Vulnerability implements Serializable {
         return cvssV2Vector;
     }
 
+    public String getNormalizedCvssV2Vector() {
+        if (cvssV2Vector == null) {
+            return null;
+        }
+
+        if (!cvssV2Vector.startsWith("CVSS:")) {
+            return "CVSS:2.0/" + cvssV2Vector.replace("(", "").replace(")", "");
+        } else {
+            return cvssV2Vector;
+        }
+    }
+
     public void setCvssV2Vector(String cvssV2Vector) {
         this.cvssV2Vector = cvssV2Vector;
     }
@@ -756,5 +769,25 @@ public class Vulnerability implements Serializable {
 
     public void setOwaspRRVector(String owaspRRVector) {
         this.owaspRRVector = owaspRRVector;
+    }
+
+    public void applyV2Score(CvssVector cvss) {
+        Objects.requireNonNull(cvss, "CVSS vector cannot be null");
+
+        final var score = cvss.getBakedScores();
+        setCvssV2BaseScore(BigDecimal.valueOf(score.getBaseScore()));
+        setCvssV2ImpactSubScore(BigDecimal.valueOf(score.getImpactScore()));
+        setCvssV2ExploitabilitySubScore(BigDecimal.valueOf(score.getExploitabilityScore()));
+        setCvssV2Vector(cvss.toString());
+    }
+
+    public void applyV3Score(CvssVector cvss) {
+        Objects.requireNonNull(cvss, "CVSS vector cannot be null");
+
+        final var score = cvss.getBakedScores();
+        setCvssV3BaseScore(BigDecimal.valueOf(score.getBaseScore()));
+        setCvssV3ImpactSubScore(BigDecimal.valueOf(score.getImpactScore()));
+        setCvssV3ExploitabilitySubScore(BigDecimal.valueOf(score.getExploitabilityScore()));
+        setCvssV3Vector(cvss.toString());
     }
 }

--- a/src/main/java/org/dependencytrack/parser/nvd/api20/ModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/nvd/api20/ModelConverter.java
@@ -34,8 +34,8 @@ import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.parser.common.resolver.CweResolver;
+import org.dependencytrack.util.CvssUtil;
 import org.dependencytrack.util.VulnerabilityUtil;
-import us.springett.cvss.Cvss;
 import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.CpeParser;
 import us.springett.parsers.cpe.exceptions.CpeEncodingException;
@@ -133,8 +133,9 @@ public final class ModelConverter {
             metrics.getCvssMetricV2().sort(comparingInt(metric -> metric.getType().ordinal()));
 
             for (final CvssV2 metric : metrics.getCvssMetricV2()) {
-                final Cvss cvss = Cvss.fromVector(metric.getCvssData().getVectorString());
-                vuln.setCvssV2Vector(cvss.getVector());
+                final var vector = metric.getCvssData().getVectorString();
+                final var cvss = CvssUtil.parse(vector);
+                vuln.setCvssV2Vector(cvss.toString());
                 vuln.setCvssV2BaseScore(BigDecimal.valueOf(metric.getCvssData().getBaseScore()));
                 vuln.setCvssV2ExploitabilitySubScore(BigDecimal.valueOf(metric.getExploitabilityScore()));
                 vuln.setCvssV2ImpactSubScore(BigDecimal.valueOf(metric.getImpactScore()));
@@ -146,8 +147,8 @@ public final class ModelConverter {
             metrics.getCvssMetricV31().sort(comparingInt(metric -> metric.getType().ordinal()));
 
             for (final CvssV3 metric : metrics.getCvssMetricV31()) {
-                final Cvss cvss = Cvss.fromVector(metric.getCvssData().getVectorString());
-                vuln.setCvssV3Vector(cvss.getVector());
+                final var cvss = CvssUtil.parse(metric.getCvssData().getVectorString());
+                vuln.setCvssV3Vector(cvss.toString());
                 vuln.setCvssV3BaseScore(BigDecimal.valueOf(metric.getCvssData().getBaseScore()));
                 vuln.setCvssV3ExploitabilitySubScore(BigDecimal.valueOf(metric.getExploitabilityScore()));
                 vuln.setCvssV3ImpactSubScore(BigDecimal.valueOf(metric.getImpactScore()));
@@ -157,8 +158,8 @@ public final class ModelConverter {
             metrics.getCvssMetricV30().sort(comparingInt(metric -> metric.getType().ordinal()));
 
             for (final CvssV3 metric : metrics.getCvssMetricV30()) {
-                final Cvss cvss = Cvss.fromVector(metric.getCvssData().getVectorString());
-                vuln.setCvssV3Vector(cvss.getVector());
+                final var cvss = CvssUtil.parse(metric.getCvssData().getVectorString());
+                vuln.setCvssV3Vector(cvss.toString());
                 vuln.setCvssV3BaseScore(BigDecimal.valueOf(metric.getCvssData().getBaseScore()));
                 vuln.setCvssV3ExploitabilitySubScore(BigDecimal.valueOf(metric.getExploitabilityScore()));
                 vuln.setCvssV3ImpactSubScore(BigDecimal.valueOf(metric.getImpactScore()));

--- a/src/main/java/org/dependencytrack/parser/osv/OsvAdvisoryParser.java
+++ b/src/main/java/org/dependencytrack/parser/osv/OsvAdvisoryParser.java
@@ -18,14 +18,13 @@
  */
 package org.dependencytrack.parser.osv;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.parser.osv.model.OsvAdvisory;
 import org.dependencytrack.parser.osv.model.OsvAffectedPackage;
-import us.springett.cvss.Cvss;
-import us.springett.cvss.Score;
+import org.dependencytrack.util.CvssUtil;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -259,9 +258,9 @@ public class OsvAdvisoryParser {
         if (databaseSpecific != null) {
             String cvssVector = databaseSpecific.optString("cvss", null);
             if (cvssVector != null) {
-                Cvss cvss = Cvss.fromVector(cvssVector);
-                Score score = cvss.calculateScore();
-                severity = String.valueOf(normalizedCvssV3Score(score.getBaseScore()));
+                final var cvss = CvssUtil.parse(cvssVector);
+                final var score = cvss.getBakedScores();
+                severity = String.valueOf(normalizedCvssV3Score(score.getOverallScore()));
             }
         }
 

--- a/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
@@ -32,6 +32,18 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Validator;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.AffectedVersionAttribution;
 import org.dependencytrack.model.Component;
@@ -47,24 +59,11 @@ import org.dependencytrack.resources.v1.openapi.PaginatedApi;
 import org.dependencytrack.resources.v1.vo.AffectedComponent;
 import org.dependencytrack.resources.v1.vo.AffectedProject;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
+import org.dependencytrack.util.CvssUtil;
 import org.dependencytrack.util.VulnerabilityUtil;
-import us.springett.cvss.Cvss;
-import us.springett.cvss.Score;
 import us.springett.owasp.riskrating.MissingFactorException;
 import us.springett.owasp.riskrating.OwaspRiskRating;
 
-import jakarta.validation.Validator;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.PUT;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.math.BigDecimal;
 import java.security.Principal;
 import java.util.ArrayList;
@@ -543,23 +542,15 @@ public class VulnerabilityResource extends AlpineResource {
 
     public void recalculateScoresAndSeverityFromVectors(Vulnerability vuln) throws MissingFactorException {
         // Recalculate V2 score based on vector passed to resource and normalize vector
-        final Cvss v2 = Cvss.fromVector(vuln.getCvssV2Vector());
+        final var v2 = CvssUtil.parse(vuln.getNormalizedCvssV2Vector());
         if (v2 != null) {
-            final Score score = v2.calculateScore();
-            vuln.setCvssV2BaseScore(BigDecimal.valueOf(score.getBaseScore()));
-            vuln.setCvssV2ImpactSubScore(BigDecimal.valueOf(score.getImpactSubScore()));
-            vuln.setCvssV2ExploitabilitySubScore(BigDecimal.valueOf(score.getExploitabilitySubScore()));
-            vuln.setCvssV2Vector(v2.getVector());
+            vuln.applyV2Score(v2);
         }
 
         // Recalculate V3 score based on vector passed to resource and normalize vector
-        final Cvss v3 = Cvss.fromVector(vuln.getCvssV3Vector());
+        final var v3 = CvssUtil.parse(vuln.getCvssV3Vector());
         if (v3 != null) {
-            final Score score = v3.calculateScore();
-            vuln.setCvssV3BaseScore(BigDecimal.valueOf(score.getBaseScore()));
-            vuln.setCvssV3ImpactSubScore(BigDecimal.valueOf(score.getImpactSubScore()));
-            vuln.setCvssV3ExploitabilitySubScore(BigDecimal.valueOf(score.getExploitabilitySubScore()));
-            vuln.setCvssV3Vector(v3.getVector());
+            vuln.applyV3Score(v3);
         }
 
         // Recalculate OWASP RR score based on vector passed to resource

--- a/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
+++ b/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
@@ -43,10 +43,9 @@ import org.dependencytrack.parser.osv.OsvAdvisoryParser;
 import org.dependencytrack.parser.osv.model.OsvAdvisory;
 import org.dependencytrack.parser.osv.model.OsvAffectedPackage;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.util.CvssUtil;
 import org.json.JSONObject;
 import org.slf4j.MDC;
-import us.springett.cvss.Cvss;
-import us.springett.cvss.Score;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -278,20 +277,20 @@ public class OsvDownloadTask implements LoggableSubscriber {
 
         // derive from database_specific cvss v3 vector if available
         if(advisory.getCvssV3Vector() != null) {
-            Cvss cvss = Cvss.fromVector(advisory.getCvssV3Vector());
+            var cvss = CvssUtil.parse(advisory.getCvssV3Vector());
             if (cvss != null) {
-                Score score = cvss.calculateScore();
-                return normalizedCvssV3Score(score.getBaseScore());
+                var score = cvss.getBakedScores();
+                return normalizedCvssV3Score(score.getOverallScore());
             } else {
                 LOGGER.warn("Unable to determine severity from CVSSv3 vector: " + advisory.getCvssV3Vector());
             }
         }
         // derive from database_specific cvss v2 vector if available
         if (advisory.getCvssV2Vector() != null) {
-            Cvss cvss = Cvss.fromVector(advisory.getCvssV2Vector());
+            var cvss = CvssUtil.parse(advisory.getCvssV2Vector());
             if (cvss != null) {
-                Score score = cvss.calculateScore();
-                return normalizedCvssV2Score(score.getBaseScore());
+                var score = cvss.getBakedScores();
+                return normalizedCvssV2Score(score.getOverallScore());
             } else {
                 LOGGER.warn("Unable to determine severity from CVSSv2 vector: " + advisory.getCvssV2Vector());
             }

--- a/src/main/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTask.java
@@ -54,17 +54,15 @@ import org.dependencytrack.parser.ossindex.OssIndexParser;
 import org.dependencytrack.parser.ossindex.model.ComponentReport;
 import org.dependencytrack.parser.ossindex.model.ComponentReportVulnerability;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.util.CvssUtil;
 import org.dependencytrack.util.DebugDataEncryption;
 import org.dependencytrack.util.HttpUtil;
 import org.dependencytrack.util.NotificationUtil;
 import org.dependencytrack.util.VulnerabilityUtil;
 import org.json.JSONObject;
-import us.springett.cvss.Cvss;
-import us.springett.cvss.CvssV2;
-import us.springett.cvss.CvssV3;
-import us.springett.cvss.Score;
+import org.metaeffekt.core.security.cvss.v2.Cvss2;
+import org.metaeffekt.core.security.cvss.v3.Cvss3;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -404,19 +402,12 @@ public class OssIndexAnalysisTask extends BaseComponentAnalyzerTask implements C
         }
 
         if (reportedVuln.getCvssVector() != null) {
-            final Cvss cvss = Cvss.fromVector(reportedVuln.getCvssVector());
+            final var cvss = CvssUtil.parse(reportedVuln.getCvssVector());
             if (cvss != null) {
-                final Score score = cvss.calculateScore();
-                if (cvss instanceof CvssV2) {
-                    vulnerability.setCvssV2BaseScore(BigDecimal.valueOf(score.getBaseScore()));
-                    vulnerability.setCvssV2ImpactSubScore(BigDecimal.valueOf(score.getImpactSubScore()));
-                    vulnerability.setCvssV2ExploitabilitySubScore(BigDecimal.valueOf(score.getExploitabilitySubScore()));
-                    vulnerability.setCvssV2Vector(cvss.getVector());
-                } else if (cvss instanceof CvssV3) {
-                    vulnerability.setCvssV3BaseScore(BigDecimal.valueOf(score.getBaseScore()));
-                    vulnerability.setCvssV3ImpactSubScore(BigDecimal.valueOf(score.getImpactSubScore()));
-                    vulnerability.setCvssV3ExploitabilitySubScore(BigDecimal.valueOf(score.getExploitabilitySubScore()));
-                    vulnerability.setCvssV3Vector(cvss.getVector());
+                if (cvss instanceof Cvss2) {
+                    vulnerability.applyV2Score(cvss);
+                } else if (cvss instanceof Cvss3) {
+                    vulnerability.applyV3Score(cvss);
                 }
             }
         }

--- a/src/main/java/org/dependencytrack/util/CvssUtil.java
+++ b/src/main/java/org/dependencytrack/util/CvssUtil.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.util;
+
+import org.metaeffekt.core.security.cvss.CvssVector;
+
+public class CvssUtil {
+    private CvssUtil() { }
+
+    public static CvssVector parse(String vector) {
+        if (vector == null || vector.isEmpty()) {
+            return null;
+        }
+
+        final var result = CvssVector.parseVector(vector);
+        if (result == null || !result.isBaseFullyDefined()) {
+            return null;
+        }
+
+        // Check if the result is valid by ensuring it has a non-empty toString() that contains at least one CVSS metric
+        // TODO this is an ugly workaround for https://github.com/org-metaeffekt/metaeffekt-core/issues/253
+        final var parsedVector = result.toString();
+        if (!parsedVector.contains(":")) {
+            return null;
+        }
+
+        return result;
+    }
+}

--- a/src/test/java/org/dependencytrack/parser/vulndb/ModelConverterTest.java
+++ b/src/test/java/org/dependencytrack/parser/vulndb/ModelConverterTest.java
@@ -1,5 +1,14 @@
 package org.dependencytrack.parser.vulndb;
 
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.VulnerabilityAlias;
+import org.dependencytrack.parser.vulndb.model.CvssV3Metric;
+import org.dependencytrack.parser.vulndb.model.Results;
+import org.dependencytrack.persistence.QueryManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -7,15 +16,6 @@ import java.time.OffsetDateTime;
 import java.util.Date;
 import java.util.List;
 
-import org.dependencytrack.model.Vulnerability;
-import org.dependencytrack.model.VulnerabilityAlias;
-import org.dependencytrack.parser.vulndb.model.CvssV3Metric;
-import org.dependencytrack.parser.vulndb.model.Results;
-import org.dependencytrack.persistence.QueryManager;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
@@ -43,7 +43,7 @@ class ModelConverterTest {
         Assertions.assertEquals("1", vulnerability.getVulnId());
         Assertions.assertEquals("test title", vulnerability.getTitle());
         Assertions.assertEquals(Date.from(odt.toInstant()), vulnerability.getUpdated());
-        Assertions.assertEquals("(AV:N/AC:M/Au:N/C:P/I:N/A:N)", vulnerability.getCvssV2Vector());
+        Assertions.assertEquals("AV:N/AC:M/Au:N/C:P/I:N/A:N", vulnerability.getCvssV2Vector());
         Assertions.assertEquals("CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N", vulnerability.getCvssV3Vector());
         Assertions.assertEquals(BigDecimal.valueOf(4.3), vulnerability.getCvssV2BaseScore());
         Assertions.assertEquals(BigDecimal.valueOf(4.3), vulnerability.getCvssV3BaseScore());

--- a/src/test/java/org/dependencytrack/resources/v1/CalculatorResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/CalculatorResourceTest.java
@@ -45,7 +45,7 @@ class CalculatorResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus());
         Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
         Assertions.assertNotNull(json);
@@ -57,11 +57,11 @@ class CalculatorResourceTest extends ResourceTest {
     @Test
     void getCvssScoresV2Test() {
         Response response = jersey.target(V1_CALCULATOR + "/cvss")
-                .queryParam("vector", "(AV:N/AC:L/Au:N/C:P/I:P/A:P)")
+                .queryParam("vector", "AV:N/AC:L/Au:N/C:P/I:P/A:P")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assertions.assertEquals(200, response.getStatus(), 0);
+        Assertions.assertEquals(200, response.getStatus());
         Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonObject json = parseJsonObject(response);
         Assertions.assertNotNull(json);
@@ -77,7 +77,7 @@ class CalculatorResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assertions.assertEquals(400, response.getStatus(), 0);
+        Assertions.assertEquals(400, response.getStatus());
         Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
         Assertions.assertEquals("An invalid CVSSv2 or CVSSv3 vector submitted.", body);

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -477,7 +477,7 @@ class VulnerabilityResourceTest extends ResourceTest {
         Assertions.assertEquals(6.0, json.getJsonNumber("cvssV2BaseScore").doubleValue(), 0);
         Assertions.assertEquals(6.4, json.getJsonNumber("cvssV2ImpactSubScore").doubleValue(), 0);
         Assertions.assertEquals(6.8, json.getJsonNumber("cvssV2ExploitabilitySubScore").doubleValue(), 0);
-        Assertions.assertEquals("(AV:N/AC:M/Au:S/C:P/I:P/A:P)", json.getString("cvssV2Vector"));
+        Assertions.assertEquals("AV:N/AC:M/Au:S/C:P/I:P/A:P", json.getString("cvssV2Vector"));
         Assertions.assertEquals(6.3, json.getJsonNumber("cvssV3BaseScore").doubleValue(), 0);
         Assertions.assertEquals(3.4, json.getJsonNumber("cvssV3ImpactSubScore").doubleValue(), 0);
         Assertions.assertEquals(2.8, json.getJsonNumber("cvssV3ExploitabilitySubScore").doubleValue(), 0);
@@ -606,7 +606,7 @@ class VulnerabilityResourceTest extends ResourceTest {
         Assertions.assertEquals(6.0, json.getJsonNumber("cvssV2BaseScore").doubleValue(), 0);
         Assertions.assertEquals(6.4, json.getJsonNumber("cvssV2ImpactSubScore").doubleValue(), 0);
         Assertions.assertEquals(6.8, json.getJsonNumber("cvssV2ExploitabilitySubScore").doubleValue(), 0);
-        Assertions.assertEquals("(AV:N/AC:M/Au:S/C:P/I:P/A:P)", json.getString("cvssV2Vector"));
+        Assertions.assertEquals("AV:N/AC:M/Au:S/C:P/I:P/A:P", json.getString("cvssV2Vector"));
         Assertions.assertEquals(6.3, json.getJsonNumber("cvssV3BaseScore").doubleValue(), 0);
         Assertions.assertEquals(3.4, json.getJsonNumber("cvssV3ImpactSubScore").doubleValue(), 0);
         Assertions.assertEquals(2.8, json.getJsonNumber("cvssV3ExploitabilitySubScore").doubleValue(), 0);

--- a/src/test/java/org/dependencytrack/tasks/NistApiMirrorTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/NistApiMirrorTaskTest.java
@@ -102,8 +102,8 @@ class NistApiMirrorTaskTest extends PersistenceCapableTest {
         assertThat(vuln.getPublished()).isEqualTo("2022-07-01T18:15:08.570Z");
         assertThat(vuln.getUpdated()).isEqualTo("2023-08-08T14:22:24.967Z");
         assertThat(vuln.getCwes()).containsOnly(1333);
-        assertThat(vuln.getCvssV2Vector()).isEqualTo("(AV:N/AC:L/Au:N/C:N/I:N/A:P)");
-        assertThat(vuln.getCvssV3Vector()).isEqualTo("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L");
+        assertThat(vuln.getCvssV2Vector()).isEqualTo("AV:N/AC:L/Au:N/C:N/I:N/A:P");
+        assertThat(vuln.getCvssV3Vector()).isEqualTo("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L");
         assertThat(vuln.getSeverity()).isEqualTo(Severity.MEDIUM);
         assertThat(vuln.getVulnerableVersions()).isNull();
         assertThat(vuln.getPatchedVersions()).isNull();

--- a/src/test/java/org/dependencytrack/tasks/NistMirrorTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/NistMirrorTaskTest.java
@@ -107,11 +107,11 @@ class NistMirrorTaskTest extends PersistenceCapableTest {
                     assertThat(vuln.getCvssV2BaseScore()).isEqualByComparingTo("2.1");
                     assertThat(vuln.getCvssV2ExploitabilitySubScore()).isEqualByComparingTo("3.9");
                     assertThat(vuln.getCvssV2ImpactSubScore()).isEqualByComparingTo("2.9");
-                    assertThat(vuln.getCvssV2Vector()).isEqualTo("(AV:L/AC:L/Au:N/C:P/I:N/A:N)");
+                    assertThat(vuln.getCvssV2Vector()).isEqualTo("AV:L/AC:L/Au:N/C:P/I:N/A:N");
                     assertThat(vuln.getCvssV3BaseScore()).isEqualByComparingTo("6.5");
                     assertThat(vuln.getCvssV3ExploitabilitySubScore()).isEqualByComparingTo("2.0");
                     assertThat(vuln.getCvssV3ImpactSubScore()).isEqualByComparingTo("4.0");
-                    assertThat(vuln.getCvssV3Vector()).isEqualTo("CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N");
+                    assertThat(vuln.getCvssV3Vector()).isEqualTo("CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N");
                     assertThat(vuln.getSeverity()).isEqualTo(Severity.MEDIUM);
                 },
                 vuln -> {
@@ -131,11 +131,11 @@ class NistMirrorTaskTest extends PersistenceCapableTest {
                     assertThat(vuln.getCvssV2BaseScore()).isEqualByComparingTo("2.1");
                     assertThat(vuln.getCvssV2ExploitabilitySubScore()).isEqualByComparingTo("3.9");
                     assertThat(vuln.getCvssV2ImpactSubScore()).isEqualByComparingTo("2.9");
-                    assertThat(vuln.getCvssV2Vector()).isEqualTo("(AV:L/AC:L/Au:N/C:P/I:N/A:N)");
+                    assertThat(vuln.getCvssV2Vector()).isEqualTo("AV:L/AC:L/Au:N/C:P/I:N/A:N");
                     assertThat(vuln.getCvssV3BaseScore()).isEqualByComparingTo("6.5");
                     assertThat(vuln.getCvssV3ExploitabilitySubScore()).isEqualByComparingTo("2.0");
                     assertThat(vuln.getCvssV3ImpactSubScore()).isEqualByComparingTo("4.0");
-                    assertThat(vuln.getCvssV3Vector()).isEqualTo("CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N");
+                    assertThat(vuln.getCvssV3Vector()).isEqualTo("CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N");
                     assertThat(vuln.getSeverity()).isEqualTo(Severity.MEDIUM);
                 },
                 vuln -> {
@@ -153,11 +153,11 @@ class NistMirrorTaskTest extends PersistenceCapableTest {
                     assertThat(vuln.getCvssV2BaseScore()).isEqualByComparingTo("7.2");
                     assertThat(vuln.getCvssV2ExploitabilitySubScore()).isEqualByComparingTo("3.9");
                     assertThat(vuln.getCvssV2ImpactSubScore()).isEqualByComparingTo("10.0");
-                    assertThat(vuln.getCvssV2Vector()).isEqualTo("(AV:L/AC:L/Au:N/C:C/I:C/A:C)");
+                    assertThat(vuln.getCvssV2Vector()).isEqualTo("AV:L/AC:L/Au:N/C:C/I:C/A:C");
                     assertThat(vuln.getCvssV3BaseScore()).isEqualByComparingTo("6.8");
                     assertThat(vuln.getCvssV3ExploitabilitySubScore()).isEqualByComparingTo("0.9");
                     assertThat(vuln.getCvssV3ImpactSubScore()).isEqualByComparingTo("5.9");
-                    assertThat(vuln.getCvssV3Vector()).isEqualTo("CVSS:3.0/AV:P/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
+                    assertThat(vuln.getCvssV3Vector()).isEqualTo("CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
                     assertThat(vuln.getSeverity()).isEqualTo(Severity.MEDIUM);
                 }
         );

--- a/src/test/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTaskTest.java
@@ -168,7 +168,7 @@ class OssIndexAnalysisTaskTest extends PersistenceCapableTest {
                             jackson-databind before 2.13.0 allows a Java StackOverflow exception and denial of service via a large depth of nested objects.
                                                     
                             Sonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2020-36518 for details""");
-                    assertThat(vuln.getCvssV3Vector()).isEqualTo("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H");
+                    assertThat(vuln.getCvssV3Vector()).isEqualTo("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H");
                     assertThat(vuln.getCvssV3BaseScore()).isEqualByComparingTo("7.5");
                     assertThat(vuln.getCvssV3ExploitabilitySubScore()).isNotNull();
                     assertThat(vuln.getCvssV3ImpactSubScore()).isNotNull();

--- a/src/test/java/org/dependencytrack/util/CvssUtilTest.java
+++ b/src/test/java/org/dependencytrack/util/CvssUtilTest.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CvssUtilTest {
+    @Test
+    void testParseNull() {
+        assertNull(CvssUtil.parse(null));
+    }
+
+    @Test
+    void testParseValidCvss2WithPrefix() {
+        final var result = CvssUtil.parse("CVSS:2.0/AV:N/AC:L/Au:N/C:P/I:P/A:P");
+        assertNotNull(result);
+        assertEquals("AV:N/AC:L/Au:N/C:P/I:P/A:P", result.toString());
+    }
+
+    @Test
+    void testParseValidCvss2WithoutPrefix() {
+        final var vector = "AV:N/AC:L/Au:N/C:P/I:P/A:P";
+        final var result = CvssUtil.parse(vector);
+        assertNotNull(result);
+        assertEquals(vector, result.toString());
+    }
+
+    @Test
+    void testParseValidCvss2WithParentheses() {
+        final var result = CvssUtil.parse("(AV:N/AC:L/Au:N/C:P/I:P/A:P)");
+        assertNotNull(result);
+        assertEquals("AV:N/AC:L/Au:N/C:P/I:P/A:P", result.toString());
+    }
+
+    @Test
+    void testParseValidCvss2WithPrefixAndParentheses() {
+        final var result = CvssUtil.parse("CVSS:2.0/(AV:N/AC:L/Au:N/C:P/I:P/A:P)");
+        assertNotNull(result);
+        assertEquals("AV:N/AC:L/Au:N/C:P/I:P/A:P", result.toString());
+    }
+
+    @Test
+    void testParseInvalidCvssVector() {
+        final var result = CvssUtil.parse("INVALID:VECTOR");
+        assertNull(result);
+    }
+
+    @Test
+    void testParseEmptyString() {
+        final var result = CvssUtil.parse("");
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
### Description

Uses metaeffekt CVSS implementation instead of us.springett.cvss-calculator.

### Addressed Issue

Preparing step for #4707.

### Additional Details

Also seems to fix a few bugs in NistMirrorTask, NistApiMirrorTask and OssIndexAnalysisTask where CVSS 3.1 vectors were silently replaced with 3.0 ones.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
