### PR TITLE
fix sneaky double quote

### DIFF
--- a/src/main/java/org/dependencytrack/upgrade/v4135/v4135Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v4135/v4135Updater.java
@@ -47,9 +47,9 @@ public class v4135Updater extends AbstractUpgradeItem {
                        SET "PART" = LOWER("PART"),
                            "VENDOR" = LOWER("VENDOR"),
                            "PRODUCT" = LOWER("PRODUCT")
-                     WHERE "PART <> LOWER("PART")
-                        OR "VENDOR <> LOWER("VENDOR")
-                        OR "PRODUCT <> LOWER("PRODUCT")"
+                     WHERE "PART" <> LOWER("PART")
+                        OR "VENDOR" <> LOWER("VENDOR")
+                        OR "PRODUCT" <> LOWER("PRODUCT")
                     """);
         }
     }


### PR DESCRIPTION
### Description

Sorry, a stray double quote sneaked in in #5418, and others were missing - this fixes it. Saw it just after that PR got merged. Not present in #5419.
### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
