### PR TITLE
count all materialized vulnerabilities for metrics

### DIFF
--- a/src/test/java/org/dependencytrack/tasks/metrics/ComponentMetricsUpdateTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/metrics/ComponentMetricsUpdateTaskTest.java
@@ -300,15 +300,15 @@ class ComponentMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest {
         final DependencyMetrics metrics = qm.getMostRecentDependencyMetrics(component);
         assertThat(metrics.getCritical()).isZero();
         assertThat(metrics.getHigh()).isEqualTo(1); // INTERNAL-001
-        assertThat(metrics.getMedium()).isEqualTo(1); // GHSA-002
-        assertThat(metrics.getLow()).isZero();
+        assertThat(metrics.getMedium()).isEqualTo(2); // GHSA-002, SONATYPE-003
+        assertThat(metrics.getLow()).isEqualTo(1); // VULNDB-004
         assertThat(metrics.getUnassigned()).isZero();
-        assertThat(metrics.getVulnerabilities()).isEqualTo(2);
+        assertThat(metrics.getVulnerabilities()).isEqualTo(4);
         assertThat(metrics.getSuppressed()).isEqualTo(0);
-        assertThat(metrics.getFindingsTotal()).isEqualTo(2);
+        assertThat(metrics.getFindingsTotal()).isEqualTo(4);
         assertThat(metrics.getFindingsAudited()).isEqualTo(0);
-        assertThat(metrics.getFindingsUnaudited()).isEqualTo(2);
-        assertThat(metrics.getInheritedRiskScore()).isEqualTo(8.0);
+        assertThat(metrics.getFindingsUnaudited()).isEqualTo(4);
+        assertThat(metrics.getInheritedRiskScore()).isEqualTo(12.0);
         assertThat(metrics.getPolicyViolationsFail()).isZero();
         assertThat(metrics.getPolicyViolationsWarn()).isZero();
         assertThat(metrics.getPolicyViolationsInfo()).isZero();
@@ -326,7 +326,7 @@ class ComponentMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest {
         assertThat(metrics.getPolicyViolationsOperationalUnaudited()).isZero();
 
         qm.getPersistenceManager().refresh(component);
-        assertThat(component.getLastInheritedRiskScore()).isEqualTo(8.0);
+        assertThat(component.getLastInheritedRiskScore()).isEqualTo(12.0);
     }
 
 }


### PR DESCRIPTION
### Description

Changes metrics calculations to count all materialized vulnerabilities for every metric instead of counting virtual (aliased) vulnerabilities in one case and materialized vulnerabilities in other cases.

### Addressed Issue

Fixes #4261

### Additional Details

I opted for counting all materialized vulnerabilities to avoid confusion when some analyses for a virtual vulnerability would be counted as audited, while others wouldn't.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
