### PR TITLE
Add AND operator and enhance vulnerability handling in policy evaluations

### DIFF
--- a/src/main/java/org/dependencytrack/model/Policy.java
+++ b/src/main/java/org/dependencytrack/model/Policy.java
@@ -66,7 +66,8 @@ public class Policy implements Serializable {
 
     public enum Operator {
         ALL,
-        ANY
+        ANY,
+        AND
     }
 
     public enum ViolationState {

--- a/src/main/java/org/dependencytrack/model/PolicyViolation.java
+++ b/src/main/java/org/dependencytrack/model/PolicyViolation.java
@@ -75,6 +75,11 @@ public class PolicyViolation implements Serializable {
     private Component component;
 
     @Persistent(defaultFetchGroup = "true")
+    @Column(name = "VULNERABILITY_ID", allowsNull = "true")
+    @Index(name = "POLICYVIOLATION_VULNERABILITY_IDX")
+    private Vulnerability vulnerability;
+
+    @Persistent(defaultFetchGroup = "true")
     @Column(name = "POLICYCONDITION_ID", allowsNull = "false")
     private PolicyCondition policyCondition;
 
@@ -125,6 +130,15 @@ public class PolicyViolation implements Serializable {
         this.component = component;
         this.project = component.getProject();
     }
+
+    public Vulnerability getVulnerability() {
+        return vulnerability;
+    }
+
+    public void setVulnerability(Vulnerability vulnerability) {
+        this.vulnerability = vulnerability;
+    }
+
 
     public Project getProject() {
         return project;

--- a/src/main/java/org/dependencytrack/persistence/PolicyQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/PolicyQueryManager.java
@@ -160,11 +160,12 @@ final class PolicyQueryManager extends QueryManager implements IQueryManager {
 
     private record ViolationIdentity(
             long componentId,
+            long vulnerabilityId,
             long conditionId,
             PolicyViolation.Type type) {
 
         private ViolationIdentity(final PolicyViolation violation) {
-            this(violation.getComponent().getId(), violation.getPolicyCondition().getId(), violation.getType());
+            this(violation.getComponent().getId(), violation.getVulnerability().getId(), violation.getPolicyCondition().getId(), violation.getType());
         }
 
     }
@@ -407,8 +408,7 @@ final class PolicyQueryManager extends QueryManager implements IQueryManager {
             query.setOrdering("timestamp desc, component.name, component.version");
         }
         if (filter != null) {
-            query.setFilter(queryFilter + " && (policyCondition.policy.name.toLowerCase().matches(:filter) || component.name.toLowerCase().matches(:filter))");
-            final String filterString = ".*" + filter.toLowerCase() + ".*";
+            query.setFilter(queryFilter + " && (policyCondition.policy.name.toLowerCase().matches(:filter) || component.name.toLowerCase().matches(:filter) || vulnerability.vulnId.toLowerCase().matches(:filter))");            final String filterString = ".*" + filter.toLowerCase() + ".*";
             result = execute(query, project.getId(), filterString);
         } else {
             query.setFilter(queryFilter);

--- a/src/main/java/org/dependencytrack/policy/PolicyConditionViolation.java
+++ b/src/main/java/org/dependencytrack/policy/PolicyConditionViolation.java
@@ -20,6 +20,7 @@ package org.dependencytrack.policy;
 
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.PolicyCondition;
+import org.dependencytrack.model.Vulnerability;
 
 /**
  * Defines a violation which contains the component and the policy condition
@@ -32,10 +33,18 @@ public class PolicyConditionViolation {
 
     private final PolicyCondition policyCondition;
     private final Component component;
+    private final Vulnerability vulnerability;
 
     public PolicyConditionViolation(PolicyCondition policyCondition, Component component) {
         this.policyCondition = policyCondition;
         this.component = component;
+        this.vulnerability = null;
+    }
+
+    public PolicyConditionViolation(PolicyCondition policyCondition, Component component, Vulnerability vulnerability) {
+        this.policyCondition = policyCondition;
+        this.component = component;
+        this.vulnerability = vulnerability;
     }
 
     public PolicyCondition getPolicyCondition() {
@@ -45,4 +54,9 @@ public class PolicyConditionViolation {
     public Component getComponent() {
         return component;
     }
+    public Vulnerability getVulnerability() {
+        return vulnerability;
+    }
+
+
 }


### PR DESCRIPTION


### Description

The policy evaluation logic for ALL operator was aggregating condition matches at the component level, which allowed different vulnerabilities to satisfy different policy conditions. This resulted in false-positive policy violations because the system treated a policy as satisfied even when no single vulnerability matched all required conditions.

A new operator ("AND") is introduced to evaluate ALL conditions per vulnerability in AND way.
Each vulnerability is now checked independently, and a policy violation is created only when:

The same vulnerability triggers every policy condition defined in the policy.

During this change, PolicyViolation was extended to include a reference to the associated vulnerability.

### Addressed Issue

https://github.com/DependencyTrack/dependency-track/issues/5490

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [X] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [X] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [X] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
