### PR TITLE
fix: dont ignore Running on info from NVD #5165

### DIFF
--- a/src/test/resources/unit/nvd/api/jsons/cve-2025-0913.json
+++ b/src/test/resources/unit/nvd/api/jsons/cve-2025-0913.json
@@ -1,0 +1,133 @@
+{
+  "resultsPerPage": 1,
+  "startIndex": 0,
+  "totalResults": 1,
+  "format": "NVD_CVE",
+  "version": "2.0",
+  "timestamp": "2025-09-04T17:31:36.790",
+  "vulnerabilities": [
+    {
+      "cve": {
+        "id": "CVE-2025-0913",
+        "sourceIdentifier": "security@golang.org",
+        "published": "2025-06-11T18:15:24.627",
+        "lastModified": "2025-08-08T14:53:03.550",
+        "vulnStatus": "Analyzed",
+        "cveTags": [],
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "os.OpenFile(path, os.O_CREATE|O_EXCL) behaved differently on Unix and Windows systems when the target path was a dangling symlink. On Unix systems, OpenFile with O_CREATE and O_EXCL flags never follows symlinks. On Windows, when the target path was a symlink to a nonexistent location, OpenFile would create a file in that location. OpenFile now always returns an error when the O_CREATE and O_EXCL flags are both set and the target path is a symlink."
+          },
+          {
+            "lang": "es",
+            "value": "os.OpenFile(path, os.O_CREATE|O_EXCL) se comportaba de forma diferente en sistemas Unix y Windows cuando la ruta de destino era un enlace simbólico pendiente. En sistemas Unix, OpenFile con los indicadores O_CREATE y O_EXCL nunca sigue enlaces simbólicos. En Windows, cuando la ruta de destino era un enlace simbólico a una ubicación inexistente, OpenFile creaba un archivo en esa ubicación. OpenFile ahora siempre devuelve un error cuando los indicadores O_CREATE y O_EXCL están activados y la ruta de destino es un enlace simbólico."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1\/AV:L\/AC:L\/PR:L\/UI:N\/S:U\/C:N\/I:H\/A:N",
+                "baseScore": 5.5,
+                "baseSeverity": "MEDIUM",
+                "attackVector": "LOCAL",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "LOW",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "NONE"
+              },
+              "exploitabilityScore": 1.8,
+              "impactScore": 3.6
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-59"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:golang:go:*:*:*:*:*:*:*:*",
+                    "versionEndExcluding": "1.23.10",
+                    "matchCriteriaId": "E629E4E8-C3BF-4BCA-969A-7F88BB968232"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:golang:go:*:*:*:*:*:*:*:*",
+                    "versionStartIncluding": "1.24.0",
+                    "versionEndExcluding": "1.24.4",
+                    "matchCriteriaId": "0925799A-339C-4155-ABC6-E772A0EB73B4"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "A2572D17-1DE6-457B-99CC-64AFD54487EA"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https:\/\/go.dev\/cl\/672396",
+            "source": "security@golang.org",
+            "tags": [
+              "Issue Tracking"
+            ]
+          },
+          {
+            "url": "https:\/\/go.dev\/issue\/73702",
+            "source": "security@golang.org",
+            "tags": [
+              "Issue Tracking"
+            ]
+          },
+          {
+            "url": "https:\/\/groups.google.com\/g\/golang-announce\/c\/ufZ8WpEsA3A",
+            "source": "security@golang.org",
+            "tags": [
+              "Mailing List"
+            ]
+          },
+          {
+            "url": "https:\/\/pkg.go.dev\/vuln\/GO-2025-3750",
+            "source": "security@golang.org",
+            "tags": [
+              "Vendor Advisory"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/unit/nvd/api/jsons/cve-2025-4056.json
+++ b/src/test/resources/unit/nvd/api/jsons/cve-2025-4056.json
@@ -1,0 +1,140 @@
+{
+  "resultsPerPage": 1,
+  "startIndex": 0,
+  "totalResults": 1,
+  "format": "NVD_CVE",
+  "version": "2.0",
+  "timestamp": "2025-09-04T06:13:13.470",
+  "vulnerabilities": [
+    {
+      "cve": {
+        "id": "CVE-2025-4056",
+        "sourceIdentifier": "secalert@redhat.com",
+        "published": "2025-07-28T13:15:30.177",
+        "lastModified": "2025-08-13T19:40:02.767",
+        "vulnStatus": "Analyzed",
+        "cveTags": [],
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "A flaw was found in GLib. A denial of service on Windows platforms may occur if an application attempts to spawn a program using long command lines."
+          },
+          {
+            "lang": "es",
+            "value": "Se encontró una falla en GLib. En plataformas Windows, puede producirse una denegación de servicio si una aplicación intenta generar un programa mediante líneas de comando largas."
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "secalert@redhat.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+                "baseScore": 3.7,
+                "baseSeverity": "LOW",
+                "attackVector": "NETWORK",
+                "attackComplexity": "HIGH",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "LOW"
+              },
+              "exploitabilityScore": 2.2,
+              "impactScore": 1.4
+            },
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                "baseScore": 7.5,
+                "baseSeverity": "HIGH",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "UNCHANGED",
+                "confidentialityImpact": "NONE",
+                "integrityImpact": "NONE",
+                "availabilityImpact": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.6
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "secalert@redhat.com",
+            "type": "Primary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-94"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "operator": "AND",
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:gnome:glib:*:*:*:*:*:*:*:*",
+                    "versionEndExcluding": "2.84.1",
+                    "matchCriteriaId": "5482ED3A-BF19-4797-82A5-0EAEA4D97D82"
+                  }
+                ]
+              },
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": false,
+                    "criteria": "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "A2572D17-1DE6-457B-99CC-64AFD54487EA"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://access.redhat.com/security/cve/CVE-2025-4056",
+            "source": "secalert@redhat.com",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2362826",
+            "source": "secalert@redhat.com",
+            "tags": [
+              "Issue Tracking",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://gitlab.gnome.org/GNOME/glib/-/issues/3668",
+            "source": "secalert@redhat.com",
+            "tags": [
+              "Issue Tracking"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description

The NVD explicitly includes the following CPE constraint:
Running on/with
cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*

Dependency-Track does not evaluate CPE platform constraints (like the OS) when matching CVEs with components.
This PR try to fix this issue by adding to targetsw CPE field the os. 

### Addressed Issue
- #5165

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
