### PR TITLE
Changed the toString() method for project objects.

### DIFF
--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -664,19 +664,15 @@ public class Project implements Serializable {
 
     @Override
     public String toString() {
-        if (getPurl() != null) {
-            return getPurl().canonicalize();
-        } else {
-            StringBuilder sb = new StringBuilder();
-            if (getGroup() != null) {
-                sb.append(getGroup()).append(" : ");
-            }
-            sb.append(getName());
-            if (getVersion() != null) {
-                sb.append(" : ").append(getVersion());
-            }
-            return sb.toString();
+        StringBuilder sb = new StringBuilder();
+        if (getGroup() != null) {
+            sb.append(getGroup()).append(" : ");
         }
+        sb.append(getName());
+        if (getVersion() != null) {
+            sb.append(" : ").append(getVersion());
+        }
+        return sb.toString();
     }
 
     private final static class BooleanDefaultTrueSerializer extends JsonSerializer<Boolean> {

--- a/src/test/java/org/dependencytrack/notification/publisher/AbstractPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/AbstractPublisherTest.java
@@ -186,7 +186,7 @@ abstract class AbstractPublisherTest<T extends Publisher> extends PersistenceCap
                 .scope(NotificationScope.PORTFOLIO)
                 .group(NotificationGroup.NEW_VULNERABILITY)
                 .level(NotificationLevel.INFORMATIONAL)
-                .title(NotificationConstants.Title.NEW_VULNERABILITY)
+                .title(NotificationUtil.generateNotificationTitle(NotificationConstants.Title.NEW_VULNERABILITY, project))
                 .content("")
                 .timestamp(LocalDateTime.ofEpochSecond(66666, 666, ZoneOffset.UTC))
                 .subject(subject);
@@ -317,6 +317,8 @@ abstract class AbstractPublisherTest<T extends Publisher> extends PersistenceCap
         assertThatNoException()
                 .isThrownBy(() -> publisherInstance.inform(PublishContext.from(notification), notification, createConfig()));
     }
+
+
 
     private static Component createComponent(final Project project) {
         final var component = new Component();

--- a/src/test/java/org/dependencytrack/notification/publisher/JiraPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/JiraPublisherTest.java
@@ -218,7 +218,7 @@ class JiraPublisherTest extends AbstractWebhookPublisherTest<JiraPublisher> {
                               "name": "Task"
                             },
                             "summary": "[Dependency-Track] [NEW_VULNERABLE_DEPENDENCY] Vulnerable dependency introduced on project projectName",
-                            "description": "A component which contains one or more vulnerabilities has been added to your project.\\n\\\\\\\\\\n\\\\\\\\\\n*Project*\\n[pkg:maven/org.acme/projectName@projectVersion|https://example.com/projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95]\\n\\n*Component*\\n[componentName : componentVersion|https://example.com/components/94f87321-a5d1-4c2f-b2fe-95165debebc6]\\n\\n*Vulnerabilities*\\n- INT-001 (Medium)\\n"
+                            "description": "A component which contains one or more vulnerabilities has been added to your project.\\n\\\\\\\\\\n\\\\\\\\\\n*Project*\\n[projectName : projectVersion|https://example.com/projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95]\\n\\n*Component*\\n[componentName : componentVersion|https://example.com/components/94f87321-a5d1-4c2f-b2fe-95165debebc6]\\n\\n*Vulnerabilities*\\n- INT-001 (Medium)\\n"
                           }
                         }
                         """)));

--- a/src/test/java/org/dependencytrack/notification/publisher/MattermostPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/MattermostPublisherTest.java
@@ -42,7 +42,7 @@ public class MattermostPublisherTest extends AbstractWebhookPublisherTest<Matter
                         {
                           "username": "Dependency Track",
                           "icon_url": "https://raw.githubusercontent.com/DependencyTrack/branding/master/dt-logo-symbol-blue-background.png",
-                          "text": "#### Bill of Materials Consumed\\nA CycloneDX BOM was consumed and will be processed\\n**Project**: pkg:maven/org.acme/projectName@projectVersion\\n[View Project](https://example.com/projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95)"
+                          "text": "#### Bill of Materials Consumed\\nA CycloneDX BOM was consumed and will be processed\\n**Project**: projectName : projectVersion\\n[View Project](https://example.com/projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95)"
                         }
                         """)));
     }
