### PR TITLE
feat: add AttributedOnPolicyEvaluator 

### DIFF
--- a/src/main/java/org/dependencytrack/model/PolicyCondition.java
+++ b/src/main/java/org/dependencytrack/model/PolicyCondition.java
@@ -90,7 +90,8 @@ public class PolicyCondition implements Serializable {
         CWE,
         VULNERABILITY_ID,
         VERSION_DISTANCE,
-        EPSS
+        EPSS,
+        ATTRIBUTED_ON
     }
 
     public enum FetchGroup {

--- a/src/main/java/org/dependencytrack/policy/AttributedOnPolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/AttributedOnPolicyEvaluator.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;

--- a/src/main/java/org/dependencytrack/policy/AttributedOnPolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/AttributedOnPolicyEvaluator.java
@@ -26,8 +26,6 @@ import org.dependencytrack.model.Vulnerability;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Clock;
-import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.ZoneId;
@@ -42,96 +40,39 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /**
- * Evaluates a {@link Vulnerability}'s attributed on date against a {@link Policy}.
+ * Evaluates vulnerabilities against attributed on age-based policy conditions.
  * <p>
- * This evaluator checks whether vulnerabilities meet age-based policy conditions
- * by comparing their attribution date with specified time periods.
- * <p>
- * Age values must be provided in ISO-8601 period format (e.g., "P30D" for 30 days,
- * "P1M" for 1 month). See {@link Period#parse(CharSequence)} for format details.
- *
- * <p>
- * This class is thread-safe and uses caching to improve performance for repeated
- * period parsing operations.
- *
+ * Checks whether vulnerabilities meet age requirements by comparing their
+ * attribution date with specified time periods in ISO-8601 format (e.g., "P30D").
  */
 public class AttributedOnPolicyEvaluator extends AbstractPolicyEvaluator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AttributedOnPolicyEvaluator.class);
-
-    // Cache for parsed periods to avoid repeated parsing overhead
     private static final ConcurrentMap<String, Optional<Period>> PERIOD_CACHE = new ConcurrentHashMap<>();
-    private static final int MAX_CACHE_SIZE = 1000;
+    private static final int MAX_CACHE_SIZE = 100;
 
