### PR TITLE
docs: FAQ entry that links to outbound-connection list (fixes #4228)

### DIFF
--- a/docs/_docs/FAQ.md
+++ b/docs/_docs/FAQ.md
@@ -7,6 +7,12 @@ order:
 
 Frequently asked questions about Dependency Track functionality that may not be covered by the documentation. If you don't find an answer here, try reaching out to the Slack [channel](https://owasp.slack.com/archives/C6R3R32H4) related to dependency track.
 
+
+#### Which domains must I allow in my firewall?
+
+See [Which external services does Dependency-Track contact?](outbound-connections.md)
+
+
 #### Dependency Check and Dependency Track Comparison
 
 This topic is heavily explained in the [Dependency Check Comparison](./../odt-odc-comparison/) to Dependency Track.

--- a/docs/_docs/outbound-connections.md
+++ b/docs/_docs/outbound-connections.md
@@ -1,0 +1,18 @@
+---
+title: Which external services does Dependency-Track contact?
+parent: FAQ
+nav_order: 80
+---
+
+Dependency-Track periodically calls external APIs to
+download vulnerability intelligence and component metadata.
+**If your instance is behind a restrictive firewall or proxy,
+allow egress to the endpoints listed in _services.bom.json_.**
+
+| Where to find the authoritative list | What it contains |
+| ------------------------------------ | ---------------- |
+| [`services.bom.json`](https://github.com/DependencyTrack/dependency-track/blob/master/services.bom.json) | Source-of-truth JSON maintained in-repo |
+| Release SBOM (e.g. [`bom.json` for v4.12.0](https://github.com/DependencyTrack/dependency-track/releases/download/4.12.0/bom.json)) | `services.bom.json` merged into the full build SBOM |
+
+**Tip** You can disable individual analyzers in `application.yml`
+to prevent calls you don’t need in air-gapped environments.


### PR DESCRIPTION
### Description

Adds a new FAQ page (“Which external services does Dependency-Track contact?”) that links to the in-repo `services.bom.json` and the merged release SBOM (`bom.json`). This makes it easy for operators behind a firewall or proxy to find the full list of outbound endpoints.

### Addressed Issue

Closes #4228

### Additional Details

- The new file lives at `docs/_docs/outbound-connections.md`.  
- Also added a “Which domains must I allow in my firewall?” heading at the top of `docs/_docs/FAQ.md` pointing to the new page.  
- Purely a documentation change, no code was touched.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)  
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective  
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended  
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)  
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly