### PR TITLE
Fix wrong NPM component coordinate separator for Trivy analysis

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTask.java
@@ -212,7 +212,8 @@ public class TrivyAnalysisTask extends BaseComponentAnalyzerTask implements Subs
                 var name = component.getPurl().getName();
 
                 if (component.getPurl().getNamespace() != null) {
-                    if (PackageURL.StandardTypes.GOLANG.equals(component.getPurl().getType())) {
+                    if (PackageURL.StandardTypes.GOLANG.equals(component.getPurl().getType()) || 
+                            PackageURL.StandardTypes.NPM.equals(component.getPurl().getType())) {
                         name = component.getPurl().getNamespace() + "/" + name;
                     } else {
                         name = component.getPurl().getNamespace() + ":" + name;


### PR DESCRIPTION
### Description

Updated the TrivyAnalysisTask to use the forward slash (/) separator for NPM scoped packages when constructing the analysis blob. Previously, the analyzer used a colon (:) for all non-Golang packages, which caused the Trivy server to fail to match scoped npm packages (e.g., @remix-run/router) against its vulnerability database, resulting in zero findings for those components.

### Addressed Issue

Fixes https://github.com/DependencyTrack/dependency-track/issues/5675

### Additional Details

Trivy's vulnerability engine is sensitive to the name field in the Application protobuf message. For the node-pkg (NPM) ecosystem, Trivy expects scoped packages to follow the standard @scope/package format.

Before: The analyzer sent @remix-run:router, which resulted in no matches.

After: The analyzer sends @remix-run/router, aligning with NPM's naming convention and allowing Trivy to correctly identify vulnerabilities.

I considered a broader refactor of separators, but opted for explicitly adding NPM to the slash-separator logic to ensure high-confidence compatibility with Golang and NPM while preserving existing behavior for other ecosystems like Maven (which typically uses colons in this context).

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [X] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
