### PR TITLE
Various tweaks for OSS Index analyzer

### DIFF
--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -87,6 +87,7 @@ import java.util.UUID;
                 @Persistent(name = "group"),
                 @Persistent(name = "name"),
                 @Persistent(name = "version"),
+                @Persistent(name = "internal"),
                 @Persistent(name = "cpe"),
                 @Persistent(name = "purl"),
                 @Persistent(name = "purlCoordinates"),

--- a/src/test/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/OssIndexAnalysisTaskTest.java
@@ -90,12 +90,12 @@ class OssIndexAnalysisTaskTest extends PersistenceCapableTest {
     @Test
     void testShouldAnalyzeWhenCacheIsCurrent() throws Exception {
         qm.updateComponentAnalysisCache(ComponentAnalysisCache.CacheType.VULNERABILITY, wmRuntimeInfo.getHttpBaseUrl(),
-                Vulnerability.Source.OSSINDEX.name(), "pkg:maven/com.fasterxml.woodstox/woodstox-core@5.0.0?foo=bar#baz", new Date(),
+                Vulnerability.Source.OSSINDEX.name(), "pkg:maven/com.fasterxml.woodstox/woodstox-core@5.0.0", new Date(),
                 Json.createObjectBuilder()
                         .add("vulnIds", Json.createArrayBuilder().add(123))
                         .build());
 
-        assertThat(analysisTask.shouldAnalyze(new PackageURL("pkg:maven/com.fasterxml.woodstox/woodstox-core@5.0.0"))).isTrue();
+        assertThat(analysisTask.shouldAnalyze(new PackageURL("pkg:maven/com.fasterxml.woodstox/woodstox-core@5.0.0"))).isFalse();
         assertThat(analysisTask.shouldAnalyze(new PackageURL("pkg:maven/com.fasterxml.woodstox/woodstox-core@6.0.0"))).isTrue();
         assertThat(analysisTask.shouldAnalyze(new PackageURL("pkg:maven/com.fasterxml.woodstox/woodstox-core@5.0.0?foo=bar#baz"))).isFalse();
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Various tweaks for OSS Index analyzer.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

* Only send components to OSS Index for which the ecosystem is supported as per https://ossindex.sonatype.org/ecosystems. This can potentially lead to fewer requests being performed, thus reducing the chance of being rate limited.
* Use only PURL coordinates (type, namespace, name, version) as cache keys, not the full PURL. Since qualifiers and subpaths are omitted for OSS Index requests, it doesn't make sense to use cache keys *with* qualifiers and subpath. This will improve cache hits for portfolios that import BOMs from multiple BOM generators, that are likely using slightly different qualifiers.
* Extend `isCapable` to take into consideration whether the given component is internal. This potentially reduces the number of components that the analyzer is invoked with. Internal components have not been analyzed before either though, so functionally this doesn't change anything.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