@@ -117,7 +117,7 @@ public class MattermostPublisherTest extends AbstractWebhookPublisherTest<Matter
                         {
                           "username": "Dependency Track",
                           "icon_url": "https://raw.githubusercontent.com/DependencyTrack/branding/master/dt-logo-symbol-blue-background.png",
-                          "text": "#### New Vulnerability Identified\\n\\n**Component**: componentName : componentVersion\\n**Vulnerability**: INT-001, MEDIUM\\n[View Component](https://example.com/components/94f87321-a5d1-4c2f-b2fe-95165debebc6) - [View Vulnerability](https://example.com/vulnerabilities/INTERNAL/INT-001)"
+                          "text": "#### New Vulnerability Identified on Project: [projectName : projectVersion]\\n\\n**Component**: componentName : componentVersion\\n**Vulnerability**: INT-001, MEDIUM\\n[View Component](https://example.com/components/94f87321-a5d1-4c2f-b2fe-95165debebc6) - [View Vulnerability](https://example.com/vulnerabilities/INTERNAL/INT-001)"
                         }
                         """)));
     }
@@ -147,7 +147,7 @@ public class MattermostPublisherTest extends AbstractWebhookPublisherTest<Matter
                         {
                           "username": "Dependency Track",
                           "icon_url": "https://raw.githubusercontent.com/DependencyTrack/branding/master/dt-logo-symbol-blue-background.png",
-                          "text": "#### Analysis Decision: Finding Suppressed\\n\\n**Project**: pkg:maven/org.acme/projectName@projectVersion\\n**Component**: componentName : componentVersion\\n**Vulnerability**: INT-001, MEDIUM\\n**Analysis**: FALSE_POSITIVE, suppressed: true\\n[View Project](https://example.com/projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95) - [View Component](https://example.com/components/94f87321-a5d1-4c2f-b2fe-95165debebc6) - [View Vulnerability](https://example.com/vulnerabilities/INTERNAL/INT-001)"
+                          "text": "#### Analysis Decision: Finding Suppressed\\n\\n**Project**: projectName : projectVersion\\n**Component**: componentName : componentVersion\\n**Vulnerability**: INT-001, MEDIUM\\n**Analysis**: FALSE_POSITIVE, suppressed: true\\n[View Project](https://example.com/projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95) - [View Component](https://example.com/components/94f87321-a5d1-4c2f-b2fe-95165debebc6) - [View Vulnerability](https://example.com/vulnerabilities/INTERNAL/INT-001)"
                         }
                         """)));
     }

