### PR TITLE
Consider OS distro during vulnerability matching

### DIFF
--- a/dev/docker-compose.postgres.yml
+++ b/dev/docker-compose.postgres.yml
@@ -28,6 +28,11 @@ services:
 
   postgres:
     image: postgres:14-alpine
+    command: >-
+      -c 'shared_preload_libraries=pg_stat_statements'
+      -c 'pg_stat_statements.track=all'
+      -c 'pg_stat_statements.max=10000'
+      -c 'track_activity_query_size=2048'
     environment:
       POSTGRES_DB: "dtrack"
       POSTGRES_USER: "dtrack"
@@ -41,6 +46,17 @@ services:
     - "127.0.0.1:5432:5432"
     volumes:
     - "postgres-data:/var/lib/postgresql/data"
+    restart: unless-stopped
+
+  pghero:
+    image: ankane/pghero
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: "postgres://dtrack:dtrack@postgres:5432/dtrack"
+    ports:
+    - "127.0.0.1:8432:8080"
     restart: unless-stopped
 
 volumes:

--- a/src/main/java/org/dependencytrack/model/OsDistribution.java
+++ b/src/main/java/org/dependencytrack/model/OsDistribution.java
@@ -1,0 +1,394 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.model;
+
+import com.github.packageurl.PackageURL;
+import org.dependencytrack.util.PurlUtil;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @since 4.14.0
+ */
+public sealed interface OsDistribution {
+
+    String purlQualifierValue();
+
+    boolean matches(OsDistribution other);
+
+    static @Nullable OsDistribution of(@Nullable PackageURL purl) {
+        final String distroQualifier = PurlUtil.getDistroQualifier(purl);
+        if (distroQualifier == null) {
+            return null;
+        }
+
+        if ("apk".equals(purl.getType())) {
+            return AlpineDistribution.of(distroQualifier);
+        }
+
+        if ("deb".equals(purl.getType())) {
+            if ("debian".equalsIgnoreCase(purl.getNamespace())) {
+                return DebianDistribution.of(distroQualifier).orElse(null);
+            }
+            if ("ubuntu".equalsIgnoreCase(purl.getNamespace())) {
+                return UbuntuDistribution.of(distroQualifier).orElse(null);
+            }
+        }
+
+        return null;
+    }
+
+    static @Nullable OsDistribution ofOsvEcosystem(@Nullable String ecosystem) {
+        if (ecosystem == null || ecosystem.isEmpty()) {
+            return null;
+        }
+
+        final int colonIndex = ecosystem.indexOf(':');
+        if (colonIndex == -1 || colonIndex == ecosystem.length() - 1) {
+            return null;
+        }
+
+        final String ecosystemName = ecosystem.substring(0, colonIndex);
+        final String suffix = ecosystem.substring(colonIndex + 1);
+
+        return switch (ecosystemName.toLowerCase()) {
+            case "alpine" -> AlpineDistribution.ofVersion(suffix);
+            case "debian" -> DebianDistribution.of(suffix).orElse(null);
+            case "ubuntu" -> {
+                // Remove :LTS and :Pro variants. This is in line with what OSV does:
+                // https://github.com/google/osv.dev/blob/60cf1d74ec77a8f40589d2bbb3cfd241a545f807/osv/ecosystems/_ecosystems.py#L154-L160
+                final String versionOrSeries = suffix.replaceAll(":(LTS|Pro)", "");
+                yield UbuntuDistribution.of(versionOrSeries).orElse(null);
+            }
+            default -> null;
+        };
+    }
+
+    record AlpineDistribution(String version) implements OsDistribution {
+
+        private static final Pattern VERSION_PATTERN = Pattern.compile("v?(\\d+\\.\\d+)(?:\\.\\d+)?");
+
+        public AlpineDistribution {
+            requireNonNull(version, "version must not be null");
+        }
+
+        @Override
+        public String purlQualifierValue() {
+            return "alpine-" + version;
+        }
+
+        @Override
+        public boolean matches(OsDistribution other) {
+            return other instanceof AlpineDistribution(final String otherVersion)
+                    && this.version.equals(otherVersion);
+        }
+
+        private static @Nullable AlpineDistribution of(@Nullable String qualifierValue) {
+            if (qualifierValue == null || qualifierValue.isEmpty()) {
+                return null;
+            }
+
+            final String version = qualifierValue.toLowerCase().startsWith("alpine-")
+                    ? qualifierValue.substring(7)
+                    : qualifierValue;
+
+            return ofVersion(version);
+        }
+
+        private static @Nullable AlpineDistribution ofVersion(@Nullable String version) {
+            if (version == null || version.isEmpty()) {
+                return null;
+            }
+
+            final Matcher matcher = VERSION_PATTERN.matcher(version);
+            if (!matcher.matches()) {
+                return null;
+            }
+
+            return new AlpineDistribution(matcher.group(1));
+        }
+
+    }
+
+    record DebianDistribution(String series, @Nullable String version) implements OsDistribution {
+
+        // https://debian.pages.debian.net/distro-info-data/debian.csv
+        private static final List<DebianDistribution> KNOWN_DISTRIBUTIONS = List.of(
+                new DebianDistribution("buzz", "1.1"),
+                new DebianDistribution("rex", "1.2"),
+                new DebianDistribution("bo", "1.3"),
+                new DebianDistribution("hamm", "2.0"),
+                new DebianDistribution("slink", "2.1"),
+                new DebianDistribution("potato", "2.2"),
+                new DebianDistribution("woody", "3.0"),
+                new DebianDistribution("sarge", "3.1"),
+                new DebianDistribution("etch", "4.0"),
+                new DebianDistribution("lenny", "5.0"),
+                new DebianDistribution("squeeze", "6.0"),
+                new DebianDistribution("wheezy", "7"),
+                new DebianDistribution("jessie", "8"),
+                new DebianDistribution("stretch", "9"),
+                new DebianDistribution("buster", "10"),
+                new DebianDistribution("bullseye", "11"),
+                new DebianDistribution("bookworm", "12"),
+                new DebianDistribution("trixie", "13"),
+                new DebianDistribution("forky", "14"),
+                new DebianDistribution("duke", "15"),
+                new DebianDistribution("sid", null));
+
+        private static final Pattern DEBIAN_SERIES_PATTERN = Pattern.compile("^[A-Za-z]+$");
+        private static final Pattern DEBIAN_VERSION_PATTERN = Pattern.compile("^(\\d+)(\\.\\d+)?$");
+        private static final Pattern DEBIAN_QUALIFIER_PATTERN =
+                Pattern.compile("(?:debian-)?(.+)", Pattern.CASE_INSENSITIVE);
+
+        public DebianDistribution {
+            requireNonNull(series, "series must not be null");
+        }
+
+        @Override
+        public String purlQualifierValue() {
+            return "debian-" + (version != null ? version : series);
+        }
+
+        @Override
+        public boolean matches(OsDistribution other) {
+            return other instanceof final DebianDistribution otherDebian
+                    && this.series.equalsIgnoreCase(otherDebian.series);
+        }
+
+        private static Optional<DebianDistribution> of(@Nullable String qualifierValue) {
+            if (qualifierValue == null || qualifierValue.isEmpty()) {
+                return Optional.empty();
+            }
+
+            final Matcher matcher = DEBIAN_QUALIFIER_PATTERN.matcher(qualifierValue);
+            if (!matcher.matches()) {
+                return Optional.empty();
+            }
+
+            final String value = matcher.group(1);
+
+            return ofKnownSeries(value)
+                    .or(() -> ofKnownVersion(value))
+                    .or(() -> ofUnknownSeries(value))
+                    .or(() -> ofUnknownVersion(value));
+        }
+
+        private static Optional<DebianDistribution> ofKnownVersion(@Nullable String version) {
+            if (version == null || version.isEmpty()) {
+                return Optional.empty();
+            }
+
+            for (final var distro : KNOWN_DISTRIBUTIONS) {
+                if (distro.version() == null) {
+                    continue;
+                }
+                if (distro.version().equals(version)) {
+                    return Optional.of(distro);
+                }
+            }
+
+            if (version.contains(".")) {
+                final String inputMajor = version.substring(0, version.indexOf('.'));
+                for (final var distro : KNOWN_DISTRIBUTIONS) {
+                    if (distro.version() == null) {
+                        continue;
+                    }
+                    if (!distro.version().contains(".") && distro.version().equals(inputMajor)) {
+                        return Optional.of(distro);
+                    }
+                }
+            }
+
+            return Optional.empty();
+        }
+
+        private static Optional<DebianDistribution> ofKnownSeries(@Nullable String series) {
+            if (series == null || series.isEmpty()) {
+                return Optional.empty();
+            }
+
+            return KNOWN_DISTRIBUTIONS.stream()
+                    .filter(distro -> distro.series().equalsIgnoreCase(series))
+                    .findAny();
+        }
+
+        private static Optional<DebianDistribution> ofUnknownSeries(@Nullable String series) {
+            if (series == null || series.isEmpty() || !DEBIAN_SERIES_PATTERN.matcher(series).matches()) {
+                return Optional.empty();
+            }
+
+            return Optional.of(new DebianDistribution(series.toLowerCase(), null));
+        }
+
+        private static Optional<DebianDistribution> ofUnknownVersion(@Nullable String version) {
+            if (version == null || version.isEmpty() || !DEBIAN_VERSION_PATTERN.matcher(version).matches()) {
+                return Optional.empty();
+            }
+
+            return Optional.of(new DebianDistribution(version, version));
+        }
+
+    }
+
+    record UbuntuDistribution(String series, String version) implements OsDistribution {
+
+        // https://debian.pages.debian.net/distro-info-data/ubuntu.csv
+        private static final List<UbuntuDistribution> KNOWN_DISTRIBUTIONS = List.of(
+                new UbuntuDistribution("warty", "4.10"),
+                new UbuntuDistribution("hoary", "5.04"),
+                new UbuntuDistribution("breezy", "5.10"),
+                new UbuntuDistribution("dapper", "6.06"),
+                new UbuntuDistribution("edgy", "6.10"),
+                new UbuntuDistribution("feisty", "7.04"),
+                new UbuntuDistribution("gutsy", "7.10"),
+                new UbuntuDistribution("hardy", "8.04"),
+                new UbuntuDistribution("intrepid", "8.10"),
+                new UbuntuDistribution("jaunty", "9.04"),
+                new UbuntuDistribution("karmic", "9.10"),
+                new UbuntuDistribution("lucid", "10.04"),
+                new UbuntuDistribution("maverick", "10.10"),
+                new UbuntuDistribution("natty", "11.04"),
+                new UbuntuDistribution("oneiric", "11.10"),
+                new UbuntuDistribution("precise", "12.04"),
+                new UbuntuDistribution("quantal", "12.10"),
+                new UbuntuDistribution("raring", "13.04"),
+                new UbuntuDistribution("saucy", "13.10"),
+                new UbuntuDistribution("trusty", "14.04"),
+                new UbuntuDistribution("utopic", "14.10"),
+                new UbuntuDistribution("vivid", "15.04"),
+                new UbuntuDistribution("wily", "15.10"),
+                new UbuntuDistribution("xenial", "16.04"),
+                new UbuntuDistribution("yakkety", "16.10"),
+                new UbuntuDistribution("zesty", "17.04"),
+                new UbuntuDistribution("artful", "17.10"),
+                new UbuntuDistribution("bionic", "18.04"),
+                new UbuntuDistribution("cosmic", "18.10"),
+                new UbuntuDistribution("disco", "19.04"),
+                new UbuntuDistribution("eoan", "19.10"),
+                new UbuntuDistribution("focal", "20.04"),
+                new UbuntuDistribution("groovy", "20.10"),
+                new UbuntuDistribution("hirsute", "21.04"),
+                new UbuntuDistribution("impish", "21.10"),
+                new UbuntuDistribution("jammy", "22.04"),
+                new UbuntuDistribution("kinetic", "22.10"),
+                new UbuntuDistribution("lunar", "23.04"),
+                new UbuntuDistribution("mantic", "23.10"),
+                new UbuntuDistribution("noble", "24.04"),
+                new UbuntuDistribution("oracular", "24.10"),
+                new UbuntuDistribution("plucky", "25.04"),
+                new UbuntuDistribution("questing", "25.10"),
+                new UbuntuDistribution("resolute", "26.04"));
+
+        private static final Pattern UBUNTU_SERIES_PATTERN = Pattern.compile("^[A-Za-z]+$");
+        private static final Pattern UBUNTU_VERSION_PATTERN = Pattern.compile("^(\\d+\\.\\d+)(\\.\\d+)?$");
+        private static final Pattern UBUNTU_QUALIFIER_PATTERN =
+                Pattern.compile("(?:ubuntu-)?(.+)", Pattern.CASE_INSENSITIVE);
+
+        public UbuntuDistribution {
+            requireNonNull(series, "series must not be null");
+            requireNonNull(version, "version must not be null");
+        }
+
+        @Override
+        public String purlQualifierValue() {
+            return "ubuntu-" + (version != null ? version : series);
+        }
+
+        @Override
+        public boolean matches(OsDistribution other) {
+            return other instanceof final UbuntuDistribution otherUbuntu
+                    && this.series.equalsIgnoreCase(otherUbuntu.series);
+        }
+
+        private static Optional<UbuntuDistribution> of(@Nullable String qualifierValue) {
+            if (qualifierValue == null || qualifierValue.isEmpty()) {
+                return Optional.empty();
+            }
+
+            final Matcher matcher = UBUNTU_QUALIFIER_PATTERN.matcher(qualifierValue);
+            if (!matcher.matches()) {
+                return Optional.empty();
+            }
+
+            final String value = matcher.group(1);
+
+            return ofKnownSeries(value)
+                    .or(() -> ofKnownVersion(value))
+                    .or(() -> ofUnknownSeries(value))
+                    .or(() -> ofUnknownVersion(value));
+        }
+
+        private static Optional<UbuntuDistribution> ofKnownVersion(@Nullable String version) {
+            if (version == null || version.isEmpty()) {
+                return Optional.empty();
+            }
+
+            final Matcher versionMatcher = UBUNTU_VERSION_PATTERN.matcher(version);
+            if (!versionMatcher.matches()) {
+                return Optional.empty();
+            }
+
+            final String majorMinor = versionMatcher.group(1);
+            return KNOWN_DISTRIBUTIONS.stream()
+                    .filter(distro -> distro.version().equals(majorMinor))
+                    .findAny();
+        }
+
+        private static Optional<UbuntuDistribution> ofKnownSeries(@Nullable String series) {
+            if (series == null || series.isEmpty()) {
+                return Optional.empty();
+            }
+
+            return KNOWN_DISTRIBUTIONS.stream()
+                    .filter(distro -> distro.series().equalsIgnoreCase(series))
+                    .findAny();
+        }
+
+        private static Optional<UbuntuDistribution> ofUnknownSeries(@Nullable String series) {
+            if (series == null || series.isEmpty() || !UBUNTU_SERIES_PATTERN.matcher(series).matches()) {
+                return Optional.empty();
+            }
+
+            return Optional.of(new UbuntuDistribution(series, series));
+        }
+
+        private static Optional<UbuntuDistribution> ofUnknownVersion(@Nullable String version) {
+            if (version == null || version.isEmpty()) {
+                return Optional.empty();
+            }
+
+            final Matcher versionMatcher = UBUNTU_VERSION_PATTERN.matcher(version);
+            if (!versionMatcher.matches()) {
+                return Optional.empty();
+            }
+
+            final String majorMinor = versionMatcher.group(1);
+            return Optional.of(new UbuntuDistribution(majorMinor, majorMinor));
+        }
+
+    }
+
+}

