### PR TITLE
feat(analyzer): add option to ignore severity reported by Trivy scan

### DIFF
--- a/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
+++ b/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
@@ -70,6 +70,7 @@ public enum ConfigPropertyConstants {
     SCANNER_TRIVY_IGNORE_UNFIXED("scanner", "trivy.ignore.unfixed", "false", PropertyType.BOOLEAN, "Flag to ignore unfixed vulnerabilities"),
     SCANNER_TRIVY_SCAN_LIBRARY("scanner", "trivy.scanner.scanLibrary", "true", PropertyType.BOOLEAN, "Flag to enable library scanning"),
     SCANNER_TRIVY_SCAN_OS("scanner", "trivy.scanner.scanOs", "true", PropertyType.BOOLEAN, "Flag to enable os scanning"),
+    SCANNER_TRIVY_IGNORE_SEVERITY("scanner", "trivy.ignore.severity", "true", PropertyType.BOOLEAN, "Flag to ignore severity levels reported by Trivy scans."),
     VULNERABILITY_SOURCE_NVD_ENABLED("vuln-source", "nvd.enabled", "true", PropertyType.BOOLEAN, "Flag to enable/disable National Vulnerability Database"),
     VULNERABILITY_SOURCE_NVD_FEEDS_URL("vuln-source", "nvd.feeds.url", "https://nvd.nist.gov/feeds", PropertyType.URL, "A base URL pointing to the hostname and path of the NVD feeds"),
     VULNERABILITY_SOURCE_NVD_API_ENABLED("vuln-source", "nvd.api.enabled", "false", PropertyType.BOOLEAN, "Whether to enable NVD mirroring via REST API"),

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -78,6 +78,7 @@ import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
 import org.dependencytrack.model.VulnerabilityMetrics;
 import org.dependencytrack.model.VulnerableSoftware;
+import org.dependencytrack.model.Severity;
 import org.dependencytrack.notification.NotificationScope;
 import org.dependencytrack.notification.publisher.Publisher;
 import org.dependencytrack.resources.v1.vo.AffectedProject;
@@ -813,6 +814,10 @@ public class QueryManager extends AlpineQueryManager {
 
     public void addVulnerability(Vulnerability vulnerability, Component component, AnalyzerIdentity analyzerIdentity) {
         getVulnerabilityQueryManager().addVulnerability(vulnerability, component, analyzerIdentity);
+    }
+
+    public void updateSeverity(Vulnerability vulnerability, Severity newSeverity, Component component) {
+        getVulnerabilityQueryManager().updateSeverity(vulnerability, newSeverity, component);
     }
 
     public void addVulnerability(Vulnerability vulnerability, Component component, AnalyzerIdentity analyzerIdentity,

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -33,6 +33,7 @@ import org.dependencytrack.model.VulnIdAndSource;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
 import org.dependencytrack.model.VulnerableSoftware;
+import org.dependencytrack.model.Severity;
 import org.dependencytrack.resources.v1.vo.AffectedProject;
 import org.dependencytrack.tasks.VulnDbSyncTask;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
@@ -213,6 +214,10 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
         this.addVulnerability(vulnerability, component, analyzerIdentity, null, null, null);
     }
 
+    public void updateSeverity(Vulnerability vulnerability, Severity newSeverity, Component component) {
+        this.updateSeverity(vulnerability, component, newSeverity);
+    }
+
     /**
      * Adds a vulnerability to a component.
      * @param vulnerability the vulnerability to add
@@ -245,6 +250,14 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
                 findingAttribution.setAttributedOn(attributedOn);
             }
             persist(findingAttribution);
+        }
+    }
+
+    public void updateSeverity(Vulnerability vulnerability, Component component, Severity newSeverity) {
+        if (contains(vulnerability, component)) {
+            Vulnerability existingVulnerability = getVulnerabilityByVulnId(vulnerability.getSource(), vulnerability.getVulnId(), false);
+            existingVulnerability.setSeverity(newSeverity);
+            persist(existingVulnerability);
         }
     }
 

--- a/src/main/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTask.java
@@ -125,6 +125,7 @@ public class TrivyAnalysisTask extends BaseComponentAnalyzerTask implements Subs
     private boolean shouldIgnoreUnfixed;
     private boolean shouldScanLibrary;
     private boolean shouldScanOs;
+    private boolean shouldIgnoreSeverity;
     private VulnerabilityAnalysisLevel vulnerabilityAnalysisLevel;
 
     @Override
@@ -160,6 +161,7 @@ public class TrivyAnalysisTask extends BaseComponentAnalyzerTask implements Subs
             shouldIgnoreUnfixed = qm.isEnabled(ConfigPropertyConstants.SCANNER_TRIVY_IGNORE_UNFIXED);
             shouldScanLibrary = qm.isEnabled(ConfigPropertyConstants.SCANNER_TRIVY_SCAN_LIBRARY);
             shouldScanOs = qm.isEnabled(ConfigPropertyConstants.SCANNER_TRIVY_SCAN_OS);
+            shouldIgnoreSeverity = qm.isEnabled(ConfigPropertyConstants.SCANNER_TRIVY_IGNORE_SEVERITY);
         }
 
         vulnerabilityAnalysisLevel = event.analysisLevel();
@@ -502,6 +504,10 @@ public class TrivyAnalysisTask extends BaseComponentAnalyzerTask implements Subs
                 LOGGER.debug("Trivy vulnerability added: " + vulnerability.getVulnId() + " to component " + persistentComponent.getName());
                 NotificationUtil.analyzeNotificationCriteria(qm, vulnerability, persistentComponent, vulnerabilityAnalysisLevel);
                 qm.addVulnerability(vulnerability, persistentComponent, this.getAnalyzerIdentity());
+                if(!shouldIgnoreSeverity){
+                    LOGGER.debug("Trivy vulnerability: " + vulnerability.getVulnId() + " to component " + persistentComponent.getName() + " updating severity: " + parsedVulnerability.getSeverity().toString());
+                    qm.updateSeverity(vulnerability, parsedVulnerability.getSeverity(), persistentComponent);
+                }
             }
 
             if (didCreateVulns) {


### PR DESCRIPTION
### Description

* A new flag in the UI under:
  `Administration → Analyzer → Trivy`
  Labeled as **"Ignore severity reported by Trivy scan"**
* This flag will be enabled by default (i.e., severity is ignored).
* When disabled, the analyzer **overwrites the existing severity of a vulnerability** with the value reported by Trivy


### Checklist

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [X] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [X] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
