### PR TITLE
feat: add batch processing for Trivy vulnerabilities and new vulnerab…

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
@@ -156,7 +156,7 @@ public class FindingsQueryManager extends QueryManager implements IQueryManager 
      * @return a List of Analysis objects, or null if not found
      */
     @SuppressWarnings("unchecked")
-    public List<Analysis> getAnalyses(Project project) {
+    List<Analysis> getAnalyses(Project project) {
         final Query<Analysis> query = pm.newQuery(Analysis.class, "project == :project");
         return (List<Analysis>) query.execute(project);
     }

--- a/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
@@ -156,7 +156,7 @@ public class FindingsQueryManager extends QueryManager implements IQueryManager 
      * @return a List of Analysis objects, or null if not found
      */
     @SuppressWarnings("unchecked")
-    List<Analysis> getAnalyses(Project project) {
+    public List<Analysis> getAnalyses(Project project) {
         final Query<Analysis> query = pm.newQuery(Analysis.class, "project == :project");
         return (List<Analysis>) query.execute(project);
     }

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -811,6 +811,11 @@ public class QueryManager extends AlpineQueryManager {
         return getVulnerabilityQueryManager().getVulnerabilityByVulnId(source, vulnId, includeVulnerableSoftware);
     }
 
+    public List<Vulnerability> getVulnerabilityByVulnIds(Map<String, Set<String>> sourceToVulnIds,
+                                                         boolean includeVulnerableSoftware) {
+        return getVulnerabilityQueryManager().getVulnerabilitiesBySourceAndVulnIds(sourceToVulnIds, includeVulnerableSoftware);
+    }
+
     public void addVulnerability(Vulnerability vulnerability, Component component, AnalyzerIdentity analyzerIdentity) {
         getVulnerabilityQueryManager().addVulnerability(vulnerability, component, analyzerIdentity);
     }
@@ -1093,7 +1098,7 @@ public class QueryManager extends AlpineQueryManager {
         return getVulnerabilityQueryManager().getVulnerabilityAliases(vulnIdAndSources);
     }
 
-    List<Analysis> getAnalyses(Project project) {
+    public List<Analysis> getAnalyses(Project project) {
         return getFindingsQueryManager().getAnalyses(project);
     }
 
@@ -1103,8 +1108,8 @@ public class QueryManager extends AlpineQueryManager {
 
     public Analysis makeAnalysis(Component component, Vulnerability vulnerability, AnalysisState analysisState,
                                  AnalysisJustification analysisJustification, AnalysisResponse analysisResponse,
-                                 String analysisDetails, Boolean isSuppressed) {
-        return getFindingsQueryManager().makeAnalysis(component, vulnerability, analysisState, analysisJustification, analysisResponse, analysisDetails, isSuppressed);
+                                 String analysisDetails, Boolean isSuppressed, Long suppressionExpiration) {
+        return getFindingsQueryManager().makeAnalysis(component, vulnerability, analysisState, analysisJustification, analysisResponse, analysisDetails, isSuppressed, suppressionExpiration);
     }
 
     public AnalysisComment makeAnalysisComment(Analysis analysis, String comment, String commenter) {
@@ -1542,10 +1547,6 @@ public class QueryManager extends AlpineQueryManager {
                 final Query<?> aclDeleteQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """
                         DELETE FROM "PROJECT_ACCESS_TEAMS" WHERE "PROJECT_ACCESS_TEAMS"."TEAM_ID" = ?""");
                 executeAndCloseWithArray(aclDeleteQuery, team.getId());
-
-                final Query<?> notificationRuleQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """
-                    DELETE FROM "NOTIFICATIONRULE_TEAMS" WHERE "NOTIFICATIONRULE_TEAMS"."TEAM_ID" = ?""");
-                executeAndCloseWithArray(notificationRuleQuery, team.getId());
             }
 
             pm.deletePersistent(team);

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1106,10 +1106,10 @@ public class QueryManager extends AlpineQueryManager {
         return getFindingsQueryManager().getAnalysis(component, vulnerability);
     }
 
-    public Analysis makeAnalysis(Component component, Vulnerability vulnerability, AnalysisState analysisState,
+    Analysis makeAnalysis(Component component, Vulnerability vulnerability, AnalysisState analysisState,
                                  AnalysisJustification analysisJustification, AnalysisResponse analysisResponse,
-                                 String analysisDetails, Boolean isSuppressed, Long suppressionExpiration) {
-        return getFindingsQueryManager().makeAnalysis(component, vulnerability, analysisState, analysisJustification, analysisResponse, analysisDetails, isSuppressed, suppressionExpiration);
+                                 String analysisDetails, Boolean isSuppressed) {
+        return getFindingsQueryManager().makeAnalysis(component, vulnerability, analysisState, analysisJustification, analysisResponse, analysisDetails, isSuppressed);
     }
 
     public AnalysisComment makeAnalysisComment(Analysis analysis, String comment, String commenter) {

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1098,7 +1098,7 @@ public class QueryManager extends AlpineQueryManager {
         return getVulnerabilityQueryManager().getVulnerabilityAliases(vulnIdAndSources);
     }
 
-    public List<Analysis> getAnalyses(Project project) {
+    List<Analysis> getAnalyses(Project project) {
         return getFindingsQueryManager().getAnalyses(project);
     }
 

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1106,7 +1106,7 @@ public class QueryManager extends AlpineQueryManager {
         return getFindingsQueryManager().getAnalysis(component, vulnerability);
     }
 
-    Analysis makeAnalysis(Component component, Vulnerability vulnerability, AnalysisState analysisState,
+    public Analysis makeAnalysis(Component component, Vulnerability vulnerability, AnalysisState analysisState,
                                  AnalysisJustification analysisJustification, AnalysisResponse analysisResponse,
                                  String analysisDetails, Boolean isSuppressed) {
         return getFindingsQueryManager().makeAnalysis(component, vulnerability, analysisState, analysisJustification, analysisResponse, analysisDetails, isSuppressed);

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -811,9 +811,8 @@ public class QueryManager extends AlpineQueryManager {
         return getVulnerabilityQueryManager().getVulnerabilityByVulnId(source, vulnId, includeVulnerableSoftware);
     }
 
-    public List<Vulnerability> getVulnerabilityByVulnIds(Map<String, Set<String>> sourceToVulnIds,
-                                                         boolean includeVulnerableSoftware) {
-        return getVulnerabilityQueryManager().getVulnerabilitiesBySourceAndVulnIds(sourceToVulnIds, includeVulnerableSoftware);
+    public List<Vulnerability> getVulnerabilitiesBySourceAndVulnIds(Collection<VulnIdAndSource> vulnIdsAndSources) {
+        return getVulnerabilityQueryManager().getVulnerabilitiesBySourceAndVulnIds(vulnIdsAndSources);
     }
 
     public void addVulnerability(Vulnerability vulnerability, Component component, AnalyzerIdentity analyzerIdentity) {

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1547,6 +1547,10 @@ public class QueryManager extends AlpineQueryManager {
                 final Query<?> aclDeleteQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """
                         DELETE FROM "PROJECT_ACCESS_TEAMS" WHERE "PROJECT_ACCESS_TEAMS"."TEAM_ID" = ?""");
                 executeAndCloseWithArray(aclDeleteQuery, team.getId());
+
+                final Query<?> notificationRuleQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """
+                    DELETE FROM "NOTIFICATIONRULE_TEAMS" WHERE "NOTIFICATIONRULE_TEAMS"."TEAM_ID" = ?""");
+                executeAndCloseWithArray(notificationRuleQuery, team.getId());
             }
 
             pm.deletePersistent(team);

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -386,34 +386,31 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
 
     /**
      * Returns vulnerabilities by source and vulnerability IDs.
-     * Most efficient for fetching multiple vulnerabilities with known sources.
-     * @param sourceToVulnIds map of source to set of vulnerability IDs
-     * @param includeVulnerableSoftware whether to include vulnerable software in fetch plan
+     * Efficiently fetches multiple vulnerabilities based on specific source/ID pairs.
+     * @param vulnIdsAndSources collection of {@link VulnIdAndSource} records to fetch
      * @return list of matching Vulnerability objects
      */
     public List<Vulnerability> getVulnerabilitiesBySourceAndVulnIds(
-            Map<String, Set<String>> sourceToVulnIds,
-            boolean includeVulnerableSoftware) {
+            Collection<VulnIdAndSource> vulnIdsAndSources) {
 
-        if (sourceToVulnIds == null || sourceToVulnIds.isEmpty()) {
+        if (vulnIdsAndSources == null || vulnIdsAndSources.isEmpty()) {
             return Collections.emptyList();
         }
 
+        Map<String, Set<String>> sourceToVulnIds = vulnIdsAndSources.stream()
+                .collect(Collectors.groupingBy(
+                        v -> v.source().name(),
+                        Collectors.mapping(VulnIdAndSource::vulnId, Collectors.toSet())
+                ));
+
         final Query<Vulnerability> query = pm.newQuery(Vulnerability.class);
         query.getFetchPlan().addGroup(Vulnerability.FetchGroup.COMPONENTS.name());
-        if (includeVulnerableSoftware) {
-            query.getFetchPlan().addGroup(Vulnerability.FetchGroup.VULNERABLE_SOFTWARE.name());
-        }
 
         StringBuilder filter = new StringBuilder();
         Map<String, Object> paramValues = new HashMap<>();
 
         int idx = 0;
         for (Map.Entry<String, Set<String>> entry : sourceToVulnIds.entrySet()) {
-            if (entry.getValue() == null || entry.getValue().isEmpty()) {
-                continue;
-            }
-
             if (!filter.isEmpty()) {
                 filter.append(" || ");
             }
@@ -421,38 +418,25 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
             String sourceParam = "source" + idx;
             String idsParam = "vulnId" + idx;
 
-            // (source == :source0 && :vulnId0.contains(vulnId))
+            // Constructs: (source == :source0 && :vulnId0.contains(vulnId))
             filter.append("(source == :").append(sourceParam)
                     .append(" && :").append(idsParam).append(".contains(vulnId))");
 
             paramValues.put(sourceParam, entry.getKey());
-            paramValues.put(idsParam, new ArrayList<>(entry.getValue()));
+            paramValues.put(idsParam, entry.getValue());
 
             idx++;
         }
 
-        if (filter.isEmpty()) {
-            return Collections.emptyList();
-        }
-
         query.setFilter(filter.toString());
-
-        @SuppressWarnings("unchecked")
-        List<Vulnerability> fetched = (List<Vulnerability>) query.executeWithMap(paramValues);
+        query.setNamedParameters(paramValues);
+        List<Vulnerability> fetched = executeAndCloseList(query);
 
         if (fetched == null || fetched.isEmpty()) {
             return Collections.emptyList();
         }
 
-        @SuppressWarnings("unchecked")
-        List<Vulnerability> detached = (List<Vulnerability>) pm.detachCopyAll(fetched);
-
-        // Safely apply aliases
-        for (Vulnerability vuln : detached) {
-            vuln.setAliases(getVulnerabilityAliases(vuln));
-        }
-
-        return detached;
+        return fetched;
     }
 
 

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -49,6 +49,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -168,8 +169,8 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
             } else {
                 // Update only if changes are detected
                 return hasChanges(existingVulnerability, vulnerability)
-                ? updateVulnerability(vulnerability, commitIndex)
-                : null;
+                        ? updateVulnerability(vulnerability, commitIndex)
+                        : null;
             }
         });
     }
@@ -382,6 +383,78 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
         }
         return result;
     }
+
+    /**
+     * Returns vulnerabilities by source and vulnerability IDs.
+     * Most efficient for fetching multiple vulnerabilities with known sources.
+     * @param sourceToVulnIds map of source to set of vulnerability IDs
+     * @param includeVulnerableSoftware whether to include vulnerable software in fetch plan
+     * @return list of matching Vulnerability objects
+     */
+    public List<Vulnerability> getVulnerabilitiesBySourceAndVulnIds(
+            Map<String, Set<String>> sourceToVulnIds,
+            boolean includeVulnerableSoftware) {
+
+        if (sourceToVulnIds == null || sourceToVulnIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        final Query<Vulnerability> query = pm.newQuery(Vulnerability.class);
+        query.getFetchPlan().addGroup(Vulnerability.FetchGroup.COMPONENTS.name());
+        if (includeVulnerableSoftware) {
+            query.getFetchPlan().addGroup(Vulnerability.FetchGroup.VULNERABLE_SOFTWARE.name());
+        }
+
+        StringBuilder filter = new StringBuilder();
+        Map<String, Object> paramValues = new HashMap<>();
+
+        int idx = 0;
+        for (Map.Entry<String, Set<String>> entry : sourceToVulnIds.entrySet()) {
+            if (entry.getValue() == null || entry.getValue().isEmpty()) {
+                continue;
+            }
+
+            if (!filter.isEmpty()) {
+                filter.append(" || ");
+            }
+
+            String sourceParam = "source" + idx;
+            String idsParam = "vulnId" + idx;
+
+            // (source == :source0 && :vulnId0.contains(vulnId))
+            filter.append("(source == :").append(sourceParam)
+                    .append(" && :").append(idsParam).append(".contains(vulnId))");
+
+            paramValues.put(sourceParam, entry.getKey());
+            paramValues.put(idsParam, new ArrayList<>(entry.getValue()));
+
+            idx++;
+        }
+
+        if (filter.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        query.setFilter(filter.toString());
+
+        @SuppressWarnings("unchecked")
+        List<Vulnerability> fetched = (List<Vulnerability>) query.executeWithMap(paramValues);
+
+        if (fetched == null || fetched.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        @SuppressWarnings("unchecked")
+        List<Vulnerability> detached = (List<Vulnerability>) pm.detachCopyAll(fetched);
+
+        // Safely apply aliases
+        for (Vulnerability vuln : detached) {
+            vuln.setAliases(getVulnerabilityAliases(vuln));
+        }
+
+        return detached;
+    }
+
 
     /**
      * Returns a List of Vulnerability for the specified Component and excludes suppressed vulnerabilities.
@@ -680,7 +753,7 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
         } else {
             query = pm.newQuery(VulnerabilityAlias.class, "internalId == :internalId");
         }
-            return (List<VulnerabilityAlias>)query.execute(vulnerability.getVulnId());
+        return (List<VulnerabilityAlias>)query.execute(vulnerability.getVulnId());
     }
 
 

--- a/src/main/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTask.java
@@ -46,6 +46,7 @@ import org.dependencytrack.model.Classifier;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentProperty;
 import org.dependencytrack.model.ConfigPropertyConstants;
+import org.dependencytrack.model.VulnIdAndSource;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAnalysisLevel;
 import org.dependencytrack.parser.trivy.TrivyParser;
@@ -77,6 +78,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNullElseGet;
@@ -364,96 +366,183 @@ public class TrivyAnalysisTask extends BaseComponentAnalyzerTask implements Subs
             }
         }
 
-        handleAllComponentsBatchOptimized(vulnsByComponent);
+        handleAllVulnsByComponent(vulnsByComponent);
     }
 
-    private void handleAllComponentsBatchOptimized(final Map<Component, List<trivy.proto.common.Vulnerability>> vulnsByComponent) {
+    private void handleAllVulnsByComponent(final Map<Component, List<trivy.proto.common.Vulnerability>> vulnsByComponent) {
         if (vulnsByComponent.isEmpty()) {
             return;
         }
 
-        try (final var qm = new QueryManager()) {
+        try (var qm = new QueryManager()) {
             final var trivyParser = new TrivyParser();
-            boolean didCreateVulns = false;
-            final var vulnerabilityAdditions = new ArrayList<VulnerabilityAddition>();
 
-            final var componentUuids = vulnsByComponent.keySet().stream()
-                    .map(Component::getUuid)
-                    .collect(Collectors.toSet());
+            final Map<UUID, Component> persistentComponents =
+                    resolvePersistentComponents(qm, vulnsByComponent.keySet());
 
-            final var persistentComponents = new HashMap<UUID, Component>();
-            for (UUID uuid : componentUuids) {
-                Component persistent = qm.getObjectByUuid(Component.class, uuid);
-                if (persistent != null) {
-                    persistentComponents.put(uuid, persistent);
-                }
-            }
+            final Map<trivy.proto.common.Vulnerability, Vulnerability> parsedCache =
+                    parseAllVulnerabilities(trivyParser, vulnsByComponent.values());
 
-            final var vulnIds = new HashMap<String, Set<String>>();
-            for (final List<trivy.proto.common.Vulnerability> trivyVulns : vulnsByComponent.values()) {
-                for (final trivy.proto.common.Vulnerability trivyVuln : trivyVulns) {
-                    final Vulnerability parsed = trivyParser.parse(trivyVuln);
-                    vulnIds.computeIfAbsent(parsed.getSource(), k -> new HashSet<>())
-                            .add(parsed.getVulnId());
-                }
-            }
+            final Map<VulnIdAndSource, Vulnerability> existingVulnerabilities =
+                    fetchExistingVulnerabilities(qm, parsedCache.values());
 
-            final var existingVulns = new HashMap<String, Vulnerability>(); // "source:vulnId" -> Vulnerability
+            final Set<VulnerabilityAddition> additions =
+                    processComponents(
+                            qm,
+                            vulnsByComponent,
+                            persistentComponents,
+                            parsedCache,
+                            existingVulnerabilities
+                    );
 
-            List<Vulnerability> fetchedVulns = qm.getVulnerabilityByVulnIds(vulnIds, false);
+            finalizeAdditions(qm, additions);
 
-            for (Vulnerability vuln : fetchedVulns) {
-                existingVulns.put(vuln.getSource() + ":" + vuln.getVulnId(), vuln);
-            }
+            qm.getPersistenceManager().evictAll();
 
-            for (final Map.Entry<Component, List<trivy.proto.common.Vulnerability>> entry : vulnsByComponent.entrySet()) {
-                final Component component = entry.getKey();
-                final List<trivy.proto.common.Vulnerability> trivyVulns = entry.getValue();
+            boolean hasNewVulnerabilities = hasNewVulnerabilities(additions, existingVulnerabilities);
 
-                final Component persistentComponent = persistentComponents.get(component.getUuid());
-                if (persistentComponent == null) {
-                    LOGGER.warn("""
-                            %s vulnerabilities were reported for component %s, \
-                            but it no longer exists; Skipping""".formatted(trivyVulns.size(), component.getUuid()));
-                    continue;
-                }
+            parsedCache.clear();
+            existingVulnerabilities.clear();
+            additions.clear();
+            persistentComponents.clear();
 
-                for (final trivy.proto.common.Vulnerability trivyVuln : trivyVulns) {
-                    final Vulnerability parsedVulnerability = trivyParser.parse(trivyVuln);
-                    final String vulnKey = parsedVulnerability.getSource() + ":" + parsedVulnerability.getVulnId();
-
-                    Vulnerability vulnerability = existingVulns.get(vulnKey);
-                    if (vulnerability == null) {
-                        LOGGER.debug("Creating unavailable vulnerability: %s - %s".formatted(parsedVulnerability.getSource(), parsedVulnerability.getVulnId()));
-                        vulnerability = qm.createVulnerability(parsedVulnerability, false);
-                        existingVulns.put(vulnKey, vulnerability);
-                        didCreateVulns = true;
-                    } else {
-                        if (parsedVulnerability.getSeverity() != null &&
-                                !parsedVulnerability.getSeverity().equals(vulnerability.getSeverity())) {
-                            qm.updateVulnerability(parsedVulnerability, false);
-                        }
-                    }
-
-                    vulnerabilityAdditions.add(new VulnerabilityAddition(vulnerability, persistentComponent));
-                }
-            }
-
-            for (VulnerabilityAddition addition : vulnerabilityAdditions) {
-                LOGGER.debug("Trivy vulnerability added: %s to component %s".formatted(addition.vulnerability.getVulnId(), addition.component.getName()));
-
-                NotificationUtil.analyzeNotificationCriteria(
-                        qm, addition.vulnerability, addition.component, vulnerabilityAnalysisLevel
-                );
-
-                qm.addVulnerability(addition.vulnerability, addition.component, this.getAnalyzerIdentity());
-            }
-
-            if (didCreateVulns) {
+            if (hasNewVulnerabilities) {
                 Event.dispatch(new IndexEvent(IndexEvent.Action.COMMIT, Vulnerability.class));
             }
-
         }
+    }
+
+    private Map<UUID, Component> resolvePersistentComponents(
+            QueryManager qm,
+            Set<Component> components
+    ) {
+        Set<UUID> uuids = components.stream()
+                .map(Component::getUuid)
+                .collect(Collectors.toSet());
+
+        if (uuids.isEmpty()) {
+            return Map.of();
+        }
+
+        List<UUID> uuidList = new ArrayList<>(uuids);
+
+        List<Component> persistentComponents =
+                qm.getObjectsByUuids(Component.class, uuidList);
+
+        return persistentComponents.stream()
+                .collect(Collectors.toMap(
+                        Component::getUuid,
+                        Function.identity()
+                ));
+    }
+
+    private Map<trivy.proto.common.Vulnerability, Vulnerability> parseAllVulnerabilities(
+            TrivyParser parser,
+            Collection<List<trivy.proto.common.Vulnerability>> trivyLists
+    ) {
+        Map<trivy.proto.common.Vulnerability, Vulnerability> cache = new HashMap<>();
+
+        for (List<trivy.proto.common.Vulnerability> list : trivyLists) {
+            for (trivy.proto.common.Vulnerability trivyVuln : list) {
+                cache.computeIfAbsent(trivyVuln, parser::parse);
+            }
+        }
+        return cache;
+    }
+
+
+    private Map<VulnIdAndSource, Vulnerability> fetchExistingVulnerabilities(
+            QueryManager qm,
+            Collection<Vulnerability> parsedVulns
+    ) {
+        Set<VulnIdAndSource> identifiers = parsedVulns.stream()
+                .map(v -> new VulnIdAndSource(v.getVulnId(), v.getSource()))
+                .collect(Collectors.toSet());
+
+        Map<VulnIdAndSource, Vulnerability> result = new HashMap<>();
+
+        for (Vulnerability vuln : qm.getVulnerabilitiesBySourceAndVulnIds(identifiers)) {
+            result.put(new VulnIdAndSource(vuln.getVulnId(), vuln.getSource()), vuln);
+        }
+        return result;
+    }
+
+    private Set<VulnerabilityAddition> processComponents(
+            QueryManager qm,
+            Map<Component, List<trivy.proto.common.Vulnerability>> vulnsByComponent,
+            Map<UUID, Component> persistentComponents,
+            Map<trivy.proto.common.Vulnerability, Vulnerability> parsedCache,
+            Map<VulnIdAndSource, Vulnerability> existingVulnerabilities
+    ) {
+        Set<VulnerabilityAddition> additions = new HashSet<>();
+
+        for (var entry : vulnsByComponent.entrySet()) {
+            Component component = entry.getKey();
+            Component persistent = persistentComponents.get(component.getUuid());
+
+            if (persistent == null) {
+                LOGGER.warn("""
+                            %s vulnerabilities were reported for component %s, \
+                            but it no longer exists; Skipping""".formatted( entry.getValue().size(), component.getUuid()));
+                continue;
+            }
+
+            for (var trivyVuln : entry.getValue()) {
+                Vulnerability parsedVulnerability = parsedCache.get(trivyVuln);
+                VulnIdAndSource key = new VulnIdAndSource(parsedVulnerability.getVulnId(), parsedVulnerability.getSource());
+
+                Vulnerability persisted = existingVulnerabilities.get(key);
+
+                if (persisted == null) {
+                    LOGGER.debug("Creating unavailable vulnerability: %s - %s".formatted(parsedVulnerability.getSource(), parsedVulnerability.getVulnId()));
+                    persisted = qm.createVulnerability(parsedVulnerability, false);
+                    existingVulnerabilities.put(key, persisted);
+                } else if (severityChanged(parsedVulnerability, persisted)) {
+                    qm.updateVulnerability(parsedVulnerability, false);
+                }
+
+                additions.add(new VulnerabilityAddition(persisted, persistent));
+            }
+        }
+        return additions;
+    }
+
+    private void finalizeAdditions(
+            QueryManager qm,
+            Set<VulnerabilityAddition> additions
+    ) {
+        int count = 0;
+
+        for (VulnerabilityAddition addition : additions) {
+            LOGGER.debug("Trivy vulnerability added: %s to component %s".formatted(addition.vulnerability.getVulnId(), addition.component.getName()));
+
+            NotificationUtil.analyzeNotificationCriteria(
+                    qm, addition.vulnerability, addition.component, vulnerabilityAnalysisLevel
+            );
+            qm.addVulnerability(addition.vulnerability, addition.component, this.getAnalyzerIdentity());
+
+            if (++count % 20 == 0) {
+                qm.getPersistenceManager().flush();
+            }
+        }
+
+        qm.getPersistenceManager().flush();
+    }
+
+    private boolean severityChanged(Vulnerability parsed, Vulnerability existing) {
+        return parsed.getSeverity() != null
+                && !parsed.getSeverity().equals(existing.getSeverity());
+    }
+
+    private boolean hasNewVulnerabilities(
+            Set<VulnerabilityAddition> additions,
+            Map<VulnIdAndSource, Vulnerability> existing
+    ) {
+        return additions.stream()
+                .map(VulnerabilityAddition::vulnerability)
+                .anyMatch(v ->
+                        !existing.containsKey(new VulnIdAndSource(v.getVulnId(), v.getSource()))
+                );
     }
 
     private record VulnerabilityAddition(Vulnerability vulnerability, Component component) {


### PR DESCRIPTION
### Description

## **New Batch Implementation Improvements (with approximate numbers)**

### **Batch Mode Behavior**

**1. Component UUID lookups:**
Instead of one lookup per component inside the loop → performed once
 **200 component queries → now 1 batched loop (≈200 ops total)** *(unchanged count but centralized)*

**2. Vulnerability existence checks:**
Old: 3,000 “source + vulnId” lookups
New: Build a map of unique `(source, vulnId)` pairs, e.g. 3,000 unique →
**Single `getVulnerabilityByVulnIds()` call**
Replaces **3,000 DB queries** with **1 batched query**

**3. Creating new vulnerabilities:**
Still O(#missing vulns), but performed in one transaction scope.
Index event dispatched just once.

**4. Adding vulnerability–component mappings:**
Still requires writes, but all done in a tight loop inside one transaction.
No repeated component fetches
No repeated vulnerability lookups

### **Estimated totals (new code)**

| Operation                      | Old           | New                               |
| ------------------------------ | ------------- | --------------------------------- |
| Vulnerability lookups          | 3,000 queries | **1 query**                       |
| Component lookups              | 200 queries   | **200 lookups in a single block** |
| Add vulnerability to component | 3,000 writes  | **3,000 writes (unavoidable)**    |
| Severity updates               | 300 writes    | **300 writes**                    |
| Index commits                  | N commits     | **1 commit**                      |

### **Grand total (new code)**

~**200 component lookups (no change)**
**1 DB query instead of 3,000 for vuln existence checks**
~3,300 writes (same as old, but in one transaction block)
**Significant transaction overhead reduction**

---

## **Impact Summary**

| Metric                | Old Code                 | New Code                               |
| --------------------- | ------------------------ | -------------------------------------- |
| Vulnerability lookups | ~3,000 DB roundtrips     | **1 DB roundtrip**                     |
| IndexEvent dispatches | many                     | **1**                                  |
| Transactions opened   | ~200 (one per component) | **1**                                  |
| Total DB operations   | ~6,500+                  | **~3,500** but batched and far cheaper |

### **Overall effect**

* Dramatically less DB round-trip latency
* Higher throughput during large Trivy scans
* Lower CPU + I/O load on the database
* More predictable performance for large SBOMs

### Addressed Issue

closes https://github.com/DependencyTrack/dependency-track/issues/5497


### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [X] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [X] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