--- a/src/main/java/org/dependencytrack/model/VulnerableSoftware.java
+++ b/src/main/java/org/dependencytrack/model/VulnerableSoftware.java
@@ -18,14 +18,10 @@
  */
 package org.dependencytrack.model;
 
-import alpine.common.logging.Logger;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
-import io.github.nscuro.versatile.Comparator;
-import io.github.nscuro.versatile.Vers;
-import io.github.nscuro.versatile.version.KnownVersioningSchemes;
 
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Element;
@@ -43,8 +39,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-
-import static io.github.nscuro.versatile.version.KnownVersioningSchemes.SCHEME_GENERIC;
 
 /**
  * The VulnerableSoftware is a model class for representing vulnerable software
@@ -65,7 +59,6 @@ import static io.github.nscuro.versatile.version.KnownVersioningSchemes.SCHEME_G
 public class VulnerableSoftware implements ICpe, Serializable {
 
     private static final long serialVersionUID = -3987946408457131098L;
-    private static final Logger LOGGER = Logger.getLogger(VulnerableSoftware.class);
 
     @PrimaryKey
     @Persistent(valueStrategy = IdGeneratorStrategy.NATIVE)
@@ -185,76 +178,11 @@ public class VulnerableSoftware implements ICpe, Serializable {
 
     private transient List<AffectedVersionAttribution> affectedVersionAttributions;
 
-    private transient Vers vers;
-
-    private transient boolean versDirty = true;
-
-    private void invalidateVers(){
-        versDirty = true;
-        vers = null;
-    }
-
-    private Vers buildVersFromFields() {
-        final String scheme = KnownVersioningSchemes
-                .fromPurlType(getPurlType())
-                .orElse(SCHEME_GENERIC);
-        final Vers.Builder b = Vers.builder(scheme);
-
-        final String endExcluding = (getVersionEndExcluding() != null && !getVersionEndExcluding().isBlank())
-                ? getVersionEndExcluding()
-                : null;
-        final String endIncluding = (getVersionEndIncluding() != null && !getVersionEndIncluding().isBlank())
-                ? getVersionEndIncluding()
-                : null;
-        final String startExcluding = (getVersionStartExcluding() != null && !getVersionStartExcluding().isBlank())
-                ? getVersionStartExcluding()
-                : null;
-        final String startIncluding = (getVersionStartIncluding() != null && !getVersionStartIncluding().isBlank())
-                ? getVersionStartIncluding()
-                : null;
-
-        final String version = (getVersion() != null && !getVersion().isBlank()) ? getVersion() : null;
-
-        final boolean hasRange = (endExcluding != null) || (endIncluding != null)
-                || (startExcluding != null) || (startIncluding != null);
-
-        if (version == null && !hasRange) {
-            b.withConstraint(Comparator.WILDCARD, null);
-            return b.build().simplify();
-        }
-
-        if (startIncluding != null) {
-            b.withConstraint(Comparator.GREATER_THAN_OR_EQUAL, startIncluding);
-        }
-        if (startExcluding != null) {
-            b.withConstraint(Comparator.GREATER_THAN, startExcluding);
-        }
-
-        if (version != null && !hasRange) {
-            b.withConstraint(Comparator.EQUAL, version);
-        }
-
-        if (endIncluding != null) {
-            b.withConstraint(Comparator.LESS_THAN_OR_EQUAL, endIncluding);
-        }
-        if (endExcluding != null) {
-            b.withConstraint(Comparator.LESS_THAN, endExcluding);
-        }
-
-        return b.build().simplify();
-    }
-
-    public Vers getVers() {
-        if(versDirty){
-            vers = buildVersFromFields();
-            versDirty = false;
-        }
-        return vers;
-    }
-
-    public void setVers(Vers vers) {
-        this.vers = vers;
-        this.versDirty = false;
+    public boolean hasVersionRange() {
+        return (versionStartIncluding != null && !versionStartIncluding.isBlank())
+                || (versionStartExcluding != null && !versionStartExcluding.isBlank())
+                || (versionEndExcluding != null && !versionEndExcluding.isBlank())
+                || (versionEndIncluding != null && !versionEndIncluding.isBlank());
     }
 
     public long getId() {
@@ -279,7 +207,6 @@ public class VulnerableSoftware implements ICpe, Serializable {
 
     public void setPurlType(String purlType) {
         this.purlType = purlType;
-        invalidateVers();
     }
 
     public String getPurlNamespace() {
@@ -368,7 +295,6 @@ public class VulnerableSoftware implements ICpe, Serializable {
 
     public void setVersion(String version) {
         this.version = version;
-        invalidateVers();
     }
 
     public String getUpdate() {
@@ -433,7 +359,6 @@ public class VulnerableSoftware implements ICpe, Serializable {
 
     public void setVersionEndExcluding(String versionEndExcluding) {
         this.versionEndExcluding = versionEndExcluding;
-        invalidateVers();
     }
 
     public String getVersionEndIncluding() {
@@ -442,7 +367,6 @@ public class VulnerableSoftware implements ICpe, Serializable {
 
     public void setVersionEndIncluding(String versionEndIncluding) {
         this.versionEndIncluding = versionEndIncluding;
-        invalidateVers();
     }
 
     public String getVersionStartExcluding() {
@@ -451,7 +375,6 @@ public class VulnerableSoftware implements ICpe, Serializable {
 
     public void setVersionStartExcluding(String versionStartExcluding) {
         this.versionStartExcluding = versionStartExcluding;
-        invalidateVers();
     }
 
     public String getVersionStartIncluding() {
@@ -460,7 +383,6 @@ public class VulnerableSoftware implements ICpe, Serializable {
 
     public void setVersionStartIncluding(String versionStartIncluding) {
         this.versionStartIncluding = versionStartIncluding;
-        invalidateVers();
     }
 
     public boolean isVulnerable() {

--- a/src/main/java/org/dependencytrack/parser/nvd/ModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/nvd/ModelConverter.java
@@ -20,10 +20,6 @@ package org.dependencytrack.parser.nvd;
 
 import org.dependencytrack.model.ICpe;
 import org.dependencytrack.model.VulnerableSoftware;
-
-import com.github.packageurl.MalformedPackageURLException;
-import com.github.packageurl.PackageURL;
-
 import us.springett.parsers.cpe.CpeParser;
 import us.springett.parsers.cpe.exceptions.CpeEncodingException;
 import us.springett.parsers.cpe.exceptions.CpeParsingException;
@@ -54,33 +50,6 @@ public final class ModelConverter {
     public static VulnerableSoftware convertCpe23UriToVulnerableSoftware(String cpe23Uri) throws CpeParsingException, CpeEncodingException {
         VulnerableSoftware vs = new VulnerableSoftware();
         return (VulnerableSoftware)convertCpe23Uri(vs, cpe23Uri);
-    }
-
-    public static VulnerableSoftware convertPurlToVulnerableSoftware(String purlString) throws MalformedPackageURLException {
-        final com.github.packageurl.PackageURL purl = new PackageURL(purlString);
-        final VulnerableSoftware vs = new VulnerableSoftware();
-
-        vs.setPurl(purl.toString());
-
-        vs.setPurlType(purl.getType());
-        vs.setPurlNamespace(purl.getNamespace());
-        vs.setPurlName(purl.getName());
-        vs.setPurlVersion(purl.getVersion());
-        vs.setPurlSubpath(purl.getSubpath());
-
-        final var qualifiers = purl.getQualifiers();
-        if (qualifiers != null && !qualifiers.isEmpty()) {
-            final String qualifiersStr = qualifiers.entrySet().stream()
-                    .sorted(java.util.Map.Entry.comparingByKey())
-                    .map(e -> e.getKey() + "=" + e.getValue())
-                    .collect(java.util.stream.Collectors.joining("&"));
-            vs.setPurlQualifiers(qualifiersStr);
-        }
-
-        vs.setVersion(purl.getVersion());
-
-        return vs;
-
     }
 
 }

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -33,6 +33,7 @@ import alpine.resources.AlpineRequest;
 import alpine.server.util.DbUtil;
 import com.github.packageurl.PackageURL;
 import com.google.common.collect.Lists;
+import jakarta.json.JsonObject;
 import org.apache.commons.lang3.ClassUtils;
 import org.datanucleus.api.jdo.JDOQuery;
 import org.dependencytrack.event.IndexEvent;
@@ -84,7 +85,6 @@ import org.dependencytrack.resources.v1.vo.AffectedProject;
 import org.dependencytrack.resources.v1.vo.DependencyGraphResponse;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
 
-import jakarta.json.JsonObject;
 import javax.jdo.FetchPlan;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
@@ -921,16 +921,45 @@ public class QueryManager extends AlpineQueryManager {
     }
 
     public VulnerableSoftware getVulnerableSoftwareByPurl(
-            final String purlType,
-            final String purlNamespace,
-            final String purlName,
-            final String version,
-            final String versionEndExcluding,
-            final String versionEndIncluding,
-            final String versionStartExcluding,
+            String purlType,
+            String purlNamespace,
+            String purlName,
+            String version,
+            String versionEndExcluding,
+            String versionEndIncluding,
+            String versionStartExcluding,
             String versionStartIncluding) {
         return getVulnerableSoftwareQueryManager().getVulnerableSoftwareByPurl(
-                purlType, purlNamespace, purlName, version, versionEndExcluding, versionEndIncluding, versionStartExcluding, versionStartIncluding);
+                purlType,
+                purlNamespace,
+                purlName,
+                version,
+                versionEndExcluding,
+                versionEndIncluding,
+                versionStartExcluding,
+                versionStartIncluding);
+    }
+
+    public VulnerableSoftware getVulnerableSoftwareByPurl(
+            String purlType,
+            String purlNamespace,
+            String purlName,
+            String purlQualifiers,
+            String version,
+            String versionEndExcluding,
+            String versionEndIncluding,
+            String versionStartExcluding,
+            String versionStartIncluding) {
+        return getVulnerableSoftwareQueryManager().getVulnerableSoftwareByPurl(
+                purlType,
+                purlNamespace,
+                purlName,
+                purlQualifiers,
+                version,
+                versionEndExcluding,
+                versionEndIncluding,
+                versionStartExcluding,
+                versionStartIncluding);
     }
 
     public List<VulnerableSoftware> getVulnerableSoftwareByVulnId(final String source, final String vulnId) {

--- a/src/main/java/org/dependencytrack/persistence/VulnerableSoftwareQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerableSoftwareQueryManager.java
@@ -145,6 +145,7 @@ final class VulnerableSoftwareQueryManager extends QueryManager implements IQuer
     /**
      * @since 4.12.3
      */
