### PR TITLE
Fix Issue#5105: OSV Ubuntu advisory contains severity without type (ubuntu priority)

### DIFF
--- a/src/main/java/org/dependencytrack/parser/osv/OsvAdvisoryParser.java
+++ b/src/main/java/org/dependencytrack/parser/osv/OsvAdvisoryParser.java
@@ -95,6 +95,7 @@ public class OsvAdvisoryParser {
                 for (int i=0; i<cvssList.length(); i++) {
                     final JSONObject cvss = cvssList.getJSONObject(i);
                     final String type = cvss.optString("type", null);
+                    if (type == null) continue;
                     if (type.equalsIgnoreCase("CVSS_V3")) {
                         advisory.setCvssV3Vector(cvss.optString("score", null));
                     }

--- a/src/test/java/org/dependencytrack/parser/osv/OsvAdvisoryParserTest.java
+++ b/src/test/java/org/dependencytrack/parser/osv/OsvAdvisoryParserTest.java
@@ -158,4 +158,13 @@ class OsvAdvisoryParserTest {
         Assertions.assertNotNull(advisory);
     }
 
+    @Test
+        // https://github.com/DependencyTrack/dependency-track/issues/5105
+    void testIssue5105() throws Exception {
+        String jsonFile = "src/test/resources/unit/osv.jsons/osv-UBUNTU-CVE-2025-6297.json";
+        String jsonString = new String(Files.readAllBytes(Paths.get(jsonFile)));
+        JSONObject jsonObject = new JSONObject(jsonString);
+        OsvAdvisory advisory = parser.parse(jsonObject);
+        Assertions.assertNotNull(advisory);
+    }
 }

--- a/src/test/java/org/dependencytrack/tasks/OsvDownloadTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/OsvDownloadTaskTest.java
@@ -455,7 +455,7 @@ class OsvDownloadTaskTest extends PersistenceCapableTest {
     void testGetEcosystems() {
         final var task = new OsvDownloadTask();
         List<String> ecosystems = task.getEcosystems();
-        Assertions.assertNotNull(ecosystems);
+        Assertions.assertFalse(ecosystems.isEmpty());
         Assertions.assertTrue(ecosystems.contains("Maven"));
     }
 

--- a/src/test/resources/unit/osv.jsons/osv-UBUNTU-CVE-2025-6297.json
+++ b/src/test/resources/unit/osv.jsons/osv-UBUNTU-CVE-2025-6297.json
@@ -1,0 +1,296 @@
+{
+  "id": "UBUNTU-CVE-2025-6297",
+  "details": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",
+  "modified": "2025-07-04T06:14:23.371059Z",
+  "published": "2025-07-01T17:15:00Z",
+  "upstream": [
+    "CVE-2025-6297"
+  ],
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://ubuntu.com/security/CVE-2025-6297"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://www.cve.org/CVERecord?id=CVE-2025-6297"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "name": "dpkg",
+        "ecosystem": "Ubuntu:Pro:14.04:LTS",
+        "purl": "pkg:deb/ubuntu/dpkg@1.17.5ubuntu5.8+esm1?arch=source&distro=esm-infra-legacy/trusty"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.16.12ubuntu1",
+        "1.17.1ubuntu1",
+        "1.17.5ubuntu1",
+        "1.17.5ubuntu2",
+        "1.17.5ubuntu3",
+        "1.17.5ubuntu4",
+        "1.17.5ubuntu5",
+        "1.17.5ubuntu5.1",
+        "1.17.5ubuntu5.2",
+        "1.17.5ubuntu5.3",
+        "1.17.5ubuntu5.4",
+        "1.17.5ubuntu5.5",
+        "1.17.5ubuntu5.6",
+        "1.17.5ubuntu5.7",
+        "1.17.5ubuntu5.8",
+        "1.17.5ubuntu5.8+esm1"
+      ],
+      "ecosystem_specific": {
+        "priority_reason": "Only leaves temp files around when manually extracting a deb file"
+      },
+      "database_specific": {
+        "source": "https://github.com/canonical/ubuntu-security-notices/blob/main/osv/cve/2025/UBUNTU-CVE-2025-6297.json"
+      }
+    },
+    {
+      "package": {
+        "name": "dpkg",
+        "ecosystem": "Ubuntu:Pro:16.04:LTS",
+        "purl": "pkg:deb/ubuntu/dpkg@1.18.4ubuntu1.7+esm1?arch=source&distro=esm-infra/xenial"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.18.2ubuntu5",
+        "1.18.3ubuntu1",
+        "1.18.4ubuntu1",
+        "1.18.4ubuntu1.1",
+        "1.18.4ubuntu1.2",
+        "1.18.4ubuntu1.3",
+        "1.18.4ubuntu1.4",
+        "1.18.4ubuntu1.5",
+        "1.18.4ubuntu1.6",
+        "1.18.4ubuntu1.7",
+        "1.18.4ubuntu1.7+esm1"
+      ],
+      "ecosystem_specific": {
+        "priority_reason": "Only leaves temp files around when manually extracting a deb file"
+      },
+      "database_specific": {
+        "source": "https://github.com/canonical/ubuntu-security-notices/blob/main/osv/cve/2025/UBUNTU-CVE-2025-6297.json"
+      }
+    },
+    {
+      "package": {
+        "name": "dpkg",
+        "ecosystem": "Ubuntu:Pro:18.04:LTS",
+        "purl": "pkg:deb/ubuntu/dpkg@1.19.0.5ubuntu2.4?arch=source&distro=esm-infra/bionic"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.18.24ubuntu1",
+        "1.19.0.4ubuntu1",
+        "1.19.0.5ubuntu1",
+        "1.19.0.5ubuntu2",
+        "1.19.0.5ubuntu2.1",
+        "1.19.0.5ubuntu2.2",
+        "1.19.0.5ubuntu2.3",
+        "1.19.0.5ubuntu2.4"
+      ],
+      "ecosystem_specific": {
+        "priority_reason": "Only leaves temp files around when manually extracting a deb file"
+      },
+      "database_specific": {
+        "source": "https://github.com/canonical/ubuntu-security-notices/blob/main/osv/cve/2025/UBUNTU-CVE-2025-6297.json"
+      }
+    },
+    {
+      "package": {
+        "name": "dpkg",
+        "ecosystem": "Ubuntu:Pro:20.04:LTS",
+        "purl": "pkg:deb/ubuntu/dpkg@1.19.7ubuntu3.2?arch=source&distro=esm-infra/focal"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.19.7ubuntu2",
+        "1.19.7ubuntu3",
+        "1.19.7ubuntu3.2"
+      ],
+      "ecosystem_specific": {
+        "priority_reason": "Only leaves temp files around when manually extracting a deb file"
+      },
+      "database_specific": {
+        "source": "https://github.com/canonical/ubuntu-security-notices/blob/main/osv/cve/2025/UBUNTU-CVE-2025-6297.json"
+      }
+    },
+    {
+      "package": {
+        "name": "dpkg",
+        "ecosystem": "Ubuntu:22.04:LTS",
+        "purl": "pkg:deb/ubuntu/dpkg@1.21.1ubuntu2.3?arch=source&distro=jammy"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.20.9ubuntu2",
+        "1.20.9ubuntu3",
+        "1.21.1ubuntu1",
+        "1.21.1ubuntu2",
+        "1.21.1ubuntu2.1",
+        "1.21.1ubuntu2.2",
+        "1.21.1ubuntu2.3"
+      ],
+      "ecosystem_specific": {
+        "priority_reason": "Only leaves temp files around when manually extracting a deb file"
+      },
+      "database_specific": {
+        "source": "https://github.com/canonical/ubuntu-security-notices/blob/main/osv/cve/2025/UBUNTU-CVE-2025-6297.json"
+      }
+    },
+    {
+      "package": {
+        "name": "dpkg",
+        "ecosystem": "Ubuntu:24.10",
+        "purl": "pkg:deb/ubuntu/dpkg@1.22.11ubuntu1?arch=source&distro=oracular"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.22.6ubuntu6",
+        "1.22.6ubuntu10",
+        "1.22.6ubuntu14",
+        "1.22.10ubuntu2",
+        "1.22.11ubuntu1"
+      ],
+      "ecosystem_specific": {
+        "priority_reason": "Only leaves temp files around when manually extracting a deb file"
+      },
+      "database_specific": {
+        "source": "https://github.com/canonical/ubuntu-security-notices/blob/main/osv/cve/2025/UBUNTU-CVE-2025-6297.json"
+      }
+    },
+    {
+      "package": {
+        "name": "dpkg",
+        "ecosystem": "Ubuntu:24.04:LTS",
+        "purl": "pkg:deb/ubuntu/dpkg@1.22.6ubuntu6.1?arch=source&distro=noble"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.22.0ubuntu1",
+        "1.22.1ubuntu2",
+        "1.22.1ubuntu3",
+        "1.22.1ubuntu5",
+        "1.22.2ubuntu2",
+        "1.22.4ubuntu3",
+        "1.22.4ubuntu5",
+        "1.22.6ubuntu5",
+        "1.22.6ubuntu6",
+        "1.22.6ubuntu6.1"
+      ],
+      "ecosystem_specific": {
+        "priority_reason": "Only leaves temp files around when manually extracting a deb file"
+      },
+      "database_specific": {
+        "source": "https://github.com/canonical/ubuntu-security-notices/blob/main/osv/cve/2025/UBUNTU-CVE-2025-6297.json"
+      }
+    },
+    {
+      "package": {
+        "name": "dpkg",
+        "ecosystem": "Ubuntu:25.04",
+        "purl": "pkg:deb/ubuntu/dpkg@1.22.18ubuntu2?arch=source&distro=plucky"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.22.11ubuntu1",
+        "1.22.11ubuntu3",
+        "1.22.11ubuntu4",
+        "1.22.15ubuntu1",
+        "1.22.18ubuntu2"
+      ],
+      "ecosystem_specific": {
+        "priority_reason": "Only leaves temp files around when manually extracting a deb file"
+      },
+      "database_specific": {
+        "source": "https://github.com/canonical/ubuntu-security-notices/blob/main/osv/cve/2025/UBUNTU-CVE-2025-6297.json"
+      }
+    }
+  ],
+  "schema_version": "1.6.0",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N"
+    },
+    {
+      "score": "low"
+    }
+  ]
+}


### PR DESCRIPTION
### Description

The missing type in some Ubuntu OSV advisories caused a NullPointerException when the OsvAdvisoryParser.parse() method tried to access the type without checking for null. My fix will check if type is null and continue the loop without further processing the item. I have also added a test for this case and additionally fixed testGetEcosystems() in the OsvDownloadTaskTest that incorrectly checked for null instead of an empty list after attempting to fetch the ecosystem list.

### Addressed Issue

fixes #5105

### Additional Details

I am still wondering why the import of these advisories has worked correctly at some point (they are present when I look for them in the frontend) and why this issue has not yet been reported here, because some of the affected advisories are very old.
Did something else change recently? Anyway it makes sense to check for null before accessing the `type`. 

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
