### PR TITLE
Fix referential integrity violation in team deletion

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -1074,12 +1074,6 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                 );
                 executeAndCloseWithArray(sqlQuery, queryParameter);
 
-                sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """
-                    DELETE FROM "POLICYVIOLATION" WHERE "PROJECT_ID" = ANY(?);
-                    """.replace("= ANY(?)", inExpression)
-                );
-                executeAndCloseWithArray(sqlQuery, queryParameter);
-
                 // Deletion with CTEs does not work with H2, but verified on Postgres and MS SQL Server
                 if (!DbUtil.isH2()) {
                     if (DbUtil.isPostgreSQL()) {
@@ -1188,6 +1182,12 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
 
                 sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """
                     DELETE FROM "VIOLATIONANALYSIS" WHERE "PROJECT_ID" = ANY(?);
+                    """.replace("= ANY(?)", inExpression)
+                );
+                executeAndCloseWithArray(sqlQuery, queryParameter);
+
+                sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """
+                    DELETE FROM "POLICYVIOLATION" WHERE "PROJECT_ID" = ANY(?);
                     """.replace("= ANY(?)", inExpression)
                 );
                 executeAndCloseWithArray(sqlQuery, queryParameter);


### PR DESCRIPTION
### Description

Fixed an internal server error occurring when invoking the team delete.
The error was caused by a referential integrity constraint violation between the NOTIFICATIONRULE_TEAMS and TEAM tables during team deletion.

### Addressed Issue

Fixes https://github.com/DependencyTrack/dependency-track/issues/5222

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [X] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