+    @Override
     public VulnerableSoftware getVulnerableSoftwareByPurl(
             final String purlType,
             final String purlNamespace,
@@ -154,6 +155,32 @@ final class VulnerableSoftwareQueryManager extends QueryManager implements IQuer
             final String versionEndIncluding,
             final String versionStartExcluding,
             final String versionStartIncluding) {
+        return getVulnerableSoftwareByPurl(
+                purlType,
+                purlNamespace,
+                purlName,
+                /* purlQualifiers */ null,
+                version,
+                versionEndExcluding,
+                versionEndIncluding,
+                versionStartExcluding,
+                versionStartIncluding);
+    }
+
+    /**
+     * @since 4.14.0
+     */
+    @Override
+    public VulnerableSoftware getVulnerableSoftwareByPurl(
+            String purlType,
+            String purlNamespace,
+            String purlName,
+            String purlQualifiers,
+            String version,
+            String versionEndExcluding,
+            String versionEndIncluding,
+            String versionStartExcluding,
+            String versionStartIncluding) {
         final var queryFilterParts = new ArrayList<>(List.of(
                 "purlType == :purlType",
                 "purlName == :purlName"));
@@ -166,6 +193,12 @@ final class VulnerableSoftwareQueryManager extends QueryManager implements IQuer
         } else {
             queryFilterParts.add("purlNamespace == :purlNamespace");
             queryParams.put("purlNamespace", purlNamespace);
+        }
+        if (purlQualifiers != null) {
+            queryFilterParts.add("purlQualifiers == :purlQualifiers");
+            queryParams.put("purlQualifiers", purlQualifiers);
+        } else {
+            queryFilterParts.add("purlQualifiers == null");
         }
 
         if (version != null) {
@@ -548,6 +581,7 @@ final class VulnerableSoftwareQueryManager extends QueryManager implements IQuer
                             vs.getPurlType(),
                             vs.getPurlNamespace(),
                             vs.getPurlName(),
+                            vs.getPurlQualifiers(),
                             vs.getVersion(),
                             vs.getVersionEndExcluding(),
                             vs.getVersionEndIncluding(),

--- a/src/main/java/org/dependencytrack/resources/v1/vo/AffectedComponent.java
+++ b/src/main/java/org/dependencytrack/resources/v1/vo/AffectedComponent.java
@@ -27,6 +27,7 @@ import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import org.dependencytrack.model.AffectedVersionAttribution;
 import org.dependencytrack.model.VulnerableSoftware;
+import org.dependencytrack.util.PurlUtil;
 import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.CpeParser;
 import us.springett.parsers.cpe.exceptions.CpeEncodingException;
@@ -226,15 +227,10 @@ public class AffectedComponent {
                 vs.setPurlName(purl.getName());
                 vs.setPurlVersion(purl.getVersion());
                 vs.setVersion(purl.getVersion());
-                if (purl.getQualifiers() != null) {
-                    vs.setPurlQualifiers(new ObjectMapper().writeValueAsString(purl.getQualifiers()));
-                }
+                vs.setPurlQualifiers(PurlUtil.serializeQualifiers(purl));
                 vs.setPurlSubpath(purl.getSubpath());
             } catch (MalformedPackageURLException e) {
                 LOGGER.warn("Error parsing PURL: " + this.identity + " (skipping)", e);
-                return null;
-            } catch (JsonProcessingException e) {
-                LOGGER.warn("Error serializing PURL qualifiers: " + this.identity + " (skipping)", e);
                 return null;
             }
         }

--- a/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
+++ b/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
@@ -43,6 +43,7 @@ import org.dependencytrack.event.IndexEvent;
 import org.dependencytrack.event.OsvMirrorEvent;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.Cwe;
+import org.dependencytrack.model.OsDistribution;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
@@ -55,7 +56,9 @@ import org.dependencytrack.parser.osv.OsvAdvisoryParser;
 import org.dependencytrack.parser.osv.model.OsvAdvisory;
 import org.dependencytrack.parser.osv.model.OsvAffectedPackage;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.persistence.listener.IndexingInstanceLifecycleListener;
 import org.dependencytrack.util.CvssUtil;
+import org.dependencytrack.util.PurlUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -64,9 +67,9 @@ import org.slf4j.MDC;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.IOException;
 import java.net.NoRouteToHostException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
@@ -77,8 +80,8 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.Clock;
 import java.time.Duration;
-import java.time.format.DateTimeParseException;
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -88,18 +91,21 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Scanner;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.StringJoiner;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
 import static io.github.resilience4j.core.IntervalFunction.ofExponentialBackoff;
+import static org.datanucleus.PropertyNames.PROPERTY_PERSISTENCE_BY_REACHABILITY_AT_COMMIT;
 import static org.dependencytrack.common.MdcKeys.MDC_VULN_ID;
+import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ALIAS_SYNC_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_BASE_URL;
 import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_NVD_ENABLED;
 import static org.dependencytrack.model.Severity.getSeverityByLevel;
 import static org.dependencytrack.util.RetryUtil.maybeClosePreviousResult;
 import static org.dependencytrack.util.VulnerabilityUtil.normalizedCvssV2Score;
