### PR TITLE
Comparing version numbers with a combination of characters and numbers more differentially. 

### DIFF
--- a/src/main/java/org/dependencytrack/util/ComponentVersion.java
+++ b/src/main/java/org/dependencytrack/util/ComponentVersion.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.util;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -250,8 +251,8 @@ public class ComponentVersion implements Iterable<String>, Comparable<ComponentV
         if (version == null) {
             return 1;
         }
-        final List<String> left = this.getVersionParts();
-        final List<String> right = version.getVersionParts();
+        final List<String> left = makeComparable(this.getVersionParts());
+        final List<String> right = makeComparable(version.getVersionParts());
         final int max = left.size() < right.size() ? left.size() : right.size();
 
         for (int i = 0; i < max; i++) {
@@ -286,5 +287,18 @@ public class ComponentVersion implements Iterable<String>, Comparable<ComponentV
         } else {
             return Integer.compare(left.size(), right.size());
         }
+    }
+
+    private List<String> makeComparable(List<String> versionParts) {
+        final List<String> comparableParts = new ArrayList<>();
+        for (String versionPart : versionParts){
+            final String[] token = versionPart.split("(?<=\\d)(?=\\D)|(?=\\d)(?<=\\D)");
+            if (token.length > 1) {
+                comparableParts.addAll(Arrays.asList(token));
+            } else {
+                comparableParts.add(versionPart);
+            }
+        }
+        return comparableParts;
     }
 }


### PR DESCRIPTION
### Description
Added a new method within /src/main/java/org/dependencytrack/util/ComponentVersion.java to further split the version number, to be able to compare the combination of characters and numbers more differentially.
Before, version numbers like this: 1.36.1-r2 & 1.36.1-r18 were split and then each part was compared. For the last part: r2 and r18, since it is no int, the method compared lexicographically, making r18 older than r2. That resulted in some false positives. 
Now, the r2 and r18 parts are split between the r and the integer, and then each of the pairs are compared. 

### Addressed Issue
Addressed issue: #3808 ("False positives due to erroneous comparison of component versions")

### Additional Details
Used ChatGPT and Copilot to understand existing structure and pattern matching, as well as sanity checks with example version numbers. 
https://stackoverflow.com/questions/11232801/regex-split-numbers-and-letter-groups-without-spaces

### Checklist
- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