--- a/src/test/java/org/dependencytrack/notification/publisher/MsTeamsPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/MsTeamsPublisherTest.java
@@ -102,7 +102,7 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
                                 },
                                 {
                                   "name": "Project",
-                                  "value": "pkg:maven/org.acme/projectName@projectVersion"
+                                  "value": "projectName : projectVersion"
                                 },
                                 {
                                   "name": "Project URL",
@@ -148,7 +148,7 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
                                 },
                                 {
                                   "name": "Project",
-                                  "value": "pkg:maven/org.acme/projectName@projectVersion"
+                                  "value": "projectName : projectVersion"
                                 },
                                 {
                                   "name": "Project URL",
@@ -198,7 +198,7 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
                                 },
                                 {
                                   "name": "Project",
-                                  "value": "pkg:maven/org.acme/projectName@projectVersion"
+                                  "value": "projectName : projectVersion"
                                 },
                                 {
                                   "name": "Project URL",
@@ -250,6 +250,7 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
                         """)));
     }
 
+
     @Test
     public void testInformWithNewVulnerabilityNotification() {
         super.baseTestInformWithNewVulnerabilityNotification();
@@ -260,8 +261,8 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
                         {
                           "@type": "MessageCard",
                           "@context": "http://schema.org/extensions",
-                          "summary": "New Vulnerability Identified",
-                          "title": "New Vulnerability Identified",
+                          "summary": "New Vulnerability Identified on Project: [projectName : projectVersion]",
+                          "title": "New Vulnerability Identified on Project: [projectName : projectVersion]",
                           "sections": [
                             {
                               "activityTitle": "Dependency-Track",
@@ -312,7 +313,7 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
                               "facts": [
                                 {
                                   "name": "Project",
-                                  "value": "pkg:maven/org.acme/projectName@projectVersion"
+                                  "value": "projectName : projectVersion"
                                 },
                                 {
                                   "name": "Component",
@@ -374,7 +375,7 @@ public class MsTeamsPublisherTest extends AbstractWebhookPublisherTest<MsTeamsPu
                                 },
                                 {
                                   "name": "Project",
-                                  "value": "pkg:maven/org.acme/projectName@projectVersion"
+                                  "value": "projectName : projectVersion"
                                 }
                               ],
                               "text": ""

--- a/src/test/java/org/dependencytrack/notification/publisher/SendMailPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/SendMailPublisherTest.java
@@ -122,6 +122,16 @@ class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
                 EMAIL_SMTP_TRUSTCERT.getDescription()
         );
     }
+    
+    @Test
+    public void testMailSubjectIsSetCorrectly() {
+        super.baseTestInformWithNewVulnerabilityNotification();
+
+        assertThat(greenMail.getReceivedMessages()).satisfiesExactly(message ->
+                assertThat(message.getSubject())
+                        .isEqualTo("[Dependency-Track] New Vulnerability Identified on Project: [projectName : projectVersion]")
+        );
+    }
 
     @Test
     public void testInformWithBomConsumedNotification() {
@@ -135,24 +145,25 @@ class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
             assertThat(content.getBodyPart(0)).isInstanceOf(MimeBodyPart.class);
             assertThat((String) content.getBodyPart(0).getContent()).isEqualToIgnoringNewLines("""
                     Bill of Materials Consumed
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     Project:           projectName
                     Version:           projectVersion
                     Description:       projectDescription
                     Project URL:       /projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     A CycloneDX BOM was consumed and will be processed
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     1970-01-01T18:31:06.000000666
                     """);
         });
     }
+
 
     @Test
     public void testInformWithBomProcessingFailedNotification() {
@@ -166,25 +177,25 @@ class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
             assertThat(content.getBodyPart(0)).isInstanceOf(MimeBodyPart.class);
             assertThat((String) content.getBodyPart(0).getContent()).isEqualToIgnoringNewLines("""
                     Bill of Materials Processing Failed
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     Project:           projectName
                     Version:           projectVersion
                     Description:       projectDescription
                     Project URL:       /projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     Cause:
                     cause
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     An error occurred while processing a BOM
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     1970-01-01T18:31:06.000000666
                     """);
         });
@@ -202,21 +213,21 @@ class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
             assertThat(content.getBodyPart(0)).isInstanceOf(MimeBodyPart.class);
             assertThat((String) content.getBodyPart(0).getContent()).isEqualToIgnoringNewLines("""
                     Bill of Materials Validation Failed
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     Project:           projectName
                     Version:           projectVersion
                     Description:       projectDescription
                     Project URL:       /projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95
                     Errors:            [$.components[928].externalReferences[1].url: does not match the iri-reference pattern must be a valid RFC 3987 IRI-reference]
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     An error occurred during BOM Validation
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     1970-01-01T00:20:34.000000888
                     """);
         });
@@ -234,25 +245,25 @@ class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
             assertThat(content.getBodyPart(0)).isInstanceOf(MimeBodyPart.class);
             assertThat((String) content.getBodyPart(0).getContent()).isEqualToIgnoringNewLines("""
                     Bill of Materials Processing Failed
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     Project:           projectName
                     Version:           projectVersion
                     Description:       projectDescription
                     Project URL:       /projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     Cause:
                     cause
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     An error occurred while processing a BOM
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     1970-01-01T18:31:06.000000666
                     """);
         });
@@ -270,19 +281,19 @@ class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
             assertThat(content.getBodyPart(0)).isInstanceOf(MimeBodyPart.class);
             assertThat((String) content.getBodyPart(0).getContent()).isEqualToIgnoringNewLines("""
                     GitHub Advisory Mirroring
-                                               
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     Level:     ERROR
                     Scope:     SYSTEM
                     Group:     DATASOURCE_MIRRORING
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     An error occurred mirroring the contents of GitHub Advisories. Check log for details.
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     1970-01-01T18:31:06.000000666
                     """);
         });
@@ -293,16 +304,16 @@ class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
         super.baseTestInformWithNewVulnerabilityNotification();
 
         assertThat(greenMail.getReceivedMessages()).satisfiesExactly(message -> {
-            assertThat(message.getSubject()).isEqualTo("[Dependency-Track] New Vulnerability Identified");
+            assertThat(message.getSubject()).isEqualTo("[Dependency-Track] New Vulnerability Identified on Project: [projectName : projectVersion]");
             assertThat(message.getContent()).isInstanceOf(MimeMultipart.class);
             final MimeMultipart content = (MimeMultipart) message.getContent();
             assertThat(content.getCount()).isEqualTo(1);
             assertThat(content.getBodyPart(0)).isInstanceOf(MimeBodyPart.class);
             assertThat((String) content.getBodyPart(0).getContent()).isEqualToIgnoringNewLines("""
-                    New Vulnerability Identified
-                                        
+                    New Vulnerability Identified on Project: [projectName : projectVersion]
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     Vulnerability ID:  INT-001
                     Vulnerability URL: /vulnerability/?source=INTERNAL&vulnId=INT-001
                     Severity:          MEDIUM
@@ -313,13 +324,13 @@ class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
                     Version:           projectVersion
                     Description:       projectDescription
                     Project URL:       /projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
-                                        
-                                        
+                    
+                    
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     1970-01-01T18:31:06.000000666
                     """);
         });
@@ -454,31 +465,31 @@ class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
             assertThat(content.getBodyPart(0)).isInstanceOf(MimeBodyPart.class);
             assertThat((String) content.getBodyPart(0).getContent()).isEqualToIgnoringNewLines("""
                     Vulnerable Dependency Introduced
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     Project:           [projectName : projectVersion]
                     Project URL:       /projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95
                     Component:         componentName : componentVersion
                     Component URL:     /component/?uuid=94f87321-a5d1-4c2f-b2fe-95165debebc6
-                                        
+                    
                     Vulnerabilities
-                                        
+                    
                     Vulnerability ID:  INT-001
                     Vulnerability URL: /vulnerability/?source=INTERNAL&vulnId=INT-001
                     Severity:          MEDIUM
                     Source:            INTERNAL
                     Description:
                     vulnerabilityDescription
-                                        
-                                        
-                                        
+                    
+                    
+                    
                     --------------------------------------------------------------------------------
-                                        
-                                        
-                                        
+                    
+                    
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     1970-01-01T18:31:06.000000666
                     """);
         });
@@ -496,30 +507,30 @@ class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
             assertThat(content.getBodyPart(0)).isInstanceOf(MimeBodyPart.class);
             assertThat((String) content.getBodyPart(0).getContent()).isEqualToIgnoringNewLines("""
                     Analysis Decision: Finding Suppressed
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     Analysis Type:  Project Analysis
-                                        
+                    
                     Analysis State:    FALSE_POSITIVE
                     Suppressed:        true
                     Vulnerability ID:  INT-001
                     Vulnerability URL: /vulnerability/?source=INTERNAL&vulnId=INT-001
                     Severity:          MEDIUM
                     Source:            INTERNAL
-                                        
+                    
                     Component:         componentName : componentVersion
                     Component URL:     /component/?uuid=94f87321-a5d1-4c2f-b2fe-95165debebc6
                     Project:           [projectName : projectVersion]
                     Description:       projectDescription
                     Project URL:       /projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
-                                        
-                                        
+                    
+                    
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     1970-01-01T18:31:06.000000666
                     """);
         });
@@ -537,23 +548,23 @@ class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
             assertThat(content.getBodyPart(0)).isInstanceOf(MimeBodyPart.class);
             assertThat((String) content.getBodyPart(0).getContent()).isEqualToIgnoringNewLines("""
                     Notification Test
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     Level:     ERROR
                     Scope:     SYSTEM
                     Group:     ANALYZER
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     ! " § $ % & / ( ) = ? \\ ' * Ö Ü Ä ®️
-                                        
+                    
                     --------------------------------------------------------------------------------
-                                        
+                    
                     1970-01-01T18:31:06.000000666
                     """);
         });
-        
+
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/notification/publisher/SlackPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/SlackPublisherTest.java
@@ -141,7 +141,7 @@ class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublisher> {
                               "type": "header",
                               "text": {
                                 "type": "plain_text",
-                                "text": "BOM_VALIDATION_FAILED | pkg:maven/org.acme/projectName@projectVersion"
+                                "text": "BOM_VALIDATION_FAILED | projectName : projectVersion"
                               }
                             },
                             {
@@ -307,7 +307,7 @@ class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublisher> {
                             {
                               "type": "section",
                               "text": {
-                                "text": "New Vulnerability Identified",
+                                "text": "New Vulnerability Identified on Project: [projectName : projectVersion]",
                                 "type": "mrkdwn"
                               },
                               "fields": [
@@ -422,7 +422,7 @@ class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublisher> {
                                 },
                                 {
                                   "type": "plain_text",
-                                  "text": "pkg:maven/org.acme/projectName@projectVersion"
+                                  "text": "projectName : projectVersion"
                                 }
                               ]
                             },
@@ -549,7 +549,7 @@ class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublisher> {
                         		},
                         		{
                         		  "type": "plain_text",
-                        		  "text": "pkg:maven/org.acme/projectName@projectVersion"
+                        		  "text": "projectName : projectVersion"
                         		}
                         	  ]
                         	},
@@ -628,7 +628,7 @@ class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublisher> {
                             {
                               "type": "section",
                               "text": {
-                                "text": "New Vulnerability Identified",
+                                "text": "New Vulnerability Identified on Project: [projectName : projectVersion]",
                                 "type": "mrkdwn"
                               },
                               "fields": [
@@ -727,7 +727,7 @@ class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublisher> {
                                 },
                                 {
                                   "type": "plain_text",
-                                  "text": "pkg:maven/org.acme/projectName@projectVersion"
+                                  "text": "projectName : projectVersion"
                                 }
                               ]
                             }
@@ -838,7 +838,7 @@ class SlackPublisherTest extends AbstractWebhookPublisherTest<SlackPublisher> {
                         		},
                         		{
                         		  "type": "plain_text",
-                        		  "text": "pkg:maven/org.acme/projectName@projectVersion"
+                        		  "text": "projectName : projectVersion"
                         		}
                         	  ]
                         	}

--- a/src/test/java/org/dependencytrack/notification/publisher/WebhookPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/WebhookPublisherTest.java
@@ -208,7 +208,7 @@ public class WebhookPublisherTest extends AbstractWebhookPublisherTest<WebhookPu
                             "scope": "PORTFOLIO",
                             "group": "NEW_VULNERABILITY",
                             "timestamp": "1970-01-01T18:31:06.000000666",
-                            "title": "New Vulnerability Identified",
+                            "title": "New Vulnerability Identified on Project: [projectName : projectVersion]",
                             "content": "",
                             "subject": {
                               "component": {


### PR DESCRIPTION
### Description
Changed the toString() method for project objects, to return the actual name and version instead of the assigned purl in any case. Added a new test to verify this and corrected existing tests to account for this change.

### Addressed Issue
Addressed issue #4484. Previous to my changes, alerts displayed the purl of the project if set, instead of the name and the version. 

### Additional Details
Used ChatGPT and Copilot to understand existing codebase and find the underlying problem in the toString() method; further used to debug and suggest changes in the tests. 

### Checklist
- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
