### PR TITLE
Implement Version Parameter when exporting BOM's

### DIFF
--- a/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXExporter.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXExporter.java
@@ -93,14 +93,11 @@ public class CycloneDXExporter {
         return bom;
     }
 
-    public String export(final Bom bom, final Format format) throws GeneratorException {
-        // TODO: The output version should be user-controllable.
-
+    public String export(final Bom bom, final Format format, final Version version) throws GeneratorException {
         if (Format.JSON == format) {
-            return BomGeneratorFactory.createJson(Version.VERSION_15, bom).toJsonString();
-        } else {
-            return BomGeneratorFactory.createXml(Version.VERSION_15, bom).toXmlString();
+            return BomGeneratorFactory.createJson(version, bom).toJsonString();
         }
+        return BomGeneratorFactory.createXml(version, bom).toXmlString();
     }
 
 }

--- a/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -37,6 +37,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BOMInputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.cyclonedx.CycloneDxMediaType;
+import org.cyclonedx.Version;
 import org.cyclonedx.exception.GeneratorException;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.event.BomUploadEvent;
@@ -117,6 +118,8 @@ import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_T
 public class BomResource extends AlpineResource {
 
     private static final Logger LOGGER = Logger.getLogger(BomResource.class);
+    private static final String DEFAULT_EXPORT_FORMAT = "JSON";
+    private static final String DEFAULT_EXPORT_VERSION = "1.5";
 
     @GET
     @Path("/cyclonedx/project/{uuid}")
@@ -139,52 +142,66 @@ public class BomResource extends AlpineResource {
     public Response exportProjectAsCycloneDx (
             @Parameter(description = "The UUID of the project to export", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid,
-            @Parameter(description = "The format to output (defaults to JSON)")
+            @Parameter(description = "The format to output (defaults to '" + DEFAULT_EXPORT_FORMAT + "')")
             @QueryParam("format") String format,
             @Parameter(description = "Specifies the CycloneDX variant to export. Value options are 'inventory' and 'withVulnerabilities'. (defaults to 'inventory')")
             @QueryParam("variant") String variant,
             @Parameter(description = "Force the resulting BOM to be downloaded as a file (defaults to 'false')")
-            @QueryParam("download") boolean download) {
+            @QueryParam("download") boolean download,
+            @Parameter(description = "The CycloneDX Spec variant exported (defaults to: '" + DEFAULT_EXPORT_VERSION + "')")
+            @QueryParam("version") String version
+    ) {
         try (QueryManager qm = new QueryManager()) {
+            String formatParameter =  Objects.toString(StringUtils.trimToNull(format), DEFAULT_EXPORT_FORMAT);
+            if (! isValidBomFormatParameter(formatParameter)) {
+                return Response.status(Response.Status.BAD_REQUEST).entity("Invalid BOM format specified.").build();
+            }
+
+            String versionParameter =  Objects.toString(StringUtils.trimToNull(version), DEFAULT_EXPORT_VERSION);
+            Version cdxOutputVersion = Version.fromVersionString(versionParameter);
+            if(cdxOutputVersion == null) {
+                return Response.status(Response.Status.BAD_REQUEST).entity("Invalid BOM version specified.").build();
+            }
+
+            CycloneDXExporter.Format cdxOutputFormat = CycloneDXExporter.Format.JSON;
+            String cdxOutputMediaType = CycloneDxMediaType.APPLICATION_CYCLONEDX_JSON;
+
+            if (formatParameter.equalsIgnoreCase("XML")) {
+                cdxOutputFormat = CycloneDXExporter.Format.XML;
+                cdxOutputMediaType = CycloneDxMediaType.APPLICATION_CYCLONEDX_XML;
+            }
+
             final Project project = qm.getObjectByUuid(Project.class, uuid);
             if (project == null) {
                 return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();
             }
+
             if (! qm.hasAccess(super.getPrincipal(), project)) {
                 return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
             }
 
-            final CycloneDXExporter exporter;
-            if (StringUtils.trimToNull(variant) == null || variant.equalsIgnoreCase("inventory")) {
-                exporter = new CycloneDXExporter(CycloneDXExporter.Variant.INVENTORY, qm);
-            } else if (variant.equalsIgnoreCase("withVulnerabilities")) {
-                exporter = new CycloneDXExporter(CycloneDXExporter.Variant.INVENTORY_WITH_VULNERABILITIES, qm);
-            } else if (variant.equalsIgnoreCase("vdr")) {
-                exporter = new CycloneDXExporter(CycloneDXExporter.Variant.VDR, qm);
-            } else {
+            String parsedVariant = Objects.toString(StringUtils.trimToNull(variant), "inventory").toLowerCase();
+
+            CycloneDXExporter.Variant exportVariant = switch (parsedVariant) {
+                case "vdr" -> CycloneDXExporter.Variant.VDR;
+                case "withvulnerabilities" -> CycloneDXExporter.Variant.INVENTORY_WITH_VULNERABILITIES;
+                case "inventory" -> CycloneDXExporter.Variant.INVENTORY;
+                default -> null;
+            }; // exportVariant
+
+            if (exportVariant == null) {
                 return Response.status(Response.Status.BAD_REQUEST).entity("Invalid BOM variant specified.").build();
             }
 
+            final CycloneDXExporter exporter = new CycloneDXExporter(exportVariant, qm);
+
             try {
-                if (StringUtils.trimToNull(format) == null || format.equalsIgnoreCase("JSON")) {
-                    if (download) {
-                        return Response.ok(exporter.export(exporter.create(project), CycloneDXExporter.Format.JSON), MediaType.APPLICATION_OCTET_STREAM)
-                                .header("content-disposition","attachment; filename=\"" + project.getUuid() + "-" + variant + ".cdx.json\"").build();
-                    } else {
-                        return Response.ok(exporter.export(exporter.create(project), CycloneDXExporter.Format.JSON),
-                                CycloneDxMediaType.APPLICATION_CYCLONEDX_JSON).build();
-                    }
-                } else if (format.equalsIgnoreCase("XML")) {
-                    if (download) {
-                        return Response.ok(exporter.export(exporter.create(project), CycloneDXExporter.Format.XML), MediaType.APPLICATION_OCTET_STREAM)
-                                .header("content-disposition","attachment; filename=\"" + project.getUuid() + "-" + variant + ".cdx.xml\"").build();
-                    } else {
-                        return Response.ok(exporter.export(exporter.create(project), CycloneDXExporter.Format.XML),
-                                CycloneDxMediaType.APPLICATION_CYCLONEDX_XML).build();
-                    }
-                } else {
-                    return Response.status(Response.Status.BAD_REQUEST).entity("Invalid BOM format specified.").build();
+                if (download) {
+                    return Response.ok(exporter.export(exporter.create(project), cdxOutputFormat, cdxOutputVersion), MediaType.APPLICATION_OCTET_STREAM)
+                            .header("content-disposition","attachment; filename=\"" + project.getUuid() + "-" + parsedVariant + ".cdx.json\"").build();
                 }
+                return Response.ok(exporter.export(exporter.create(project), cdxOutputFormat, cdxOutputVersion), cdxOutputMediaType).build();
+
             } catch (GeneratorException e) {
                 LOGGER.error("An error occurred while building a CycloneDX document for export", e);
                 return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
@@ -213,28 +230,43 @@ public class BomResource extends AlpineResource {
     public Response exportComponentAsCycloneDx (
             @Parameter(description = "The UUID of the component to export", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid,
-            @Parameter(description = "The format to output (defaults to JSON)")
-            @QueryParam("format") String format) {
+            @Parameter(description = "The format to output (defaults to '" + DEFAULT_EXPORT_FORMAT + "')")
+            @QueryParam("format") String format,
+            @Parameter(description = "The CycloneDX Spec variant exported (defaults to: '" + DEFAULT_EXPORT_VERSION + "')")
+            @QueryParam("version") String version
+            ) {
         try (QueryManager qm = new QueryManager()) {
             final Component component = qm.getObjectByUuid(Component.class, uuid);
             if (component == null) {
                 return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();
             }
-            if (! qm.hasAccess(super.getPrincipal(), component.getProject())) {
+
+            String formatParameter = Objects.toString(StringUtils.trimToNull(format), DEFAULT_EXPORT_FORMAT);
+            if (!isValidBomFormatParameter(formatParameter)) {
+                return Response.status(Response.Status.BAD_REQUEST).entity("Invalid BOM format specified.").build();
+            }
+
+            String versionParameter = Objects.toString(StringUtils.trimToNull(version), DEFAULT_EXPORT_VERSION);
+            Version cdxOutputVersion = Version.fromVersionString(versionParameter);
+            if (cdxOutputVersion == null) {
+                return Response.status(Response.Status.BAD_REQUEST).entity("Invalid BOM version specified.").build();
+            }
+
+            String cdxOutputMediaType = CycloneDxMediaType.APPLICATION_CYCLONEDX_JSON;
+            CycloneDXExporter.Format cdxOutputFormat = CycloneDXExporter.Format.JSON;
+
+            if (formatParameter.equalsIgnoreCase("XML")) {
+                cdxOutputFormat = CycloneDXExporter.Format.XML;
+                cdxOutputMediaType = CycloneDxMediaType.APPLICATION_CYCLONEDX_XML;
+            }
+
+            if (!qm.hasAccess(super.getPrincipal(), component.getProject())) {
                 return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified component is forbidden").build();
             }
 
             final CycloneDXExporter exporter = new CycloneDXExporter(CycloneDXExporter.Variant.INVENTORY, qm);
             try {
-                if (StringUtils.trimToNull(format) == null || format.equalsIgnoreCase("JSON")) {
-                    return Response.ok(exporter.export(exporter.create(component), CycloneDXExporter.Format.JSON),
-                            CycloneDxMediaType.APPLICATION_CYCLONEDX_JSON).build();
-                } else if (format.equalsIgnoreCase("XML")) {
-                    return Response.ok(exporter.export(exporter.create(component), CycloneDXExporter.Format.XML),
-                            CycloneDxMediaType.APPLICATION_CYCLONEDX_XML).build();
-                } else {
-                    return Response.status(Response.Status.BAD_REQUEST).entity("Invalid BOM format specified.").build();
-                }
+                return Response.ok(exporter.export(exporter.create(component), cdxOutputFormat, cdxOutputVersion), cdxOutputMediaType).build();
             } catch (GeneratorException e) {
                 LOGGER.error("An error occurred while building a CycloneDX document for export", e);
                 return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
@@ -701,5 +733,10 @@ public class BomResource extends AlpineResource {
             .content("An error occurred during BOM Validation")
             .subject(new BomValidationFailed(project, bom, errors, bomFormat)));
     }
-
+    private static boolean isValidBomFormatParameter(final String format) {
+        if (format == null) {
+            return false;
+        }
+        return format.equalsIgnoreCase("json") || format.equalsIgnoreCase("xml");
+    }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -112,13 +112,13 @@ class BomResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        String body = getPlainTextBody(response);
         Assertions.assertEquals(200, response.getStatus(), 0);
         Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        String body = getPlainTextBody(response);
         Assertions.assertTrue(body.startsWith("{"));
 
-        String expectedCdxVersionSpec = cdxExportVersionParameter == null ? "1.5": cdxExportVersionParameter;
-        assertThatJson(body).withMatcher("specVersion", equalTo(expectedCdxVersionSpec));
+        String expectedCdxVersionSpec = cdxExportVersionParameter == null ? "1.5" : cdxExportVersionParameter;
+        assertThatJson(body, json -> json.inPath("specVersion").isEqualTo("\"" + expectedCdxVersionSpec + "\""));
     }
 
     @ParameterizedTest
@@ -139,23 +139,23 @@ class BomResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         String body = getPlainTextBody(response);
-        if(cdxExportVersionParameter == null) {
+        if (cdxExportVersionParameter == null) {
             cdxExportVersionParameter = "1.5"; // Expect 1.5 as default for null / not set parameter
         }
         Assertions.assertEquals(200, response.getStatus(), 0);
         Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         Assertions.assertTrue(body.startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
-        Assertions.assertTrue(body.contains("version=\"1\" xmlns=\"http://cyclonedx.org/schema/bom/" + cdxExportVersionParameter +"\">"));
+        Assertions.assertTrue(body.contains("version=\"1\" xmlns=\"http://cyclonedx.org/schema/bom/" + cdxExportVersionParameter + "\">"));
 
-        
+
     }
 
-    private static String[] jsonVersionSpecTests(){
+    private static String[] jsonVersionSpecTests() {
         return new String[]{"1.2", "1.3", "1.4", "1.5", "1.6", null}; // JSON is only supported  >= 1.2
     }
 
-    private static String[] xmlVersionSpecTests(){
-        return new String[]{"1.0","1.1", "1.2", "1.3", "1.4", "1.5", "1.6", null};
+    private static String[] xmlVersionSpecTests() {
+        return new String[]{"1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", null};
     }
 
     @Test
@@ -863,12 +863,12 @@ class BomResourceTest extends ResourceTest {
         String body = getPlainTextBody(response);
         Assertions.assertTrue(body.startsWith("{"));
 
-        String expectedCdxVersionSpec = cdxExportVersionParameter == null ? "1.5": cdxExportVersionParameter;
+        String expectedCdxVersionSpec = cdxExportVersionParameter == null ? "1.5" : cdxExportVersionParameter;
         assertThatJson(body).withMatcher("specVersion", equalTo(expectedCdxVersionSpec));
     }
 
     @Test
-    void exportComponentAsCycloneDxInvalid(){
+    void exportComponentAsCycloneDxInvalid() {
         Response response = jersey.target(V1_BOM + "/cyclonedx/component/" + UUID.randomUUID())
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -880,8 +880,8 @@ class BomResourceTest extends ResourceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"99", "-15", "1.9"," 0.9", "invalidString"})
-    void exportComponentAsCycloneDxInvalidVersion(String  cdxExportVersionParameter) {
+    @ValueSource(strings = {"99", "-15", "1.9", " 0.9", "invalidString"})
+    void exportComponentAsCycloneDxInvalidVersion(String cdxExportVersionParameter) {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, false, false);
         Component c = new Component();
         c.setProject(project);
@@ -1072,7 +1072,7 @@ class BomResourceTest extends ResourceTest {
         project.setVersion("1.0.0");
         project.setIsLatest(true);
         qm.persist(project);
-        
+
         String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
 
         StringBuilder jsonBuilder = new StringBuilder();

--- a/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
@@ -490,78 +490,7 @@ class VexResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(200);
         final String jsonResponse = getPlainTextBody(response);
         assertThatNoException().isThrownBy(() -> CycloneDxValidator.getInstance().validate(jsonResponse.getBytes()));
-        assertThatJson(jsonResponse)
-                .withMatcher("specVersion", equalTo(expectedCdxVersionSpec))
-                .withMatcher("vulnUuid", equalTo(vuln.getUuid().toString()))
-                .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
-                .withMatcher("compAUuid", equalTo(componentAWithVuln.getUuid().toString()))
-                .withMatcher("compBUuid", equalTo(componentBWithVuln.getUuid().toString()))
-                .isEqualTo( /* language=JSON */ """
-                        {
-                           "bomFormat" : "CycloneDX",
-                           "specVersion" : "${json-unit.matches:specVersion}",
-                           "serialNumber": "${json-unit.any-string}",
-                           "version" : 1,
-                           "metadata" : {
-                             "timestamp" : "${json-unit.any-string}",
-                             "tools" : [ {
-                               "vendor" : "OWASP",
-                               "name" : "Dependency-Track",
-                               "version" : "${json-unit.any-string}"
-                             } ],
-                             "component" : {
-                               "type" : "application",
-                               "bom-ref" : "${json-unit.matches:projectUuid}",
-                               "name" : "acme-app",
-                               "version" : "1.0.0"
-                             }
-                           },
-                           "vulnerabilities" : [ {
-                             "bom-ref" : "${json-unit.matches:vulnUuid}",
-                             "id" : "INT-001",
-                             "source" : {
-                               "name" : "INTERNAL"
-                             },
-                             "ratings" : [ {
-                               "source" : {
-                                 "name" : "INTERNAL"
-                               },
-                               "severity" : "high",
-                               "method" : "other"
-                             } ],
-                             "analysis" : {
-                               "state" : "in_triage",
-                               "response" : [ "update" ]
-                             },
-                             "affects" : [ {
-                               "ref" : "${json-unit.matches:projectUuid}"
-                             } ]
-                           }, {
-                             "bom-ref" : "${json-unit.matches:vulnUuid}",
-                             "id" : "INT-001",
-                             "source" : {
-                               "name" : "INTERNAL"
-                             },
-                             "ratings" : [ {
-                               "source" : {
-                                 "name" : "INTERNAL"
-                               },
-                               "severity" : "high",
-                               "method" : "other"
-                             } ],
-                             "analysis" : {
-                               "state" : "exploitable",
-                               "response" : [ "update" ]
-                             },
-                             "affects" : [ {
-                               "ref" : "${json-unit.matches:projectUuid}"
-                             } ]
-                           } ]
-                         }
-                        """)
-        ;
-
-
+        assertThatJson(jsonResponse, json -> json.inPath("specVersion").isEqualTo("\"" + expectedCdxVersionSpec + "\""));
     }
 
     private static String[] jsonVersionSpecTests(){

--- a/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.StreamReadConstraints;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
@@ -44,6 +45,9 @@ import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.jupiter.DefaultLocale;
 
 import java.util.Base64;
@@ -440,6 +444,148 @@ class VexResourceTest extends ResourceTest {
                           ]
                         }
                         """);
+    }
+
+    @ParameterizedTest
+    @MethodSource("jsonVersionSpecTests")
+    void exportVexWithValidJsonVersions(String cdxVersion){
+        Project project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        project.setClassifier(Classifier.APPLICATION);
+        qm.persist(project);
+
+        Component componentAWithVuln = new Component();
+        componentAWithVuln.setProject(project);
+        componentAWithVuln.setName("acme-lib-a");
+        componentAWithVuln.setVersion("1.0.0");
+        componentAWithVuln = qm.createComponent(componentAWithVuln, false);
+
+        Component componentBWithVuln = new Component();
+        componentBWithVuln.setProject(project);
+        componentBWithVuln.setName("acme-lib-b");
+        componentBWithVuln.setVersion("1.0.0");
+        componentBWithVuln = qm.createComponent(componentBWithVuln, false);
+
+        Vulnerability vuln = new Vulnerability();
+        vuln.setVulnId("INT-001");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        vuln = qm.createVulnerability(vuln, false);
+        qm.addVulnerability(vuln, componentAWithVuln, AnalyzerIdentity.NONE);
+        qm.makeAnalysis(componentAWithVuln, vuln, AnalysisState.IN_TRIAGE, null, AnalysisResponse.UPDATE, null, true);
+        qm.addVulnerability(vuln, componentBWithVuln, AnalyzerIdentity.NONE);
+        qm.makeAnalysis(componentBWithVuln, vuln, AnalysisState.EXPLOITABLE, null, AnalysisResponse.UPDATE, null, true);
+
+        qm.persist(project);
+
+        cdxVersion = StringUtils.trimToNull(cdxVersion);
+        String expectedCdxVersionSpec = cdxVersion == null ? "1.5" : cdxVersion;
+        Response response = jersey.target("%s/cyclonedx/project/%s".formatted(V1_VEX, project.getUuid()))
+                .queryParam("version", cdxVersion)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        final String jsonResponse = getPlainTextBody(response);
+        assertThatNoException().isThrownBy(() -> CycloneDxValidator.getInstance().validate(jsonResponse.getBytes()));
+        assertThatJson(jsonResponse)
+                .withMatcher("specVersion", equalTo(expectedCdxVersionSpec))
+                .withMatcher("vulnUuid", equalTo(vuln.getUuid().toString()))
+                .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
+                .withMatcher("compAUuid", equalTo(componentAWithVuln.getUuid().toString()))
+                .withMatcher("compBUuid", equalTo(componentBWithVuln.getUuid().toString()))
+                .isEqualTo( /* language=JSON */ """
+                        {
+                           "bomFormat" : "CycloneDX",
+                           "specVersion" : "${json-unit.matches:specVersion}",
+                           "serialNumber": "${json-unit.any-string}",
+                           "version" : 1,
+                           "metadata" : {
+                             "timestamp" : "${json-unit.any-string}",
+                             "tools" : [ {
+                               "vendor" : "OWASP",
+                               "name" : "Dependency-Track",
+                               "version" : "${json-unit.any-string}"
+                             } ],
+                             "component" : {
+                               "type" : "application",
+                               "bom-ref" : "${json-unit.matches:projectUuid}",
+                               "name" : "acme-app",
+                               "version" : "1.0.0"
+                             }
+                           },
+                           "vulnerabilities" : [ {
+                             "bom-ref" : "${json-unit.matches:vulnUuid}",
+                             "id" : "INT-001",
+                             "source" : {
+                               "name" : "INTERNAL"
+                             },
+                             "ratings" : [ {
+                               "source" : {
+                                 "name" : "INTERNAL"
+                               },
+                               "severity" : "high",
+                               "method" : "other"
+                             } ],
+                             "analysis" : {
+                               "state" : "in_triage",
+                               "response" : [ "update" ]
+                             },
+                             "affects" : [ {
+                               "ref" : "${json-unit.matches:projectUuid}"
+                             } ]
+                           }, {
+                             "bom-ref" : "${json-unit.matches:vulnUuid}",
+                             "id" : "INT-001",
+                             "source" : {
+                               "name" : "INTERNAL"
+                             },
+                             "ratings" : [ {
+                               "source" : {
+                                 "name" : "INTERNAL"
+                               },
+                               "severity" : "high",
+                               "method" : "other"
+                             } ],
+                             "analysis" : {
+                               "state" : "exploitable",
+                               "response" : [ "update" ]
+                             },
+                             "affects" : [ {
+                               "ref" : "${json-unit.matches:projectUuid}"
+                             } ]
+                           } ]
+                         }
+                        """)
+        ;
+
+
+    }
+
+    private static String[] jsonVersionSpecTests(){
+        return new String[]{"1.4", "1.5", "1.6", null}; // Vulnerabilities are only supported starting spec 1.4
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"99", "-15", "1.9"," 0.9", "invalidString"})
+    void exportVexWithInvalidVersionsStrings(String version){
+        Project project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        project.setClassifier(Classifier.APPLICATION);
+        qm.persist(project);
+
+        Response response = jersey.target("%s/cyclonedx/project/%s".formatted(V1_VEX, project.getUuid()))
+                .queryParam("version", version)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+
+        Assertions.assertEquals(400, response.getStatus(), 0);
+        String body = getPlainTextBody(response);
+        Assertions.assertEquals("Invalid CycloneDX version specified.", body);
     }
 
     @Test


### PR DESCRIPTION
Version Parameter for exporting BOM/VEX Resources see #5062

### Description

Added optional Version parameter for exporting BOM's in specific Versions.

### Addressed Issue

Closes #5062

### Additional Details

 * Added a simple, additional paramater for `version`. Instead of expanding the `if-elseif-else` branches, opted for earlier argument checks with corresponding exits. 
 * Expanded Tests which were already testing the changed endpoints.
 * Added additional positive and negativ tests 

### Checklist

-  [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] ~~This PR fixes a defect, and I have provided tests to verify that the fix is effective~~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
