### PR TITLE
New IgnoreSuppressedFindings feature

### DIFF
--- a/docs/_docs/integrations/notifications.md
+++ b/docs/_docs/integrations/notifications.md
@@ -761,8 +761,9 @@ The next planned trigger is calculated based on the configured cron expression, 
 Both the last successful, and the next planned trigger timestamp can be viewed in a notification rule's configuration panel.
 
 To further reduce the noise produced by the system, users can opt into skipping the publishing of a notification,  
-if no new data has been identified since the last time it triggered. Another option is to only publish unsuppressed findings. If enabled, 
-the notification will filter the suppressed findings out of its results.
+if no new data has been identified since the last time it triggered. 
+Another option is to only publish unsuppressed findings. 
+If enabled, the notification will filter the suppressed findings out of its results.
 
 Certain notification groups may require the alert to be limited to specific projects.  
 This is to protect the system from generating payloads that are too resource intensive to compute,  

--- a/docs/_docs/integrations/notifications.md
+++ b/docs/_docs/integrations/notifications.md
@@ -197,6 +197,7 @@ projects. This limitation exists to prevent payloads from growing too large.
     "title": "New Vulnerabilities Summary",
     "content": "Identified 1 new vulnerabilities across 1 projects and 1 components since 1970-01-01T00:01:06Z, of which 1 are suppressed.",
     "subject": {
+      "scheduleIgnoreSuppressed": false,
       "overview": {
         "affectedProjectsCount": 1,
         "affectedComponentsCount": 1,
@@ -524,6 +525,7 @@ projects. This limitation exists to prevent payloads from growing too large.
     "title": "New Policy Violations Summary",
     "content": "Identified 1 new policy violations across 1 project and 1 components since 1970-01-01T00:01:06Z, of which 0 are suppressed.",
     "subject": {
+      "scheduleIgnoreSuppressed": false,
       "overview": {
         "affectedProjectsCount": 1,
         "affectedComponentsCount": 1,
@@ -614,7 +616,7 @@ projects. This limitation exists to prevent payloads from growing too large.
       "id": "user",
       "username": "user",
       "name": "User 1",
-      "email": "user@example.com",
+      "email": "user@example.com"
       }
   }
 }
@@ -632,7 +634,7 @@ projects. This limitation exists to prevent payloads from growing too large.
     "title": "User Deleted",
     "content": "LDAP user deleted",
     "subject": {
-      "username": "user",
+      "username": "user"
     }
   }
 }
@@ -759,7 +761,8 @@ The next planned trigger is calculated based on the configured cron expression, 
 Both the last successful, and the next planned trigger timestamp can be viewed in a notification rule's configuration panel.
 
 To further reduce the noise produced by the system, users can opt into skipping the publishing of a notification,  
-if no new data has been identified since the last time it triggered.
+if no new data has been identified since the last time it triggered. Another option is to only publish unsuppressed findings. If enabled, 
+the notification will filter the suppressed findings out of its results.
 
 Certain notification groups may require the alert to be limited to specific projects.  
 This is to protect the system from generating payloads that are too resource intensive to compute,  

