### PR TITLE
Add page on users and permissions

### DIFF
--- a/docs/_docs/administration/users-and-permissions.md
+++ b/docs/_docs/administration/users-and-permissions.md
@@ -25,4 +25,4 @@ call. This page gives a short, non-exhaustive overview.
 | `VIEW_PORTFOLIO`            | Read projects, services, tags, vulnerabilities, BOMs, Dependency Graph, metrics; use Search   |
 | `VIEW_VULNERABILITY`        | Read analysis decisions and findings                                                          |
 | `VULNERABILITY_ANALYSIS`    | Record analysis decision                                                                      |
-| `VULNERABILITY_MANAGEMENT`  | Modify vunlerabilities                                                                        |
+| `VULNERABILITY_MANAGEMENT`  | Modify vulnerabilities                                                                        |


### PR DESCRIPTION
### Description

Docs: Summarise permissions

### Addressed Issue

Permissions are currently only documented in the OpenAPI specification, which is fine for developers, but not for normal users or for getting started with permissions.

closes #5830 

### Additional Details

I'm not entirely sure about chapter ordering, please let me know if changes are required and how you would do that (i.e. if there is an alternative to modifying countless .md front matters by hand to change the chapter number).

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
