### PR TITLE
SecObserve has been moved to another GitHub organisation

### DIFF
--- a/docs/_docs/integrations/community-integrations.md
+++ b/docs/_docs/integrations/community-integrations.md
@@ -24,7 +24,7 @@ to make custom tools and integrations. Many tools that integrate with Dependency
 | [Github action OWASP Dependency Track Check](https://github.com/marketplace/actions/owasp-dependency-track-check)| [Quobis](https://www.quobis.com/)|
 | [Mixeway Hub](https://github.com/mixeway/mixewayhub) | [Mixeway](https://mixeway.io/) |
 | [SD Elements](https://www.securitycompass.com/sdelements) | [Security Compass](https://www.securitycompass.com/) |
-| [SecObserve](https://github.com/SecObserve/SecObserve) | |
+| [SecObserve](https://github.com/SecObserve/SecObserve) |  |
 | [ThreadFix](https://threadfix.it/) | [Denim Group](https://www.denimgroup.com/) |
 | [dependency-track-exporter](https://github.com/jetstack/dependency-track-exporter) | [Jetstack](https://jetstack.io) |
 | [dependency-track-maven-plugin](https://github.com/pmckeown/dependency-track-maven-plugin) | |


### PR DESCRIPTION
### Description

SecObserve has already been listed in the community integrations, but its URL has changed.

### Addressed Issue

The documentation page for community integrations shall include the new URL of SecObserve.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
