### PR TITLE
Add whitespace sanitization in fuzzySearch CPE to fix CPE validation errors

### DIFF
--- a/src/main/java/org/dependencytrack/search/FuzzyVulnerableSoftwareSearchManager.java
+++ b/src/main/java/org/dependencytrack/search/FuzzyVulnerableSoftwareSearchManager.java
@@ -150,7 +150,9 @@ public class FuzzyVulnerableSoftwareSearchManager {
     }
     private List<VulnerableSoftware> fuzzySearch(QueryManager qm, Part part, String vendor, String product)  {
         try {
-            us.springett.parsers.cpe.Cpe cpe = new us.springett.parsers.cpe.Cpe(part, escape(vendor), escape(product), "*", "*", "*", "*", "*", "*", "*", "*");
+            String sanitizedVendor = vendor.replace(" ", "_");
+            String sanitizedProduct = product.replace(" ", "_");
+            us.springett.parsers.cpe.Cpe cpe = new us.springett.parsers.cpe.Cpe(part, escapeLuceneQuery(sanitizedVendor), escapeLuceneQuery(sanitizedProduct), "*", "*", "*", "*", "*", "*", "*", "*");
             String cpeSearch = getLuceneCpeRegexp(cpe.toCpe23FS());
             return fuzzySearch(qm, cpeSearch);
         } catch (CpeValidationException cpeValidationException) {
@@ -239,8 +241,8 @@ public class FuzzyVulnerableSoftwareSearchManager {
                 exp.insert(0, "cpe22:/");
                 exp.append("\\/").append(cpe.getPart().getAbbreviation());
             }
-            exp.append("\\:").append(escape(getComponentRegex(cpe.getVendor())));
-            exp.append("\\:").append(escape(getComponentRegex(cpe.getProduct())));
+            exp.append("\\:").append(escapeLuceneQuery(getComponentRegex(cpe.getVendor())));
+            exp.append("\\:").append(escapeLuceneQuery(getComponentRegex(cpe.getProduct())));
             exp.append("\\:").append(getComponentRegex(cpe.getVersion()));
             exp.append("\\:").append(getComponentRegex(cpe.getUpdate()));
             exp.append("\\:").append(getComponentRegex(cpe.getEdition()));
@@ -266,7 +268,7 @@ public class FuzzyVulnerableSoftwareSearchManager {
         }
     }
 
-    private static String escape(final String input) {
+    private static String escapeLuceneQuery(final String input) {
         if(input == null) {
             return null;
         } else if (input.equals(".*")) {


### PR DESCRIPTION
### Description

The vendor and product String parameters passed to fuzzySearch() might contain spaces, as the frontend does not prevent inputting strings containing spaces when manually creating a component. As far as I know CycloneDX and SPDX also do not restrict this, so imported components could also contain spaces in their name and vendor properties (unless they are sanitized when importing).

As `fuzzySearch()` creates a new CPE object which validates the attributes inside the constructor, this will cause exceptions to be logged for all components that contain spaces in name and/or vendor.

I have added a simple replace before passing these strings to the CPE constructor to prevent the exceptions from being thrown.
I have also renamed the private method `escape()` to `escapeLuceneQuery()` to be more descriptive, as it calls the Lucene `QueryParser.escape()` method. 


### Addressed Issue

Fixes #4920 


### Additional Details

I wanted to add a test for the fix, but the only testable difference is that the exceptions no longer appear in the logs. I tried to find ways to elegantly test this, but could only find solutions which would require adding dependencies to catch the log entries from the tests and asserting that no log entry appears for components with spaces in name or vendor. 
If there is a better way to test such cases please let me know.
I ran all tests related to the `FuzzyVulnerableSoftwareSearchManager` and they passed. 


### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic]~~(https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
