### PR TITLE
Include CVSS vectors and metadata in Finding model

### DIFF
--- a/src/main/java/org/dependencytrack/model/Finding.java
+++ b/src/main/java/org/dependencytrack/model/Finding.java
@@ -76,14 +76,20 @@ public class Finding implements Serializable {
                  , "VULNERABILITY"."RECOMMENDATION"
                  , "VULNERABILITY"."SEVERITY"
                  , "VULNERABILITY"."CVSSV2BASESCORE"
+                 , "VULNERABILITY"."CVSSV2VECTOR"
                  , "VULNERABILITY"."CVSSV3BASESCORE"
+                 , "VULNERABILITY"."CVSSV3VECTOR"
                  , "VULNERABILITY"."CVSSV4SCORE"
+                 , "VULNERABILITY"."CVSSV4VECTOR"
                  , "VULNERABILITY"."OWASPRRLIKELIHOODSCORE"
                  , "VULNERABILITY"."OWASPRRTECHNICALIMPACTSCORE"
                  , "VULNERABILITY"."OWASPRRBUSINESSIMPACTSCORE"
+                 , "VULNERABILITY"."OWASPRRVECTOR"
                  , "VULNERABILITY"."EPSSSCORE"
                  , "VULNERABILITY"."EPSSPERCENTILE"
                  , "VULNERABILITY"."CWES"
+                 , "VULNERABILITY"."REFERENCES"
+                 , "VULNERABILITY"."PUBLISHED"
                  , "FINDINGATTRIBUTION"."ANALYZERIDENTITY"
                  , "FINDINGATTRIBUTION"."ATTRIBUTED_ON"
                  , "FINDINGATTRIBUTION"."ALT_ID"
@@ -125,21 +131,26 @@ public class Finding implements Serializable {
                  , "VULNERABILITY"."RECOMMENDATION"
                  , "VULNERABILITY"."SEVERITY"
                  , "VULNERABILITY"."CVSSV2BASESCORE"
+                 , "VULNERABILITY"."CVSSV2VECTOR"
                  , "VULNERABILITY"."CVSSV3BASESCORE"
+                 , "VULNERABILITY"."CVSSV3VECTOR"
                  , "VULNERABILITY"."CVSSV4SCORE"
+                 , "VULNERABILITY"."CVSSV4VECTOR"
                  , "VULNERABILITY"."OWASPRRLIKELIHOODSCORE"
                  , "VULNERABILITY"."OWASPRRTECHNICALIMPACTSCORE"
                  , "VULNERABILITY"."OWASPRRBUSINESSIMPACTSCORE"
+                 , "VULNERABILITY"."OWASPRRVECTOR"
                  , "VULNERABILITY"."EPSSSCORE"
                  , "VULNERABILITY"."EPSSPERCENTILE"
                  , "VULNERABILITY"."CWES"
+                 , "VULNERABILITY"."REFERENCES"
+                 , "VULNERABILITY"."PUBLISHED"
                  , "FINDINGATTRIBUTION"."ANALYZERIDENTITY"
                  , "FINDINGATTRIBUTION"."ATTRIBUTED_ON"
                  , "FINDINGATTRIBUTION"."ALT_ID"
                  , "FINDINGATTRIBUTION"."REFERENCE_URL"
                  , "ANALYSIS"."STATE"
                  , "ANALYSIS"."SUPPRESSED"
-                 , "VULNERABILITY"."PUBLISHED"
                  , "PROJECT"."UUID"
                  , "PROJECT"."NAME"
                  , "PROJECT"."VERSION"
@@ -197,35 +208,47 @@ public class Finding implements Serializable {
         } else {
             optValue(vulnerability, "recommendation", o[13]);
         }
-        final Severity severity = VulnerabilityUtil.getSeverity(o[14], (BigDecimal) o[15], (BigDecimal) o[16], (BigDecimal) o[17], (BigDecimal) o[18], (BigDecimal) o[19], (BigDecimal) o[20]);
+        final Severity severity = VulnerabilityUtil.getSeverity(o[14], (BigDecimal) o[15], (BigDecimal) o[17], (BigDecimal) o[19], (BigDecimal) o[21], (BigDecimal) o[22], (BigDecimal) o[23]);
         optValue(vulnerability, "cvssV2BaseScore", o[15]);
-        optValue(vulnerability, "cvssV3BaseScore", o[16]);
-        optValue(vulnerability, "cvssV4Score", o[17]);
-        optValue(vulnerability, "owaspLikelihoodScore", o[18]);
-        optValue(vulnerability, "owaspTechnicalImpactScore", o[19]);
-        optValue(vulnerability, "owaspBusinessImpactScore", o[20]);
+        optValue(vulnerability, "cvssV2Vector", o[16]);
+        optValue(vulnerability, "cvssV3BaseScore", o[17]);
+        optValue(vulnerability, "cvssV3Vector", o[18]);
+        optValue(vulnerability, "cvssV4Score", o[19]);
+        optValue(vulnerability, "cvssV4Vector", o[20]);
+        optValue(vulnerability, "owaspLikelihoodScore", o[21]);
+        optValue(vulnerability, "owaspTechnicalImpactScore", o[22]);
+        optValue(vulnerability, "owaspBusinessImpactScore", o[23]);
+        optValue(vulnerability, "owaspRRVector", o[24]);
         optValue(vulnerability, "severity", severity.name());
         optValue(vulnerability, "severityRank", severity.ordinal());
-        optValue(vulnerability, "epssScore", o[21]);
-        optValue(vulnerability, "epssPercentile", o[22]);
-        final List<Cwe> cwes = getCwes(o[23]);
+        optValue(vulnerability, "epssScore", o[25]);
+        optValue(vulnerability, "epssPercentile", o[26]);
+        final List<Cwe> cwes = getCwes(o[27]);
         if (cwes != null && !cwes.isEmpty()) {
             // Ensure backwards-compatibility with DT < 4.5.0. Remove this in v5!
             optValue(vulnerability, "cweId", cwes.get(0).getCweId());
             optValue(vulnerability, "cweName", cwes.get(0).getName());
         }
         optValue(vulnerability, "cwes", cwes);
-        optValue(attribution, "analyzerIdentity", o[24]);
-        optValue(attribution, "attributedOn", o[25]);
-        optValue(attribution, "alternateIdentifier", o[26]);
-        optValue(attribution, "referenceUrl", o[27]);
 
-        optValue(analysis, "state", o[28]);
-        optValue(analysis, "isSuppressed", o[29], false);
-        if (o.length > 31) {
-            optValue(vulnerability, "published", o[30]);
-            optValue(component, "projectName", o[32]);
-            optValue(component, "projectVersion", o[33]);
+        if (o[28] instanceof final Clob clob) {
+            optValue(vulnerability, "references", toString(clob));
+        } else {
+            optValue(vulnerability, "references", o[28]);
+        }
+        optValue(vulnerability, "published", o[29]);
+
+        optValue(attribution, "analyzerIdentity", o[30]);
+        optValue(attribution, "attributedOn", o[31]);
+        optValue(attribution, "alternateIdentifier", o[32]);
+        optValue(attribution, "referenceUrl", o[33]);
+
+        optValue(analysis, "state", o[34]);
+        optValue(analysis, "isSuppressed", o[35], false);
+
+        if (o.length > 36) {
+            optValue(component, "projectName", o[37]);
+            optValue(component, "projectVersion", o[38]);
         }
     }
 

--- a/src/main/java/org/dependencytrack/persistence/FindingsSearchQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/FindingsSearchQueryManager.java
@@ -137,7 +137,7 @@ public class FindingsSearchQueryManager extends QueryManager implements IQueryMa
         final List<Object[]> list = totalList.subList(this.pagination.getOffset(), Math.min(this.pagination.getOffset() + this.pagination.getLimit(), totalList.size()));
         final List<Finding> findings = new ArrayList<>();
         for (final Object[] o : list) {
-            final Finding finding = new Finding(UUID.fromString((String) o[31]), o);
+            final Finding finding = new Finding(UUID.fromString((String) o[36]), o);
             final Component component = getObjectByUuid(Component.class, (String) finding.getComponent().get("uuid"));
             final Vulnerability vulnerability = getObjectByUuid(Vulnerability.class, (String) finding.getVulnerability().get("uuid"));
             final Analysis analysis = getAnalysis(component, vulnerability);
@@ -147,6 +147,12 @@ public class FindingsSearchQueryManager extends QueryManager implements IQueryMa
             // These are CLOB fields. Handle these here so that database-specific deserialization doesn't need to be performed (in Finding)
             finding.getVulnerability().put("description", vulnerability.getDescription());
             finding.getVulnerability().put("recommendation", vulnerability.getRecommendation());
+            finding.getVulnerability().put("references", vulnerability.getReferences());
+            finding.getVulnerability().put("cvssV2Vector", vulnerability.getCvssV2Vector());
+            finding.getVulnerability().put("cvssV3Vector", vulnerability.getCvssV3Vector());
+            finding.getVulnerability().put("cvssV4Vector", vulnerability.getCvssV4Vector());
+            finding.getVulnerability().put("owaspRRVector", vulnerability.getOwaspRRVector());
+
             final PackageURL purl = component.getPurl();
             if (purl != null) {
                 final RepositoryType type = RepositoryType.resolve(purl);
@@ -255,13 +261,17 @@ public class FindingsSearchQueryManager extends QueryManager implements IQueryMa
                            , "VULNERABILITY"."TITLE"
                            , "VULNERABILITY"."SEVERITY"
                            , "VULNERABILITY"."CVSSV2BASESCORE"
+                           , "VULNERABILITY"."CVSSV2VECTOR"
                            , "VULNERABILITY"."CVSSV3BASESCORE"
+                           , "VULNERABILITY"."CVSSV3VECTOR"
                            , "VULNERABILITY"."CVSSV4SCORE"
+                           , "VULNERABILITY"."CVSSV4VECTOR"
                            , "VULNERABILITY"."EPSSSCORE"
                            , "VULNERABILITY"."EPSSPERCENTILE"
                            , "VULNERABILITY"."OWASPRRLIKELIHOODSCORE"
                            , "VULNERABILITY"."OWASPRRTECHNICALIMPACTSCORE"
                            , "VULNERABILITY"."OWASPRRBUSINESSIMPACTSCORE"
+                           , "VULNERABILITY"."OWASPRRVECTOR"
                            , "FINDINGATTRIBUTION"."ANALYZERIDENTITY"
                            , "VULNERABILITY"."PUBLISHED"
                            , "VULNERABILITY"."CWES"

--- a/src/test/java/org/dependencytrack/integrations/FindingPackagingFormatTest.java
+++ b/src/test/java/org/dependencytrack/integrations/FindingPackagingFormatTest.java
@@ -70,15 +70,57 @@ class FindingPackagingFormatTest extends PersistenceCapableTest {
 
         Finding findingWithoutAlias = new Finding(project.getUuid(), "component-uuid-1", "component-name-1", "component-group",
                 "component-version", "Optional","component-purl", "component-cpe", "vuln-uuid", Vulnerability.Source.GITHUB, "vuln-vulnId-1", "vuln-title",
-                "vuln-subtitle", "vuln-description", "vuln-recommendation", Severity.CRITICAL, BigDecimal.valueOf(7.2), BigDecimal.valueOf(8.4),
-                null, BigDecimal.valueOf(1.25), BigDecimal.valueOf(1.75), BigDecimal.valueOf(1.3),
-                "0.5", "0.9", null, AnalyzerIdentity.OSSINDEX_ANALYZER, new Date(), null, null, AnalysisState.NOT_AFFECTED, true);
+                "vuln-subtitle", "vuln-description", "vuln-recommendation",
+                Severity.CRITICAL, // 14
+                BigDecimal.valueOf(7.2), // 15
+                "vector2", // 16
+                BigDecimal.valueOf(8.4), // 17
+                "vector3", // 18
+                null, // 19
+                null, // 20
+                BigDecimal.valueOf(1.25), // 21
+                BigDecimal.valueOf(1.75), // 22
+                BigDecimal.valueOf(1.3), // 23
+                null, // 24
+                BigDecimal.valueOf(0.5), // 25
+                BigDecimal.valueOf(0.9), // 26
+                "787", // 27
+                "references", // 28
+                new Date(), // 29
+                AnalyzerIdentity.OSSINDEX_ANALYZER, // 30
+                new Date(), // 31
+                null, // 32
+                null, // 33
+                AnalysisState.NOT_AFFECTED, // 34
+                true // 35
+        );
 
         Finding findingWithAlias = new Finding(project.getUuid(), "component-uuid-2", "component-name-2", "component-group",
                 "component-version", "Required","component-purl", "component-cpe", "vuln-uuid", Vulnerability.Source.NVD, "vuln-vulnId-2", "vuln-title",
-                "vuln-subtitle", "vuln-description", "vuln-recommendation", Severity.HIGH, BigDecimal.valueOf(7.2), BigDecimal.valueOf(8.4),
-                null, BigDecimal.valueOf(1.25), BigDecimal.valueOf(1.75), BigDecimal.valueOf(1.3),
-                "0.5", "0.9", null, AnalyzerIdentity.INTERNAL_ANALYZER, new Date(), null, null, AnalysisState.NOT_AFFECTED, true);
+                "vuln-subtitle", "vuln-description", "vuln-recommendation",
+                Severity.HIGH, // 14
+                BigDecimal.valueOf(7.2), // 15
+                "vector2", // 16
+                BigDecimal.valueOf(8.4), // 17
+                "vector3", // 18
+                null, // 19
+                null, // 20
+                BigDecimal.valueOf(1.25), // 21
+                BigDecimal.valueOf(1.75), // 22
+                BigDecimal.valueOf(1.3), // 23
+                null, // 24
+                BigDecimal.valueOf(0.5), // 25
+                BigDecimal.valueOf(0.9), // 26
+                "787", // 27
+                "references", // 28
+                new Date(), // 29
+                AnalyzerIdentity.INTERNAL_ANALYZER, // 30
+                new Date(), // 31
+                null, // 32
+                null, // 33
+                AnalysisState.NOT_AFFECTED, // 34
+                true // 35
+        );
 
         var alias = new VulnerabilityAlias();
         alias.setCveId("someCveId");

--- a/src/test/java/org/dependencytrack/model/FindingTest.java
+++ b/src/test/java/org/dependencytrack/model/FindingTest.java
@@ -36,9 +36,30 @@ class FindingTest extends PersistenceCapableTest {
     private final Date attributedOn = new Date();
     private final Finding finding = new Finding(projectUuid, "component-uuid", "component-name", "component-group",
             "component-version", "Required","component-purl", "component-cpe", "vuln-uuid", "vuln-source", "vuln-vulnId", "vuln-title",
-            "vuln-subtitle", "vuln-description", "vuln-recommendation", Severity.HIGH, BigDecimal.valueOf(7.2), BigDecimal.valueOf(8.4),
-            BigDecimal.valueOf(9.2), BigDecimal.valueOf(1.25), BigDecimal.valueOf(1.75), BigDecimal.valueOf(1.3),
-            "0.5", "0.9", null, AnalyzerIdentity.INTERNAL_ANALYZER, attributedOn, null, null, AnalysisState.NOT_AFFECTED, true);
+            "vuln-subtitle", "vuln-description", "vuln-recommendation",
+            Severity.HIGH, // 14
+            BigDecimal.valueOf(7.2), // 15
+            "CVSS:2.0/AV:N/AC:L/Au:N/C:P/I:P/A:P", // 16
+            BigDecimal.valueOf(8.4), // 17
+            "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", // 18
+            BigDecimal.valueOf(9.2), // 19
+            "CVSS:4.0/...", // 20
+            BigDecimal.valueOf(1.25), // 21
+            BigDecimal.valueOf(1.75), // 22
+            BigDecimal.valueOf(1.3), // 23
+            "OWASP_VECTOR", // 24
+            BigDecimal.valueOf(0.5), // 25
+            BigDecimal.valueOf(0.9), // 26
+            "787,79", // 27
+            "vuln-references", // 28
+            attributedOn, // 29
+            AnalyzerIdentity.INTERNAL_ANALYZER, // 30
+            attributedOn, // 31
+            null, // 32
+            null, // 33
+            AnalysisState.NOT_AFFECTED, // 34
+            true // 35
+    );
 
     @Test
     void testComponent() {
@@ -61,13 +82,19 @@ class FindingTest extends PersistenceCapableTest {
         //Assertions.assertEquals("vuln-description", map.get("description"));
         //Assertions.assertEquals("vuln-recommendation", map.get("recommendation"));
         Assertions.assertEquals(BigDecimal.valueOf(7.2), map.get("cvssV2BaseScore"));
+        Assertions.assertEquals("CVSS:2.0/AV:N/AC:L/Au:N/C:P/I:P/A:P", map.get("cvssV2Vector"));
         Assertions.assertEquals(BigDecimal.valueOf(8.4), map.get("cvssV3BaseScore"));
+        Assertions.assertEquals("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", map.get("cvssV3Vector"));
         Assertions.assertEquals(BigDecimal.valueOf(9.2), map.get("cvssV4Score"));
+        Assertions.assertEquals("CVSS:4.0/...", map.get("cvssV4Vector"));
         Assertions.assertEquals(BigDecimal.valueOf(1.25), map.get("owaspLikelihoodScore"));
         Assertions.assertEquals(BigDecimal.valueOf(1.75), map.get("owaspTechnicalImpactScore"));
         Assertions.assertEquals(BigDecimal.valueOf(1.3), map.get("owaspBusinessImpactScore"));
+        Assertions.assertEquals("OWASP_VECTOR", map.get("owaspRRVector"));
         Assertions.assertEquals(Severity.HIGH.name(), map.get("severity"));
         Assertions.assertEquals(1, map.get("severityRank"));
+        Assertions.assertEquals("vuln-references", map.get("references"));
+        Assertions.assertEquals(attributedOn, map.get("published"));
     }
 
     @Test
@@ -103,5 +130,4 @@ class FindingTest extends PersistenceCapableTest {
     void testGetCwesWhenInputIsNull() {
         assertThat(Finding.getCwes(null)).isNull();
     }
-
 }

--- a/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -98,6 +98,8 @@ class FindingResourceTest extends ResourceTest {
         Assertions.assertEquals("1.0", json.getJsonObject(0).getJsonObject("component").getString("version"));
         Assertions.assertEquals("Vuln-1", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
         Assertions.assertEquals(Severity.CRITICAL.name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", json.getJsonObject(0).getJsonObject("vulnerability").getString("cvssV3Vector"));
+        Assertions.assertEquals("http://example.org/vuln-1", json.getJsonObject(0).getJsonObject("vulnerability").getString("references"));
         Assertions.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getInt("cweId"));
         Assertions.assertEquals(2, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").size());
         Assertions.assertEquals(80, json.getJsonObject(0).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
@@ -198,6 +200,7 @@ class FindingResourceTest extends ResourceTest {
         Assertions.assertEquals("1.0", findings.getJsonObject(0).getJsonObject("component").getString("version"));
         Assertions.assertEquals("Vuln-1", findings.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
         Assertions.assertEquals(Severity.CRITICAL.name(), findings.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
+        Assertions.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", findings.getJsonObject(0).getJsonObject("vulnerability").getString("cvssV3Vector"));
         Assertions.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getInt("cweId"));
         Assertions.assertEquals(2, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
         Assertions.assertEquals(80, findings.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
@@ -631,16 +634,16 @@ class FindingResourceTest extends ResourceTest {
         Component c1 = createComponent(p1, "Component A", "1.0");
         Component c2 = createComponent(p1, "Component B", "1.0");
         Component c3 = createComponent(p1, "Component C", "1.0");
-        
+
         // Create vulnerabilities with different EPSS scores
         Vulnerability v1 = createVulnerabilityWithEpss("Vuln-1", Severity.CRITICAL, new BigDecimal("0.1"));
         Vulnerability v2 = createVulnerabilityWithEpss("Vuln-2", Severity.HIGH, new BigDecimal("0.5"));
         Vulnerability v3 = createVulnerabilityWithEpss("Vuln-3", Severity.MEDIUM, new BigDecimal("0.9"));
-        
+
         qm.addVulnerability(v1, c1, AnalyzerIdentity.NONE);
         qm.addVulnerability(v2, c2, AnalyzerIdentity.NONE);
         qm.addVulnerability(v3, c3, AnalyzerIdentity.NONE);
-        
+
         // Test filtering by epssFrom
         Response response = jersey.target(V1_FINDING)
                 .queryParam("epssFrom", "0.3")
@@ -652,7 +655,7 @@ class FindingResourceTest extends ResourceTest {
         JsonArray json = parseJsonArray(response);
         Assertions.assertNotNull(json);
         Assertions.assertEquals(2, json.size());
-        
+
         // Test filtering by epssTo
         response = jersey.target(V1_FINDING)
                 .queryParam("epssTo", "0.7")
@@ -661,7 +664,7 @@ class FindingResourceTest extends ResourceTest {
                 .get(Response.class);
         Assertions.assertEquals(200, response.getStatus());
         Assertions.assertEquals("2", response.getHeaderString(TOTAL_COUNT_HEADER));
-        
+
         // Test filtering by epssFrom and epssTo range
         response = jersey.target(V1_FINDING)
                 .queryParam("epssFrom", "0.3")
@@ -683,16 +686,16 @@ class FindingResourceTest extends ResourceTest {
         Component c1 = createComponent(p1, "Component A", "1.0");
         Component c2 = createComponent(p1, "Component B", "1.0");
         Component c3 = createComponent(p1, "Component C", "1.0");
-        
+
         // Create vulnerabilities with different EPSS scores
         Vulnerability v1 = createVulnerabilityWithEpss("Vuln-1", Severity.CRITICAL, new BigDecimal("0.2"));
         Vulnerability v2 = createVulnerabilityWithEpss("Vuln-2", Severity.HIGH, new BigDecimal("0.6"));
         Vulnerability v3 = createVulnerabilityWithEpss("Vuln-3", Severity.MEDIUM, new BigDecimal("0.8"));
-        
+
         qm.addVulnerability(v1, c1, AnalyzerIdentity.NONE);
         qm.addVulnerability(v2, c2, AnalyzerIdentity.NONE);
         qm.addVulnerability(v3, c3, AnalyzerIdentity.NONE);
-        
+
         // Test filtering grouped findings by EPSS range
         Response response = jersey.target(V1_FINDING + "/grouped")
                 .queryParam("epssFrom", "0.5")
@@ -714,16 +717,16 @@ class FindingResourceTest extends ResourceTest {
         Component c1 = createComponent(p1, "Component A", "1.0");
         Component c2 = createComponent(p1, "Component B", "1.0");
         Component c3 = createComponent(p1, "Component C", "1.0");
-        
+
         // Create vulnerabilities with different EPSS percentiles
         Vulnerability v1 = createVulnerabilityWithEpssPercentile("Vuln-1", Severity.CRITICAL, new BigDecimal("0.1"));
         Vulnerability v2 = createVulnerabilityWithEpssPercentile("Vuln-2", Severity.HIGH, new BigDecimal("0.5"));
         Vulnerability v3 = createVulnerabilityWithEpssPercentile("Vuln-3", Severity.MEDIUM, new BigDecimal("0.9"));
-        
+
         qm.addVulnerability(v1, c1, AnalyzerIdentity.NONE);
         qm.addVulnerability(v2, c2, AnalyzerIdentity.NONE);
         qm.addVulnerability(v3, c3, AnalyzerIdentity.NONE);
-        
+
         // Test filtering by epssPercentileFrom
         Response response = jersey.target(V1_FINDING)
                 .queryParam("epssPercentileFrom", "0.3")
@@ -735,7 +738,7 @@ class FindingResourceTest extends ResourceTest {
         JsonArray json = parseJsonArray(response);
         Assertions.assertNotNull(json);
         Assertions.assertEquals(2, json.size());
-        
+
         // Test filtering by epssPercentileTo
         response = jersey.target(V1_FINDING)
                 .queryParam("epssPercentileTo", "0.7")
@@ -744,7 +747,7 @@ class FindingResourceTest extends ResourceTest {
                 .get(Response.class);
         Assertions.assertEquals(200, response.getStatus());
         Assertions.assertEquals("2", response.getHeaderString(TOTAL_COUNT_HEADER));
-        
+
         // Test filtering by epssPercentileFrom and epssPercentileTo range
         response = jersey.target(V1_FINDING)
                 .queryParam("epssPercentileFrom", "0.3")
@@ -766,16 +769,16 @@ class FindingResourceTest extends ResourceTest {
         Component c1 = createComponent(p1, "Component A", "1.0");
         Component c2 = createComponent(p1, "Component B", "1.0");
         Component c3 = createComponent(p1, "Component C", "1.0");
-        
+
         // Create vulnerabilities with different EPSS percentiles
         Vulnerability v1 = createVulnerabilityWithEpssPercentile("Vuln-1", Severity.CRITICAL, new BigDecimal("0.2"));
         Vulnerability v2 = createVulnerabilityWithEpssPercentile("Vuln-2", Severity.HIGH, new BigDecimal("0.6"));
         Vulnerability v3 = createVulnerabilityWithEpssPercentile("Vuln-3", Severity.MEDIUM, new BigDecimal("0.8"));
-        
+
         qm.addVulnerability(v1, c1, AnalyzerIdentity.NONE);
         qm.addVulnerability(v2, c2, AnalyzerIdentity.NONE);
         qm.addVulnerability(v3, c3, AnalyzerIdentity.NONE);
-        
+
         // Test filtering grouped findings by EPSS percentile range
         Response response = jersey.target(V1_FINDING + "/grouped")
                 .queryParam("epssPercentileFrom", "0.5")
@@ -818,9 +821,9 @@ class FindingResourceTest extends ResourceTest {
             target = target.queryParam("source", query);
         }
         Response response = target.request()
-            .header(HttpHeaders.ACCEPT, MEDIA_TYPE_SARIF_JSON)
-            .header(X_API_KEY, apiKey)
-            .get(Response.class);
+                .header(HttpHeaders.ACCEPT, MEDIA_TYPE_SARIF_JSON)
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
 
         Assertions.assertEquals(200, response.getStatus(), 0);
         Assertions.assertEquals(MEDIA_TYPE_SARIF_JSON, response.getHeaderString(HttpHeaders.CONTENT_TYPE));
@@ -829,15 +832,15 @@ class FindingResourceTest extends ResourceTest {
         final String fullName = "OWASP Dependency-Track - " + version;
         String expectedTemplate = resourceToString(expectedResponsePath, StandardCharsets.UTF_8);
         String expected = expectedTemplate
-            .replace("{{VERSION}}", version)
-            .replace("{{FULL_NAME}}", fullName);
+                .replace("{{VERSION}}", version)
+                .replace("{{FULL_NAME}}", fullName);
         assertThatJson(jsonResponse).isEqualTo(expected);
     }
 
     private static Stream<Arguments> getSARIFFindingsByProjectTestParameters() {
         return Stream.of(
-            Arguments.of("INTERNAL", "/unit/sarif/expected-internal.sarif.json"),
-            Arguments.of(null, "/unit/sarif/expected-all.sarif.json")
+                Arguments.of("INTERNAL", "/unit/sarif/expected-internal.sarif.json"),
+                Arguments.of(null, "/unit/sarif/expected-all.sarif.json")
         );
     }
 
@@ -855,6 +858,9 @@ class FindingResourceTest extends ResourceTest {
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(severity);
         vulnerability.setCwes(List.of(80, 666));
+        vulnerability.setCvssV3Vector("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
+        vulnerability.setCvssV3BaseScore(BigDecimal.valueOf(9.8));
+        vulnerability.setReferences("http://example.org/" + vulnId.toLowerCase());
         return qm.createVulnerability(vulnerability, false);
     }
 
@@ -867,6 +873,8 @@ class FindingResourceTest extends ResourceTest {
         vulnerability.setDescription(description);
         vulnerability.setRecommendation(recommendation);
         vulnerability.setCwes(List.of(cweId));
+        vulnerability.setCvssV3Vector("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
+        vulnerability.setReferences("http://example.org/" + vulnId.toLowerCase());
         return qm.createVulnerability(vulnerability, false);
     }
 
@@ -877,6 +885,7 @@ class FindingResourceTest extends ResourceTest {
         vulnerability.setSeverity(severity);
         vulnerability.setCwes(List.of(80, 666));
         vulnerability.setEpssScore(epssScore);
+        vulnerability.setCvssV3Vector("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
         return qm.createVulnerability(vulnerability, false);
     }
 
@@ -887,6 +896,7 @@ class FindingResourceTest extends ResourceTest {
         vulnerability.setSeverity(severity);
         vulnerability.setCwes(List.of(80, 666));
         vulnerability.setEpssPercentile(epssPercentile);
+        vulnerability.setCvssV3Vector("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
         return qm.createVulnerability(vulnerability, false);
     }
 }


### PR DESCRIPTION
### Description

This PR enhances the Finding model to include critical vulnerability metadata previously missing from API responses and the Finding Packaging Format (FPF) export. It specifically adds CVSS v2/v3 vectors, external references, and the vulnerability publication date to the findings data structure. These additions are necessary to provide better context for downstream integrations, such as DefectDojo, which rely on vector strings for accurate risk assessment and publication dates for SLA tracking.

### Addressed Issue

Closes #5843

### Additional Details

To implement this enhancement, the following technical adjustments were made:

* SQL Updates: The QUERY and QUERY_ALL_FINDINGS constants in Finding.java were expanded to select the new columns from the VULNERABILITY table.

* Index Management: Because the result set from the SQL queries is handled as a flat Object[], indices in the Finding constructor and FindingsSearchQueryManager were shifted to accommodate the new columns.

* Persistence Layer: FindingsSearchQueryManager was updated to correctly map the project UUID from the new index and include the new fields in the GROUP BY clause for grouped finding queries.

* Test Maintenance: The test suite (FindingTest, FindingPackagingFormatTest, and FindingResourceTest) was updated to match the new constructor signatures and verify that the enriched data is correctly serialized in API responses.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
