### PR TITLE
docs: specify newer version of docker compose in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ CI/CD environments.
 curl -LO https://dependencytrack.org/docker-compose.yml
 
 # Starts the stack using Docker Compose
-docker-compose up -d
+docker compose up -d
 ```
 
 ### Quickstart (Docker Swarm)


### PR DESCRIPTION
### Description

The original python project (docker-compose) has already been deprecated, and moved over to v2.

### Addressed Issue

n/a

### Additional Details

n/a

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
