### PR TITLE
Check for non-empty timestamp files in doDownload of NistMirrorTask

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/NistMirrorTask.java
+++ b/src/main/java/org/dependencytrack/tasks/NistMirrorTask.java
@@ -252,7 +252,7 @@ public class NistMirrorTask extends AbstractNistMirrorTask implements LoggableSu
     private long checkHead(final String cveUrl) {
         final HttpUriRequest request = new HttpHead(cveUrl);
         try (final CloseableHttpResponse response = HttpClientPool.getClient().execute(request)) {
-            return Long.valueOf(response.getFirstHeader(HttpHeaders.CONTENT_LENGTH).getValue());
+            return Long.parseLong(response.getFirstHeader(HttpHeaders.CONTENT_LENGTH).getValue());
         } catch (IOException | NumberFormatException | NullPointerException e) {
             LOGGER.error("Failed to determine content length");
         }
@@ -273,7 +273,7 @@ public class NistMirrorTask extends AbstractNistMirrorTask implements LoggableSu
             if (file.exists()) {
                 long modificationTime = 0;
                 File timestampFile = new File(outputDir, filename + ".ts");
-                if(timestampFile.exists()) {
+                if(timestampFile.exists() && timestampFile.length() > 0) {
                     BufferedReader tsBufReader = new BufferedReader(new FileReader(timestampFile));
                     String text = tsBufReader.readLine();
                     modificationTime = Long.parseLong(text);
@@ -345,7 +345,7 @@ public class NistMirrorTask extends AbstractNistMirrorTask implements LoggableSu
             }
         } catch (Throwable e) {
             mirroredWithoutErrors = false;
-            LOGGER.error("Download failed : " + e.getMessage());
+            LOGGER.error("Download failed: " + e.getMessage());
             Notification.dispatch(new Notification()
                     .scope(NotificationScope.SYSTEM)
                     .group(NotificationGroup.DATASOURCE_MIRRORING)


### PR DESCRIPTION
### Description

In the rare case that a timestamp file (.ts) is empty due to a crash or other ungraceful shutdown, the affected file will be read and parsed which causes an exception to be thrown. This would happen every time the task runs and thus not self correct. This fix will make sure the empty/corrupted .ts files are overwritten and the corresponding file is reacquired.

### Addressed Issue

Fixes #5322

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
