### PR TITLE
Backport: Fix NullPointerException in GithubMetaAnalyzer when analyzing GitHub Actions

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/repositories/GithubMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/GithubMetaAnalyzer.java
@@ -144,8 +144,12 @@ public class GithubMetaAnalyzer extends AbstractMetaAnalyzer {
                     }
                     GHRelease current_release = repository.getReleaseByTagName(component.getPurl().getVersion());
                     if (current_release != null) {
-                        meta.setPublishedTimestamp(current_release.getPublished_at());
-                        LOGGER.debug(String.format("Current version published at: %s", meta.getPublishedTimestamp()));
+                        if (current_release.getPublished_at() != null) {
+                            meta.setPublishedTimestamp(current_release.getPublished_at());
+                            LOGGER.debug(String.format("Current version published at: %s", meta.getPublishedTimestamp()));
+                        } else {
+                            LOGGER.debug("Current version has no published timestamp available");
+                        }
                     }
                 }
 
@@ -155,8 +159,12 @@ public class GithubMetaAnalyzer extends AbstractMetaAnalyzer {
                     meta.setLatestVersion(latest_release.getSHA1());
                     LOGGER.debug(String.format("Latest version: %s", meta.getLatestVersion()));
                     GHCommit current_release = repository.getCommit(component.getPurl().getVersion());
-                    meta.setPublishedTimestamp(current_release.getCommitDate());
-                    LOGGER.debug(String.format("Current version published at: %s", meta.getPublishedTimestamp()));
+                    if (current_release.getCommitDate() != null) {
+                        meta.setPublishedTimestamp(current_release.getCommitDate());
+                        LOGGER.debug(String.format("Current version published at: %s", meta.getPublishedTimestamp()));
+                    } else {
+                        LOGGER.debug("Current version has no published timestamp available");
+                    }
                 }
             } catch (IOException ex) {
                 handleRequestException(LOGGER, ex);


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes NullPointerException in GithubMetaAnalyzer when analyzing GitHub Actions.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/dependency-track/issues/5274
Backports https://github.com/DependencyTrack/dependency-track/pull/5275

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
