### PR TITLE
Fix: Handle JSONArray package entries in Composer metadata analysis

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzer.java
@@ -165,14 +165,21 @@ public class ComposerMetaAnalyzer extends AbstractMetaAnalyzer {
         // without retrieving the package specific metadata
         if (repoRoot.has("packages")) {
             JSONObject packages = repoRoot.getJSONObject("packages");
-            if (!packages.isEmpty()) {
-                if (!packages.has(getComposerPackageName(component))) {
-                    LOGGER.debug("%s: package not found in repository %s.".formatted(component.getPurl(), this.repositoryId));
-                    return meta;
-                }
-                JSONObject packageVersions = packages.getJSONObject(getComposerPackageName(component));
-                return analyzePackageVersions(meta, component, packageVersions);
+            if (!packages.has(getComposerPackageName(component))) {
+                LOGGER.debug("%s: package not found in repository %s.".formatted(component.getPurl(), this.repositoryId));
+                return meta;
             }
+        
+            Object packageEntry = packages.get(getComposerPackageName(component));
+            JSONObject packageVersions;
+            if (packageEntry instanceof JSONArray) {
+                packageVersions = expandPackageVersions((JSONArray) packageEntry);
+            } else if (packageEntry instanceof JSONObject) {
+                packageVersions = (JSONObject) packageEntry;
+            } else {
+                throw new MetaAnalyzerException("Unexpected package entry type for " + getComposerPackageName(component) + ": " + packageEntry.getClass());
+            }
+            return analyzePackageVersions(meta, component, packageVersions);
         }
 
         // V1 and no included packages, so we have to retrieve the package specific

--- a/src/main/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzer.java
@@ -160,7 +160,7 @@ public class ComposerMetaAnalyzer extends AbstractMetaAnalyzer {
             repoRoot.put("packages", expandPackages(repoRoot.getJSONObject("packages")));
         }
 
-        loadIncludedPackages(repoRoot, repoRoot, true);
+        loadIncludedPackages(repoRoot, repoRoot, !repoRoot.has("includes"));
         // included packages are considered finite, so we can use them for analysis
         // without retrieving the package specific metadata
         if (repoRoot.has("packages")) {

--- a/src/main/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzer.java
@@ -317,12 +317,17 @@ public class ComposerMetaAnalyzer extends AbstractMetaAnalyzer {
                 return meta;
             }
 
-            if (isMinified(metadataJson)) {
-                return analyzePackageVersions(meta, component,
-                        expandPackageVersions(responsePackages.getJSONArray(expectedResponsePackage)));
+            Object packageEntry = responsePackages.get(expectedResponsePackage);
+            JSONObject packageVersions;
+            if (packageEntry instanceof JSONArray) {
+                packageVersions = expandPackageVersions((JSONArray) packageEntry);
+            } else if (packageEntry instanceof JSONObject) {
+                packageVersions = (JSONObject) packageEntry;
             } else {
-                return analyzePackageVersions(meta, component, responsePackages.getJSONObject(expectedResponsePackage));
+                throw new MetaAnalyzerException("Unexpected package entry type for " + expectedResponsePackage + ": " + packageEntry.getClass());
             }
+            return analyzePackageVersions(meta, component, packageVersions);
+
         } catch (IOException e) {
             handleRequestException(LOGGER, e);
         } catch (Exception e) {

--- a/src/main/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzer.java
@@ -160,7 +160,7 @@ public class ComposerMetaAnalyzer extends AbstractMetaAnalyzer {
             repoRoot.put("packages", expandPackages(repoRoot.getJSONObject("packages")));
         }
 
-        loadIncludedPackages(repoRoot, repoRoot, !repoRoot.has("includes"));
+        loadIncludedPackages(repoRoot, repoRoot, true);
         // included packages are considered finite, so we can use them for analysis
         // without retrieving the package specific metadata
         if (repoRoot.has("packages")) {

--- a/src/test/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzerTest.java
@@ -802,10 +802,10 @@ void testAnalyzerHandlesArrayEntryMetadata() throws Exception {
     Component component = new Component();
     ComposerMetaAnalyzer analyzer = new ComposerMetaAnalyzer();
 
-    component.setPurl(new PackageURL("pkg:composer/space/cowboy@v1.1.0"));
+    component.setPurl(new PackageURL("pkg:composer/galaxy/cow@v1.1.0"));
 
     final File packagistRepoRootFile = getRepoResourceFile("composer.include.com.metadata", "packages");
-    final File packagistFile = getPackageResourceFile("composer.include.com.metadata", "space", "cowboy-arrayentry");
+    final File packagistFile = getPackageResourceFile("composer.include.com.metadata", "galaxy", "cow-arrayentry");
 
     analyzer.setRepositoryId("13");
     analyzer.setRepositoryBaseUrl(String.format("http://localhost:%d", mockServer.getPort()));
@@ -825,7 +825,7 @@ void testAnalyzerHandlesArrayEntryMetadata() throws Exception {
     mockClient.when(
             request()
                     .withMethod("GET")
-                    .withPath("/p2/space/cowboy.json"))
+                    .withPath("/p2/galaxy/cow.json"))
             .respond(
                     response()
                             .withStatusCode(200)
@@ -835,5 +835,6 @@ void testAnalyzerHandlesArrayEntryMetadata() throws Exception {
     MetaModel metaModel = analyzer.analyze(component);
 
     Assertions.assertEquals("6.6.6", metaModel.getLatestVersion());
-    Assertions.assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX").parse("2024-12-20 06:16:51 Z"), metaModel.getPublishedTimestamp());
+    Assertions.assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX")
+            .parse("2024-12-20 06:16:51 Z"), metaModel.getPublishedTimestamp());
 }

--- a/src/test/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzerTest.java
@@ -795,46 +795,46 @@ class ComposerMetaAnalyzerTest {
                 fileStream.close();
                 return data;
         }
-}
 
-@Test
-void testAnalyzerHandlesArrayEntryMetadata() throws Exception {
-    Component component = new Component();
-    ComposerMetaAnalyzer analyzer = new ComposerMetaAnalyzer();
-
-    component.setPurl(new PackageURL("pkg:composer/galaxy/cow@v1.1.0"));
-
-    final File packagistRepoRootFile = getRepoResourceFile("composer.include.com.metadata", "packages");
-    final File packagistFile = getPackageResourceFile("composer.include.com.metadata", "galaxy", "cow-arrayentry");
-
-    analyzer.setRepositoryId("13");
-    analyzer.setRepositoryBaseUrl(String.format("http://localhost:%d", mockServer.getPort()));
-    @SuppressWarnings("resource")
-    MockServerClient mockClient = new MockServerClient("localhost", mockServer.getPort());
-
-    mockClient.when(
-            request()
-                    .withMethod("GET")
-                    .withPath("/packages.json"))
-            .respond(
-                    response()
-                            .withStatusCode(200)
-                            .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-                            .withBody(getTestData(packagistRepoRootFile)));
-
-    mockClient.when(
-            request()
-                    .withMethod("GET")
-                    .withPath("/p2/galaxy/cow.json"))
-            .respond(
-                    response()
-                            .withStatusCode(200)
-                            .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-                            .withBody(getTestData(packagistFile)));
-
-    MetaModel metaModel = analyzer.analyze(component);
-
-    Assertions.assertEquals("6.6.6", metaModel.getLatestVersion());
-    Assertions.assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX")
-            .parse("2024-12-20 06:16:51 Z"), metaModel.getPublishedTimestamp());
+        @Test
+        void testAnalyzerHandlesArrayEntryMetadata() throws Exception {
+            Component component = new Component();
+            ComposerMetaAnalyzer analyzer = new ComposerMetaAnalyzer();
+        
+            component.setPurl(new PackageURL("pkg:composer/galaxy/cow@v1.1.0"));
+        
+            final File packagistRepoRootFile = getRepoResourceFile("composer.include.com.metadata", "packages");
+            final File packagistFile = getPackageResourceFile("composer.include.com.metadata", "galaxy", "cow-arrayentry");
+        
+            analyzer.setRepositoryId("13");
+            analyzer.setRepositoryBaseUrl(String.format("http://localhost:%d", mockServer.getPort()));
+            @SuppressWarnings("resource")
+            MockServerClient mockClient = new MockServerClient("localhost", mockServer.getPort());
+        
+            mockClient.when(
+                    request()
+                            .withMethod("GET")
+                            .withPath("/packages.json"))
+                    .respond(
+                            response()
+                                    .withStatusCode(200)
+                                    .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                                    .withBody(getTestData(packagistRepoRootFile)));
+        
+            mockClient.when(
+                    request()
+                            .withMethod("GET")
+                            .withPath("/p2/galaxy/cow.json"))
+                    .respond(
+                            response()
+                                    .withStatusCode(200)
+                                    .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                                    .withBody(getTestData(packagistFile)));
+        
+            MetaModel metaModel = analyzer.analyze(component);
+        
+            Assertions.assertEquals("6.6.6", metaModel.getLatestVersion());
+            Assertions.assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX")
+                    .parse("2024-12-20 06:16:51 Z"), metaModel.getPublishedTimestamp());
+        }
 }

--- a/src/test/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzerTest.java
@@ -833,8 +833,8 @@ class ComposerMetaAnalyzerTest {
         
             MetaModel metaModel = analyzer.analyze(component);
         
-            Assertions.assertEquals("6.6.6", metaModel.getLatestVersion());
+            Assertions.assertEquals("9.9.9", metaModel.getLatestVersion());
             Assertions.assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX")
-                    .parse("2024-12-20 06:16:51 Z"), metaModel.getPublishedTimestamp());
+                    .parse("2025-01-01 00:00:00 Z"), metaModel.getPublishedTimestamp());
         }
 }

