### PR TITLE
Fix inverted component matching

### DIFF
--- a/docs/_docs/FAQ.md
+++ b/docs/_docs/FAQ.md
@@ -110,4 +110,16 @@ nginx.ingress.kubernetes.io/proxy-body-size: "100m"
 
 Please consult the [official documentation](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-max-body-size)
 
+#### Policy conditions do not work for some PURLs
+
+Policy condition values are treated as regular expressions.
+
+1. Policy condition values are implicitly treated as substring matches.
+   They must be explicitly anchored with `^` and `$` to make them an exact match.
+2. Characters with special meaning in regular expressions should be escaped with a `\\`.
+   This is needed if the PURL contains a `?`, since the question mark makes the previous character optional and is not treated literally.
+   Another special character is `.`, which should also be escaped.
+3. Policy condition values support wildcards, so an `*` means that any text is allowed, including missing text.
+   For example, `^vendor/*$` would match `vendor/lib-1`, `vendor/app`, or even only `vendor/`.
+
 [defect report]: https://github.com/DependencyTrack/dependency-track/issues/new?assignees=&labels=defect%2Cin+triage&template=defect-report.yml

--- a/src/test/java/org/dependencytrack/policy/CoordinatesPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/CoordinatesPolicyEvaluatorTest.java
@@ -444,4 +444,29 @@ class CoordinatesPolicyEvaluatorTest extends PersistenceCapableTest {
         Assertions.assertEquals(0, evaluator.evaluate(policy, component).size());
     }
 
+    @Test
+    void noMatchWithInvertedMatch() {
+        String def = "{ 'group': 'Acme', 'name': 'Test Component', 'version': '1.0.0' }";
+        Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
+        Component component = new Component();
+        component.setGroup("Acme");
+        component.setName("Test Component");
+        component.setVersion("1.0.0");
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        Assertions.assertEquals(0, violations.size());
+    }
+
+    @Test
+    void matchWithInvertedMatch() {
+        String def = "{ 'group': 'Acme', 'name': 'Test Component', 'version': '1.0.0' }";
+        Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        PolicyCondition condition = qm.createPolicyCondition(policy, PolicyCondition.Subject.COORDINATES, PolicyCondition.Operator.NO_MATCH, def);
+        Component component = new Component();
+        component.setGroup("Acme");
+        component.setName("Test Component");
+        component.setVersion("2.0.0");
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, component);
+        Assertions.assertEquals(1, violations.size());
+    }
 }


### PR DESCRIPTION
### Description

Fixes wrong negative matches with coordinate policies. Also adds a FAQ section about common policy value issues.

### Addressed Issue

Related to #5158 #5142 #4444 (I think it's possible that this PR is enough to consider these issues being fixed)
Fixes #5136
Fixes #5135
Fixes #5109

### Additional Details

Introduces some minor breaking changes for the `NO_MATCH` operator, but should work exactly the same otherwise, at least according to the unit tests. I wonder where to note that this changes behaviour and will introduce (probably) unexpected changes in some cases.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
