### PR TITLE
Fix NullPointerException in GithubMetaAnalyzer when analyzing GitHub Actions

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/repositories/GithubMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/GithubMetaAnalyzer.java
@@ -144,8 +144,12 @@ public class GithubMetaAnalyzer extends AbstractMetaAnalyzer {
                     }
                     GHRelease current_release = repository.getReleaseByTagName(component.getPurl().getVersion());
                     if (current_release != null) {
-                        meta.setPublishedTimestamp(current_release.getPublished_at());
-                        LOGGER.debug(String.format("Current version published at: %s", meta.getPublishedTimestamp()));
+                        if (current_release.getPublished_at() != null) {
+                            meta.setPublishedTimestamp(current_release.getPublished_at());
+                            LOGGER.debug(String.format("Current version published at: %s", meta.getPublishedTimestamp()));
+                        } else {
+                            LOGGER.debug("Current version has no published timestamp available");
+                        }
                     }
                 }
 
@@ -155,8 +159,12 @@ public class GithubMetaAnalyzer extends AbstractMetaAnalyzer {
                     meta.setLatestVersion(latest_release.getSHA1());
                     LOGGER.debug(String.format("Latest version: %s", meta.getLatestVersion()));
                     GHCommit current_release = repository.getCommit(component.getPurl().getVersion());
-                    meta.setPublishedTimestamp(current_release.getCommitDate());
-                    LOGGER.debug(String.format("Current version published at: %s", meta.getPublishedTimestamp()));
+                    if (current_release.getCommitDate() != null) {
+                        meta.setPublishedTimestamp(current_release.getCommitDate());
+                        LOGGER.debug(String.format("Current version published at: %s", meta.getPublishedTimestamp()));
+                    } else {
+                        LOGGER.debug("Current version has no published timestamp available");
+                    }
                 }
             } catch (IOException ex) {
                 handleRequestException(LOGGER, ex);


### PR DESCRIPTION
### Description

The GithubMetaAnalyzer was throwing NullPointerException at line 159 when analyzing certain GitHub Actions repositories (e.g., enricomi/publish-unit-test-result-action). This occurred because the GitHub API returns null for commit dates on some GitHub Actions repositories, particularly composite actions and repos with unusual commit histories. When the code attempted to log the null timestamp using String.format(), it caused the NPE and prevented successful repository metadata analysis.

This fix adds proper null checks before setting and logging the published timestamp in both COMMIT and RELEASE version handling paths.


### Addressed Issue
Fixes https://github.com/DependencyTrack/dependency-track/issues/5274

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect  ~~, and I have provided tests to verify that the fix is effective~~ 
- [ ] ~~This PR implements an enhancement, and I have provided tests to verify that it works as intended~~
- [ ] ~~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~~
- [ ] ~~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~~
