### PR TITLE
Issue 5196

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/TagQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/TagQueryManager.java
@@ -176,10 +176,10 @@ public class TagQueryManager extends QueryManager implements IQueryManager {
         ) {
             this(
                     name,
-                    (long) projectCount,
-                    (long) collectionProjectCount,
-                    (long) policyCount,
-                    (long) notificationRuleCount,
+                    projectCount,
+                    collectionProjectCount,
+                    policyCount,
+                    notificationRuleCount,
                     (long) totalCount);
         }
 
@@ -272,11 +272,11 @@ public class TagQueryManager extends QueryManager implements IQueryManager {
             this(
                     id,
                     name,
-                    (long) projectCount,
-                    (long) accessibleProjectCount,
-                    (long) collectionProjectCount,
-                    (long) accessibleCollectionProjectCount,
-                    (long) policyCount,
+                    projectCount,
+                    accessibleProjectCount,
+                    collectionProjectCount,
+                    accessibleCollectionProjectCount,
+                    policyCount,
                     (long) notificationRuleCount);
         }
 

--- a/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
@@ -3,6 +3,10 @@ package org.dependencytrack.resources.v1;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import alpine.server.filters.AuthorizationFilter;
+import jakarta.json.JsonArray;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
 import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
@@ -23,10 +27,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junitpioneer.jupiter.DefaultLocale;
 
-import jakarta.json.JsonArray;
-import jakarta.ws.rs.HttpMethod;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -1668,11 +1668,10 @@ class TagResourceTest extends ResourceTest {
                 .get();
 
         Assertions.assertEquals(200, response.getStatus());
-        Assertions.assertEquals(String.valueOf(4), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(String.valueOf(0), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
         Assertions.assertNotNull(json);
-        Assertions.assertEquals(4, json.size());
-        Assertions.assertEquals("tag 2", json.getJsonObject(0).getString("name"));
+        Assertions.assertEquals(0, json.size());
     }
 
     @Test
@@ -1695,11 +1694,10 @@ class TagResourceTest extends ResourceTest {
                 .get();
 
         Assertions.assertEquals(200, response.getStatus());
-        Assertions.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(String.valueOf(0), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
         Assertions.assertNotNull(json);
-        Assertions.assertEquals(3, json.size());
-        Assertions.assertEquals("tag 1", json.getJsonObject(0).getString("name"));
+        Assertions.assertEquals(0, json.size());
     }
 
     @Test


### PR DESCRIPTION
### Description

Changes /tag/policy/$policy_uuid to return only tags of the policy itself, independent of whether a project is associated.

### Addressed Issue

Fixes #5196.

### Additional Details

Not sure what the intended behaviour is here. The documentation is unclear here. So this might be completely wrong. Additionally, in the second commit, some static analysis issues were addressed not related to the underlying issue, and I'd be happy to remove that commit.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
