### PR TITLE
Feature: Show/Hide Suppressed Findings on Vulnerability Audit Grouped View

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/FindingsSearchQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/FindingsSearchQueryManager.java
@@ -75,6 +75,29 @@ public class FindingsSearchQueryManager extends QueryManager implements IQueryMa
             Map.entry("vulnerability.affectedProjectCount", "COUNT(DISTINCT \"PROJECT\".\"ID\")")
     );
 
+    private static final String COUNT_FINDINGS_GROUPED_BY_VULN_SELECT_CLAUSE = """
+            SELECT COUNT(*)
+            FROM (
+                SELECT 1
+                FROM       "COMPONENT"
+                INNER JOIN "COMPONENTS_VULNERABILITIES"
+                ON         "COMPONENT"."ID" = "COMPONENTS_VULNERABILITIES"."COMPONENT_ID"
+                INNER JOIN "VULNERABILITY"
+                ON         "COMPONENTS_VULNERABILITIES"."VULNERABILITY_ID" = "VULNERABILITY"."ID"
+                INNER JOIN "FINDINGATTRIBUTION"
+                ON         "COMPONENT"."ID" = "FINDINGATTRIBUTION"."COMPONENT_ID"
+                AND        "VULNERABILITY"."ID" = "FINDINGATTRIBUTION"."VULNERABILITY_ID"
+                LEFT JOIN  "ANALYSIS"
+                ON         "COMPONENT"."ID" = "ANALYSIS"."COMPONENT_ID"
+                AND        "VULNERABILITY"."ID" = "ANALYSIS"."VULNERABILITY_ID"
+                AND        "COMPONENT"."PROJECT_ID" = "ANALYSIS"."PROJECT_ID"
+                INNER JOIN "PROJECT"
+                ON         "COMPONENT"."PROJECT_ID" = "PROJECT"."ID"
+            """;
+
+    private static final String COUNT_FINDINGS_GROUPED_BY_VULN_TERMINATOR = ") AS VULN_COUNT_SUBQUERY";
+
+
     /**
      * Constructs a new QueryManager.
      * @param pm a PersistenceManager object
@@ -153,24 +176,61 @@ public class FindingsSearchQueryManager extends QueryManager implements IQueryMa
 
     /**
      * Returns a List of all Finding objects filtered by ACL and other optional filters. The resulting list is grouped by vulnerability.
-     * @param filters      determines the filters to apply on the list of Finding objects
-     * @param showInactive determines if inactive projects should be included or not
+     * @param filters        determines the filters to apply on the list of Finding objects
+     * @param showSuppressed determines if suppressed vulnerabilities should be included or not
+     * @param showInactive   determines if inactive projects should be included or not
      * @return a List of Finding objects
      */
