### PR TITLE
fix(api): prevent PolicyCondition.policy from being exposed in API schema and payloads

### DIFF
--- a/src/main/java/org/dependencytrack/model/PolicyCondition.java
+++ b/src/main/java/org/dependencytrack/model/PolicyCondition.java
@@ -144,6 +144,7 @@ public class PolicyCondition implements Serializable {
         this.id = id;
     }
 
+    @JsonIgnore
     public Policy getPolicy() {
         return policy;
     }


### PR DESCRIPTION
### Description

This change hides the `policy` property of `PolicyCondition` from both JSON serialization and the generated OpenAPI schema by marking the `getPolicy()` method with `@JsonIgnore`.

The `policy` field is internal to the persistence layer and is not meant to be exposed or accepted through the REST API. When clients submit a payload containing `"policy": "string"`, Jackson attempts to deserialize the value into a `Policy` object, resulting in a `400` error:

    Cannot construct instance of `org.dependencytrack.model.Policy`

By ignoring the getter, the field is no longer included in JSON payloads or in the OpenAPI definition (YAML and JSON), while still being intact for persistence.

This restores the intended API contract without affecting database structure or application behavior.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
