### PR TITLE
feat(email): include notification level in email subject line

### DIFF
--- a/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
+++ b/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
@@ -39,6 +39,7 @@ public enum ConfigPropertyConstants {
     EMAIL_SMTP_PASSWORD("email", "smtp.password", null, PropertyType.ENCRYPTEDSTRING, "The optional password for the username used for authentication"),
     EMAIL_SMTP_SSLTLS("email", "smtp.ssltls", "false", PropertyType.BOOLEAN, "Flag to enable/disable the use of SSL/TLS when connecting to the SMTP server"),
     EMAIL_SMTP_TRUSTCERT("email", "smtp.trustcert", "false", PropertyType.BOOLEAN, "Flag to enable/disable the trust of the certificate presented by the SMTP server"),
+    EMAIL_SUBJECT_SHOW_LEVEL("email", "subject.show.level", "false", PropertyType.BOOLEAN,"If true, email subjects include the notification level"),
     INTERNAL_COMPONENTS_GROUPS_REGEX("internal-components", "groups.regex", null, PropertyType.STRING, "Regex that matches groups of internal components"),
     INTERNAL_COMPONENTS_NAMES_REGEX("internal-components", "names.regex", null, PropertyType.STRING, "Regex that matches names of internal components"),
     INTERNAL_COMPONENTS_MATCH_MODE("internal-components", "match-mode", "OR", PropertyType.STRING, "Determines how internal component regexes are combined: OR (default) or AND"),

--- a/src/test/java/org/dependencytrack/notification/publisher/SendMailPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/SendMailPublisherTest.java
@@ -41,6 +41,7 @@ import static org.dependencytrack.model.ConfigPropertyConstants.EMAIL_SMTP_SERVE
 import static org.dependencytrack.model.ConfigPropertyConstants.EMAIL_SMTP_SSLTLS;
 import static org.dependencytrack.model.ConfigPropertyConstants.EMAIL_SMTP_TRUSTCERT;
 import static org.dependencytrack.model.ConfigPropertyConstants.EMAIL_SMTP_USERNAME;
+import static org.dependencytrack.model.ConfigPropertyConstants.EMAIL_SUBJECT_SHOW_LEVEL;
 
 class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
 
@@ -120,6 +121,13 @@ class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
                 "false",
                 EMAIL_SMTP_TRUSTCERT.getPropertyType(),
                 EMAIL_SMTP_TRUSTCERT.getDescription()
+        );
+        qm.createConfigProperty(
+                EMAIL_SUBJECT_SHOW_LEVEL.getGroupName(),
+                EMAIL_SUBJECT_SHOW_LEVEL.getPropertyName(),
+                "true",
+                EMAIL_SUBJECT_SHOW_LEVEL.getPropertyType(),
+                EMAIL_SUBJECT_SHOW_LEVEL.getDescription()
         );
     }
     
@@ -952,6 +960,21 @@ class SendMailPublisherTest extends AbstractPublisherTest<SendMailPublisher> {
                         "ldapUser@Test.com",
                         "managedUser@Test.com",
                         "steve@jobs.org");
+    }
+
+    @Test
+    public void testMailSubjectWithoutLevelWhenDisabled() {
+        qm.getConfigProperty(
+                EMAIL_SUBJECT_SHOW_LEVEL.getGroupName(),
+                EMAIL_SUBJECT_SHOW_LEVEL.getPropertyName())
+        .setPropertyValue("false");
+
+        super.baseTestInformWithNewVulnerabilityNotification();
+
+        assertThat(greenMail.getReceivedMessages()).satisfiesExactly(message ->
+                assertThat(message.getSubject())
+                        .isEqualTo("[Dependency-Track] New Vulnerability Identified on Project: [projectName : projectVersion]")
+        );
     }
 
     private NotificationRule createNotificationRule() {


### PR DESCRIPTION
Adds the NotificationRule's level (e.g. [WARNING], [ERROR]) to the subject of outgoing SMTP emails. Improves clarity and urgency of notifications received by users. Uses ctx.ruleLevel() for formatting.

### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds the notification level (e.g., [WARNING], [ERROR], [INFORMATIONAL]) to the subject line of outgoing SMTP notification emails. This improves visibility and urgency of alerts directly from the subject without needing to open the email.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
