### PR TITLE
fix: use repositoryUrl in GithubMetaAnalyzer

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/repositories/GithubMetaAnalyzer.java
+++ b/src/main/java/org/dependencytrack/tasks/repositories/GithubMetaAnalyzer.java
@@ -128,7 +128,7 @@ public class GithubMetaAnalyzer extends AbstractMetaAnalyzer {
                 } else if (isBlank(repositoryUser) && isNotBlank(repositoryPassword)) {
                     github = GitHub.connectUsingOAuth(repositoryUrl, repositoryPassword);
                 } else {
-                    github = GitHub.connectAnonymously();
+                    github = GitHub.connectToEnterpriseAnonymously(repositoryUrl);
                 }
 
                 GHRepository repository = github.getRepository(String.format("%s/%s", urlEncode(component.getPurl().getNamespace()), urlEncode(component.getPurl().getName())));


### PR DESCRIPTION
### Description

`GithubMetaAnalyzer` should use `repositoryUrl` even if no password is provided

### Addressed Issue

fixes #5621

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [~] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [~] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [~] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
