### PR TITLE
Stale vulnerabilities remain when analyzer (Trivy) no longer reports them

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -841,6 +841,10 @@ public class QueryManager extends AlpineQueryManager {
         getVulnerabilityQueryManager().deleteFindingAttributions(project);
     }
 
+    public void reconcileFindingsForComponentAnalyzer(Component component, AnalyzerIdentity analyzerIdentity, Set<VulnIdAndSource> currentVulnIdAndSources) {
+        getVulnerabilityQueryManager().reconcileFindingsForComponentAnalyzer(component, analyzerIdentity, currentVulnIdAndSources);
+    }
+
     public List<VulnerableSoftware> reconcileVulnerableSoftware(final Vulnerability vulnerability,
                                                                 final List<VulnerableSoftware> vsListOld,
                                                                 final List<VulnerableSoftware> vsList,

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -49,6 +49,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -296,6 +297,36 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
         final Query<FindingAttribution> query = pm.newQuery(FindingAttribution.class, "project == :project");
         query.deletePersistentAll(project);
     }
+
+    /**
+     * Reconciles findings for a component from a specific analyzer by removing
+     * any FindingAttributions that are no longer reported by the analyzer.
+     *
+     * @param component the component to reconcile findings for
+     * @param analyzerIdentity the analyzer identity to scope reconciliation
+     * @param currentVulnIdAndSources the set of VulnIdAndSource reported by the latest scan
+     */
+    public void reconcileFindingsForComponentAnalyzer(Component component, AnalyzerIdentity analyzerIdentity, Set<VulnIdAndSource> currentVulnIdAndSources) {
+        runInTransaction(() -> {
+            final Query<FindingAttribution> query = pm.newQuery(FindingAttribution.class, "component == :component && analyzerIdentity == :analyzerIdentity");
+            final List<FindingAttribution> existing = (List<FindingAttribution>) query.execute(component, analyzerIdentity);
+            final Component persistentComponent = getObjectById(Component.class, component.getId());
+            boolean changed = false;
+            for (final FindingAttribution fa : existing) {
+                final Vulnerability vuln = getObjectById(Vulnerability.class, fa.getVulnerability().getId());
+                final VulnIdAndSource vid = new VulnIdAndSource(vuln.getVulnId(), vuln.getSource());
+                if (!currentVulnIdAndSources.contains(vid)) {
+                    persistentComponent.removeVulnerability(vuln);
+                    delete(fa);
+                    changed = true;
+                }
+            }
+            if (changed) {
+                persist(persistentComponent);
+            }
+        });
+    }
+
 
     /**
      * Determines if a Component is affected by a specific Vulnerability by checking


### PR DESCRIPTION
### Description

This change prevents stale vulnerability findings from persisting when an analyser (specifically Trivy) no longer reports those vulnerabilities for a component.

Previously, Dependency-Track only added new vulnerability findings during analysis, but did not reconcile findings that were absent in subsequent analyser results. As a result, vulnerabilities that were reverted, withdrawn, or fixed upstream (e.g., false positives in the Trivy vulnerability database) continued to appear as active findings indefinitely.

With this change, vulnerability findings are reconciled per analyser run so that findings not present in the latest analysis are marked as resolved (or deactivated), ensuring that Dependency-Track reflects the analyser’s current assessment.

### Addressed Issue

Fixes https://github.com/DependencyTrack/dependency-track/issues/5764

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [X] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [X] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