@@ -283,6 +289,8 @@ public class OsvDownloadTask implements LoggableSubscriber {
             if (success) {
                 LOGGER.info("Incremental update completed for " + ecosystem);
                 writeTimestampFile(incrementalTimestampFile, startTime);
+                Event.dispatch(new IndexEvent(IndexEvent.Action.COMMIT, Vulnerability.class));
+                Event.dispatch(new IndexEvent(IndexEvent.Action.COMMIT, VulnerableSoftware.class));
             }
         } else {
             Path osvZipFile = downloadOsvZipFile(url, ecosystem);
@@ -519,6 +527,9 @@ public class OsvDownloadTask implements LoggableSubscriber {
              final var bufferedIn = new BufferedInputStream(in);
              final var zipInput = new ZipInputStream(bufferedIn)) {
             unzipOsvZipFile(zipInput, count);
+        } finally {
+            Event.dispatch(new IndexEvent(IndexEvent.Action.COMMIT, Vulnerability.class));
+            Event.dispatch(new IndexEvent(IndexEvent.Action.COMMIT, VulnerableSoftware.class));
         }
         final long end = System.currentTimeMillis();
         metricParseTime += end - start;
@@ -618,66 +629,67 @@ public class OsvDownloadTask implements LoggableSubscriber {
     }
 
     public void updateDatasource(final OsvAdvisory advisory) {
+        LOGGER.debug("Synchronizing Google OSV advisory: " + advisory.getId());
+        final Vulnerability vulnerability = mapAdvisoryToVulnerability(advisory);
 
-        try (QueryManager qm = new QueryManager()) {
-
-            LOGGER.debug("Synchronizing Google OSV advisory: " + advisory.getId());
-            final Vulnerability vulnerability = mapAdvisoryToVulnerability(advisory);
-            final List<VulnerableSoftware> vsListOld = qm.detach(qm.getVulnerableSoftwareByVulnId(vulnerability.getSource(), vulnerability.getVulnId()));
-            final Vulnerability existingVulnerability = qm.getVulnerabilityByVulnId(vulnerability.getSource(), vulnerability.getVulnId());
-            final Vulnerability.Source vulnerabilitySource = extractSource(advisory.getId());
-            final ConfigPropertyConstants vulnAuthoritativeSourceToggle = switch (vulnerabilitySource) {
-                case NVD -> ConfigPropertyConstants.VULNERABILITY_SOURCE_NVD_ENABLED;
-                case GITHUB -> ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED;
-                default -> VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED;
-            };
-            final boolean vulnAuthoritativeSourceEnabled = Boolean.parseBoolean(qm.getConfigProperty(vulnAuthoritativeSourceToggle.getGroupName(), vulnAuthoritativeSourceToggle.getPropertyName()).getPropertyValue());
-            Vulnerability synchronizedVulnerability = existingVulnerability;
-            if (shouldUpdateExistingVulnerability(existingVulnerability, vulnerabilitySource, vulnAuthoritativeSourceEnabled)) {
-                synchronizedVulnerability = qm.synchronizeVulnerability(vulnerability, false);
-                if (synchronizedVulnerability == null) return; // Exit if nothing to update
+        final var vsList = new ArrayList<VulnerableSoftware>();
+        for (final OsvAffectedPackage osvAffectedPackage : advisory.getAffectedPackages()) {
+            final VulnerableSoftware vs = mapAffectedPackageToVulnerableSoftware(osvAffectedPackage);
+            if (vs != null) {
+                vsList.add(vs);
             }
-
-            if (aliasSyncEnabled && advisory.getAliases() != null) {
-                for (int i = 0; i < advisory.getAliases().size(); i++) {
-                    final String alias = advisory.getAliases().get(i);
-                    final VulnerabilityAlias vulnerabilityAlias = new VulnerabilityAlias();
-
-                    // OSV will use IDs of other vulnerability databases for its
-                    // primary advisory ID (e.g. GHSA-45hx-wfhj-473x). We need to ensure
-                    // that we don't falsely report GHSA IDs as stemming from OSV.
-                    switch (vulnerabilitySource) {
-                        case NVD -> vulnerabilityAlias.setCveId(advisory.getId());
-                        case GITHUB -> vulnerabilityAlias.setGhsaId(advisory.getId());
-                        default -> vulnerabilityAlias.setOsvId(advisory.getId());
-                    }
-
-                    if (alias.startsWith("CVE") && Vulnerability.Source.NVD != vulnerabilitySource) {
-                        vulnerabilityAlias.setCveId(alias);
-                        qm.synchronizeVulnerabilityAlias(vulnerabilityAlias);
-                    } else if (alias.startsWith("GHSA") && Vulnerability.Source.GITHUB != vulnerabilitySource) {
-                        vulnerabilityAlias.setGhsaId(alias);
-                        qm.synchronizeVulnerabilityAlias(vulnerabilityAlias);
-                    }
-
-                    //TODO - OSV supports GSD and DLA/DSA identifiers (possibly others). Determine how to handle.
-                }
-            }
-
-            List<VulnerableSoftware> vsList = new ArrayList<>();
-            for (OsvAffectedPackage osvAffectedPackage : advisory.getAffectedPackages()) {
-                VulnerableSoftware vs = mapAffectedPackageToVulnerableSoftware(qm, osvAffectedPackage);
-                if (vs != null) {
-                    vsList.add(vs);
-                }
-            }
-            qm.persist(vsList);
-            qm.updateAffectedVersionAttributions(synchronizedVulnerability, vsList, Vulnerability.Source.OSV);
-            vsList = qm.reconcileVulnerableSoftware(synchronizedVulnerability, vsListOld, vsList, Vulnerability.Source.OSV);
-            synchronizedVulnerability.setVulnerableSoftware(vsList);
-            qm.persist(synchronizedVulnerability);
         }
-        Event.dispatch(new IndexEvent(IndexEvent.Action.COMMIT, Vulnerability.class));
+
+        try (final var qm = new QueryManager()) {
+            qm.getPersistenceManager().setProperty(PROPERTY_PERSISTENCE_BY_REACHABILITY_AT_COMMIT, "false");
+            qm.getPersistenceManager().addInstanceLifecycleListener(
+                    new IndexingInstanceLifecycleListener(Event::dispatch),
+                    Vulnerability.class,
+                    VulnerableSoftware.class);
+            qm.runInTransaction(() -> {
+                final Vulnerability existingVulnerability = qm.getVulnerabilityByVulnId(vulnerability.getSource(), vulnerability.getVulnId());
+                final Vulnerability.Source vulnerabilitySource = extractSource(advisory.getId());
+                final ConfigPropertyConstants vulnAuthoritativeSourceToggle = switch (vulnerabilitySource) {
+                    case NVD -> VULNERABILITY_SOURCE_NVD_ENABLED;
+                    case GITHUB -> VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED;
+                    default -> VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED;
+                };
+                final boolean vulnAuthoritativeSourceEnabled = Boolean.parseBoolean(qm.getConfigProperty(vulnAuthoritativeSourceToggle.getGroupName(), vulnAuthoritativeSourceToggle.getPropertyName()).getPropertyValue());
+                Vulnerability synchronizedVulnerability = existingVulnerability;
+                if (shouldUpdateExistingVulnerability(existingVulnerability, vulnerabilitySource, vulnAuthoritativeSourceEnabled)) {
+                    synchronizedVulnerability = qm.synchronizeVulnerability(vulnerability, false);
+                    if (synchronizedVulnerability == null) return; // Exit if nothing to update
+                }
+
+                if (aliasSyncEnabled && advisory.getAliases() != null) {
+                    for (int i = 0; i < advisory.getAliases().size(); i++) {
+                        final String alias = advisory.getAliases().get(i);
+                        final VulnerabilityAlias vulnerabilityAlias = new VulnerabilityAlias();
+
+                        // OSV will use IDs of other vulnerability databases for its
+                        // primary advisory ID (e.g. GHSA-45hx-wfhj-473x). We need to ensure
+                        // that we don't falsely report GHSA IDs as stemming from OSV.
+                        switch (vulnerabilitySource) {
+                            case NVD -> vulnerabilityAlias.setCveId(advisory.getId());
+                            case GITHUB -> vulnerabilityAlias.setGhsaId(advisory.getId());
+                            default -> vulnerabilityAlias.setOsvId(advisory.getId());
+                        }
+
+                        if (alias.startsWith("CVE") && Vulnerability.Source.NVD != vulnerabilitySource) {
+                            vulnerabilityAlias.setCveId(alias);
+                            qm.synchronizeVulnerabilityAlias(vulnerabilityAlias);
+                        } else if (alias.startsWith("GHSA") && Vulnerability.Source.GITHUB != vulnerabilitySource) {
+                            vulnerabilityAlias.setGhsaId(alias);
+                            qm.synchronizeVulnerabilityAlias(vulnerabilityAlias);
+                        }
+
+                        //TODO - OSV supports GSD and DLA/DSA identifiers (possibly others). Determine how to handle.
+                    }
+                }
+
+                qm.synchronizeVulnerableSoftware(synchronizedVulnerability, vsList, Vulnerability.Source.OSV);
+            });
+        }
     }
 
     private boolean shouldUpdateExistingVulnerability(Vulnerability existingVulnerability, Vulnerability.Source vulnerabilitySource, boolean vulnAuthoritativeSourceEnabled) {
@@ -783,18 +795,35 @@ public class OsvDownloadTask implements LoggableSubscriber {
         };
     }
 
-    public VulnerableSoftware mapAffectedPackageToVulnerableSoftware(final QueryManager qm, final OsvAffectedPackage affectedPackage) {
+    public VulnerableSoftware mapAffectedPackageToVulnerableSoftware(OsvAffectedPackage affectedPackage) {
         if (affectedPackage.getPurl() == null) {
             LOGGER.debug("No PURL provided for affected package " + affectedPackage.getPackageName() + " - skipping");
             return null;
         }
 
-        final PackageURL purl;
+        PackageURL purl;
         try {
             purl = new PackageURL(affectedPackage.getPurl());
         } catch (MalformedPackageURLException e) {
             LOGGER.debug("Invalid PURL provided for affected package  " + affectedPackage.getPackageName() + " - skipping", e);
             return null;
+        }
+
+        // Some PURLs already include the distro qualifier, e.g. "pkg:deb/ubuntu/php7.0?distro=xenial",
+        // while for others we may need to infer it from the package ecosystem, e.g. "Debian:13".
+        final String distroQualifier = PurlUtil.getDistroQualifier(purl);
+        if (distroQualifier == null) {
+            final var distro = OsDistribution.ofOsvEcosystem(affectedPackage.getPackageEcosystem());
+            if (distro != null) {
+                try {
+                    purl = purl
+                            .toBuilder()
+                            .withQualifier("distro", distro.purlQualifierValue())
+                            .build();
+                } catch (MalformedPackageURLException e) {
+                    LOGGER.warn("Failed to add distro qualifier to PURL for " + affectedPackage.getPackageName(), e);
+                }
+            }
         }
 
         // Other sources do not populate the versionStartIncluding with 0.
@@ -806,16 +835,11 @@ public class OsvDownloadTask implements LoggableSubscriber {
         final String versionEndExcluding = affectedPackage.getUpperVersionRangeExcluding();
         final String versionEndIncluding = affectedPackage.getUpperVersionRangeIncluding();
 
-        VulnerableSoftware vs = qm.getVulnerableSoftwareByPurl(purl.getType(), purl.getNamespace(), purl.getName(),
-                purl.getVersion(), versionEndExcluding, versionEndIncluding, null, versionStartIncluding);
-        if (vs != null) {
-            return vs;
-        }
-
-        vs = new VulnerableSoftware();
+        final var vs = new VulnerableSoftware();
         vs.setPurlType(purl.getType());
         vs.setPurlNamespace(purl.getNamespace());
         vs.setPurlName(purl.getName());
+        vs.setPurlQualifiers(PurlUtil.serializeQualifiers(purl));
         vs.setPurl(purl.canonicalize());
         vs.setVulnerable(true);
         vs.setVersion(affectedPackage.getVersion());

--- a/src/main/java/org/dependencytrack/tasks/scanners/AbstractVulnerableSoftwareAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/AbstractVulnerableSoftwareAnalysisTask.java
@@ -19,25 +19,25 @@
 package org.dependencytrack.tasks.scanners;
 
 import alpine.common.logging.Logger;
+import com.github.packageurl.PackageURL;
+import io.github.nscuro.versatile.Comparator;
+import io.github.nscuro.versatile.Vers;
+import io.github.nscuro.versatile.VersException;
+import io.github.nscuro.versatile.spi.InvalidVersionException;
+import io.github.nscuro.versatile.version.KnownVersioningSchemes;
 import org.dependencytrack.model.Component;
+import org.dependencytrack.model.OsDistribution;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAnalysisLevel;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.NotificationUtil;
-import org.dependencytrack.util.ComponentVersion;
-
-import com.github.packageurl.PackageURL;
-
+import org.dependencytrack.util.PurlUtil;
 import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.util.Relation;
 
 import java.util.List;
-
-import io.github.nscuro.versatile.spi.InvalidVersionException;
-import io.github.nscuro.versatile.spi.Version;
-import io.github.nscuro.versatile.VersionFactory;
-import io.github.nscuro.versatile.Vers;
+import java.util.Optional;
 
 /**
  * Base analysis task for using the internal VulnerableSoftware model as the source of truth for
@@ -47,7 +47,8 @@ import io.github.nscuro.versatile.Vers;
  * @since 3.6.0
  */
 public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseComponentAnalyzerTask {
-    private static final Logger LOGGER = Logger.getLogger(AbstractVulnerableSoftwareAnalysisTask.class);
+
+    private final Logger logger = Logger.getLogger(getClass());
 
     /**
      * Analyzes the targetVersion against a list of VulnerableSoftware objects which may contain
@@ -72,25 +73,21 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
             ran = true;
         }
         if (!ran) {
-            LOGGER.info("Neither CPE nor PURL available for component %s, skipping version range analysis"
-                    .formatted(component.getUuid()));
-            return;
+            logger.info(
+                    "Neither CPE nor PURL available for component %s, skipping version range analysis"
+                            .formatted(component.getUuid()));
         }
     }
 
-    protected void analyzePurlVersionRange(final QueryManager qm, final List<VulnerableSoftware> vsList,
-            final PackageURL targetPurl, final String targetVersion, final Component component,
-            final VulnerabilityAnalysisLevel vulnerabilityAnalysisLevel) {
-
-        final Version version;
-        try {
-            version = VersionFactory.forScheme(targetPurl.getType(), targetVersion);
-        } catch (InvalidVersionException e) {
-            LOGGER.warn("Unable to parse version (" + targetVersion + ") for component (" + component.getUuid() + ")");
-            return;
-        }
+    protected void analyzePurlVersionRange(
+            QueryManager qm,
+            List<VulnerableSoftware> vsList,
+            PackageURL targetPurl,
+            String targetVersion,
+            Component component,
+            VulnerabilityAnalysisLevel vulnerabilityAnalysisLevel) {
         for (final VulnerableSoftware vs : vsList) {
-            if (comparePurlVersions(vs, version)) {
+            if (comparePurlVersions(targetPurl, vs, targetVersion)) {
                 if (vs.getVulnerabilities() != null) {
                     for (final Vulnerability vulnerability : vs.getVulnerabilities()) {
                         NotificationUtil.analyzeNotificationCriteria(qm, vulnerability, component,
@@ -100,15 +97,18 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
                 }
             }
         }
-
     }
 
-    protected void analyzeCpeVersionRange(final QueryManager qm, final List<VulnerableSoftware> vsList,
-                                       final Cpe targetCpe, final String targetVersion, final Component component,
-                                       final VulnerabilityAnalysisLevel vulnerabilityAnalysisLevel){
+    private void analyzeCpeVersionRange(
+            QueryManager qm,
+            List<VulnerableSoftware> vsList,
+            Cpe targetCpe,
+            String targetVersion,
+            Component component,
+            VulnerabilityAnalysisLevel vulnerabilityAnalysisLevel) {
         for (final VulnerableSoftware vs : vsList) {
             final Boolean isCpeMatch = maybeMatchCpe(vs, targetCpe, targetVersion);
-            if ((isCpeMatch == null || isCpeMatch) && compareCpeVersions(vs, targetVersion)) {
+            if ((isCpeMatch == null || isCpeMatch) && compareCpeVersions(vs, targetVersion, component)) {
                 if (vs.getVulnerabilities() != null) {
                     for (final Vulnerability vulnerability : vs.getVulnerabilities()) {
                         NotificationUtil.analyzeNotificationCriteria(qm, vulnerability, component, vulnerabilityAnalysisLevel);
@@ -154,22 +154,52 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
         isMatch &= !(vendorRelation == Relation.SUBSET && productRelation == Relation.SUPERSET);
         isMatch &= !(vendorRelation == Relation.SUPERSET && productRelation == Relation.SUBSET);
         if (!isMatch) {
-            Logger.getLogger(getClass()).debug("%s: Dropped match with %s due to ambiguous vendor/product relation"
+            logger.debug("%s: Dropped match with %s due to ambiguous vendor/product relation"
                     .formatted(targetCpe.toCpe23FS(), vs.getCpe23()));
         }
 
         return isMatch;
     }
 
-    
-    private static boolean comparePurlVersions(VulnerableSoftware vs, Version targetVersion) {
-        final Vers vulnerableVersionRange = vs.getVers();
+    private boolean comparePurlVersions(PackageURL componentPurl, VulnerableSoftware vs, String targetVersion) {
+        final String componentDistroQualifier = PurlUtil.getDistroQualifier(componentPurl);
+        final String vsDistroQualifier = PurlUtil.getDistroQualifier(vs.getPurl());
 
-        if (vulnerableVersionRange == null) {
-            return false;
+        // When both the component and the vulnerable software record have a distro
+        // qualifier, they must match *before* we perform the actual version comparison.
+        if (componentDistroQualifier != null && vsDistroQualifier != null) {
+            // Simplest case: the qualifiers just match without special interpretation.
+            if (!componentDistroQualifier.equals(vsDistroQualifier)) {
+                // Could still match, but depends on distro semantics.
+                // e.g. "debian-13" should match "trixie".
+                final var componentDistro = OsDistribution.of(componentPurl);
+                final var vsDistro = OsDistribution.of(PurlUtil.silentPurl(vs.getPurl()));
+
+                if (componentDistro != null && vsDistro != null) {
+                    if (!componentDistro.matches(vsDistro)) {
+                        // Actual mismatch, e.g. "debian-13" != "sid".
+                        return false;
+                    }
+                } else if (componentDistro != null || vsDistro != null) {
+                    // One side was parsed, the other wasn't. The raw qualifier
+                    // strings already differ, so this is a mismatch.
+                    return false;
+                } else {
+                    // Neither side could be parsed. The raw qualifier strings
+                    // already differ, so treat as mismatch to avoid false positives.
+                    logger.debug("Neither distro qualifier could be parsed for comparison: %s vs %s"
+                            .formatted(componentDistroQualifier, vsDistroQualifier));
+                    return false;
+                }
+            }
         }
 
-        return vs.getVers().contains(targetVersion.toString());
+        final String versioningScheme = Optional
+                .ofNullable(componentPurl)
+                .flatMap(KnownVersioningSchemes::fromPurl)
+                .orElse(KnownVersioningSchemes.SCHEME_GENERIC);
+
+        return compareWithVers(vs, targetVersion, versioningScheme);
     }
 
     /**
@@ -184,7 +214,7 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
      * <p>
      * Ported from Dependency-Check v5.2.1
      */
-    private static boolean compareCpeVersions(VulnerableSoftware vs, String targetVersion) {
+    private boolean compareCpeVersions(VulnerableSoftware vs, String targetVersion, Component component) {
         // Modified from original by @nscuro.
         // Special cases for CPE matching of ANY (*) and NA (*) versions.
         // These don't make sense to use for version range comparison and
@@ -208,11 +238,7 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
             return "*".equals(vs.getVersion()) || "-".equals(vs.getVersion());
         }
 
-        //if any of the four conditions will be evaluated - then true;
-        boolean result = (vs.getVersionEndExcluding() != null && !vs.getVersionEndExcluding().isEmpty())
-                || (vs.getVersionStartExcluding() != null && !vs.getVersionStartExcluding().isEmpty())
-                || (vs.getVersionEndIncluding() != null && !vs.getVersionEndIncluding().isEmpty())
-                || (vs.getVersionStartIncluding() != null && !vs.getVersionStartIncluding().isEmpty());
+        boolean result = vs.hasVersionRange();
 
         // Modified from original by Steve Springett
         // Added null check: vs.getVersion() != null as purl sources that use version ranges may not have version populated.
@@ -220,27 +246,68 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
             return true;
         }
 
-        final ComponentVersion target = new ComponentVersion(targetVersion);
-        if (target.getVersionParts().isEmpty()) {
+        // If the component has a PURL, we can deduce the applicable versioning scheme from it.
+        final String versioningScheme = Optional
+                .ofNullable(component.getPurl())
+                .flatMap(KnownVersioningSchemes::fromPurl)
+                .orElse(KnownVersioningSchemes.SCHEME_GENERIC);
+
+        return compareWithVers(vs, targetVersion, versioningScheme);
+    }
+
+    private boolean compareWithVers(VulnerableSoftware vs, String targetVersion, String versioningScheme) {
+        try {
+            return buildVers(vs, versioningScheme).contains(targetVersion);
+        } catch (VersException | InvalidVersionException e) {
+            // NB: We don't log the full exception in any of the error cases,
+            // because they would lead to extremely noisy logs.
+
+            // It's always possible that versatile has a bug, or components / vulnerabilities
+            // do not strictly follow versioning schemes. Fall back to generic scheme
+            // to prevent false negatives.
+            if (!KnownVersioningSchemes.SCHEME_GENERIC.equals(versioningScheme)) {
+                logger.warn("""
+                        Failed to compare %s against %s with scheme %s: %s; \
+                        Retrying with scheme %s""".formatted(targetVersion, vs, versioningScheme, e.getMessage(), KnownVersioningSchemes.SCHEME_GENERIC));
+                try {
+                    return buildVers(vs, KnownVersioningSchemes.SCHEME_GENERIC).contains(targetVersion);
+                } catch (VersException | InvalidVersionException e2) {
+                    logger.warn("Failed to compare %s against %s with fallback: %s".formatted(targetVersion, vs, e2.getMessage()));
+                }
+            } else {
+                logger.warn("Failed to compare %s against %s: %s".formatted(targetVersion, vs, e.getMessage()));
+            }
+
             return false;
         }
-        if (result && vs.getVersionEndExcluding() != null && !vs.getVersionEndExcluding().isEmpty()) {
-            final ComponentVersion endExcluding = new ComponentVersion(vs.getVersionEndExcluding());
-            result = endExcluding.compareTo(target) > 0;
+    }
+
+    private static Vers buildVers(VulnerableSoftware vs, String versioningScheme) {
+        final var versBuilder = Vers.builder(versioningScheme);
+
+        if (!vs.hasVersionRange()) {
+            final String vsVersion = vs.getVersion();
+            if (vsVersion == null || vsVersion.isBlank()) {
+                versBuilder.withConstraint(Comparator.WILDCARD, null);
+            } else {
+                versBuilder.withConstraint(Comparator.EQUAL, vsVersion);
+            }
+        } else {
+            if (vs.getVersionStartIncluding() != null && !vs.getVersionStartIncluding().isBlank()) {
+                versBuilder.withConstraint(Comparator.GREATER_THAN_OR_EQUAL, vs.getVersionStartIncluding());
+            }
+            if (vs.getVersionStartExcluding() != null && !vs.getVersionStartExcluding().isBlank()) {
+                versBuilder.withConstraint(Comparator.GREATER_THAN, vs.getVersionStartExcluding());
+            }
+            if (vs.getVersionEndExcluding() != null && !vs.getVersionEndExcluding().isBlank()) {
+                versBuilder.withConstraint(Comparator.LESS_THAN, vs.getVersionEndExcluding());
+            }
+            if (vs.getVersionEndIncluding() != null && !vs.getVersionEndIncluding().isBlank()) {
+                versBuilder.withConstraint(Comparator.LESS_THAN_OR_EQUAL, vs.getVersionEndIncluding());
+            }
         }
-        if (result && vs.getVersionStartExcluding() != null && !vs.getVersionStartExcluding().isEmpty()) {
-            final ComponentVersion startExcluding = new ComponentVersion(vs.getVersionStartExcluding());
-            result = startExcluding.compareTo(target) < 0;
-        }
-        if (result && vs.getVersionEndIncluding() != null && !vs.getVersionEndIncluding().isEmpty()) {
-            final ComponentVersion endIncluding = new ComponentVersion(vs.getVersionEndIncluding());
-            result &= endIncluding.compareTo(target) >= 0;
-        }
-        if (result && vs.getVersionStartIncluding() != null && !vs.getVersionStartIncluding().isEmpty()) {
-            final ComponentVersion startIncluding = new ComponentVersion(vs.getVersionStartIncluding());
-            result &= startIncluding.compareTo(target) <= 0;
-        }
-        return result;
+
+        return versBuilder.build();
     }
 
 }

--- a/src/main/java/org/dependencytrack/util/PurlUtil.java
+++ b/src/main/java/org/dependencytrack/util/PurlUtil.java
@@ -20,6 +20,10 @@ package org.dependencytrack.util;
 
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
+import jakarta.json.Json;
+import org.jspecify.annotations.Nullable;
+
+import java.util.TreeMap;
 
 import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 
@@ -69,6 +73,42 @@ public class PurlUtil {
         } catch (MalformedPackageURLException ignored) {
             return null;
         }
+    }
+
+    public static @Nullable String serializeQualifiers(@Nullable PackageURL purl) {
+        if (purl == null || purl.getQualifiers() == null || purl.getQualifiers().isEmpty()) {
+            return null;
+        }
+
+        // Ensure that we produce deterministic output in case of multiple qualifiers.
+        final var orderedQualifiers = new TreeMap<>(purl.getQualifiers());
+
+        final var builder = Json.createObjectBuilder();
+        orderedQualifiers.forEach(builder::add);
+        return builder.build().toString();
+    }
+
+    public static @Nullable String getDistroQualifier(@Nullable PackageURL purl) {
+        if (purl == null || purl.getQualifiers() == null || purl.getQualifiers().isEmpty()) {
+            return null;
+        }
+
+        for (final var qualifier : purl.getQualifiers().entrySet()) {
+            if ("distro".equals(qualifier.getKey())) {
+                return qualifier.getValue();
+            }
+        }
+
+        return null;
+    }
+
+    public static @Nullable String getDistroQualifier(@Nullable String purl) {
+        final PackageURL parsedPurl = silentPurl(purl);
+        if (parsedPurl == null) {
+            return null;
+        }
+
+        return getDistroQualifier(parsedPurl);
     }
 
 }

--- a/src/test/java/org/dependencytrack/model/OsDistributionTest.java
+++ b/src/test/java/org/dependencytrack/model/OsDistributionTest.java
@@ -1,0 +1,454 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.model;
+
+import com.github.packageurl.PackageURL;
+import org.dependencytrack.model.OsDistribution.DebianDistribution;
+import org.dependencytrack.model.OsDistribution.UbuntuDistribution;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OsDistributionTest {
+
+    @Nested
+    class OfPurlTest {
+
+        @ParameterizedTest
+        @CsvSource(value = {
+                "pkg:deb/debian/sudo@1.9.5p2-3%2Bdeb11u1?arch=amd64&distro=debian-11.6, DebianDistribution, debian-11",
+                "pkg:deb/debian/sudo@1.9.5p2-3%2Bdeb11u1?distro=debian-11, DebianDistribution, debian-11",
+                "pkg:deb/debian/sudo@1.9.5p2-3%2Bdeb11u1?distro=debian-7, DebianDistribution, debian-7",
+                "pkg:deb/debian/sudo@1.9.5p2-3%2Bdeb11u1?distro=bullseye, DebianDistribution, debian-11",
+                "pkg:deb/debian/sudo@1.9.5p2-3%2Bdeb11u1?distro=debian-bullseye, DebianDistribution, debian-11",
+                "pkg:deb/debian/sudo@1.9.5p2-3%2Bdeb11u1?distro=debian-sid, DebianDistribution, debian-sid",
+                "pkg:deb/debian/sudo@1.9.5p2-3%2Bdeb11u1?distro=sid, DebianDistribution, debian-sid",
+                "pkg:deb/ubuntu/sudo@1.9.5?distro=ubuntu-22.04, UbuntuDistribution, ubuntu-22.04",
+                "pkg:deb/ubuntu/sudo@1.9.5?distro=jammy, UbuntuDistribution, ubuntu-22.04",
+                "pkg:deb/ubuntu/sudo@1.9.5?distro=ubuntu-20.04, UbuntuDistribution, ubuntu-20.04",
+                "pkg:deb/ubuntu/sudo@1.9.5?distro=focal, UbuntuDistribution, ubuntu-20.04",
+                "pkg:apk/alpine/curl@8.5.0-r0?distro=alpine-3.16, AlpineDistribution, alpine-3.16",
+                "pkg:apk/alpine/curl@8.5.0-r0?distro=3.16, AlpineDistribution, alpine-3.16",
+                "pkg:apk/alpine/curl@8.5.0-r0?distro=3.16.4, AlpineDistribution, alpine-3.16",
+                "pkg:apk/alpine/curl@8.5.0-r0?distro=alpine-3.18.5, AlpineDistribution, alpine-3.18",
+        })
+        void shouldParseDistro(String purl, String expectedType, String expectedPurlQualifier) throws Exception {
+            final var packageUrl = new PackageURL(purl);
+
+            final var distro = OsDistribution.of(packageUrl);
+            assertThat(distro).isNotNull();
+            assertThat(distro.getClass().getSimpleName()).isEqualTo(expectedType);
+            assertThat(distro.purlQualifierValue()).isEqualTo(expectedPurlQualifier);
+        }
+
+        @Test
+        void shouldReturnNullForNullPurl() {
+            assertThat(OsDistribution.of(null)).isNull();
+        }
+
+        @Test
+        void shouldReturnNullForPurlWithoutQualifiers() throws Exception {
+            final var purl = new PackageURL("pkg:deb/debian/sudo@1.9.5p2-3");
+            assertThat(OsDistribution.of(purl)).isNull();
+        }
+
+        @Test
+        void shouldReturnNullForPurlWithoutDistroQualifier() throws Exception {
+            final var purl = new PackageURL("pkg:deb/debian/sudo@1.9.5p2-3?arch=amd64");
+            assertThat(OsDistribution.of(purl)).isNull();
+        }
+
+        @Test
+        void shouldReturnNullForNonDebianPurl() throws Exception {
+            final var purl = new PackageURL("pkg:npm/lodash@4.17.21?distro=debian-11");
+            assertThat(OsDistribution.of(purl)).isNull();
+        }
+    }
+
+    @Nested
+    class FromEcosystemTest {
+
+        @ParameterizedTest
+        @CsvSource(value = {
+                "Debian:7, DebianDistribution, debian-7",
+                "Debian:11, DebianDistribution, debian-11",
+                "Debian:sid, DebianDistribution, debian-sid",
+                "Debian:wheezy, DebianDistribution, debian-7",
+                "Debian:bullseye, DebianDistribution, debian-11",
+                "debian:11, DebianDistribution, debian-11",
+        })
+        void shouldParseEcosystemSuffix(String ecosystem, String expectedType, String expectedPurlQualifier) {
+            final var distro = OsDistribution.ofOsvEcosystem(ecosystem);
+            assertThat(distro).isNotNull();
+            assertThat(distro.getClass().getSimpleName()).isEqualTo(expectedType);
+            assertThat(distro.purlQualifierValue()).isEqualTo(expectedPurlQualifier);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"Debian", "Debian:", "PyPI", "npm"})
+        void shouldReturnNullForInvalidEcosystem(String ecosystem) {
+            assertThat(OsDistribution.ofOsvEcosystem(ecosystem)).isNull();
+        }
+
+        @Test
+        void shouldReturnNullForUnknownEcosystem() {
+            assertThat(OsDistribution.ofOsvEcosystem("Fedora:38")).isNull();
+        }
+
+        @ParameterizedTest
+        @CsvSource(value = {
+                "Ubuntu:22.04, ubuntu-22.04",
+                "Ubuntu:20.04, ubuntu-20.04",
+                "Ubuntu:jammy, ubuntu-22.04",
+                "Ubuntu:focal, ubuntu-20.04",
+                "ubuntu:22.04, ubuntu-22.04",
+                "Ubuntu:16.04:LTS, ubuntu-16.04",
+                "Ubuntu:22.04:LTS, ubuntu-22.04",
+                "Ubuntu:14.04:LTS, ubuntu-14.04",
+        })
+        void shouldParseUbuntuEcosystemSuffix(String ecosystem, String expectedPurlQualifier) {
+            final var distro = OsDistribution.ofOsvEcosystem(ecosystem);
+            assertThat(distro).isNotNull();
+            assertThat(distro).isInstanceOf(UbuntuDistribution.class);
+            assertThat(distro.purlQualifierValue()).isEqualTo(expectedPurlQualifier);
+        }
+
+        @ParameterizedTest
+        @CsvSource(value = {
+                "Alpine:v3.5, alpine-3.5",
+                "Alpine:v3.16, alpine-3.16",
+                "Alpine:v3.22, alpine-3.22",
+                "alpine:v3.18, alpine-3.18",
+                "Alpine:3.16, alpine-3.16",
+        })
+        void shouldParseAlpineEcosystemSuffix(String ecosystem, String expectedPurlQualifier) {
+            final var distro = OsDistribution.ofOsvEcosystem(ecosystem);
+            assertThat(distro).isNotNull();
+            assertThat(distro).isInstanceOf(OsDistribution.AlpineDistribution.class);
+            assertThat(distro.purlQualifierValue()).isEqualTo(expectedPurlQualifier);
+        }
+    }
+
+    @Nested
+    class MatchesTest {
+
+        @ParameterizedTest
+        @CsvSource(value = {
+                "Debian:7, pkg:deb/debian/apt?distro=debian-7, true",
+                "Debian:7, pkg:deb/debian/apt?distro=debian-7.11, true",
+                "Debian:7, pkg:deb/debian/apt?distro=wheezy, true",
+                "Debian:7, pkg:deb/debian/apt?distro=debian-wheezy, true",
+                "Debian:11, pkg:deb/debian/apt?distro=debian-11, true",
+                "Debian:11, pkg:deb/debian/apt?distro=debian-11.6, true",
+                "Debian:11, pkg:deb/debian/apt?distro=bullseye, true",
+                "Debian:bullseye, pkg:deb/debian/apt?distro=debian-11, true",
+                "Debian:sid, pkg:deb/debian/apt?distro=debian-sid, true",
+                "Debian:sid, pkg:deb/debian/apt?distro=sid, true",
+                "Debian:7, pkg:deb/debian/apt?distro=debian-11, false",
+                "Debian:11, pkg:deb/debian/apt?distro=debian-7, false",
+                "Debian:wheezy, pkg:deb/debian/apt?distro=debian-bullseye, false",
+                "Debian:sid, pkg:deb/debian/apt?distro=debian-11, false",
+        })
+        void shouldMatch(String ecosystem, String purl, boolean shouldMatch) throws Exception {
+            final var ecosystemDistro = OsDistribution.ofOsvEcosystem(ecosystem);
+            assertThat(ecosystemDistro).isNotNull();
+
+            final var qualifierDistro = OsDistribution.of(new PackageURL(purl));
+            assertThat(qualifierDistro).isNotNull();
+
+            assertThat(ecosystemDistro.matches(qualifierDistro)).isEqualTo(shouldMatch);
+            assertThat(qualifierDistro.matches(ecosystemDistro)).isEqualTo(shouldMatch);
+        }
+
+        @Test
+        void shouldMatchMajorVersionWithPointRelease() throws Exception {
+            final var distroA = OsDistribution.of(new PackageURL("pkg:deb/debian/sudo@1.9.5?distro=debian-11.6"));
+            final var distroB = OsDistribution.of(new PackageURL("pkg:deb/debian/sudo@1.9.5?distro=debian-11"));
+
+            assertThat(distroA).isNotNull();
+            assertThat(distroB).isNotNull();
+            assertThat(distroA.matches(distroB)).isTrue();
+        }
+
+        @Test
+        void shouldMatchCodenameWithVersion() throws Exception {
+            final var distroA = OsDistribution.of(new PackageURL("pkg:deb/debian/sudo@1.9.5?distro=wheezy"));
+            final var distroB = OsDistribution.of(new PackageURL("pkg:deb/debian/sudo@1.9.5?distro=debian-7"));
+
+            assertThat(distroA).isNotNull();
+            assertThat(distroB).isNotNull();
+            assertThat(distroA.matches(distroB)).isTrue();
+        }
+
+        @Test
+        void shouldNotMatchDifferentMajorVersions() throws Exception {
+            final var distroA = OsDistribution.of(new PackageURL("pkg:deb/debian/sudo@1.9.5?distro=debian-11"));
+            final var distroB = OsDistribution.of(new PackageURL("pkg:deb/debian/sudo@1.9.5?distro=debian-7"));
+
+            assertThat(distroA).isNotNull();
+            assertThat(distroB).isNotNull();
+            assertThat(distroA.matches(distroB)).isFalse();
+        }
+
+        @Test
+        void shouldMatchUbuntuVersionWithCodename() throws Exception {
+            final var distroA = OsDistribution.of(new PackageURL("pkg:deb/ubuntu/sudo@1.9.5?distro=ubuntu-22.04"));
+            final var distroB = OsDistribution.of(new PackageURL("pkg:deb/ubuntu/sudo@1.9.5?distro=jammy"));
+
+            assertThat(distroA).isNotNull();
+            assertThat(distroB).isNotNull();
+            assertThat(distroA.matches(distroB)).isTrue();
+        }
+
+        @Test
+        void shouldNotMatchDifferentUbuntuVersions() throws Exception {
+            final var distroA = OsDistribution.of(new PackageURL("pkg:deb/ubuntu/sudo@1.9.5?distro=ubuntu-22.04"));
+            final var distroB = OsDistribution.of(new PackageURL("pkg:deb/ubuntu/sudo@1.9.5?distro=ubuntu-20.04"));
+
+            assertThat(distroA).isNotNull();
+            assertThat(distroB).isNotNull();
+            assertThat(distroA.matches(distroB)).isFalse();
+        }
+
+        @Test
+        void shouldNotMatchDebianWithUbuntu() throws Exception {
+            final var debian = OsDistribution.of(new PackageURL("pkg:deb/debian/sudo@1.9.5?distro=debian-11"));
+            final var ubuntu = OsDistribution.of(new PackageURL("pkg:deb/ubuntu/sudo@1.9.5?distro=ubuntu-22.04"));
+
+            assertThat(debian).isNotNull();
+            assertThat(ubuntu).isNotNull();
+            assertThat(debian.matches(ubuntu)).isFalse();
+            assertThat(ubuntu.matches(debian)).isFalse();
+        }
+
+        @Test
+        void shouldMatchAlpineMajorMinorVersions() throws Exception {
+            final var distroA = OsDistribution.of(new PackageURL("pkg:apk/alpine/curl@8.5.0?distro=3.16.4"));
+            final var distroB = OsDistribution.of(new PackageURL("pkg:apk/alpine/curl@8.5.0?distro=alpine-3.16"));
+
+            assertThat(distroA).isNotNull();
+            assertThat(distroB).isNotNull();
+            assertThat(distroA.matches(distroB)).isTrue();
+        }
+
+        @Test
+        void shouldNotMatchDifferentAlpineMinorVersions() throws Exception {
+            final var distroA = OsDistribution.of(new PackageURL("pkg:apk/alpine/curl@8.5.0?distro=3.16"));
+            final var distroB = OsDistribution.of(new PackageURL("pkg:apk/alpine/curl@8.5.0?distro=3.18"));
+
+            assertThat(distroA).isNotNull();
+            assertThat(distroB).isNotNull();
+            assertThat(distroA.matches(distroB)).isFalse();
+        }
+
+        @Test
+        void shouldNotMatchAlpineWithDebian() throws Exception {
+            final var alpine = OsDistribution.of(new PackageURL("pkg:apk/alpine/curl@8.5.0?distro=3.16"));
+            final var debian = OsDistribution.of(new PackageURL("pkg:deb/debian/curl@8.5.0?distro=debian-11"));
+
+            assertThat(alpine).isNotNull();
+            assertThat(debian).isNotNull();
+            assertThat(alpine.matches(debian)).isFalse();
+            assertThat(debian.matches(alpine)).isFalse();
+        }
+
+    }
+
+    @Nested
+    class DebianDistributionKnownReleasesTest {
+
+        @ParameterizedTest
+        @CsvSource(value = {
+                "1.1, buzz",
+                "1.2, rex",
+                "1.3, bo",
+                "2.0, hamm",
+                "2.1, slink",
+                "2.2, potato",
+                "3.0, woody",
+                "3.1, sarge",
+                "4.0, etch",
+                "5.0, lenny",
+                "6.0, squeeze",
+                "7, wheezy",
+                "8, jessie",
+                "9, stretch",
+                "10, buster",
+                "11, bullseye",
+                "12, bookworm",
+                "13, trixie",
+                "14, forky",
+        })
+        void shouldResolveKnownReleasesFromVersion(String version, String expectedSeries) {
+            final var distro = OsDistribution.ofOsvEcosystem("Debian:" + version);
+            assertThat(distro).isNotNull();
+            assertThat(distro).isInstanceOf(DebianDistribution.class);
+
+            final var debian = (DebianDistribution) distro;
+            assertThat(debian.series()).isEqualTo(expectedSeries);
+            assertThat(debian.version()).isEqualTo(version);
+        }
+
+        @Test
+        void shouldHandleSidWithNoVersion() {
+            final var distro = OsDistribution.ofOsvEcosystem("Debian:sid");
+            assertThat(distro).isNotNull();
+            assertThat(distro).isInstanceOf(DebianDistribution.class);
+
+            final var debian = (DebianDistribution) distro;
+            assertThat(debian.series()).isEqualTo("sid");
+            assertThat(debian.version()).isNull();
+            assertThat(debian.purlQualifierValue()).isEqualTo("debian-sid");
+        }
+    }
+
+    @Nested
+    class UnknownDistributionFallbackTest {
+
+        @Test
+        void shouldFallbackForUnknownDebianVersion() {
+            final var distro = OsDistribution.ofOsvEcosystem("Debian:666");
+            assertThat(distro).isNotNull();
+            assertThat(distro).isInstanceOf(DebianDistribution.class);
+
+            final var debian = (DebianDistribution) distro;
+            assertThat(debian.series()).isEqualTo("666");
+            assertThat(debian.version()).isEqualTo("666");
+            assertThat(debian.purlQualifierValue()).isEqualTo("debian-666");
+        }
+
+        @Test
+        void shouldFallbackForUnknownDebianCodename() {
+            final var distro = OsDistribution.ofOsvEcosystem("Debian:foo");
+            assertThat(distro).isNotNull();
+            assertThat(distro).isInstanceOf(DebianDistribution.class);
+
+            final var debian = (DebianDistribution) distro;
+            assertThat(debian.series()).isEqualTo("foo");
+            assertThat(debian.version()).isNull();
+            assertThat(debian.purlQualifierValue()).isEqualTo("debian-foo");
+        }
+
+        @Test
+        void shouldMatchUnknownDebianVersions() throws Exception {
+            // Both sides use same unknown version - should match
+            final var distroA = OsDistribution.of(new PackageURL("pkg:deb/debian/curl@8.0?distro=debian-99"));
+            final var distroB = OsDistribution.ofOsvEcosystem("Debian:99");
+
+            assertThat(distroA).isNotNull();
+            assertThat(distroB).isNotNull();
+            assertThat(distroA.matches(distroB)).isTrue();
+        }
+
+        @Test
+        void shouldMatchUnknownDebianCodenames() throws Exception {
+            // Both sides use same unknown codename - should match
+            final var distroA = OsDistribution.of(new PackageURL("pkg:deb/debian/curl@8.0?distro=zzz"));
+            final var distroB = OsDistribution.ofOsvEcosystem("Debian:zzz");
+
+            assertThat(distroA).isNotNull();
+            assertThat(distroB).isNotNull();
+            assertThat(distroA.matches(distroB)).isTrue();
+        }
+
+        @Test
+        void shouldNotMatchUnknownDebianVersionWithCodename() throws Exception {
+            final var distroA = OsDistribution.of(new PackageURL("pkg:deb/debian/curl@8.0?distro=debian-666"));
+            final var distroB = OsDistribution.ofOsvEcosystem("Debian:foo");
+
+            assertThat(distroA).isNotNull();
+            assertThat(distroB).isNotNull();
+            assertThat(distroA.matches(distroB)).isFalse();
+        }
+
+        @Test
+        void shouldFallbackForUnknownUbuntuVersion() {
+            final var distro = OsDistribution.ofOsvEcosystem("Ubuntu:66.66");
+            assertThat(distro).isNotNull();
+            assertThat(distro).isInstanceOf(UbuntuDistribution.class);
+
+            final var ubuntu = (UbuntuDistribution) distro;
+            assertThat(ubuntu.series()).isEqualTo("66.66");
+            assertThat(ubuntu.version()).isEqualTo("66.66");
+            assertThat(ubuntu.purlQualifierValue()).isEqualTo("ubuntu-66.66");
+        }
+
+        @Test
+        void shouldFallbackForUnknownUbuntuSeries() {
+            final var distro = OsDistribution.ofOsvEcosystem("Ubuntu:xyz");
+            assertThat(distro).isNotNull();
+            assertThat(distro).isInstanceOf(UbuntuDistribution.class);
+
+            final var ubuntu = (UbuntuDistribution) distro;
+            assertThat(ubuntu.series()).isEqualTo("xyz");
+            assertThat(ubuntu.version()).isEqualTo("xyz");
+            assertThat(ubuntu.purlQualifierValue()).isEqualTo("ubuntu-xyz");
+        }
+
+        @Test
+        void shouldMatchUnknownUbuntuVersions() throws Exception {
+            // Both sides use same unknown version - should match
+            final var distroA = OsDistribution.of(new PackageURL("pkg:deb/ubuntu/curl@8.0?distro=ubuntu-28.04"));
+            final var distroB = OsDistribution.ofOsvEcosystem("Ubuntu:28.04");
+
+            assertThat(distroA).isNotNull();
+            assertThat(distroB).isNotNull();
+            assertThat(distroA.matches(distroB)).isTrue();
+        }
+
+        @Test
+        void shouldNormalizeUbuntuPointRelease() throws Exception {
+            final var distroA = OsDistribution.of(new PackageURL("pkg:deb/ubuntu/curl@8.0?distro=ubuntu-22.04.4"));
+            assertThat(distroA).isNotNull();
+            assertThat(distroA).isInstanceOf(UbuntuDistribution.class);
+
+            final var ubuntu = (UbuntuDistribution) distroA;
+            assertThat(ubuntu.series()).isEqualTo("jammy");
+            assertThat(ubuntu.version()).isEqualTo("22.04");
+        }
+
+        @Test
+        void shouldMatchUbuntuPointReleaseWithMajorMinor() throws Exception {
+            final var distroA = OsDistribution.of(new PackageURL("pkg:deb/ubuntu/curl@8.0?distro=ubuntu-22.04.4"));
+            final var distroB = OsDistribution.ofOsvEcosystem("Ubuntu:22.04");
+
+            assertThat(distroA).isNotNull();
+            assertThat(distroB).isNotNull();
+            assertThat(distroA.matches(distroB)).isTrue();
+        }
+
+        @Test
+        void shouldNotMatchUnknownUbuntuVersionWithSeries() throws Exception {
+            // Version "28.04" vs series "xyz" - can't resolve mapping, won't match
+            final var distroA = OsDistribution.of(new PackageURL("pkg:deb/ubuntu/curl@8.0?distro=ubuntu-28.04"));
+            final var distroB = OsDistribution.ofOsvEcosystem("Ubuntu:xyz");
+
+            assertThat(distroA).isNotNull();
+            assertThat(distroB).isNotNull();
+            assertThat(distroA.matches(distroB)).isFalse();
+        }
+    }
+
+}

--- a/src/test/java/org/dependencytrack/tasks/OsvDownloadTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/OsvDownloadTaskTest.java
@@ -382,6 +382,7 @@ class OsvDownloadTaskTest extends PersistenceCapableTest {
     @Test
     void testUpdateDatasourceVulnerableVersionRanges() {
         var vs1 = new VulnerableSoftware();
+        vs1.setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind");
         vs1.setPurlType("maven");
         vs1.setPurlNamespace("com.fasterxml.jackson.core");
         vs1.setPurlName("jackson-databind");
@@ -391,6 +392,7 @@ class OsvDownloadTaskTest extends PersistenceCapableTest {
         vs1 = qm.persist(vs1);
 
         var vs2 = new VulnerableSoftware();
+        vs2.setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind");
         vs2.setPurlType("maven");
         vs2.setPurlNamespace("com.fasterxml.jackson.core");
         vs2.setPurlName("jackson-databind");
@@ -399,6 +401,7 @@ class OsvDownloadTaskTest extends PersistenceCapableTest {
         vs2 = qm.persist(vs2);
 
         var vs3 = new VulnerableSoftware();
+        vs3.setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind");
         vs3.setPurlType("maven");
         vs3.setPurlNamespace("com.fasterxml.jackson.core");
         vs3.setPurlName("jackson-databind");

--- a/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskDistroMatchingTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskDistroMatchingTest.java
@@ -1,0 +1,162 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.tasks.scanners;
+
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.event.InternalAnalysisEvent;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.VulnerabilityAnalysisLevel;
+import org.dependencytrack.model.VulnerableSoftware;
+import org.dependencytrack.tasks.scanners.InternalAnalysisTaskPurlMatchingTest.Range;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_INTERNAL_ENABLED;
+
+public class InternalAnalysisTaskDistroMatchingTest extends PersistenceCapableTest {
+
+    private static final boolean MATCHES = true;
+    private static final boolean DOES_NOT_MATCH = false;
+
+    private static final Range RANGE = Range.withRange().havingEndExcluding("2.0.0");
+
+    static Stream<Arguments> parameters() {
+        return Stream.of(
+                // ---
+                // Debian
+                // ---
+                // Scenario: Same distro qualifier string
+                Arguments.of("pkg:deb/debian/sudo?distro=debian-11", RANGE, MATCHES, "pkg:deb/debian/sudo@1.9.5?distro=debian-11"),
+                // Scenario: Codename vs version (semantic match)
+                Arguments.of("pkg:deb/debian/sudo?distro=debian-11", RANGE, MATCHES, "pkg:deb/debian/sudo@1.9.5?distro=bullseye"),
+                // Scenario: Version vs codename
+                Arguments.of("pkg:deb/debian/sudo?distro=bullseye", RANGE, MATCHES, "pkg:deb/debian/sudo@1.9.5?distro=debian-11"),
+                // Scenario: Point release vs major version
+                Arguments.of("pkg:deb/debian/sudo?distro=debian-11", RANGE, MATCHES, "pkg:deb/debian/sudo@1.9.5?distro=debian-11.6"),
+                // Scenario: Different Debian versions
+                Arguments.of("pkg:deb/debian/sudo?distro=debian-11", RANGE, DOES_NOT_MATCH, "pkg:deb/debian/sudo@1.9.5?distro=debian-12"),
+                // Scenario: Different Debian codenames
+                Arguments.of("pkg:deb/debian/sudo?distro=bullseye", RANGE, DOES_NOT_MATCH, "pkg:deb/debian/sudo@1.9.5?distro=bookworm"),
+                // ---
+                // Ubuntu
+                // ---
+                // Scenario: Same Ubuntu version
+                Arguments.of("pkg:deb/ubuntu/sudo?distro=ubuntu-22.04", RANGE, MATCHES, "pkg:deb/ubuntu/sudo@1.9.5?distro=ubuntu-22.04"),
+                // Scenario: Ubuntu codename vs version
+                Arguments.of("pkg:deb/ubuntu/sudo?distro=ubuntu-22.04", RANGE, MATCHES, "pkg:deb/ubuntu/sudo@1.9.5?distro=jammy"),
+                // Scenario: Different Ubuntu versions
+                Arguments.of("pkg:deb/ubuntu/sudo?distro=ubuntu-22.04", RANGE, DOES_NOT_MATCH, "pkg:deb/ubuntu/sudo@1.9.5?distro=ubuntu-20.04"),
+                // ---
+                // Alpine
+                // ---
+                // Scenario: Same Alpine version
+                Arguments.of("pkg:apk/alpine/curl?distro=alpine-3.16", RANGE, MATCHES, "pkg:apk/alpine/curl@1.0.0?distro=alpine-3.16"),
+                // Scenario: Alpine point release vs major.minor
+                Arguments.of("pkg:apk/alpine/curl?distro=alpine-3.16", RANGE, MATCHES, "pkg:apk/alpine/curl@1.0.0?distro=3.16.4"),
+                // Scenario: Different Alpine versions
+                Arguments.of("pkg:apk/alpine/curl?distro=alpine-3.16", RANGE, DOES_NOT_MATCH, "pkg:apk/alpine/curl@1.0.0?distro=alpine-3.18"),
+                // ---
+                // One side missing distro
+                // ---
+                // Scenario: VS has distro, component does not
+                Arguments.of("pkg:deb/debian/sudo?distro=debian-11", RANGE, MATCHES, "pkg:deb/debian/sudo@1.9.5"),
+                // Scenario: Component has distro, VS does not
+                Arguments.of("pkg:deb/debian/sudo", RANGE, MATCHES, "pkg:deb/debian/sudo@1.9.5?distro=debian-11"),
+                // Scenario: Neither has distro
+                Arguments.of("pkg:deb/debian/sudo", RANGE, MATCHES, "pkg:deb/debian/sudo@1.9.5"),
+                // ---
+                // Distro match does not bypass version check
+                // ---
+                // Scenario: Distro matches but version out of range
+                Arguments.of("pkg:deb/debian/sudo?distro=debian-11", Range.withRange().havingEndExcluding("1.0.0"), DOES_NOT_MATCH, "pkg:deb/debian/sudo@1.9.5?distro=debian-11"),
+                // ---
+                // Unsupported PURL type with distro qualifiers
+                // ---
+                // Scenario: Both have distro, neither parseable, same string
+                Arguments.of("pkg:rpm/redhat/sudo?distro=el-9", RANGE, MATCHES, "pkg:rpm/redhat/sudo@1.9.5?distro=el-9"),
+                // Scenario: Both have distro, neither parseable, different strings (mismatch)
+                Arguments.of("pkg:rpm/redhat/sudo?distro=rhel-9", RANGE, DOES_NOT_MATCH, "pkg:rpm/redhat/sudo@1.9.5?distro=el-9")
+        );
+    }
+
+    @BeforeEach
+    public void setUp() {
+        qm.createConfigProperty(
+                SCANNER_INTERNAL_ENABLED.getGroupName(),
+                SCANNER_INTERNAL_ENABLED.getPropertyName(),
+                "true",
+                SCANNER_INTERNAL_ENABLED.getPropertyType(),
+                SCANNER_INTERNAL_ENABLED.getDescription()
+        );
+    }
+
+    @ParameterizedTest(name = "[{index}] expect={2} src={0} target={3}")
+    @MethodSource("parameters")
+    void test(
+            String sourcePurlString,
+            Range sourceRange,
+            boolean expectMatch,
+            String targetPurlString) throws Exception {
+
+        final VulnerableSoftware vs = VulnerableSoftwareTestUtil.fromPurl(sourcePurlString);
+        if (sourceRange != null) {
+            Optional.ofNullable(sourceRange.startIncluding()).ifPresent(vs::setVersionStartIncluding);
+            Optional.ofNullable(sourceRange.startExcluding()).ifPresent(vs::setVersionStartExcluding);
+            Optional.ofNullable(sourceRange.endIncluding()).ifPresent(vs::setVersionEndIncluding);
+            Optional.ofNullable(sourceRange.endExcluding()).ifPresent(vs::setVersionEndExcluding);
+        }
+        vs.setVulnerable(true);
+        qm.persist(vs);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-2024-0001");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setVulnerableSoftware(List.of(vs));
+        qm.persist(vuln);
+
+        final var project = new Project();
+        project.setName("test-project");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("test-component");
+        component.setPurl(targetPurlString);
+        qm.persist(component);
+
+        new InternalAnalysisTask().inform(new InternalAnalysisEvent(
+                List.of(component), VulnerabilityAnalysisLevel.BOM_UPLOAD_ANALYSIS));
+
+        if (expectMatch) {
+            assertThat(qm.getAllVulnerabilities(component)).hasSize(1);
+        } else {
+            assertThat(qm.getAllVulnerabilities(component)).isEmpty();
+        }
+    }
+
+}

--- a/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskPurlMatchingTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskPurlMatchingTest.java
@@ -1,11 +1,6 @@
 package org.dependencytrack.tasks.scanners;
 
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.Arrays;
-
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.event.InternalAnalysisEvent;
 import org.dependencytrack.model.Component;
@@ -13,11 +8,15 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAnalysisLevel;
 import org.dependencytrack.model.VulnerableSoftware;
-import org.dependencytrack.parser.nvd.ModelConverter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.model.ConfigPropertyConstants.SCANNER_INTERNAL_ENABLED;
@@ -92,7 +91,7 @@ public class InternalAnalysisTaskPurlMatchingTest extends PersistenceCapableTest
               final boolean expectMatch,
               final String targetPurlString) throws Exception {
 
-        final VulnerableSoftware vs = ModelConverter.convertPurlToVulnerableSoftware(sourcePurlString);
+        final VulnerableSoftware vs = VulnerableSoftwareTestUtil.fromPurl(sourcePurlString);
 
         if (sourceRange != null) {
             Optional.ofNullable(sourceRange.startIncluding).ifPresent(vs::setVersionStartIncluding);

--- a/src/test/java/org/dependencytrack/tasks/scanners/VulnerableSoftwareTestUtil.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/VulnerableSoftwareTestUtil.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.tasks.scanners;
+
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import org.dependencytrack.model.VulnerableSoftware;
+import org.dependencytrack.util.PurlUtil;
+
+final class VulnerableSoftwareTestUtil {
+
+    private VulnerableSoftwareTestUtil() {
+    }
+
+    static VulnerableSoftware fromPurl(String purlString) throws MalformedPackageURLException {
+        final var purl = new PackageURL(purlString);
+
+        final var vs = new VulnerableSoftware();
+        vs.setPurl(purl.canonicalize());
+        vs.setPurlType(purl.getType());
+        vs.setPurlNamespace(purl.getNamespace());
+        vs.setPurlName(purl.getName());
+        vs.setPurlVersion(purl.getVersion());
+        vs.setPurlSubpath(purl.getSubpath());
+        vs.setPurlQualifiers(PurlUtil.serializeQualifiers(purl));
+        vs.setVersion(purl.getVersion());
+        return vs;
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Considers OS distro during vulnerability matching.

* Where possible, enriches an affected package's PURL with `distro` qualifier inferred from the package's `ecosystem`. e.g. `ecosystem=Debian:11` becomes `distro=debian-11`, `ecosystem=Ubuntu:20.04:LTS` becomes `distro=ubuntu-20.04` etc.
* During vulnerability analysis, if both component and matching criteria have a PURL `distro` qualifier, ensures they match. Matching can handle codename <-> version comparisons, e.g. for Ubuntu `focal` would match `20.04` and vice versa.
* Generally improves performance of OSV mirroring by using fewer transactions and disabling ORM features that caused expensive unnecessary queries.

Currently Alpine, Debian, and Ubuntu distribution matching is implemented. These seem to work for SBOMs generated with Trivy and Syft.

The codename <-> version mapping is currently hardcoded for Debian and Ubuntu. There is a fallback mechanism that will handle exact matches, such that when Debian publishes a hypothetical "foo" release, we can still match components with vulnerabilities if both `distro` qualifiers are exactly "foo".

Debian and Ubuntu provide CSV which we could regularly fetch at runtime, but this involves more work to coordinate.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/dependency-track/issues/1374 
Fixes https://github.com/DependencyTrack/dependency-track/issues/5776 
Fixes https://github.com/DependencyTrack/dependency-track/issues/4445 
Fixes https://github.com/DependencyTrack/dependency-track/issues/4725

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

A container image for this PR is available at `dependencytrack/bundled:feature-distro-matching`. 

OSV is enabled by default and configured to mirror the `Alpine`, `Debian`, and `Ubuntu` ecosystems.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
