### PR TITLE
CompressUtil: handle ArchiveException

### DIFF
--- a/src/main/java/org/dependencytrack/util/CompressUtil.java
+++ b/src/main/java/org/dependencytrack/util/CompressUtil.java
@@ -45,7 +45,7 @@ public final class CompressUtil {
             if (ais.canReadEntryData(entry)) {
                 return IOUtils.toByteArray(ais);
             }
-        } catch (IOException e) {
+        } catch (IOException | org.apache.commons.compress.archivers.ArchiveException e) {
             // throw it away and return the original byte array
         }
         return input;


### PR DESCRIPTION
Fixes this build problem:

[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /home/build/src/main/java/org/dependencytrack/util/CompressUtil.java:[43,96]
  unreported exception org.apache.commons.compress.archivers.ArchiveException; must be caught or declared to be thrown
[INFO] 1 error

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
