### PR TITLE
Added backend implementation for the banner configuration.

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/BannerResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BannerResource.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1;
+
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.resources.v1.vo.BannerConfig;
+
+import alpine.server.auth.PermissionRequired;
+import alpine.server.resources.AlpineResource;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import io.swagger.v3.oas.annotations.Operation;
+
+@Path("/v1/banner")
+@Tag(name = "banner")
+@SecurityRequirements({
+        @SecurityRequirement(name = "ApiKeyAuth"),
+        @SecurityRequirement(name = "BearerAuth")
+})
+
+public class BannerResource extends AlpineResource {
+
+    public static final String CFG_GROUP = "banner";
+    public static final String CFG_NAME = "config";
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Fetch banner configuration.")
+
+    public Response getBannerConfiguration() {
+        try (final QueryManager qm = new QueryManager(getAlpineRequest())) {
+            final BannerConfig config = qm.getBannerConfig();
+            return Response.ok(config).build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Failed to fetch banner configuration")
+                    .build();
+        }
+
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Update banner configuration.")
+    @PermissionRequired(Permissions.Constants.ACCESS_MANAGEMENT)
+
+    public Response updateBannerConfiguration(BannerConfig config) {
+        if (config == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Banner configuration is required").build();
+        }
+        if (config.activateBanner) {
+            if (config.customMode) {
+                if (config.html == null || config.html.trim().isEmpty()) {
+                    return Response.status(Response.Status.BAD_REQUEST)
+                            .entity("Banner HTML is required when banner is active in custom mode").build();
+                }
+            } else {
+                if (config.message == null || config.message.trim().isEmpty()) {
+                    return Response.status(Response.Status.BAD_REQUEST)
+                            .entity("Banner message is required when banner is active").build();
+                }
+            }
+        }
+        try (final QueryManager qm = new QueryManager(getAlpineRequest())) {
+            final BannerConfig saved = qm.setBannerConfig(config);
+            return Response.ok(saved).build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("Failed to update banner configuration").build();
+        }
+    }
+
+}

--- a/src/main/java/org/dependencytrack/resources/v1/vo/BannerConfig.java
+++ b/src/main/java/org/dependencytrack/resources/v1/vo/BannerConfig.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+public class BannerConfig {
+    public boolean activateBanner;
+    public boolean makeBannerDismissable;
+    public String message;
+    public String colorScheme;
+    public boolean customMode;
+    public String html;
+
+    public BannerConfig() {
+    }
+
+    public BannerConfig(boolean activateBanner, boolean makeBannerDismissable, String message, String colorScheme,
+            boolean customMode, String html) {
+        this.activateBanner = activateBanner;
+        this.makeBannerDismissable = makeBannerDismissable;
+        this.message = message;
+        this.colorScheme = colorScheme;
+        this.customMode = customMode;
+        this.html = html;
+    }
+
+}

--- a/src/test/java/org/dependencytrack/resources/v1/BannerResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BannerResourceTest.java
@@ -1,0 +1,106 @@
+package org.dependencytrack.resources.v1;
+
+import alpine.server.filters.ApiFilter;
+import alpine.server.filters.AuthenticationFilter;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.auth.Permissions;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.dependencytrack.resources.v1.vo.BannerConfig;
+
+public class BannerResourceTest extends ResourceTest {
+    @RegisterExtension
+    public static JerseyTestExtension jersey = new JerseyTestExtension(
+            () -> new ResourceConfig(BannerResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
+
+    @Test
+    void getBannerConfigurationForPresetActive() {
+        BannerConfig bannerConfiguration = new BannerConfig();
+        bannerConfiguration.activateBanner = true;
+        bannerConfiguration.customMode = false;
+        bannerConfiguration.message = "Banner Test Preset";
+        qm.setBannerConfig(bannerConfiguration);
+
+        Response response = jersey.target("/v1/banner").request().header(X_API_KEY, apiKey).get();
+        assertEquals(200, response.getStatus());
+        JsonObject bannerJson = parseJsonObject(response);
+        assertEquals(true, bannerJson.getBoolean("activateBanner"));
+        assertEquals(false, bannerJson.getBoolean("customMode"));
+        assertEquals("Banner Test Preset", bannerJson.getString("message"));
+    }
+
+    @Test
+    void updateBannerConfigurationForCustomHTMLActive() {
+
+        initializeWithPermissions(Permissions.ACCESS_MANAGEMENT);
+
+        Response response = jersey.target("/v1/banner").request().header(X_API_KEY, apiKey)
+                .post(Entity.entity(
+                        /* language=JSON */ """
+                                {"activateBanner": true, "customMode": true, "html": "<div style=\\\"position:relative;background:#321FDB;color:#fff;padding:${padding};border-bottom:1px solid rgba(0,0,0,.2);font-size:18px;line-height:1.4;text-align:center\\\"><strong>Example:</strong> <span>Your HTML-Banner Text</span>"}
+                                """,
+                        MediaType.APPLICATION_JSON));
+
+        assertEquals(200, response.getStatus());
+        JsonObject bannerJson = parseJsonObject(response);
+        assertTrue(bannerJson.getBoolean("activateBanner"));
+        assertTrue(bannerJson.getBoolean("customMode"));
+        final var expected = "<div style=\"position:relative;background:#321FDB;color:#fff;padding:${padding};border-bottom:1px solid rgba(0,0,0,.2);font-size:18px;line-height:1.4;text-align:center\"><strong>Example:</strong> <span>Your HTML-Banner Text</span>";
+        assertEquals(
+                expected,
+                bannerJson.getString("html"));
+    }
+
+    @Test
+    void updateBannerConfigurationForCustomHTMLMissingHTML() {
+        Response response = jersey.target("/v1/banner").request().header(X_API_KEY, apiKey)
+                .post(Entity.entity(
+                        /* language=JSON */ """
+                                {"activateBanner": true, "customMode": true, "html": ""}
+                                """,
+                        MediaType.APPLICATION_JSON));
+
+        assertEquals(400, response.getStatus());
+        assertEquals("Banner HTML is required when banner is active in custom mode", getPlainTextBody(response));
+    }
+
+    @Test
+    void updateBannerConfigurationForPresetMissingMessage() {
+        Response response = jersey.target("/v1/banner").request().header(X_API_KEY, apiKey)
+                .post(Entity.entity(
+                        /* language=JSON */ """
+                                {"activateBanner": true, "customMode": false, "message": ""}
+                                """,
+                        MediaType.APPLICATION_JSON));
+
+        assertEquals(400, response.getStatus());
+        assertEquals("Banner message is required when banner is active", getPlainTextBody(response));
+    }
+
+    @Test
+    void setBannerConfigurationForPreset() {
+        BannerConfig bannerConfiguration = new BannerConfig(false, true, "Test Banner", "blue", false, "");
+
+        Response post = jersey.target("/v1/banner").request().header(X_API_KEY, apiKey).post(Entity.entity(bannerConfiguration, MediaType.APPLICATION_JSON));
+        assertEquals(200, post.getStatus());
+        JsonObject bannerJson = parseJsonObject(post);
+        assertEquals(false, bannerJson.getBoolean("activateBanner"));
+        assertEquals(true, bannerJson.getBoolean("makeBannerDismissable"));
+        assertEquals("Test Banner", bannerJson.getString("message"));
+        assertEquals("blue", bannerJson.getString("colorScheme"));
+        assertEquals(false, bannerJson.getBoolean("customMode"));
+        assertEquals("", bannerJson.getString("html"));
+    }
+}


### PR DESCRIPTION
### Description
Added backend implementation for the banner configuration. Add site banner feature: GET /v1/banner and POST /v1/banner. POST requires ACCESS_MANAGEMENT permission; GET is public. 
Config is stored as JSON in ConfigProperty. At least requires message/html when active.

### Addressed Issue
Addressed issue #1418 in /frontend. 

### Additional Details
Used GithubCopilot and ChatGPT for understanding existing codebase and suggest changes.

### Checklist
- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