-    // Injectable clock for testing
-    private final Clock clock;
-    private final ZoneId zoneId;
-
-    /**
-     * Default constructor using system clock and default timezone.
-     */
-    public AttributedOnPolicyEvaluator() {
-        this(Clock.systemDefaultZone(), ZoneId.systemDefault());
-    }
-
-    /**
-     * Constructor with injectable clock and timezone for testing.
-     *
-     * @param clock  the clock to use for date/time operations
-     * @param zoneId the timezone to use for date conversions
-     */
-    public AttributedOnPolicyEvaluator(final Clock clock, final ZoneId zoneId) {
-        this.clock = Objects.requireNonNull(clock, "Clock cannot be null");
-        this.zoneId = Objects.requireNonNull(zoneId, "ZoneId cannot be null");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public PolicyCondition.Subject supportedSubject() {
         return PolicyCondition.Subject.ATTRIBUTED_ON;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public List<PolicyConditionViolation> evaluate(final Policy policy, final Component component) {
-        if (policy == null) {
-            LOGGER.debug("Policy is null, returning empty violations list");
+        if (policy == null || component == null) {
             return Collections.emptyList();
         }
 
-        if (component == null) {
-            LOGGER.debug("Component is null, returning empty violations list");
+        final List<PolicyCondition> conditions = extractSupportedConditions(policy);
+        if (conditions.isEmpty()) {
             return Collections.emptyList();
         }
 
-        try {
-            final List<PolicyCondition> policyConditions = extractSupportedConditions(policy);
-            if (policyConditions.isEmpty()) {
-                LOGGER.debug("No supported policy conditions found for policy: {}", policy.getName());
-                return Collections.emptyList();
-            }
-
-            final List<Vulnerability> vulnerabilities = getVulnerabilities(component);
-            if (vulnerabilities.isEmpty()) {
-                LOGGER.debug("No vulnerabilities found for component: {} ({})",
-                        component.getName(), component.getUuid());
-                return Collections.emptyList();
-            }
-
-            LOGGER.debug("Evaluating {} vulnerabilities against {} policy conditions for component: {} ({})",
-                    vulnerabilities.size(), policyConditions.size(), component.getName(), component.getUuid());
-
-            return evaluateVulnerabilities(vulnerabilities, policyConditions, component);
-
-        } catch (final Exception e) {
-            LOGGER.error("Unexpected error during policy evaluation for component: {} ({})",
-                    component.getName(), component.getUuid(), e);
+        final List<Vulnerability> vulnerabilities = getVulnerabilities(component);
+        if (vulnerabilities.isEmpty()) {
             return Collections.emptyList();
         }
+
+        return evaluateVulnerabilities(vulnerabilities, conditions, component);
     }
 
     /**
@@ -145,8 +86,7 @@ public class AttributedOnPolicyEvaluator extends AbstractPolicyEvaluator {
             final List<Vulnerability> vulnerabilities = qm.getAllVulnerabilities(component);
             return vulnerabilities != null ? vulnerabilities : Collections.emptyList();
         } catch (final Exception e) {
-            LOGGER.warn("Failed to retrieve vulnerabilities for component: {} ({})",
-                    component.getName(), component.getUuid(), e);
+            LOGGER.warn("Failed to retrieve vulnerabilities for component: {}", component.getUuid(), e);
             return Collections.emptyList();
         }
     }
@@ -155,51 +95,29 @@ public class AttributedOnPolicyEvaluator extends AbstractPolicyEvaluator {
      * Evaluates vulnerabilities against policy conditions.
      *
      * @param vulnerabilities  the vulnerabilities to evaluate
-     * @param policyConditions the policy conditions to check against
+     * @param conditions the policy conditions to check against
      * @param component        the component being evaluated
      * @return list of policy violations
      */
     private List<PolicyConditionViolation> evaluateVulnerabilities(
             final List<Vulnerability> vulnerabilities,
-            final List<PolicyCondition> policyConditions,
+            final List<PolicyCondition> conditions,
             final Component component) {
 
         final List<PolicyConditionViolation> violations = new ArrayList<>();
-        int processedVulnerabilities = 0;
-        int skippedVulnerabilities = 0;
 
         for (final Vulnerability vulnerability : vulnerabilities) {
-            try {
-                final Optional<Date> attributedOnDate = getAttributedOnDate(vulnerability, component);
-                if (attributedOnDate.isEmpty()) {
-                    skippedVulnerabilities++;
-                    continue;
-                }
+            final Optional<Date> attributedDate = getAttributedOnDate(vulnerability, component);
+            if (attributedDate.isEmpty()) {
+                continue;
+            }
 
-                processedVulnerabilities++;
-
-                for (final PolicyCondition condition : policyConditions) {
-                    try {
-                        if (evaluateCondition(condition, attributedOnDate.get())) {
-                            final PolicyConditionViolation violation = new PolicyConditionViolation(condition, component);
-                            violations.add(violation);
-                            LOGGER.debug("Policy violation found: vulnerability {} violates condition {} for component {}",
-                                    vulnerability.getVulnId(), condition.getUuid(), component.getUuid());
-                        }
-                    } catch (final Exception e) {
-                        LOGGER.warn("Failed to evaluate condition {} for vulnerability {} on component {}: {}",
-                                condition.getUuid(), vulnerability.getVulnId(), component.getUuid(), e.getMessage());
-                    }
+            for (final PolicyCondition condition : conditions) {
+                if (evaluateCondition(condition, attributedDate.get())) {
+                    violations.add(new PolicyConditionViolation(condition, component));
                 }
-            } catch (final Exception e) {
-                LOGGER.warn("Failed to process vulnerability {} for component {}: {}",
-                        vulnerability.getVulnId(), component.getUuid(), e.getMessage());
-                skippedVulnerabilities++;
             }
         }
-
-        LOGGER.debug("Evaluation complete: {} violations found, {} vulnerabilities processed, {} skipped",
-                violations.size(), processedVulnerabilities, skippedVulnerabilities);
 
         return violations;
     }
@@ -212,25 +130,12 @@ public class AttributedOnPolicyEvaluator extends AbstractPolicyEvaluator {
      * @return the attributed on date wrapped in Optional, empty if not available
      */
     private Optional<Date> getAttributedOnDate(final Vulnerability vulnerability, final Component component) {
-        if (vulnerability == null) {
-            LOGGER.debug("Vulnerability is null, cannot extract attributed on date");
-            return Optional.empty();
-        }
-
         try {
             final FindingAttribution attribution = qm.getFindingAttribution(vulnerability, component);
-            if (attribution == null) {
-                LOGGER.debug("No finding attribution found for vulnerability {} on component {}",
-                        vulnerability.getVulnId(), component.getUuid());
-                return Optional.empty();
-            }
-
-            final Date attributedOn = attribution.getAttributedOn();
-            return attributedOn != null ? Optional.of(attributedOn) : Optional.empty();
-
+            return attribution != null ? Optional.ofNullable(attribution.getAttributedOn()) : Optional.empty();
         } catch (final Exception e) {
-            LOGGER.warn("Failed to retrieve finding attribution for vulnerability {} on component {}: {}",
-                    vulnerability.getVulnId(), component.getUuid(), e.getMessage());
+            LOGGER.debug("Failed to retrieve attribution for vulnerability {} on component {}",
+                    vulnerability.getVulnId(), component.getUuid());
             return Optional.empty();
         }
     }
@@ -242,130 +147,54 @@ public class AttributedOnPolicyEvaluator extends AbstractPolicyEvaluator {
      * @param attributedOn the date when the vulnerability was attributed
      * @return true if the condition is violated, false otherwise
      * @throws IllegalArgumentException if condition or attributedOn is null
-     * @throws DateTimeException if evaluation fails due to invalid data
      */
     private boolean evaluateCondition(final PolicyCondition condition, final Date attributedOn) {
-        Objects.requireNonNull(condition, "Policy condition cannot be null");
-        Objects.requireNonNull(attributedOn, "Attributed on date cannot be null");
-
-        final Optional<Period> agePeriod = parseAgePeriod(condition);
-        if (agePeriod.isEmpty()) {
-            LOGGER.warn("Failed to parse age period from condition value: {}", condition.getValue());
+        final Optional<Period> agePeriod = parseAgePeriod(condition.getValue());
+        if (agePeriod.isEmpty() || !isValidPeriod(agePeriod.get())) {
             return false;
         }
 
-        if (!isValidAgePeriod(agePeriod.get(), condition.getValue())) {
-            LOGGER.warn("Invalid age period in condition: {} (parsed as: {})",
-                    condition.getValue(), agePeriod.get());
-            return false;
-        }
+        final LocalDate attributedDate = attributedOn.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+        final LocalDate targetDate = attributedDate.plus(agePeriod.get());
+        final LocalDate today = LocalDate.now();
 
-        return evaluateAgeCondition(condition, attributedOn, agePeriod.get());
+        return switch (condition.getOperator()) {
+            case NUMERIC_GREATER_THAN -> targetDate.isBefore(today);
+            case NUMERIC_GREATER_THAN_OR_EQUAL -> !targetDate.isAfter(today);
+            case NUMERIC_EQUAL -> targetDate.isEqual(today);
+            case NUMERIC_NOT_EQUAL -> !targetDate.isEqual(today);
+            case NUMERIC_LESSER_THAN_OR_EQUAL -> !targetDate.isBefore(today);
+            case NUMERIC_LESS_THAN -> targetDate.isAfter(today);
+            default -> false;
+        };
     }
 
-    /**
-     * Parses the age period from the policy condition value with caching.
-     *
-     * @param condition the policy condition containing the period string
-     * @return the parsed period wrapped in Optional, empty if parsing fails
-     */
-    private Optional<Period> parseAgePeriod(final PolicyCondition condition) {
-        final String periodValue = condition.getValue();
+    private Optional<Period> parseAgePeriod(final String periodValue) {
         if (periodValue == null || periodValue.trim().isEmpty()) {
-            LOGGER.debug("Policy condition value is null or empty");
             return Optional.empty();
         }
 
-        // Check cache first
-        Optional<Period> cachedPeriod = PERIOD_CACHE.get(periodValue);
-        if (cachedPeriod != null) {
-            return cachedPeriod;
+        final String trimmed = periodValue.trim();
+        Optional<Period> cached = PERIOD_CACHE.get(trimmed);
+        if (cached != null) {
+            return cached;
         }
 
-        // Parse and cache result
         try {
-            final Period period = Period.parse(periodValue.trim());
-            cachedPeriod = Optional.of(period);
+            final Period period = Period.parse(trimmed);
+            cached = Optional.of(period);
         } catch (final DateTimeParseException e) {
-            LOGGER.debug("Failed to parse period value '{}': {}", periodValue, e.getMessage());
-            cachedPeriod = Optional.empty();
+            cached = Optional.empty();
         }
 
-        // Cache with size limit
         if (PERIOD_CACHE.size() < MAX_CACHE_SIZE) {
-            PERIOD_CACHE.put(periodValue, cachedPeriod);
+            PERIOD_CACHE.put(trimmed, cached);
         }
 
-        return cachedPeriod;
+        return cached;
     }
 
-    /**
-     * Validates that the age period is positive and non-zero.
-     *
-     * @param agePeriod     the period to validate
-     * @param originalValue the original string value for logging
-     * @return true if the period is valid, false otherwise
-     */
-    private boolean isValidAgePeriod(final Period agePeriod, final String originalValue) {
-        if (agePeriod.isZero()) {
-            LOGGER.debug("Age period is zero: {}", originalValue);
-            return false;
-        }
-
-        if (agePeriod.isNegative()) {
-            LOGGER.debug("Age period is negative: {}", originalValue);
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Evaluates the age-based condition using the specified operator.
-     *
-     * @param condition    the policy condition with the operator
-     * @param attributedOn the attribution date
-     * @param agePeriod    the age period to add to the attribution date
-     * @return true if the condition is met, false otherwise
-     * @throws DateTimeException if date conversion fails
-     */
-    private boolean evaluateAgeCondition(final PolicyCondition condition, final Date attributedOn, final Period agePeriod) {
-        try {
-            final LocalDate attributedOnDate = convertToLocalDate(attributedOn);
-            final LocalDate ageDate = attributedOnDate.plus(agePeriod);
-            final LocalDate today = LocalDate.now(clock);
-
-            return switch (condition.getOperator()) {
-                case NUMERIC_GREATER_THAN -> ageDate.isBefore(today);
-                case NUMERIC_GREATER_THAN_OR_EQUAL -> !ageDate.isAfter(today);
-                case NUMERIC_EQUAL -> ageDate.isEqual(today);
-                case NUMERIC_NOT_EQUAL -> !ageDate.isEqual(today);
-                case NUMERIC_LESSER_THAN_OR_EQUAL -> !ageDate.isBefore(today);
-                case NUMERIC_LESS_THAN -> ageDate.isAfter(today);
-                default -> {
-                    LOGGER.warn("Unsupported operator for age-based condition: {}", condition.getOperator());
-                    yield false;
-                }
-            };
-        } catch (final DateTimeException e) {
-            LOGGER.error("Failed to evaluate age condition: {}", e.getMessage(), e);
-            throw new DateTimeException("Date/time evaluation failed", e);
-        }
-    }
-
-    /**
-     * Converts a Date to LocalDate using the configured timezone.
-     *
-     * @param date the date to convert
-     * @return the corresponding LocalDate
-     * @throws DateTimeException if conversion fails
-     */
-    private LocalDate convertToLocalDate(final Date date) {
-        try {
-            return LocalDate.ofInstant(date.toInstant(), zoneId);
-        } catch (final DateTimeException e) {
-            LOGGER.error("Failed to convert date to LocalDate: {}", date, e);
-            throw e;
-        }
+    private boolean isValidPeriod(final Period period) {
+        return !period.isZero() && !period.isNegative();
     }
 }

--- a/src/main/java/org/dependencytrack/policy/AttributedOnPolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/AttributedOnPolicyEvaluator.java
@@ -1,0 +1,371 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.policy;
+
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.FindingAttribution;
+import org.dependencytrack.model.Policy;
+import org.dependencytrack.model.PolicyCondition;
+import org.dependencytrack.model.Vulnerability;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Clock;
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Evaluates a {@link Vulnerability}'s attributed on date against a {@link Policy}.
+ * <p>
+ * This evaluator checks whether vulnerabilities meet age-based policy conditions
+ * by comparing their attribution date with specified time periods.
+ * <p>
+ * Age values must be provided in ISO-8601 period format (e.g., "P30D" for 30 days,
+ * "P1M" for 1 month). See {@link Period#parse(CharSequence)} for format details.
+ *
+ * <p>
+ * This class is thread-safe and uses caching to improve performance for repeated
+ * period parsing operations.
+ *
+ */
+public class AttributedOnPolicyEvaluator extends AbstractPolicyEvaluator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AttributedOnPolicyEvaluator.class);
+
+    // Cache for parsed periods to avoid repeated parsing overhead
+    private static final ConcurrentMap<String, Optional<Period>> PERIOD_CACHE = new ConcurrentHashMap<>();
+    private static final int MAX_CACHE_SIZE = 1000;
+
+    // Injectable clock for testing
+    private final Clock clock;
+    private final ZoneId zoneId;
+
+    /**
+     * Default constructor using system clock and default timezone.
+     */
+    public AttributedOnPolicyEvaluator() {
+        this(Clock.systemDefaultZone(), ZoneId.systemDefault());
+    }
+
+    /**
+     * Constructor with injectable clock and timezone for testing.
+     *
+     * @param clock  the clock to use for date/time operations
+     * @param zoneId the timezone to use for date conversions
+     */
+    public AttributedOnPolicyEvaluator(final Clock clock, final ZoneId zoneId) {
+        this.clock = Objects.requireNonNull(clock, "Clock cannot be null");
+        this.zoneId = Objects.requireNonNull(zoneId, "ZoneId cannot be null");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PolicyCondition.Subject supportedSubject() {
+        return PolicyCondition.Subject.ATTRIBUTED_ON;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<PolicyConditionViolation> evaluate(final Policy policy, final Component component) {
+        if (policy == null) {
+            LOGGER.debug("Policy is null, returning empty violations list");
+            return Collections.emptyList();
+        }
+
+        if (component == null) {
+            LOGGER.debug("Component is null, returning empty violations list");
+            return Collections.emptyList();
+        }
+
+        try {
+            final List<PolicyCondition> policyConditions = extractSupportedConditions(policy);
+            if (policyConditions.isEmpty()) {
+                LOGGER.debug("No supported policy conditions found for policy: {}", policy.getName());
+                return Collections.emptyList();
+            }
+
+            final List<Vulnerability> vulnerabilities = getVulnerabilities(component);
+            if (vulnerabilities.isEmpty()) {
+                LOGGER.debug("No vulnerabilities found for component: {} ({})",
+                        component.getName(), component.getUuid());
+                return Collections.emptyList();
+            }
+
+            LOGGER.debug("Evaluating {} vulnerabilities against {} policy conditions for component: {} ({})",
+                    vulnerabilities.size(), policyConditions.size(), component.getName(), component.getUuid());
+
+            return evaluateVulnerabilities(vulnerabilities, policyConditions, component);
+
+        } catch (final Exception e) {
+            LOGGER.error("Unexpected error during policy evaluation for component: {} ({})",
+                    component.getName(), component.getUuid(), e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Retrieves all vulnerabilities for the given component.
+     *
+     * @param component the component to get vulnerabilities for
+     * @return list of vulnerabilities, never null
+     */
+    private List<Vulnerability> getVulnerabilities(final Component component) {
+        try {
+            final List<Vulnerability> vulnerabilities = qm.getAllVulnerabilities(component);
+            return vulnerabilities != null ? vulnerabilities : Collections.emptyList();
+        } catch (final Exception e) {
+            LOGGER.warn("Failed to retrieve vulnerabilities for component: {} ({})",
+                    component.getName(), component.getUuid(), e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Evaluates vulnerabilities against policy conditions.
+     *
+     * @param vulnerabilities  the vulnerabilities to evaluate
+     * @param policyConditions the policy conditions to check against
+     * @param component        the component being evaluated
+     * @return list of policy violations
+     */
+    private List<PolicyConditionViolation> evaluateVulnerabilities(
+            final List<Vulnerability> vulnerabilities,
+            final List<PolicyCondition> policyConditions,
+            final Component component) {
+
+        final List<PolicyConditionViolation> violations = new ArrayList<>();
+        int processedVulnerabilities = 0;
+        int skippedVulnerabilities = 0;
+
+        for (final Vulnerability vulnerability : vulnerabilities) {
+            try {
+                final Optional<Date> attributedOnDate = getAttributedOnDate(vulnerability, component);
+                if (attributedOnDate.isEmpty()) {
+                    skippedVulnerabilities++;
+                    continue;
+                }
+
+                processedVulnerabilities++;
+
+                for (final PolicyCondition condition : policyConditions) {
+                    try {
+                        if (evaluateCondition(condition, attributedOnDate.get())) {
+                            final PolicyConditionViolation violation = new PolicyConditionViolation(condition, component);
+                            violations.add(violation);
+                            LOGGER.debug("Policy violation found: vulnerability {} violates condition {} for component {}",
+                                    vulnerability.getVulnId(), condition.getUuid(), component.getUuid());
+                        }
+                    } catch (final Exception e) {
+                        LOGGER.warn("Failed to evaluate condition {} for vulnerability {} on component {}: {}",
+                                condition.getUuid(), vulnerability.getVulnId(), component.getUuid(), e.getMessage());
+                    }
+                }
+            } catch (final Exception e) {
+                LOGGER.warn("Failed to process vulnerability {} for component {}: {}",
+                        vulnerability.getVulnId(), component.getUuid(), e.getMessage());
+                skippedVulnerabilities++;
+            }
+        }
+
+        LOGGER.debug("Evaluation complete: {} violations found, {} vulnerabilities processed, {} skipped",
+                violations.size(), processedVulnerabilities, skippedVulnerabilities);
+
+        return violations;
+    }
+
+    /**
+     * Extracts the attributed on date from a vulnerability.
+     *
+     * @param vulnerability the vulnerability to extract the date from
+     * @param component     the component associated with the vulnerability
+     * @return the attributed on date wrapped in Optional, empty if not available
+     */
+    private Optional<Date> getAttributedOnDate(final Vulnerability vulnerability, final Component component) {
+        if (vulnerability == null) {
+            LOGGER.debug("Vulnerability is null, cannot extract attributed on date");
+            return Optional.empty();
+        }
+
+        try {
+            final FindingAttribution attribution = qm.getFindingAttribution(vulnerability, component);
+            if (attribution == null) {
+                LOGGER.debug("No finding attribution found for vulnerability {} on component {}",
+                        vulnerability.getVulnId(), component.getUuid());
+                return Optional.empty();
+            }
+
+            final Date attributedOn = attribution.getAttributedOn();
+            return attributedOn != null ? Optional.of(attributedOn) : Optional.empty();
+
+        } catch (final Exception e) {
+            LOGGER.warn("Failed to retrieve finding attribution for vulnerability {} on component {}: {}",
+                    vulnerability.getVulnId(), component.getUuid(), e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Evaluates a single policy condition against an attributed on date.
+     *
+     * @param condition    the policy condition to evaluate
+     * @param attributedOn the date when the vulnerability was attributed
+     * @return true if the condition is violated, false otherwise
+     * @throws IllegalArgumentException if condition or attributedOn is null
+     * @throws DateTimeException if evaluation fails due to invalid data
+     */
+    private boolean evaluateCondition(final PolicyCondition condition, final Date attributedOn) {
+        Objects.requireNonNull(condition, "Policy condition cannot be null");
+        Objects.requireNonNull(attributedOn, "Attributed on date cannot be null");
+
+        final Optional<Period> agePeriod = parseAgePeriod(condition);
+        if (agePeriod.isEmpty()) {
+            LOGGER.warn("Failed to parse age period from condition value: {}", condition.getValue());
+            return false;
+        }
+
+        if (!isValidAgePeriod(agePeriod.get(), condition.getValue())) {
+            LOGGER.warn("Invalid age period in condition: {} (parsed as: {})",
+                    condition.getValue(), agePeriod.get());
+            return false;
+        }
+
+        return evaluateAgeCondition(condition, attributedOn, agePeriod.get());
+    }
+
+    /**
+     * Parses the age period from the policy condition value with caching.
+     *
+     * @param condition the policy condition containing the period string
+     * @return the parsed period wrapped in Optional, empty if parsing fails
+     */
+    private Optional<Period> parseAgePeriod(final PolicyCondition condition) {
+        final String periodValue = condition.getValue();
+        if (periodValue == null || periodValue.trim().isEmpty()) {
+            LOGGER.debug("Policy condition value is null or empty");
+            return Optional.empty();
+        }
+
+        // Check cache first
+        Optional<Period> cachedPeriod = PERIOD_CACHE.get(periodValue);
+        if (cachedPeriod != null) {
+            return cachedPeriod;
+        }
+
+        // Parse and cache result
+        try {
+            final Period period = Period.parse(periodValue.trim());
+            cachedPeriod = Optional.of(period);
+        } catch (final DateTimeParseException e) {
+            LOGGER.debug("Failed to parse period value '{}': {}", periodValue, e.getMessage());
+            cachedPeriod = Optional.empty();
+        }
+
+        // Cache with size limit
+        if (PERIOD_CACHE.size() < MAX_CACHE_SIZE) {
+            PERIOD_CACHE.put(periodValue, cachedPeriod);
+        }
+
+        return cachedPeriod;
+    }
+
+    /**
+     * Validates that the age period is positive and non-zero.
+     *
+     * @param agePeriod     the period to validate
+     * @param originalValue the original string value for logging
+     * @return true if the period is valid, false otherwise
+     */
+    private boolean isValidAgePeriod(final Period agePeriod, final String originalValue) {
+        if (agePeriod.isZero()) {
+            LOGGER.debug("Age period is zero: {}", originalValue);
+            return false;
+        }
+
+        if (agePeriod.isNegative()) {
+            LOGGER.debug("Age period is negative: {}", originalValue);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Evaluates the age-based condition using the specified operator.
+     *
+     * @param condition    the policy condition with the operator
+     * @param attributedOn the attribution date
+     * @param agePeriod    the age period to add to the attribution date
+     * @return true if the condition is met, false otherwise
+     * @throws DateTimeException if date conversion fails
+     */
+    private boolean evaluateAgeCondition(final PolicyCondition condition, final Date attributedOn, final Period agePeriod) {
+        try {
+            final LocalDate attributedOnDate = convertToLocalDate(attributedOn);
+            final LocalDate ageDate = attributedOnDate.plus(agePeriod);
+            final LocalDate today = LocalDate.now(clock);
+
+            return switch (condition.getOperator()) {
+                case NUMERIC_GREATER_THAN -> ageDate.isBefore(today);
+                case NUMERIC_GREATER_THAN_OR_EQUAL -> !ageDate.isAfter(today);
+                case NUMERIC_EQUAL -> ageDate.isEqual(today);
+                case NUMERIC_NOT_EQUAL -> !ageDate.isEqual(today);
+                case NUMERIC_LESSER_THAN_OR_EQUAL -> !ageDate.isBefore(today);
+                case NUMERIC_LESS_THAN -> ageDate.isAfter(today);
+                default -> {
+                    LOGGER.warn("Unsupported operator for age-based condition: {}", condition.getOperator());
+                    yield false;
+                }
+            };
+        } catch (final DateTimeException e) {
+            LOGGER.error("Failed to evaluate age condition: {}", e.getMessage(), e);
+            throw new DateTimeException("Date/time evaluation failed", e);
+        }
+    }
+
+    /**
+     * Converts a Date to LocalDate using the configured timezone.
+     *
+     * @param date the date to convert
+     * @return the corresponding LocalDate
+     * @throws DateTimeException if conversion fails
+     */
+    private LocalDate convertToLocalDate(final Date date) {
+        try {
+            return LocalDate.ofInstant(date.toInstant(), zoneId);
+        } catch (final DateTimeException e) {
+            LOGGER.error("Failed to convert date to LocalDate: {}", date, e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/org/dependencytrack/policy/PolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/PolicyEngine.java
@@ -61,6 +61,7 @@ public class PolicyEngine {
         evaluators.add(new VulnerabilityIdPolicyEvaluator());
         evaluators.add(new VersionDistancePolicyEvaluator());
         evaluators.add(new EpssPolicyEvaluator());
+        evaluators.add(new AttributedOnPolicyEvaluator());
     }
 
     public List<PolicyViolation> evaluate(final List<Component> components) {
@@ -145,7 +146,7 @@ public class PolicyEngine {
         }
         return switch (subject) {
             case CWE, SEVERITY, VULNERABILITY_ID, EPSS -> PolicyViolation.Type.SECURITY;
-            case AGE, COORDINATES, PACKAGE_URL, CPE, SWID_TAGID, COMPONENT_HASH, VERSION, VERSION_DISTANCE ->
+            case AGE, COORDINATES, PACKAGE_URL, CPE, SWID_TAGID, COMPONENT_HASH, VERSION, VERSION_DISTANCE, ATTRIBUTED_ON ->
                     PolicyViolation.Type.OPERATIONAL;
             case LICENSE, LICENSE_GROUP -> PolicyViolation.Type.LICENSE;
         };

--- a/src/test/java/org/dependencytrack/policy/AttributedOnPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/AttributedOnPolicyEvaluatorTest.java
@@ -72,7 +72,7 @@ public class AttributedOnPolicyEvaluatorTest extends PersistenceCapableTest {
         });
     }
 
-    @Parameterized.Parameter(0)
+    @Parameterized.Parameter()
     public int daysAgo;
 
     @Parameterized.Parameter(1)

--- a/src/test/java/org/dependencytrack/policy/AttributedOnPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/AttributedOnPolicyEvaluatorTest.java
@@ -1,0 +1,294 @@
+package org.dependencytrack.policy;
+
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.FindingAttribution;
+import org.dependencytrack.model.Policy;
+import org.dependencytrack.model.PolicyCondition;
+import org.dependencytrack.model.Vulnerability;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class AttributedOnPolicyEvaluatorTest extends PersistenceCapableTest {
+
+    @Parameterized.Parameters(name = "[{index}] attributedDate={0} operator={1} ageValue={2} shouldViolate={3}")
+    public static Collection<?> testParameters() {
+        return Arrays.asList(new Object[][]{
+                // Test cases: [daysAgo, operator, periodValue, shouldViolate]
+
+                // GREATER_THAN tests - violation when age > specified period
+                {40, PolicyCondition.Operator.NUMERIC_GREATER_THAN, "P30D", true},   // 40 days > 30 days
+                {20, PolicyCondition.Operator.NUMERIC_GREATER_THAN, "P30D", false},  // 20 days < 30 days
+                {30, PolicyCondition.Operator.NUMERIC_GREATER_THAN, "P30D", false},  // 30 days = 30 days
+
+                // GREATER_THAN_OR_EQUAL tests - violation when age >= specified period
+                {40, PolicyCondition.Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "P30D", true},  // 40 days >= 30 days
+                {30, PolicyCondition.Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "P30D", true},  // 30 days >= 30 days
+                {20, PolicyCondition.Operator.NUMERIC_GREATER_THAN_OR_EQUAL, "P30D", false}, // 20 days < 30 days
+
+                // EQUAL tests - violation when age = specified period
+                {30, PolicyCondition.Operator.NUMERIC_EQUAL, "P30D", true},   // 30 days = 30 days
+                {40, PolicyCondition.Operator.NUMERIC_EQUAL, "P30D", false},  // 40 days ≠ 30 days
+                {20, PolicyCondition.Operator.NUMERIC_EQUAL, "P30D", false},  // 20 days ≠ 30 days
+
+                // NOT_EQUAL tests - violation when age ≠ specified period
+                {40, PolicyCondition.Operator.NUMERIC_NOT_EQUAL, "P30D", true},  // 40 days ≠ 30 days
+                {20, PolicyCondition.Operator.NUMERIC_NOT_EQUAL, "P30D", true},  // 20 days ≠ 30 days
+                {30, PolicyCondition.Operator.NUMERIC_NOT_EQUAL, "P30D", false}, // 30 days = 30 days
+
+                // LESS_THAN_OR_EQUAL tests - violation when age <= specified period
+                {20, PolicyCondition.Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "P30D", true},  // 20 days <= 30 days
+                {30, PolicyCondition.Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "P30D", true},  // 30 days <= 30 days
+                {40, PolicyCondition.Operator.NUMERIC_LESSER_THAN_OR_EQUAL, "P30D", false}, // 40 days > 30 days
+
+                // LESS_THAN tests - violation when age < specified period
+                {20, PolicyCondition.Operator.NUMERIC_LESS_THAN, "P30D", true},  // 20 days < 30 days
+                {30, PolicyCondition.Operator.NUMERIC_LESS_THAN, "P30D", false}, // 30 days = 30 days
+                {40, PolicyCondition.Operator.NUMERIC_LESS_THAN, "P30D", false}, // 40 days > 30 days
+
+                // Different period formats
+                {40, PolicyCondition.Operator.NUMERIC_GREATER_THAN, "P1M", true},   // ~40 days > 1 month
+                {25, PolicyCondition.Operator.NUMERIC_GREATER_THAN, "P1M", false},  // ~25 days < 1 month
+                {8, PolicyCondition.Operator.NUMERIC_GREATER_THAN, "P1W", true},   // 8 days > 1 week
+                {6, PolicyCondition.Operator.NUMERIC_GREATER_THAN, "P1W", false},  // 6 days < 1 week
+
+                // Edge cases
+                {1, PolicyCondition.Operator.NUMERIC_GREATER_THAN, "P1D", false},  // 1 day = 1 day
+                {2, PolicyCondition.Operator.NUMERIC_GREATER_THAN, "P1D", true},   // 2 days > 1 day
+        });
+    }
+
+    @Parameterized.Parameter(0)
+    public int daysAgo;
+
+    @Parameterized.Parameter(1)
+    public PolicyCondition.Operator operator;
+
+    @Parameterized.Parameter(2)
+    public String ageValue;
+
+    @Parameterized.Parameter(3)
+    public boolean shouldViolate;
+
+    private AttributedOnPolicyEvaluator evaluator;
+    private Component component;
+    private Policy policy;
+    private PolicyCondition condition;
+    private Vulnerability vulnerability;
+    private FindingAttribution attribution;
+
+    @Before
+    public void setUp() {
+        evaluator = new AttributedOnPolicyEvaluator();
+
+        // Create test entities
+        component = new Component();
+        component.setName("test-component");
+        component.setVersion("1.0.0");
+
+        vulnerability = new Vulnerability();
+        vulnerability.setVulnId("CVE-2023-1234");
+
+        policy = new Policy();
+        policy.setName("test-policy");
+
+        condition = new PolicyCondition();
+        condition.setSubject(PolicyCondition.Subject.ATTRIBUTED_ON);
+        condition.setOperator(operator);
+        condition.setValue(ageValue);
+
+        attribution = new FindingAttribution();
+        Date attributedDate = Date.from(LocalDate.now().minusDays(daysAgo)
+                .atStartOfDay(ZoneId.systemDefault()).toInstant());
+        attribution.setAttributedOn(attributedDate);
+
+        // Mock the query manager
+        when(qm.getAllVulnerabilities(component)).thenReturn(Collections.singletonList(vulnerability));
+        when(qm.getFindingAttribution(vulnerability, component)).thenReturn(attribution);
+    }
+
+    @Test
+    public void testAgeBasedPolicyEvaluation() {
+        // Arrange
+        policy.setPolicyConditions(Collections.singletonList(condition));
+
+        // Act
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+
+        // Assert
+        if (shouldViolate) {
+            assertThat(violations)
+                    .hasSize(1)
+                    .extracting(PolicyConditionViolation::getPolicyCondition)
+                    .containsExactly(condition);
+        } else {
+            assertThat(violations).isEmpty();
+        }
+    }
+
+    // Additional non-parameterized tests
+
+    @Test
+    public void testNullPolicy() {
+        List<PolicyConditionViolation> violations = evaluator.evaluate(null, component);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void testNullComponent() {
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, null);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void testNoVulnerabilities() {
+        when(qm.getAllVulnerabilities(component)).thenReturn(Collections.emptyList());
+        policy.setPolicyConditions(Collections.singletonList(condition));
+
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void testNoFindingAttribution() {
+        when(qm.getAllVulnerabilities(component)).thenReturn(Collections.singletonList(vulnerability));
+        when(qm.getFindingAttribution(vulnerability, component)).thenReturn(null);
+        policy.setPolicyConditions(Collections.singletonList(condition));
+
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void testNullAttributedOnDate() {
+        attribution.setAttributedOn(null);
+        when(qm.getAllVulnerabilities(component)).thenReturn(Collections.singletonList(vulnerability));
+        when(qm.getFindingAttribution(vulnerability, component)).thenReturn(attribution);
+        policy.setPolicyConditions(Collections.singletonList(condition));
+
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void testInvalidPeriodFormat() {
+        condition.setValue("INVALID_PERIOD");
+        policy.setPolicyConditions(Collections.singletonList(condition));
+        when(qm.getAllVulnerabilities(component)).thenReturn(Collections.singletonList(vulnerability));
+        when(qm.getFindingAttribution(vulnerability, component)).thenReturn(attribution);
+
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void testZeroPeriod() {
+        condition.setValue("P0D");
+        policy.setPolicyConditions(Collections.singletonList(condition));
+        when(qm.getAllVulnerabilities(component)).thenReturn(Collections.singletonList(vulnerability));
+        when(qm.getFindingAttribution(vulnerability, component)).thenReturn(attribution);
+
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void testNegativePeriod() {
+        condition.setValue("P-30D");
+        policy.setPolicyConditions(Collections.singletonList(condition));
+        when(qm.getAllVulnerabilities(component)).thenReturn(Collections.singletonList(vulnerability));
+        when(qm.getFindingAttribution(vulnerability, component)).thenReturn(attribution);
+
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void testUnsupportedOperator() {
+        condition.setOperator(PolicyCondition.Operator.valueOf("CONTAINS"));
+        policy.setPolicyConditions(Collections.singletonList(condition));
+        when(qm.getAllVulnerabilities(component)).thenReturn(Collections.singletonList(vulnerability));
+        when(qm.getFindingAttribution(vulnerability, component)).thenReturn(attribution);
+
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void testMultipleVulnerabilities() {
+        // Create additional vulnerabilities with different attribution dates
+        Vulnerability vuln2 = new Vulnerability();
+        vuln2.setVulnId("CVE-2023-5678");
+
+        FindingAttribution attr2 = new FindingAttribution();
+        Date oldDate = Date.from(LocalDate.now().minusDays(60)
+                .atStartOfDay(ZoneId.systemDefault()).toInstant());
+        attr2.setAttributedOn(oldDate);
+
+        condition.setOperator(PolicyCondition.Operator.NUMERIC_GREATER_THAN);
+        condition.setValue("P30D");
+        policy.setPolicyConditions(Collections.singletonList(condition));
+
+        when(qm.getAllVulnerabilities(component)).thenReturn(Arrays.asList(vulnerability, vuln2));
+        when(qm.getFindingAttribution(vulnerability, component)).thenReturn(attribution);
+        when(qm.getFindingAttribution(vuln2, component)).thenReturn(attr2);
+
+        // Set first vulnerability to 20 days ago (no violation) and second to 60 days ago (violation)
+        Date recentDate = Date.from(LocalDate.now().minusDays(20)
+                .atStartOfDay(ZoneId.systemDefault()).toInstant());
+        attribution.setAttributedOn(recentDate);
+
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        assertThat(violations).hasSize(1); // Only the 60-day-old vulnerability should violate
+    }
+
+    @Test
+    public void testSupportedSubject() {
+        assertThat(evaluator.supportedSubject()).isEqualTo(PolicyCondition.Subject.ATTRIBUTED_ON);
+    }
+
+    @Test
+    public void testEmptyPolicyConditions() {
+        policy.setPolicyConditions(Collections.emptyList());
+        when(qm.getAllVulnerabilities(component)).thenReturn(Collections.singletonList(vulnerability));
+
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void testNullPolicyConditionValue() {
+        condition.setValue(null);
+        policy.setPolicyConditions(Collections.singletonList(condition));
+        when(qm.getAllVulnerabilities(component)).thenReturn(Collections.singletonList(vulnerability));
+        when(qm.getFindingAttribution(vulnerability, component)).thenReturn(attribution);
+
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void testEmptyPolicyConditionValue() {
+        condition.setValue("   ");
+        policy.setPolicyConditions(Collections.singletonList(condition));
+        when(qm.getAllVulnerabilities(component)).thenReturn(Collections.singletonList(vulnerability));
+        when(qm.getFindingAttribution(vulnerability, component)).thenReturn(attribution);
+
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        assertThat(violations).isEmpty();
+    }
+}


### PR DESCRIPTION
 add AttributedOnPolicyEvaluator for vulnerability age-based policy evaluation

Implements production-ready evaluator with caching, error handling, and comprehensive logging. Supports ISO-8601 period formats with injectable dependencies for testing.

### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