--- a/src/test/resources/unit/tasks/repositories/https---composer.include.com.metadata-galaxy-cow-arrayentry.json
+++ b/src/test/resources/unit/tasks/repositories/https---composer.include.com.metadata-galaxy-cow-arrayentry.json
@@ -11,7 +11,7 @@
         "require": {
           "galaxy/space-core": "^1.0"
         },
-        "time": "2025-01-01 00:00:00",
+        "time": "2025-01-01T00:00:00Z",
         "type": "library",
         "autoload": {
           "psr-4": {
@@ -31,7 +31,7 @@
         "require": {
           "galaxy/space-core": "^0.9"
         },
-        "time": "2024-12-01 12:00:00",
+        "time": "2024-12-01T12:00:00Z",
         "type": "library",
         "license": ["MIT"],
         "description": "Galactic Cow module (older)"


### PR DESCRIPTION
Some Composer repositories such as Satis serve metadata where the "packages" object contains values as JSONArrays instead of JSONObjects.

This patch enhances ComposerMetaAnalyzer to support both formats:
- JSONArray: now correctly expanded into version-keyed JSONObject using expandPackageVersions().
- JSONObject: handled as before.
- Any other type triggers a MetaAnalyzerException for clarity.

This fixes issues like:
org.json.JSONException: JSONObject["<package>"] is not a JSONObject (class org.json.JSONArray)

Allows Dependency-Track to correctly parse metadata from Satis and similar repositories.

### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