--- a/src/main/java/org/dependencytrack/model/NotificationRule.java
+++ b/src/main/java/org/dependencytrack/model/NotificationRule.java
@@ -201,6 +201,14 @@ public class NotificationRule implements Serializable {
             Must not be set for rules with trigger type EVENT.""")
     private Boolean scheduleSkipUnchanged;
 
+    @Persistent
+    @Column(name = "SCHEDULE_IGNORE_SUPPRESSED")
+    @Schema(description = """
+            Whether to ignore suppressed findings from scheduled notifications. \
+            If there are non-suppressed findings, only they will be included in the notification. \
+            If all findings are suppressed, new findings are empty.""")
+    private Boolean scheduleIgnoreSuppressed;
+
     @Persistent(defaultFetchGroup = "true", customValueStrategy = "uuid")
     @Unique(name = "NOTIFICATIONRULE_UUID_IDX")
     @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
@@ -409,6 +417,17 @@ public class NotificationRule implements Serializable {
                 NotificationTriggerType.SCHEDULE,
                 "scheduleSkipUnchanged can not be set for rule with trigger type " + this.triggerType);
         this.scheduleSkipUnchanged = scheduleSkipUnchanged;
+    }
+
+    public Boolean isScheduleIgnoreSuppressed() {
+        return scheduleIgnoreSuppressed;
+    }
+
+    public void setScheduleIgnoreSuppressed(final Boolean scheduleIgnoreSuppressed) {
+        requireTriggerType(
+                NotificationTriggerType.SCHEDULE,
+                "scheduleIgnoreSuppressed can not be set for rule with trigger type " + this.triggerType);
+        this.scheduleIgnoreSuppressed = scheduleIgnoreSuppressed;
     }
 
     @NotNull

--- a/src/main/java/org/dependencytrack/notification/vo/NewPolicyViolationsSummary.java
+++ b/src/main/java/org/dependencytrack/notification/vo/NewPolicyViolationsSummary.java
@@ -37,7 +37,8 @@ public record NewPolicyViolationsSummary(
         Summary summary,
         Details details,
         Date since,
-        long ruleId) implements ScheduledNotificationSubject {
+        long ruleId,
+        Boolean scheduleIgnoreSuppressed) implements ScheduledNotificationSubject {
 
     /**
      * High-level overview of the contents of this summary.
@@ -159,13 +160,15 @@ public record NewPolicyViolationsSummary(
     public static NewPolicyViolationsSummary of(
             final Map<Project, List<ProjectPolicyViolation>> violationsByProject,
             final Date since,
-            final long ruleId) {
+            final long ruleId,
+            final Boolean scheduleIgnoreSuppressed) {
         return new NewPolicyViolationsSummary(
                 Overview.of(violationsByProject),
                 Summary.of(violationsByProject),
                 new Details(violationsByProject),
                 since,
-                ruleId);
+                ruleId,
+                scheduleIgnoreSuppressed);
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/notification/vo/NewVulnerabilitiesSummary.java
+++ b/src/main/java/org/dependencytrack/notification/vo/NewVulnerabilitiesSummary.java
@@ -36,7 +36,8 @@ public record NewVulnerabilitiesSummary(
         Summary summary,
         Details details,
         Date since,
-        long ruleId) implements ScheduledNotificationSubject {
+        long ruleId,
+        Boolean scheduleIgnoreSuppressed) implements ScheduledNotificationSubject {
 
     /**
      * High-level overview of the contents of this summary.
@@ -159,13 +160,15 @@ public record NewVulnerabilitiesSummary(
     public static NewVulnerabilitiesSummary of(
             final Map<Project, List<ProjectFinding>> findingsByProject,
             final Date since,
-            final long ruleId) {
+            final long ruleId,
+            final Boolean scheduleIgnoreSuppressed) {
         return new NewVulnerabilitiesSummary(
                 Overview.of(findingsByProject),
                 Summary.of(findingsByProject),
                 new Details(findingsByProject),
                 since,
-                ruleId);
+                ruleId,
+                scheduleIgnoreSuppressed);
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/persistence/NotificationQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/NotificationQueryManager.java
@@ -112,6 +112,7 @@ public class NotificationQueryManager extends QueryManager implements IQueryMana
         rule.setScheduleCron("0 * * * *");
         rule.setScheduleLastTriggeredAt(new Date());
         rule.setScheduleSkipUnchanged(false);
+        rule.setScheduleIgnoreSuppressed(false);
         rule.updateScheduleNextTriggerAt();
         return persist(rule);
     }
@@ -141,6 +142,7 @@ public class NotificationQueryManager extends QueryManager implements IQueryMana
 
                 rule.setScheduleCron(transientRule.getScheduleCron());
                 rule.setScheduleSkipUnchanged(transientRule.isScheduleSkipUnchanged());
+                rule.setScheduleIgnoreSuppressed(transientRule.isScheduleIgnoreSuppressed());
                 rule.updateScheduleNextTriggerAt();
             } else if (rule.getTriggerType() == NotificationTriggerType.EVENT) {
                 final List<NotificationGroup> invalidGroups = transientRule.getNotifyOn().stream()

--- a/src/main/java/org/dependencytrack/tasks/ScheduledNotificationDispatchTask.java
+++ b/src/main/java/org/dependencytrack/tasks/ScheduledNotificationDispatchTask.java
@@ -167,7 +167,7 @@ public class ScheduledNotificationDispatchTask implements Subscriber {
         }
 
         // Fetch findings that were attributed since the last notification.
-        final List<NewFinding> newFindings = new ArrayList<>(getNewFindingsSince(qm, projectIds, rule.getScheduleLastTriggeredAt()));
+        final var newFindings = new ArrayList<>(getNewFindingsSince(qm, projectIds, rule.getScheduleLastTriggeredAt()));
         if (newFindings.isEmpty() && Boolean.TRUE.equals(rule.isScheduleSkipUnchanged())) {
             LOGGER.info("No new findings since rule was last processed at %s".formatted(
                     DateUtil.toISO8601(rule.getScheduleLastTriggeredAt())));
@@ -175,9 +175,9 @@ public class ScheduledNotificationDispatchTask implements Subscriber {
         }
 
         if(!newFindings.isEmpty() && Boolean.TRUE.equals(rule.isScheduleIgnoreSuppressed())) {
-            Iterator<NewFinding> iterator = newFindings.iterator();
+            final Iterator<NewFinding> iterator = newFindings.iterator();
             while (iterator.hasNext()) {
-                NewFinding finding = iterator.next();
+                final var finding = iterator.next();
                 if (Boolean.TRUE.equals(finding.isSuppressed())) {
                     iterator.remove();
                 }
@@ -272,7 +272,7 @@ public class ScheduledNotificationDispatchTask implements Subscriber {
             return null;
         }
 
-        final List<NewPolicyViolation> newViolations = new ArrayList<>(getNewPolicyViolationsSince(qm, projectIds, rule.getScheduleLastTriggeredAt()));
+        final var newViolations = new ArrayList<>(getNewPolicyViolationsSince(qm, projectIds, rule.getScheduleLastTriggeredAt()));
         if (newViolations.isEmpty() && Boolean.TRUE.equals(rule.isScheduleSkipUnchanged())) {
             LOGGER.info("No new policy violations since rule was last processed at %s".formatted(
                     DateUtil.toISO8601(rule.getScheduleLastTriggeredAt())));
@@ -280,9 +280,9 @@ public class ScheduledNotificationDispatchTask implements Subscriber {
         }
 
         if(!newViolations.isEmpty() && Boolean.TRUE.equals(rule.isScheduleIgnoreSuppressed())) {
-            Iterator<NewPolicyViolation> iterator = newViolations.iterator();
+            final Iterator<NewPolicyViolation> iterator = newViolations.iterator();
             while (iterator.hasNext()) {
-                NewPolicyViolation violation = iterator.next();
+                final var violation = iterator.next();
                 if (Boolean.TRUE.equals(violation.isSuppressed())) {
                     iterator.remove();
                 }

--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -542,6 +542,7 @@ public final class NotificationUtil {
 
     public static JsonObject toJson(final NewPolicyViolationsSummary vo) {
         return Json.createObjectBuilder()
+                .add("scheduleIgnoreSuppressed", vo.scheduleIgnoreSuppressed())
                 .add("overview", toJson(vo.overview()))
                 .add("summary", toJson(vo.summary()))
                 .add("details", toJson(vo.details()))
@@ -624,6 +625,7 @@ public final class NotificationUtil {
 
     public static JsonObject toJson(final NewVulnerabilitiesSummary vo) {
         return Json.createObjectBuilder()
+                .add("scheduleIgnoreSuppressed", vo.scheduleIgnoreSuppressed())
                 .add("overview", toJson(vo.overview()))
                 .add("summary", toJson(vo.summary()))
                 .add("details", toJson(vo.details()))
@@ -805,6 +807,13 @@ public final class NotificationUtil {
         if (vo.overview().totalNewVulnerabilitiesCount() == 0) {
             return "No new vulnerabilities identified since %s.".formatted(DateUtil.toISO8601(vo.since()));
         } else {
+            if (vo.scheduleIgnoreSuppressed()) {
+                return "Identified %d new vulnerabilities across %d projects and %d components since %s. \nNote: Ignored all suppressed vulnerabilities.".formatted(
+                        vo.overview().totalNewVulnerabilitiesCount(),
+                        vo.overview().affectedProjectsCount(),
+                        vo.overview().affectedComponentsCount(),
+                        DateUtil.toISO8601(vo.since()));
+            }
             return "Identified %d new vulnerabilities across %d projects and %d components since %s, of which %d are suppressed.".formatted(
                     vo.overview().totalNewVulnerabilitiesCount(),
                     vo.overview().affectedProjectsCount(),
@@ -818,6 +827,13 @@ public final class NotificationUtil {
         if (vo.overview().totalNewViolationsCount() == 0) {
             return "No new policy violations identified since %s.".formatted(DateUtil.toISO8601(vo.since()));
         } else {
+            if (vo.scheduleIgnoreSuppressed()) {
+                return "Identified %d new policy violations across %d project and %d components since %s. \nNote: Ignored all suppressed violations.".formatted(
+                        vo.overview().totalNewViolationsCount(),
+                        vo.overview().affectedProjectsCount(),
+                        vo.overview().affectedComponentsCount(),
+                        DateUtil.toISO8601(vo.since()));
+            }
             return "Identified %d new policy violations across %d project and %d components since %s, of which %d are suppressed.".formatted(
                     vo.overview().totalNewViolationsCount(),
                     vo.overview().affectedProjectsCount(),
@@ -890,7 +906,8 @@ public final class NotificationUtil {
                 yield NewPolicyViolationsSummary.of(
                         Map.of(project, List.of(projectPolicyViolation)),
                         rule.getScheduleLastTriggeredAt(),
-                        rule.getId());
+                        rule.getId(),
+                        rule.isScheduleIgnoreSuppressed());
             }
             case NEW_VULNERABILITIES_SUMMARY -> {
                 final var projectFinding = new ProjectFinding(
@@ -904,7 +921,8 @@ public final class NotificationUtil {
                 yield NewVulnerabilitiesSummary.of(
                         Map.of(project, List.of(projectFinding)),
                         rule.getScheduleLastTriggeredAt(),
-                        rule.getId());
+                        rule.getId(),
+                        rule.isScheduleIgnoreSuppressed());
             }
             default -> null;
         };

--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -808,7 +808,7 @@ public final class NotificationUtil {
             return "No new vulnerabilities identified since %s.".formatted(DateUtil.toISO8601(vo.since()));
         } else {
             if (vo.scheduleIgnoreSuppressed()) {
-                return "Identified %d new vulnerabilities across %d projects and %d components since %s. \nNote: Ignored all suppressed vulnerabilities.".formatted(
+                return "Identified %d new vulnerabilities across %d projects and %d components since %s.\nNote: Ignored all suppressed vulnerabilities.".formatted(
                         vo.overview().totalNewVulnerabilitiesCount(),
                         vo.overview().affectedProjectsCount(),
                         vo.overview().affectedComponentsCount(),
@@ -828,7 +828,7 @@ public final class NotificationUtil {
             return "No new policy violations identified since %s.".formatted(DateUtil.toISO8601(vo.since()));
         } else {
             if (vo.scheduleIgnoreSuppressed()) {
-                return "Identified %d new policy violations across %d project and %d components since %s. \nNote: Ignored all suppressed violations.".formatted(
+                return "Identified %d new policy violations across %d project and %d components since %s.\nNote: Ignored all suppressed violations.".formatted(
                         vo.overview().totalNewViolationsCount(),
                         vo.overview().affectedProjectsCount(),
                         vo.overview().affectedComponentsCount(),

--- a/src/main/resources/templates/notification/publisher/email.peb
+++ b/src/main/resources/templates/notification/publisher/email.peb
@@ -121,10 +121,15 @@ Violated Policy:   {{ subject.policyViolation.policyCondition.policy.name }}
 {% elseif notification.group == "NEW_POLICY_VIOLATIONS_SUMMARY" %}
 {% set newViolationsSummarySubject = subject -%}
 Overview:
+{% if newViolationsSummarySubject.scheduleIgnoreSuppressed %}
+- New Violations:      {{ newViolationsSummarySubject.overview.totalNewViolationsCount }}
+{%else%}
 - New Violations:      {{ newViolationsSummarySubject.overview.totalNewViolationsCount }} (Suppressed: {{ newViolationsSummarySubject.overview.suppressedNewViolationsCount }})
+{% endif %}
 {%- for newViolationsCountByType in newViolationsSummarySubject.overview.newViolationsCountByType %}
   - Of Type {{ newViolationsCountByType.key.name }}: {{ newViolationsCountByType.value }}
 {%- endfor %}
+
 - Affected Projects:   {{ newViolationsSummarySubject.overview.affectedProjectsCount }}
 - Affected Components: {{ newViolationsSummarySubject.overview.affectedComponentsCount }}
 - Since:               {{ newViolationsSummarySubject.since | date("yyyy-MM-dd'T'HH:mm:ssX", timeZone="UTC") }}
@@ -137,7 +142,11 @@ Project Summaries:
 - Project: [{{ summaryByProject.key.name }} : {{ summaryByProject.key.version }}]
   Project URL: {{ baseUrl }}/projects/{{ summaryByProject.key.uuid }}
 {% for entry in summaryByProject.value.totalNewViolationsCountByType %}
+  {% if newViolationsSummarySubject.scheduleIgnoreSuppressed %}
+  + New Violations Of Type {{ entry.key.name }}: {{ entry.value }}
+  {%else%}
   + New Violations Of Type {{ entry.key.name }}: {{ entry.value }} (Suppressed: {{ summaryByProject.value.suppressedNewViolationsCountByType.get(entry.key) | default(0) }})
+  {% endif %}
 {%- endfor %}
 {% endfor %}
 {%- endif %}
@@ -156,17 +165,23 @@ Violation Details:
     Component URL:         {{ baseUrl }}/component/?uuid={{ violation.component.uuid }}
     Timestamp:             {{ violation.timestamp | date("yyyy-MM-dd'T'HH:mm:ssX", timeZone="UTC") }}
     Analysis State:        {{ violation.analysisState | default("-") }}
-    Suppressed:            {{ violation.suppressed }}
+    {% if not newViolationsSummarySubject.scheduleIgnoreSuppressed %}
+    Suppressed:             {{ violation.suppressed }}
+    {% endif %}
 {% endfor -%}
 {% endfor -%}
 {% endif %}
 {% elseif notification.group == "NEW_VULNERABILITIES_SUMMARY" %}
 {% set newVulnsSummarySubject = subject -%}
 Overview:
+{% if newVulnsSummarySubject.scheduleIgnoreSuppressed %}
+- New Vulnerabilities: {{ newVulnsSummarySubject.overview.totalNewVulnerabilitiesCount }}
+{%else%}
 - New Vulnerabilities: {{ newVulnsSummarySubject.overview.totalNewVulnerabilitiesCount }} (Suppressed: {{ newVulnsSummarySubject.overview.suppressedNewVulnerabilitiesCount }})
+{% endif %}
 {% for newVulnsCountBySeverity in newVulnsSummarySubject.overview.newVulnerabilitiesCountBySeverity %}
   - Of Severity {{ newVulnsCountBySeverity.key.name }}: {{ newVulnsCountBySeverity.value }}
-{%- endfor -%}
+{%- endfor %}
 - Affected Projects:   {{ newVulnsSummarySubject.overview.affectedProjectsCount }}
 - Affected Components: {{ newVulnsSummarySubject.overview.affectedComponentsCount }}
 - Since:               {{ newVulnsSummarySubject.since | date("yyyy-MM-dd'T'HH:mm:ssX", timeZone="UTC") }}
@@ -179,7 +194,11 @@ Project Summaries:
 - Project: [{{ summaryByProject.key.name }} : {{ summaryByProject.key.version }}]
   Project URL: {{ baseUrl }}/projects/{{ summaryByProject.key.uuid }}
 {% for entry in summaryByProject.value.totalNewVulnerabilitiesCountBySeverity %}
+  {% if newVulnsSummarySubject.scheduleIgnoreSuppressed %}
+  + New Vulnerabilities Of Severity {{ entry.key.name }}: {{ entry.value }}
+  {%else%}
   + New Vulnerabilities Of Severity {{ entry.key.name }}: {{ entry.value }} (Suppressed: {{ summaryByProject.value.suppressedNewVulnerabilitiesCountBySeverity.get(entry.key) | default(0) }})
+  {% endif %}
 {%- endfor %}
 {% endfor %}
 {%- endif %}
@@ -199,7 +218,9 @@ Vulnerability Details:
     Component URL:          {{ baseUrl }}/component/?uuid={{ finding.component.uuid }}
     Timestamp:              {{ finding.attributedOn | date("yyyy-MM-dd'T'HH:mm:ssX", timeZone="UTC") }}
     Analysis State:         {{ finding.analysisState | default("-") }}
+    {% if not newVulnsSummarySubject.scheduleIgnoreSuppressed %}
     Suppressed:             {{ finding.suppressed }}
+    {% endif %}
 {% endfor -%}
 {% endfor -%}
 {% endif %}

--- a/src/test/java/org/dependencytrack/notification/publisher/AbstractPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/AbstractPublisherTest.java
@@ -182,11 +182,11 @@ abstract class AbstractPublisherTest<T extends Publisher> extends PersistenceCap
 
         final var finding1 = new ProjectFinding(
                 component, vuln1, AnalyzerIdentity.INTERNAL_ANALYZER, Date.from(Instant.ofEpochSecond(66666, 666)),
-                "", AnalysisState.NOT_SET, Boolean.FALSE);
+                "", AnalysisState.NOT_SET, false);
 
         final var filteredFindingsByProject = Map.of(project, List.of(finding1));
 
-        final var subject = NewVulnerabilitiesSummary.of(filteredFindingsByProject, new Date(66666), 1, Boolean.TRUE);
+        final var subject = NewVulnerabilitiesSummary.of(filteredFindingsByProject, new Date(66666), 1, true);
 
         final var notification = new Notification()
                 .scope(NotificationScope.PORTFOLIO)
@@ -303,7 +303,7 @@ abstract class AbstractPublisherTest<T extends Publisher> extends PersistenceCap
                 component, vuln, AnalyzerIdentity.INTERNAL_ANALYZER, Date.from(Instant.ofEpochSecond(66666, 666)),
                 "", AnalysisState.FALSE_POSITIVE, true)));
 
-        final var subject = NewVulnerabilitiesSummary.of(findingsByProject, new Date(66666), 666, Boolean.FALSE);
+        final var subject = NewVulnerabilitiesSummary.of(findingsByProject, new Date(66666), 666, false);
 
         final var notification = new Notification()
                 .scope(NotificationScope.PORTFOLIO)
@@ -330,7 +330,7 @@ abstract class AbstractPublisherTest<T extends Publisher> extends PersistenceCap
                 violation.getAnalysis().getAnalysisState(),
                 violation.getAnalysis().isSuppressed())));
 
-        final var subject = NewPolicyViolationsSummary.of(violationsByProject, new Date(66666), 666, Boolean.FALSE);
+        final var subject = NewPolicyViolationsSummary.of(violationsByProject, new Date(66666), 666, false);
 
         final var notification = new Notification()
                 .scope(NotificationScope.PORTFOLIO)
@@ -362,7 +362,7 @@ abstract class AbstractPublisherTest<T extends Publisher> extends PersistenceCap
                 )
         );
 
-        final var subject = NewPolicyViolationsSummary.of(violationsByProject, new Date(66666), 666, Boolean.TRUE);
+        final var subject = NewPolicyViolationsSummary.of(violationsByProject, new Date(66666), 666, true);
 
         final var notification = new Notification()
                 .scope(NotificationScope.PORTFOLIO)

--- a/src/test/java/org/dependencytrack/notification/publisher/SendMailPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/SendMailPublisherTest.java
@@ -337,6 +337,65 @@ class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
     }
 
     @Test
+    public void testPublishWithScheduledNewVulnerabilitiesNotificationAndIgnoreSuppressed() {
+        super.baseTestInformWithScheduledNewVulnerabilitiesNotificationIgnoreSuppressed();
+
+        assertThat(greenMail.getReceivedMessages()).satisfiesExactly(message -> {
+            assertThat(message.getSubject()).isEqualTo("[Dependency-Track] New Vulnerabilities Summary");
+            assertThat(message.getContent()).isInstanceOf(MimeMultipart.class);
+            final MimeMultipart content = (MimeMultipart) message.getContent();
+            assertThat(content.getCount()).isEqualTo(1);
+            assertThat(content.getBodyPart(0)).isInstanceOf(MimeBodyPart.class);
+            assertThat((String) content.getBodyPart(0).getContent()).isEqualToIgnoringWhitespace("""
+                    New Vulnerabilities Summary
+                    
+                    --------------------------------------------------------------------------------
+                    
+                    Overview:
+                    - New Vulnerabilities: 1
+                      - Of Severity MEDIUM: 1
+                    - Affected Projects:   1
+                    - Affected Components: 1
+                    - Since:               1970-01-01T00:01:06Z
+                    
+                    --------------------------------------------------------------------------------
+                    
+                    Project Summaries:
+                    
+                    - Project: [projectName : projectVersion]
+                      Project URL: /projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95
+                    
+                      + New Vulnerabilities Of Severity MEDIUM: 1 
+                    
+                    --------------------------------------------------------------------------------
+                    
+                    Vulnerability Details:
+                    
+                    - Project: [projectName : projectVersion]
+                      Project URL: /projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95
+                    
+                      + Vulnerability ID:       INT-001
+                        Vulnerability Source:   INTERNAL
+                        Vulnerability Severity: MEDIUM
+                        Vulnerability URL:      /vulnerability/?source=INTERNAL&vulnId=INT-001
+                        Component:              componentName : componentVersion
+                        Component URL:          /component/?uuid=94f87321-a5d1-4c2f-b2fe-95165debebc6
+                        Timestamp:              1970-01-01T18:31:06Z
+                        Analysis State:         NOT_SET
+                    
+                    --------------------------------------------------------------------------------
+                    
+                    Identified 1 new vulnerabilities across 1 projects and 1 components since 1970-01-01T00:01:06Z.                                                                                                                                    \s
+                    Note: Ignored all suppressed vulnerabilities.
+                    
+                    --------------------------------------------------------------------------------
+                    
+                    1970-01-01T18:31:06.000000666
+                    """);
+        });
+    }
+
+    @Test
     public void testPublishWithScheduledNewVulnerabilitiesNotification() {
         super.baseTestPublishWithScheduledNewVulnerabilitiesNotification();
 
@@ -386,6 +445,65 @@ class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
                     --------------------------------------------------------------------------------
                     
                     Identified 1 new vulnerabilities across 1 projects and 1 components since 1970-01-01T00:01:06Z, of which 1 are suppressed.
+                    
+                    --------------------------------------------------------------------------------
+                    
+                    1970-01-01T18:31:06.000000666
+                    """);
+        });
+    }
+
+    @Test
+    public void testPublishWithScheduledNewPolicyViolationsNotificationAndIgnoreSuppressed() {
+        super.baseTestPublishWithScheduledNewPolicyViolationsNotificationIgnoreSuppressed();
+
+        assertThat(greenMail.getReceivedMessages()).satisfiesExactly(message -> {
+            assertThat(message.getSubject()).isEqualTo("[Dependency-Track] New Policy Violations Summary");
+            assertThat(message.getContent()).isInstanceOf(MimeMultipart.class);
+            final MimeMultipart content = (MimeMultipart) message.getContent();
+            assertThat(content.getCount()).isEqualTo(1);
+            assertThat(content.getBodyPart(0)).isInstanceOf(MimeBodyPart.class);
+
+            assertThat((String) content.getBodyPart(0).getContent()).isEqualToIgnoringWhitespace("""
+                    New Policy Violations Summary
+                    
+                    --------------------------------------------------------------------------------
+                    
+                    Overview:
+                    - New Violations:      1 
+                      - Of Type LICENSE: 1
+                    - Affected Projects:   1
+                    - Affected Components: 1
+                    - Since:               1970-01-01T00:01:06Z
+                    
+                    --------------------------------------------------------------------------------
+                    
+                    Project Summaries:
+                    
+                    - Project: [projectName : projectVersion]
+                      Project URL: /projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95
+                    
+                      + New Violations Of Type LICENSE: 1 
+                    
+                    --------------------------------------------------------------------------------
+                    
+                    Violation Details:
+                    
+                    - Project: [projectName : projectVersion]
+                      Project URL: /projects/c9c9539a-e381-4b36-ac52-6a7ab83b2c95
+                    
+                      + Policy:                policyName
+                        Policy Condition:      AGE NUMERIC_EQUAL P666D
+                        Policy Violation Type: LICENSE
+                        Component:             componentName : componentVersion
+                        Component URL:         /component/?uuid=94f87321-a5d1-4c2f-b2fe-95165debebc6
+                        Timestamp:             1970-01-01T18:31:06Z
+                        Analysis State:        APPROVED
+                    
+                    --------------------------------------------------------------------------------
+                    
+                    Identified 1 new policy violations across 1 project and 1 components since 1970-01-01T00:01:06Z.                                                                                                                                   
+                    Note: Ignored all suppressed violations.                                                                                                                                                                                                               
                     
                     --------------------------------------------------------------------------------
                     

--- a/src/test/java/org/dependencytrack/notification/publisher/WebhookPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/WebhookPublisherTest.java
@@ -435,6 +435,7 @@ public class WebhookPublisherTest extends AbstractWebhookPublisherTest<WebhookPu
                             "title": "New Vulnerabilities Summary",
                             "content": "Identified 1 new vulnerabilities across 1 projects and 1 components since 1970-01-01T00:01:06Z, of which 1 are suppressed.",
                             "subject": {
+                              "scheduleIgnoreSuppressed" : false,
                               "overview": {
                                 "affectedProjectsCount": 1,
                                 "affectedComponentsCount": 1,
@@ -551,6 +552,7 @@ public class WebhookPublisherTest extends AbstractWebhookPublisherTest<WebhookPu
                             "title": "New Policy Violations Summary",
                             "content": "Identified 1 new policy violations across 1 project and 1 components since 1970-01-01T00:01:06Z, of which 0 are suppressed.",
                             "subject": {
+                              "scheduleIgnoreSuppressed" : false,
                               "overview": {
                                 "affectedProjectsCount": 1,
                                 "affectedComponentsCount": 1,

--- a/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
@@ -185,6 +185,7 @@ class NotificationRuleResourceTest extends ResourceTest {
                   "scheduleNextTriggerAt": "${json-unit.any-number}",
                   "scheduleCron": "0 * * * *",
                   "scheduleSkipUnchanged": false,
+                  "scheduleIgnoreSuppressed": false,
                   "uuid": "${json-unit.any-string}"
                 }
                 """);


### PR DESCRIPTION
### Description
Added a new toggle in the scheduled alert creation menu called "Ignore suppressed findings". Included the implementation and the related test(s). The logic in NotificationRule and ScheduledNotificationDispatchTask follows the pattern of the existing "Skip publish if unchanged" toggle, adapted for the different behavior. The option is propagated via the JSON for NewVulnerabilitySummary/NewPolicyViolationSummary and subsequently handled within the e-mail template, etc. The UI toggle is provided in a separate PR in the frontend repository.
Also introduced a slightly different e-mail template when suppressed findings are ignored.
Added a new test to verify the correct template is used, another one that checks whether the DispatchTask works correctly and updated the docs to reflect the new functionality.

### Addressed Issue
Addresses issue #5488.

### Additional Details
Used GitHub Copilot and ChatGPT to understand the codebase and debug, and to suggest approaches that fit the existing patterns.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