-    public PaginatedResult getAllFindingsGroupedByVulnerability(final Map<String, String> filters, final boolean showInactive) {
+    public PaginatedResult getAllFindingsGroupedByVulnerability(final Map<String, String> filters, final boolean showSuppressed, final boolean showInactive) {
         StringBuilder queryFilter = new StringBuilder();
         Map<String, Object> params = new HashMap<>();
+
         if (!showInactive) {
             queryFilter.append(" WHERE (\"PROJECT\".\"ACTIVE\" = :active OR \"PROJECT\".\"ACTIVE\" IS NULL)");
             params.put("active", true);
         }
+
+        if (!showSuppressed) {
+            if (queryFilter.isEmpty()) {
+                queryFilter.append(" WHERE ");
+            } else {
+                queryFilter.append(" AND ");
+            }
+            queryFilter.append("(\"ANALYSIS\".\"SUPPRESSED\" = :showSuppressed OR \"ANALYSIS\".\"SUPPRESSED\" IS NULL)");
+            params.put("showSuppressed", false);
+        }
+
         processFilters(filters, queryFilter, params, true);
-        final Query<Object[]> query = pm.newQuery(Query.SQL, GroupedFinding.QUERY + queryFilter + (this.orderBy != null ? " ORDER BY " + sortingAttributes.get(this.orderBy) + " " + (this.orderDirection == OrderDirection.DESCENDING ? " DESC" : "ASC") : ""));
+
+        var queryBuilder = new StringBuilder(GroupedFinding.QUERY);
+        queryBuilder.append(queryFilter);
+
+        if (this.orderBy != null) {
+            queryBuilder
+                    .append(" ORDER BY ")
+                    .append(sortingAttributes.get(this.orderBy))
+                    .append(' ')
+                    .append(this.orderDirection == OrderDirection.DESCENDING ? "DESC" : "ASC");
+
+            // Add secondary sort if not already sorting by vulnId
+            if (!"vulnerability.vulnId".equals(this.orderBy)) {
+                queryBuilder
+                        .append(", ")
+                        .append(sortingAttributes.get("vulnerability.vulnId"))
+                        .append(' ')
+                        .append(this.orderDirection == OrderDirection.DESCENDING ? "DESC" : "ASC");
+            }
+        }
+
+        queryBuilder.append(' ');
+        queryBuilder.append(getOffsetLimitSqlClause());
+
+        final Query<Object[]> query = pm.newQuery(Query.SQL, queryBuilder.toString());
+
         PaginatedResult result = new PaginatedResult();
         query.setNamedParameters(params);
-        final List<Object[]> totalList = query.executeList();
-        result.setTotal(totalList.size());
-        final List<Object[]> list = totalList.subList(this.pagination.getOffset(), Math.min(this.pagination.getOffset() + this.pagination.getLimit(), totalList.size()));
+        final List<Object[]> list = query.executeList();
+        result.setTotal(getAllFindingsGroupedByVulnerabilityCount(filters, showSuppressed, showInactive));
         final List<GroupedFinding> findings = new ArrayList<>();
         for (Object[] o : list) {
             final GroupedFinding finding = new GroupedFinding(o);
@@ -179,6 +239,42 @@ public class FindingsSearchQueryManager extends QueryManager implements IQueryMa
         result.setObjects(findings);
         return result;
     }
+
+    /**
+     * Returns the total number of unique vulnerabilities
+     * @param filters        determines the filters to apply on the list of Finding objects
+     * @param showSuppressed determines if suppressed vulnerabilities should be included or not
+     * @param showInactive   determines if inactive projects should be included or not
+     * @return a Long containing the number of findings
+     */
+    public Long getAllFindingsGroupedByVulnerabilityCount(final Map<String, String> filters, final boolean showSuppressed, final boolean showInactive) {
+        StringBuilder queryFilter = new StringBuilder();
+        Map<String, Object> params = new HashMap<>();
+
+        if (!showInactive) {
+            queryFilter.append(" WHERE (\"PROJECT\".\"ACTIVE\" = :active OR \"PROJECT\".\"ACTIVE\" IS NULL)");
+            params.put("active", true);
+        }
+
+        if (!showSuppressed) {
+            if (queryFilter.isEmpty()) {
+                queryFilter.append(" WHERE ");
+            } else {
+                queryFilter.append(" AND ");
+            }
+            queryFilter.append("(\"ANALYSIS\".\"SUPPRESSED\" = :showSuppressed OR \"ANALYSIS\".\"SUPPRESSED\" IS NULL)");
+            params.put("showSuppressed", false);
+        }
+
+        processFilters(filters, queryFilter, params, true);
+
+        var sqlString = COUNT_FINDINGS_GROUPED_BY_VULN_SELECT_CLAUSE + queryFilter.toString() + COUNT_FINDINGS_GROUPED_BY_VULN_TERMINATOR;
+
+        final Query<Object[]> query = pm.newQuery(Query.SQL, sqlString);
+        query.setNamedParameters(params);
+        return query.executeResultUnique(Long.class);
+    }
+
 
     private void processFilters(Map<String, String> filters, StringBuilder queryFilter, Map<String, Object> params, boolean isGroupedByVulnerabilities) {
         for (String filter : filters.keySet()) {
@@ -302,25 +398,6 @@ public class FindingsSearchQueryManager extends QueryManager implements IQueryMa
         }
     }
 
-    private void processAggregatedDateRangeFilter(StringBuilder queryFilter, Map<String, Object> params, String paramName, String filter, String column, boolean fromValue, boolean isMin) {
-        if (filter != null && !filter.isEmpty()) {
-            if (queryFilter.isEmpty()) {
-                queryFilter.append(" HAVING (");
-            } else {
-                queryFilter.append(isMin ? " AND (" : " OR ");
-            }
-            if (DbUtil.isPostgreSQL()) {
-                queryFilter.append(column).append(fromValue ? " >= " : " <= ");
-                queryFilter.append("TO_TIMESTAMP(:").append(paramName).append(", 'YYYY-MM-DD HH24:MI:SS')");
-            } else {
-                queryFilter.append(column).append(fromValue ? " >= :" : " <= :").append(paramName);
-            }
-            params.put(paramName, filter + (fromValue ? " 00:00:00" : " 23:59:59"));
-            if (!isMin) {
-                queryFilter.append(")");
-            }
-        }
-    }
 
     private void processInputFilter(StringBuilder queryFilter, Map<String, Object> params, String paramName, String filter, String input) {
         if (filter != null && !filter.isEmpty() && input != null && !input.isEmpty()) {

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1131,8 +1131,12 @@ public class QueryManager extends AlpineQueryManager {
         return getFindingsSearchQueryManager().getAllFindings(filters, showSuppressed, showInactive);
     }
 
-    public PaginatedResult getAllFindingsGroupedByVulnerability(final Map<String, String> filters, final boolean showInactive) {
-        return getFindingsSearchQueryManager().getAllFindingsGroupedByVulnerability(filters, showInactive);
+    public PaginatedResult getAllFindingsGroupedByVulnerability(final Map<String, String> filters, final boolean showSuppressed, final boolean showInactive) {
+        return getFindingsSearchQueryManager().getAllFindingsGroupedByVulnerability(filters, showSuppressed, showInactive);
+    }
+
+    public Long getAllFindingsGroupedByVulnerabilityCount(final Map<String, String> filters, final boolean showSuppressed, final boolean showInactive) {
+        return getFindingsSearchQueryManager().getAllFindingsGroupedByVulnerabilityCount(filters, showSuppressed, showInactive);
     }
 
     public List<VulnerabilityMetrics> getVulnerabilityMetrics() {

--- a/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
@@ -330,6 +330,8 @@ public class FindingResource extends AlpineResource {
     @PermissionRequired(Permissions.Constants.VIEW_VULNERABILITY)
     public Response getAllFindings(@Parameter(description = "Show inactive projects")
                                    @QueryParam("showInactive") boolean showInactive,
+                                   @Parameter(description = "Show suppressed findings")
+                                   @QueryParam("showSuppressed") boolean showSuppressed,
                                    @Parameter(description = "Filter by severity")
                                    @QueryParam("severity") String severity,
                                    @Parameter(description = "Filter published from this date")
@@ -377,7 +379,7 @@ public class FindingResource extends AlpineResource {
             filters.put("epssPercentileTo", epssPercentileTo);
             filters.put("occurrencesFrom", occurrencesFrom);
             filters.put("occurrencesTo", occurrencesTo);
-            final PaginatedResult result = qm.getAllFindingsGroupedByVulnerability(filters, showInactive);
+            final PaginatedResult result = qm.getAllFindingsGroupedByVulnerability(filters, showSuppressed, showInactive);
             return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
         }
     }

--- a/src/test/java/org/dependencytrack/persistence/FindingsSearchQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/FindingsSearchQueryManagerTest.java
@@ -1,0 +1,411 @@
+package org.dependencytrack.persistence;
+
+import alpine.persistence.OrderDirection;
+import alpine.persistence.PaginatedResult;
+import alpine.persistence.Pagination;
+import alpine.resources.AlpineRequest;
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.*;
+import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.Date;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class FindingsSearchQueryManagerTest extends PersistenceCapableTest {
+
+    public FindingsSearchQueryManagerTest() {
+
+        // Using a constructor rather than a @BeforeEach setup() method as it seems to be faster - tests run in 50ms
+        // using a constructor versus 3000ms using an annotated setup method. End result is identical in both cases.
+        super();
+
+        AlpineRequest alpineRequest = Mockito.mock(AlpineRequest.class);
+        Mockito.when(alpineRequest.getPagination()).thenReturn(new Pagination(Pagination.Strategy.OFFSET, 0, 25));
+        this.qm = new QueryManager(alpineRequest);
+
+        buildAndPersistTestVulnerability("INT-2025-00001", Severity.UNASSIGNED);
+        buildAndPersistTestVulnerability("INT-2025-00002", Severity.CRITICAL);
+        buildAndPersistTestVulnerability("INT-2025-00003", Severity.MEDIUM);
+        buildAndPersistTestVulnerability("INT-2025-00004", Severity.MEDIUM);
+        buildAndPersistTestVulnerability("INT-2025-00005", Severity.LOW);
+
+        buildTestProject("Test Project 1 - Active", false, true);
+        buildTestProject("Test Project 2 - Active - No Suppression", true, true);
+        buildTestProject("Test Project 3 - Inactive - No Suppression", false, false);
+        buildTestProject("Test Project 4 - Inactive", true, false);
+
+        for (var projectNum = 5; projectNum <= 10; projectNum++) {
+            buildTestProject("Test Project " + projectNum + " - Active", true, true);
+        }
+
+    }
+
+
+    private void buildAndPersistTestVulnerability(String vulnId, Severity severity) {
+        var vuln = new Vulnerability();
+        vuln.setVulnId(vulnId);
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(severity);
+        qm.persist(vuln);
+    }
+
+
+    private Project buildTestProject(final String testProjectName, final boolean suppressFinding, final boolean isActive) {
+        var project = qm.createProject(testProjectName, "Description 1", "1.0", null, null, null, isActive, false);
+
+        var comp1 = new Component();
+        comp1.setName("Component 1");
+        comp1.setProject(project);
+        comp1.setVersion("1.0");
+        qm.createComponent(comp1, false);
+
+        var vuln11 = qm.getVulnerabilityByVulnId(Vulnerability.Source.INTERNAL, "INT-2025-00001");
+        qm.addVulnerability(vuln11, comp1, AnalyzerIdentity.INTERNAL_ANALYZER, "Test Vulnerability 1 on Project " + project.getId(), "https://test.com/INT-2025-00001", new Date(1754397285));
+        if (suppressFinding) {
+            qm.makeAnalysis(comp1, vuln11, AnalysisState.NOT_AFFECTED, null, AnalysisResponse.UPDATE, null, true);
+        }
+
+        var vuln12 = qm.getVulnerabilityByVulnId(Vulnerability.Source.INTERNAL, "INT-2025-00002");
+        qm.addVulnerability(vuln12, comp1, AnalyzerIdentity.INTERNAL_ANALYZER, "Test Vulnerability 2 on Project " + project.getId(), "https://test.com/INT-2025-00002", new Date(1754397285));
+
+        var vuln13 = qm.getVulnerabilityByVulnId(Vulnerability.Source.INTERNAL, "INT-2025-00003");
+        qm.addVulnerability(vuln13, comp1, AnalyzerIdentity.INTERNAL_ANALYZER, "Test Vulnerability 3 on Project " + project.getId(), "https://test.com/INT-2025-00005", new Date(1754397285));
+
+        var comp2 = new Component();
+        comp2.setName("Component 2");
+        comp2.setProject(project);
+        comp2.setVersion("1.0");
+        qm.createComponent(comp2, false);
+
+        // Apply INT-2025-00002 to both components - total number of affected projects should be unaffected
+        var vuln22 = qm.getVulnerabilityByVulnId(Vulnerability.Source.INTERNAL, "INT-2025-00002");
+        qm.addVulnerability(vuln22, comp2, AnalyzerIdentity.INTERNAL_ANALYZER, "Test Vulnerability 2 on Project " + project.getId(), "https://test.com/INT-2025-00002", new Date(1754397285));
+
+        var vuln24 = qm.getVulnerabilityByVulnId(Vulnerability.Source.INTERNAL, "INT-2025-00004");
+        qm.addVulnerability(vuln24, comp2, AnalyzerIdentity.INTERNAL_ANALYZER, "Test Vulnerability 5 on Project " + project.getId(), "https://test.com/INT-2025-00004", new Date(1754397285));
+
+        // Test our setup logic - we should have 5 findings on the project overall including suppressions
+        assertEquals(5, qm.getFindings(project, true).size(), "Total number of findings including suppressions is wrong");
+        assertEquals(suppressFinding ? 4 : 5, qm.getFindings(project, false).size(), "Total number of findings excluding suppressions is wrong");
+
+        return project;
+    }
+
+
+    private Matcher<GroupedFinding> hasVulnerabilityWith(String expectedVulnId, Long expectedProjectCount) {
+        return allOf(
+                hasProperty("vulnerability", hasEntry("vulnId", expectedVulnId)),
+                hasProperty("vulnerability", hasEntry("affectedProjectCount", expectedProjectCount))
+        );
+    }
+
+
+    @Nested
+    class GetAllFindingsGroupedByVulnerabilityCountTests {
+
+        @Test
+        void testCountWithHideSuppressionsHideInactive() {
+            Long count = qm.getAllFindingsGroupedByVulnerabilityCount(Collections.emptyMap(), false, false);
+            assertNotNull(count, "Count should not be null");
+            assertEquals(4, count, "Count incorrect");
+        }
+
+
+        @Test
+        void testCountWithShowSuppressionsHideInactive() {
+            Long count = qm.getAllFindingsGroupedByVulnerabilityCount(Collections.emptyMap(), true, false);
+            assertNotNull(count, "Count should not be null");
+            assertEquals(4, count, "Count incorrect");
+        }
+
+
+        @Test
+        void testCountWithHideSuppressionsShowInactive() {
+            Long count = qm.getAllFindingsGroupedByVulnerabilityCount(Collections.emptyMap(), false, true);
+            assertNotNull(count, "Count should not be null");
+            assertEquals(4, count, "Count incorrect");
+        }
+
+
+        @Test
+        void testCountWithShowSuppressionsShowInactive() {
+            Long count = qm.getAllFindingsGroupedByVulnerabilityCount(Collections.emptyMap(), true, true);
+            assertNotNull(count, "Count should not be null");
+            assertEquals(4, count, "Count incorrect");
+        }
+
+    }
+
+
+    @Nested
+    class SortingTests {
+
+        @Test
+        void testSortingByVulnIdDesc() {
+
+            AlpineRequest alpineRequest = Mockito.mock(AlpineRequest.class);
+            Mockito.when(alpineRequest.getOrderBy()).thenReturn("vulnerability.vulnId");
+            Mockito.when(alpineRequest.getOrderDirection()).thenReturn(OrderDirection.DESCENDING);
+            qm = new QueryManager(alpineRequest);
+
+            PaginatedResult allFindingsGroupedByVulnerability = qm.getAllFindingsGroupedByVulnerability(Collections.emptyMap(), true, true);
+            assertNotNull(allFindingsGroupedByVulnerability, "Findings should not be null");
+            assertEquals(4, allFindingsGroupedByVulnerability.getTotal(), "Total item count incorrect");
+            assertEquals(4, allFindingsGroupedByVulnerability.getList(GroupedFinding.class).size(), "Page item count incorrect");
+
+            var findings = allFindingsGroupedByVulnerability.getList(GroupedFinding.class);
+
+            assertThat(findings, contains(
+                    hasVulnerabilityWith("INT-2025-00004", 10L),
+                    hasVulnerabilityWith("INT-2025-00003", 10L),
+                    hasVulnerabilityWith("INT-2025-00002", 10L),
+                    hasVulnerabilityWith("INT-2025-00001", 10L)
+            ));
+        }
+
+
+        @Test
+        void testSortingByVulnIdAsc() {
+
+            AlpineRequest alpineRequest = Mockito.mock(AlpineRequest.class);
+            Mockito.when(alpineRequest.getOrderBy()).thenReturn("vulnerability.vulnId");
+            Mockito.when(alpineRequest.getOrderDirection()).thenReturn(OrderDirection.ASCENDING);
+            qm = new QueryManager(alpineRequest);
+
+            PaginatedResult allFindingsGroupedByVulnerability = qm.getAllFindingsGroupedByVulnerability(Collections.emptyMap(), true, true);
+            assertNotNull(allFindingsGroupedByVulnerability, "Findings should not be null");
+            assertEquals(4, allFindingsGroupedByVulnerability.getTotal(), "Total item count incorrect");
+            assertEquals(4, allFindingsGroupedByVulnerability.getList(GroupedFinding.class).size(), "Page item count incorrect");
+
+            var findings = allFindingsGroupedByVulnerability.getList(GroupedFinding.class);
+
+            assertThat(findings, contains(
+                    hasVulnerabilityWith("INT-2025-00001", 10L),
+                    hasVulnerabilityWith("INT-2025-00002", 10L),
+                    hasVulnerabilityWith("INT-2025-00003", 10L),
+                    hasVulnerabilityWith("INT-2025-00004", 10L)
+            ));
+        }
+
+
+        @Test
+        void testSortingBySeverityDescWithSecondaryVulnIdDesc() {
+
+            AlpineRequest alpineRequest = Mockito.mock(AlpineRequest.class);
+            Mockito.when(alpineRequest.getOrderBy()).thenReturn("vulnerability.severity");
+            Mockito.when(alpineRequest.getOrderDirection()).thenReturn(OrderDirection.DESCENDING);
+            qm = new QueryManager(alpineRequest);
+
+            PaginatedResult allFindingsGroupedByVulnerability = qm.getAllFindingsGroupedByVulnerability(Collections.emptyMap(), true, true);
+            assertNotNull(allFindingsGroupedByVulnerability, "Findings should not be null");
+            assertEquals(4, allFindingsGroupedByVulnerability.getTotal(), "Total item count incorrect");
+            assertEquals(4, allFindingsGroupedByVulnerability.getList(GroupedFinding.class).size(), "Page item count incorrect");
+
+            var findings = allFindingsGroupedByVulnerability.getList(GroupedFinding.class);
+
+            assertThat(findings, contains(
+                    hasVulnerabilityWith("INT-2025-00002", 10L), // Crit
+                    hasVulnerabilityWith("INT-2025-00004", 10L), // Med
+                    hasVulnerabilityWith("INT-2025-00003", 10L), // Med
+                    hasVulnerabilityWith("INT-2025-00001", 10L)  // Unassigned
+            ));
+        }
+
+
+        @Test
+        void testSortingBySeverityDescWithSecondaryVulnIdAsc() {
+
+            AlpineRequest alpineRequest = Mockito.mock(AlpineRequest.class);
+            Mockito.when(alpineRequest.getOrderBy()).thenReturn("vulnerability.severity");
+            Mockito.when(alpineRequest.getOrderDirection()).thenReturn(OrderDirection.ASCENDING);
+            qm = new QueryManager(alpineRequest);
+
+            PaginatedResult allFindingsGroupedByVulnerability = qm.getAllFindingsGroupedByVulnerability(Collections.emptyMap(), true, true);
+            assertNotNull(allFindingsGroupedByVulnerability, "Findings should not be null");
+            assertEquals(4, allFindingsGroupedByVulnerability.getTotal(), "Total item count incorrect");
+            assertEquals(4, allFindingsGroupedByVulnerability.getList(GroupedFinding.class).size(), "Page item count incorrect");
+
+            var findings = allFindingsGroupedByVulnerability.getList(GroupedFinding.class);
+
+            assertThat(findings, contains(
+                    hasVulnerabilityWith("INT-2025-00001", 10L), // Unassigned
+                    hasVulnerabilityWith("INT-2025-00003", 10L), // Med
+                    hasVulnerabilityWith("INT-2025-00004", 10L), // Med
+                    hasVulnerabilityWith("INT-2025-00002", 10L)  // Crit
+            ));
+        }
+    }
+
+
+    @Nested
+    class PaginationTests {
+
+        @Test
+        void testPaginationWithLargePageSizeReturnsSinglePage() {
+
+            AlpineRequest alpineRequest = Mockito.mock(AlpineRequest.class);
+            Mockito.when(alpineRequest.getPagination()).thenReturn(new Pagination(Pagination.Strategy.OFFSET, 0, 100));
+            Mockito.when(alpineRequest.getOrderBy()).thenReturn("vulnerability.vulnId");
+            Mockito.when(alpineRequest.getOrderDirection()).thenReturn(OrderDirection.DESCENDING);
+            qm = new QueryManager(alpineRequest);
+
+            PaginatedResult allFindingsGroupedByVulnerability = qm.getAllFindingsGroupedByVulnerability(Collections.emptyMap(), false, false);
+            assertNotNull(allFindingsGroupedByVulnerability, "Findings should not be null");
+            assertEquals(4, allFindingsGroupedByVulnerability.getTotal(), "Total item count incorrect");
+            assertEquals(4, allFindingsGroupedByVulnerability.getList(GroupedFinding.class).size(), "Page item count incorrect");
+
+            var findings = allFindingsGroupedByVulnerability.getList(GroupedFinding.class);
+
+            assertThat(findings, contains(
+                    hasVulnerabilityWith("INT-2025-00004", 8L),
+                    hasVulnerabilityWith("INT-2025-00003", 8L),
+                    hasVulnerabilityWith("INT-2025-00002", 8L),
+                    hasVulnerabilityWith("INT-2025-00001", 1L)
+            ));
+        }
+
+
+        @Test
+        void testPaginationWithPageSizeOfTwoCheckFirstPage() {
+
+            // Set up pagination behaviour - max of 2 results per page
+            AlpineRequest alpineRequest = Mockito.mock(AlpineRequest.class);
+            Mockito.when(alpineRequest.getPagination()).thenReturn(new Pagination(Pagination.Strategy.PAGES, 1, 2));
+            Mockito.when(alpineRequest.getOrderBy()).thenReturn("vulnerability.vulnId");
+            Mockito.when(alpineRequest.getOrderDirection()).thenReturn(OrderDirection.DESCENDING);
+            qm = new QueryManager(alpineRequest);
+
+            PaginatedResult allFindingsGroupedByVulnerability = qm.getAllFindingsGroupedByVulnerability(Collections.emptyMap(), false, false);
+            assertNotNull(allFindingsGroupedByVulnerability, "Findings should not be null");
+            assertEquals(4, allFindingsGroupedByVulnerability.getTotal(), "Total item count incorrect");
+            assertEquals(2, allFindingsGroupedByVulnerability.getList(GroupedFinding.class).size(), "Page item count incorrect");
+
+            var findings = allFindingsGroupedByVulnerability.getList(GroupedFinding.class);
+
+            assertThat(findings, contains(
+                    hasVulnerabilityWith("INT-2025-00004", 8L),
+                    hasVulnerabilityWith("INT-2025-00003", 8L)
+            ));
+        }
+
+
+        @Test
+        void testPaginationWithPageSizeOfTwoCheckSecondPage() {
+
+            // Set up pagination behaviour - max of 2 results per page
+            AlpineRequest alpineRequest = Mockito.mock(AlpineRequest.class);
+            Mockito.when(alpineRequest.getPagination()).thenReturn(new Pagination(Pagination.Strategy.PAGES, 2, 2));
+            Mockito.when(alpineRequest.getOrderBy()).thenReturn("vulnerability.vulnId");
+            Mockito.when(alpineRequest.getOrderDirection()).thenReturn(OrderDirection.DESCENDING);
+            qm = new QueryManager(alpineRequest);
+
+            // Page 2
+            PaginatedResult allFindingsGroupedByVulnerability = qm.getAllFindingsGroupedByVulnerability(Collections.emptyMap(), false, false);
+            assertNotNull(allFindingsGroupedByVulnerability, "Findings should not be null");
+            assertEquals(4, allFindingsGroupedByVulnerability.getTotal(), "Total item count incorrect");
+            assertEquals(2, allFindingsGroupedByVulnerability.getList(GroupedFinding.class).size(), "Page item count incorrect");
+
+            var findings2 = allFindingsGroupedByVulnerability.getList(GroupedFinding.class);
+
+            assertThat(findings2, contains(
+                    hasVulnerabilityWith("INT-2025-00002", 8L),
+                    hasVulnerabilityWith("INT-2025-00001", 1L)
+            ));
+        }
+    }
+
+
+    @Nested
+    class GetAllFindingsGroupedByVulnerabilityTests {
+
+        @Test
+        void getAllFindingsGroupedByVulnerabilityReturnsExpectedFindingsActiveProjectsExclSuppressed() {
+
+            // Get findings - hide suppressed, hide inactive projects
+            PaginatedResult allFindingsGroupedByVulnerability = qm.getAllFindingsGroupedByVulnerability(Collections.emptyMap(), false, false);
+            assertNotNull(allFindingsGroupedByVulnerability, "Findings should not be null");
+            assertEquals(4, allFindingsGroupedByVulnerability.getTotal(), "Findings collection item count incorrect");
+
+            var findings = allFindingsGroupedByVulnerability.getList(GroupedFinding.class);
+
+            assertThat(findings, containsInAnyOrder(
+                    hasVulnerabilityWith("INT-2025-00001", 1L),
+                    hasVulnerabilityWith("INT-2025-00002", 8L),
+                    hasVulnerabilityWith("INT-2025-00003", 8L),
+                    hasVulnerabilityWith("INT-2025-00004", 8L)
+            ));
+
+        }
+
+
+        @Test
+        void getAllFindingsGroupedByVulnerabilityReturnsExpectedFindingsActiveProjectsInclSuppressed() {
+
+            // Get findings - show suppressed, hide inactive projects
+            PaginatedResult allFindingsGroupedByVulnerability = qm.getAllFindingsGroupedByVulnerability(Collections.emptyMap(), true, false);
+            assertNotNull(allFindingsGroupedByVulnerability, "Findings should not be null");
+            assertEquals(4, allFindingsGroupedByVulnerability.getTotal(), "Findings collection item count incorrect");
+
+            var findings = allFindingsGroupedByVulnerability.getList(GroupedFinding.class);
+
+            assertThat(findings, containsInAnyOrder(
+                    hasVulnerabilityWith("INT-2025-00001", 8L),
+                    hasVulnerabilityWith("INT-2025-00002", 8L),
+                    hasVulnerabilityWith("INT-2025-00003", 8L),
+                    hasVulnerabilityWith("INT-2025-00004", 8L)
+            ));
+
+        }
+
+
+        @Test
+        void getAllFindingsGroupedByVulnerabilityReturnsExpectedFindingsActiveAndInactiveProjectsExclSuppressed() {
+
+            // Get findings - hide suppressed, show inactive projects
+            PaginatedResult allFindingsGroupedByVulnerability = qm.getAllFindingsGroupedByVulnerability(Collections.emptyMap(), false, true);
+            assertNotNull(allFindingsGroupedByVulnerability, "Findings should not be null");
+            assertEquals(4, allFindingsGroupedByVulnerability.getTotal(), "Findings collection item count incorrect");
+
+            var findings = allFindingsGroupedByVulnerability.getList(GroupedFinding.class);
+
+            assertThat(findings, containsInAnyOrder(
+                    hasVulnerabilityWith("INT-2025-00001", 2L),
+                    hasVulnerabilityWith("INT-2025-00002", 10L),
+                    hasVulnerabilityWith("INT-2025-00003", 10L),
+                    hasVulnerabilityWith("INT-2025-00004", 10L)
+            ));
+
+        }
+
+
+        @Test
+        void getAllFindingsGroupedByVulnerabilityReturnsExpectedFindingsActiveAndInactiveProjectsInclSuppressed() {
+
+            // Get findings - show suppressed, show inactive projects
+            PaginatedResult allFindingsGroupedByVulnerability = qm.getAllFindingsGroupedByVulnerability(Collections.emptyMap(), true, true);
+            assertNotNull(allFindingsGroupedByVulnerability, "Findings should not be null");
+            assertEquals(4, allFindingsGroupedByVulnerability.getTotal(), "Findings collection item count incorrect");
+
+            var findings = allFindingsGroupedByVulnerability.getList(GroupedFinding.class);
+
+            assertThat(findings, containsInAnyOrder(
+                    hasVulnerabilityWith("INT-2025-00001", 10L),
+                    hasVulnerabilityWith("INT-2025-00002", 10L),
+                    hasVulnerabilityWith("INT-2025-00003", 10L),
+                    hasVulnerabilityWith("INT-2025-00004", 10L)
+            ));
+        }
+
+    }
+
+
+}


### PR DESCRIPTION
### Description

Adds the ability to exclude suppressed findings from the Vulnerability Audit "Grouped Vulnerabilities" tab, mirroring the functionality in the "Vulnerabilities By Occurrence" tab. Defaults to hiding suppressed findings.

Existing behaviour with suppressed findings visible:

<img width="3762" height="1420" alt="issue-4507-show-suppressed-on" src="https://github.com/user-attachments/assets/9796ceff-245a-4d1c-8bf7-f94949c0968f" />

New behaviour with suppressed findings hidden:

<img width="3762" height="1420" alt="issue-4507-show-suppressed-off" src="https://github.com/user-attachments/assets/ae524aa0-ab19-4311-8a72-3a38c1576ac5" />

### Addressed Issue
Resolves #4507

### Additional Details
Added showSuppressed filtering based on getAllFindings(). Differs from that method though in that pagination is handled via SQL instead of retrieving all records then sublisting results which should be more performant on large result sets.

Separate PR will be raised to cover the front end change - this PR will be edited to link to that PR.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~[ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
