### PR TITLE
Strip quotes from JAVA_OPTIONS environment variable

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -85,8 +85,9 @@ ENTRYPOINT ["/usr/bin/tini", "--"]
 # Launch Dependency-Track
 CMD [ \
     "/bin/sh", "-c", \
-    "exec java \
-        ${JAVA_OPTIONS} ${EXTRA_JAVA_OPTIONS} \
+    "java_opts=\$(printf '%s' \"\$JAVA_OPTIONS\" | sed \"s/^['\\\"']//;s/['\\\"']\\$//\"); \
+    extra_opts=\$(printf '%s' \"\$EXTRA_JAVA_OPTIONS\" | sed \"s/^['\\\"']//;s/['\\\"']\\$//\"); \
+    exec java \$java_opts \$extra_opts \
         --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
         --sun-misc-unsafe-memory-access=allow \
         -Dlogback.configurationFile=${LOGGING_CONFIG_PATH} \

--- a/src/main/docker/Dockerfile.alpine
+++ b/src/main/docker/Dockerfile.alpine
@@ -90,8 +90,9 @@ ENTRYPOINT ["/sbin/tini", "--"]
 # Launch Dependency-Track
 CMD [ \
     "/bin/sh", "-c", \
-    "exec java \
-        ${JAVA_OPTIONS} ${EXTRA_JAVA_OPTIONS} \
+    "java_opts=\$(printf '%s' \"\$JAVA_OPTIONS\" | sed \"s/^['\\\"']//;s/['\\\"']\\$//\"); \
+    extra_opts=\$(printf '%s' \"\$EXTRA_JAVA_OPTIONS\" | sed \"s/^['\\\"']//;s/['\\\"']\\$//\"); \
+    exec java \$java_opts \$extra_opts \
         --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
         --sun-misc-unsafe-memory-access=allow \
         -Dlogback.configurationFile=${LOGGING_CONFIG_PATH} \


### PR DESCRIPTION
### Description
When users set `JAVA_OPTIONS` in docker-compose with quotes (e.g., `JAVA_OPTIONS="-XX:+UseG1GC -XX:MaxRAMPercentage=50.0"`), Docker Compose passes the quotes as literal characters in the environment variable value. This causes Java to interpret the entire quoted string as a class name, resulting in `ClassNotFoundException`.

This fix strips leading and trailing quotes (both single and double) from `JAVA_OPTIONS `and `EXTRA_JAVA_OPTIONS` before passing them to the Java process.
<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue
Fixes #3350
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details
#### Root cause: 
Docker Compose preserves quotes in YAML as literal characters. When `JAVA_OPTIONS="-XX:+UseG1GC"`is set in docker-compose.yml, the environment variable value becomes `"-XX:+UseG1GC"` (with quotes).

#### Solution: 
Added sed command to strip leading/trailing quotes before Java processes the arguments.

  The Dockerfile uses escaped shell syntax because Docker parses the CMD string first, then the shell executes it:
  `java_opts=\$(printf '%s' \"\$JAVA_OPTIONS\" | sed \"s/^['\\\"']//;s/['\\\"']\\$//\")`

  This escapes to the following command at runtime in the container:
  `java_opts=$(printf '%s' "$JAVA_OPTIONS" | sed "s/^['\"]//;s/['\"]$//")`

  The `\$` becomes `$` and `\\\"` becomes `\"` (backslash-quote) for sed's pattern matching.

#### Testing: Built and tested the Docker container with multiple scenarios:
  - Double quotes: `JAVA_OPTIONS="-XX:+UseG1GC" `
  - Single quotes: `JAVA_OPTIONS='-XX:+UseG1GC' `
  - No quotes: `JAVA_OPTIONS=-XX:+UseG1GC `
  - Docker Compose (the bug scenario) 
#### Backward compatibility: This fix is fully backward compatible:
  - Users who set `JAVA_OPTIONS` without quotes (existing working syntax) - continues to work
  - Users who don't set J`AVA_OPTIONS` at all - uses Dockerfile defaults as before
  - `EXTRA_JAVA_OPTIONS`- works with or without quotes
  - All existing deployments continue to work unchanged
<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
        (Manual testing: Built and tested Docker container with quoted/unquoted JAVA_OPTIONS)
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
