### PR TITLE
improve detection if version is commit sha or release tag for github purl

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/repositories/GithubMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/GithubMetaAnalyzer.java
@@ -43,6 +43,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 public class GithubMetaAnalyzer extends AbstractMetaAnalyzer {
 
     private static final Logger LOGGER = Logger.getLogger(GithubMetaAnalyzer.class);
+    private static final String COMMIT_SHA_REGEXP = "^(?:[0-9a-fA-F]{7}|[0-9a-fA-F]{40})$";
 
     private enum VersionType {
         RELEASE,
@@ -97,16 +98,20 @@ public class GithubMetaAnalyzer extends AbstractMetaAnalyzer {
      * @throws IOException when GitHub API Calls fail
      */
     private VersionType get_version_type(final Component component, GHRepository repository) throws IOException {
-        if (component.getPurl().getVersion() == null){
+        if (component.getPurl().getVersion() == null) {
             LOGGER.debug(String.format("Version is not set, assuming %s", DEFAULT_VERSION_TYPE.name()));
             return DEFAULT_VERSION_TYPE;
         }
-        if (repository.getReleaseByTagName(component.getPurl().getVersion()) != null){
+        if (repository.getReleaseByTagName(component.getPurl().getVersion()) != null) {
             LOGGER.debug("Version is release");
             return VersionType.RELEASE;
-        } else {
-            LOGGER.debug("Version is commit");
+        }
+        if (component.getPurl().getVersion().matches(COMMIT_SHA_REGEXP)) {
+            LOGGER.debug("Version is commit sha");
             return VersionType.COMMIT;
+        } else {
+            LOGGER.debug(String.format("Most probably version is incorrect, assuming %s", DEFAULT_VERSION_TYPE.name()));
+            return DEFAULT_VERSION_TYPE;
         }
     }
 

--- a/src/test/java/org/dependencytrack/tasks/repositories/GitHubMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/GitHubMetaAnalyzerTest.java
@@ -24,101 +24,57 @@ import org.dependencytrack.model.RepositoryType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 
 // TODO this depends on an external API and will fail if that API doesn't respond fast enough; this especially
 //      happens rather fast when executing tests locally repeatedly
 @Timeout(value = 5, unit = TimeUnit.SECONDS)
 class GitHubMetaAnalyzerTest {
 
-    private static final String VERSION_TYPE_PATTERN = "[a-f,0-9]{6,40}";
-    @Test
-    void testAnalyzerRelease() throws Exception {
+    private static final String COMMIT_LATEST_VERSION_TYPE_PATTERN = "^[a-f0-9]{7,40}$";
+    private static final String RELEASE_LATEST_VERSION_TYPE_PATTERN = "^v.*$";
+
+    @ParameterizedTest
+    @MethodSource("testAnalyzerData")
+    void testAnalyzerInvalidTag(String purl, String latestVersionPattern, Boolean versionExists) throws Exception {
         final var component = new Component();
-        component.setPurl(new PackageURL("pkg:github/CycloneDX/cdxgen@v9.8.9"));
+        component.setPurl(new PackageURL(purl));
 
         final var analyzer = new GithubMetaAnalyzer();
         Assertions.assertTrue(analyzer.isApplicable(component));
         Assertions.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
 
         MetaModel metaModel = analyzer.analyze(component);
-        Assertions.assertNotNull(metaModel.getLatestVersion());
-        Assertions.assertTrue(metaModel.getLatestVersion().startsWith("v"));
-        Assertions.assertNotNull(metaModel.getPublishedTimestamp());
-    }
-    @Test
-    void testAnalyzerLongCommit() throws Exception{
-        final var component = new Component();
-        component.setPurl(new PackageURL("pkg:github/CycloneDX/cdxgen@4359dee1b7bd29ee25bc78e358a1254a0277ee96"));
-        Pattern version_pattern = Pattern.compile(VERSION_TYPE_PATTERN);
 
-        final var analyzer = new GithubMetaAnalyzer();
-        Assertions.assertTrue(analyzer.isApplicable(component));
-        Assertions.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
-
-        MetaModel metaModel = analyzer.analyze(component);
         Assertions.assertNotNull(metaModel.getLatestVersion());
-        Assertions.assertTrue(version_pattern.matcher(metaModel.getLatestVersion()).find());
-        Assertions.assertNotNull(metaModel.getPublishedTimestamp());
+        Assertions.assertTrue(metaModel.getLatestVersion().matches(latestVersionPattern));
+        if (versionExists) {
+            Assertions.assertNotNull(metaModel.getPublishedTimestamp());
+        } else {
+            Assertions.assertNull(metaModel.getPublishedTimestamp());
+        }
     }
 
-    @Test
-    void testAnalyzerShortCommit() throws Exception{
-        final var component = new Component();
-        component.setPurl(new PackageURL("pkg:github/CycloneDX/cdxgen@4359dee"));
-        Pattern version_pattern = Pattern.compile(VERSION_TYPE_PATTERN);
 
-        final var analyzer = new GithubMetaAnalyzer();
-        Assertions.assertTrue(analyzer.isApplicable(component));
-        Assertions.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
-
-        MetaModel metaModel = analyzer.analyze(component);
-        Assertions.assertNotNull(metaModel.getLatestVersion());
-        Assertions.assertTrue(version_pattern.matcher(metaModel.getLatestVersion()).find());
-        Assertions.assertNotNull(metaModel.getPublishedTimestamp());
-    }
-
-    @Test
-    void testAnalyzerNoVersion() throws Exception{
-        final var component = new Component();
-        component.setPurl(new PackageURL("pkg:github/CycloneDX/cdxgen"));
-
-        final var analyzer = new GithubMetaAnalyzer();
-        Assertions.assertTrue(analyzer.isApplicable(component));
-        Assertions.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
-
-        MetaModel metaModel = analyzer.analyze(component);
-        Assertions.assertNotNull(metaModel.getLatestVersion());
-        Assertions.assertTrue(metaModel.getLatestVersion().startsWith("v"));
-        Assertions.assertNull(metaModel.getPublishedTimestamp());
-    }
-    @Test
-    void testAnalyzerInvalidCommit() throws Exception{
-        final var component = new Component();
-        component.setPurl(new PackageURL("pkg:github/CycloneDX/cdxgen@0000000"));
-
-        final var analyzer = new GithubMetaAnalyzer();
-        Assertions.assertTrue(analyzer.isApplicable(component));
-        Assertions.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
-
-        MetaModel metaModel = analyzer.analyze(component);
-        Assertions.assertNotNull(metaModel.getLatestVersion());
-        Assertions.assertNull(metaModel.getPublishedTimestamp());
-    }
-
-    @Test
-    void testAnalyzerInvalidRelease() throws Exception {
-        final var component = new Component();
-        component.setPurl(new PackageURL("pkg:github/CycloneDX/cdxgen@invalid-release"));
-
-        final var analyzer = new GithubMetaAnalyzer();
-        Assertions.assertTrue(analyzer.isApplicable(component));
-        Assertions.assertEquals(RepositoryType.GITHUB, analyzer.supportedRepositoryType());
-
-        MetaModel metaModel = analyzer.analyze(component);
-        Assertions.assertNotNull(metaModel.getLatestVersion());
-        Assertions.assertNull(metaModel.getPublishedTimestamp());
+    static Stream<Arguments> testAnalyzerData() {
+        return Stream.of(
+                Arguments.of("pkg:github/CycloneDX/cdxgen@v9.8.9", RELEASE_LATEST_VERSION_TYPE_PATTERN, TRUE),
+                Arguments.of("pkg:github/CycloneDX/cdxgen@4359dee1b7bd29ee25bc78e358a1254a0277ee96", COMMIT_LATEST_VERSION_TYPE_PATTERN, TRUE),
+                Arguments.of("pkg:github/CycloneDX/cdxgen@4359dee", COMMIT_LATEST_VERSION_TYPE_PATTERN, TRUE),
+                Arguments.of("pkg:github/CycloneDX/cdxgen", RELEASE_LATEST_VERSION_TYPE_PATTERN, FALSE),
+                Arguments.of("pkg:github/CycloneDX/cdxgen@0000000", COMMIT_LATEST_VERSION_TYPE_PATTERN, FALSE),
+                Arguments.of("pkg:github/CycloneDX/cdxgen@invalid-release", RELEASE_LATEST_VERSION_TYPE_PATTERN, FALSE),
+                Arguments.of("pkg:github/google/gtm-session-fetcher@3.1.0", RELEASE_LATEST_VERSION_TYPE_PATTERN, FALSE),
+                Arguments.of("pkg:github/boostorg/boost@1.88.0.beta1", "boost-.*", FALSE)
+        );
     }
 }


### PR DESCRIPTION
### Description
Improve detection if version is commit sha or release tag for github purl

### Addressed Issue

Fixes #4945


### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
