### PR TITLE
Fix referential integrity violation in project batch delete

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -1074,6 +1074,12 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                 );
                 executeAndCloseWithArray(sqlQuery, queryParameter);
 
+                sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """
+                    DELETE FROM "POLICYVIOLATION" WHERE "PROJECT_ID" = ANY(?);
+                    """.replace("= ANY(?)", inExpression)
+                );
+                executeAndCloseWithArray(sqlQuery, queryParameter);
+
                 // Deletion with CTEs does not work with H2, but verified on Postgres and MS SQL Server
                 if (!DbUtil.isH2()) {
                     if (DbUtil.isPostgreSQL()) {
@@ -1182,12 +1188,6 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
 
                 sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """
                     DELETE FROM "VIOLATIONANALYSIS" WHERE "PROJECT_ID" = ANY(?);
-                    """.replace("= ANY(?)", inExpression)
-                );
-                executeAndCloseWithArray(sqlQuery, queryParameter);
-
-                sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """
-                    DELETE FROM "POLICYVIOLATION" WHERE "PROJECT_ID" = ANY(?);
                     """.replace("= ANY(?)", inExpression)
                 );
                 executeAndCloseWithArray(sqlQuery, queryParameter);


### PR DESCRIPTION
### Description

Fixed an internal server error occurring when invoking the /v1/project/batchDelete endpoint.
The error was caused by a referential integrity constraint violation between the POLICYVIOLATION and COMPONENT tables during project deletion.

### Addressed Issue
Fixes https://github.com/DependencyTrack/dependency-track/issues/5390

### Checklist

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [X] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
