### PR TITLE
Update OssIndexAnalysisTask.java

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTask.java
@@ -247,13 +247,6 @@ public class OssIndexAnalysisTask extends BaseComponentAnalyzerTask implements C
      * Therefore, this method will return a String representation of a PackageURL without qualifier
      * or subpath.
      * <p>
-     * Additionally, as of October 2021, versions prefixed with "v" (as commonly done in the Go and PHP ecosystems)
-     * are triggering a bug in OSS Index that causes all vulnerabilities for the given component to be returned,
-     * not just the ones for the requested version: https://github.com/OSSIndex/vulns/issues/129#issuecomment-740666614
-     * As a result, this method will remove "v" prefixes from versions.
-     * <p>
-     * This method should be removed at a future date when OSSIndex resolves the issues.
-     * <p>
      * TODO: Delete this method and workaround for OSSIndex bugs once Sonatype resolves them.
      *
      * @since 3.4.0
@@ -264,7 +257,6 @@ public class OssIndexAnalysisTask extends BaseComponentAnalyzerTask implements C
             return null;
         }
         String p = purl.canonicalize();
-        p = p.replaceFirst("@v", "@");
         if (p.contains("?")) {
             p = p.substring(0, p.lastIndexOf("?"));
         }


### PR DESCRIPTION
Removed workaround for OssIndexAnalysis when component had "v" as version prefix

### Description

I've noticed that calling the OSS Index API `https://ossindex.sonatype.org/api/v3/component-report` with `pkg:composer/symfony/validator@v3.3.18` correctly returns the vulnerability CVE-2024-50343, while calling the API with `pkg:composer/symfony/validator@3.3.18` (note the absence of `v`) I get back no vulnerability.
In the `OssIndexAnalysisTask` class I found that the `minimizePurl()` method removes the `v` just before calling the API, apparently because previously there was a bug (as explained in the comment block above the function definition) that now seems solved.

### Addressed Issue

https://github.com/DependencyTrack/dependency-track/pull/1220

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [X] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [X] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [X] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [X] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
