### PR TITLE
Always set ACL on new projects when using API key with team

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -1032,13 +1032,13 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                 );
                 executeAndCloseWithArray(sqlQuery, queryParameter);
 
-                sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """                        
+                sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """
                     DELETE FROM "DEPENDENCYMETRICS" WHERE "PROJECT_ID" = ANY(?);
                     """.replaceAll(Pattern.quote("= ANY(?)"), inExpression)
                 );
                 executeAndCloseWithArray(sqlQuery, queryParameter);
 
-                sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """                        
+                sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """
                     DELETE FROM "FINDINGATTRIBUTION" WHERE "PROJECT_ID" = ANY(?);
                     """.replaceAll(Pattern.quote("= ANY(?)"), inExpression)
                 );
@@ -1060,13 +1060,13 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                 );
                 executeAndCloseWithArray(sqlQuery, queryParameter);
 
-                sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """                        
+                sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """
                     DELETE FROM "ANALYSIS" WHERE "PROJECT_ID" = ANY(?);
                     """.replace("= ANY(?)", inExpression)
                 );
                 executeAndCloseWithArray(sqlQuery, queryParameter);
 
-                sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """                        
+                sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """
                     DELETE FROM "COMPONENT_PROPERTY" WHERE "COMPONENT_ID" IN (
                         SELECT "ID" FROM "COMPONENT" WHERE "PROJECT_ID" = ANY(?)
                     );
@@ -1119,7 +1119,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                     executeAndCloseWithArray(sqlQuery, queryParameter);
                 }
 
-                sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """                        
+                sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """
                     DELETE FROM "COMPONENT" WHERE "PROJECT_ID" = ANY(?);
                     """.replace("= ANY(?)", inExpression)
                 );
@@ -1318,7 +1318,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                     executeAndCloseWithArray(sqlQuery, queryParameter);
                 }
 
-                sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """                        
+                sqlQuery = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, """
                     DELETE FROM "PROJECT" WHERE "ID" = ANY(?);
                     """.replace("= ANY(?)", inExpression)
                 );
@@ -1564,7 +1564,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
 
     /**
      * Updates a Project ACL to add the principals Team to the AccessTeams
-     * This only happens if Portfolio Access Control is enabled and the @param principal is an ApyKey
+     * This only happens if @param principal is an ApyKey
      * For a UserPrincipal we don't know which Team(s) to add to the ACL,
      * See https://github.com/DependencyTrack/dependency-track/issues/1435
      * @param project
@@ -1573,7 +1573,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
      */
     @Override
     public boolean updateNewProjectACL(Project project, Principal principal) {
-        if (isEnabled(ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED) && principal instanceof ApiKey apiKey) {
+        if (principal instanceof ApiKey apiKey) {
             final var apiTeam = apiKey.getTeams().stream().findFirst();
             if (apiTeam.isPresent()) {
                 LOGGER.debug("adding Team to ACL of newly created project");

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -20,6 +20,7 @@ package org.dependencytrack.resources.v1;
 
 import alpine.common.util.UuidUtil;
 import alpine.model.IConfigProperty;
+import alpine.model.Team;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import com.fasterxml.jackson.core.StreamReadConstraints;
@@ -945,6 +946,23 @@ class BomResourceTest extends ResourceTest {
         Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
         Project project = qm.getProject("Acme Example", "1.0");
         Assertions.assertNotNull(project);
+    }
+
+    @Test
+    void uploadBomAutoCreateWithAclDisabledAddsApiKeyTeamTest() throws Exception {
+        initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
+        // ACL is not enabled - updateNewProjectACL should still add the API key's team
+        String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
+        BomSubmitRequest request = new BomSubmitRequest(null, "AclDisabled Example", "1.0", null, true, false, bomString);
+        Response response = jersey.target(V1_BOM).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(request, MediaType.APPLICATION_JSON));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        Project project = qm.getProject("AclDisabled Example", "1.0");
+        Assertions.assertNotNull(project);
+        assertThat(project.getAccessTeams())
+                .extracting(Team::getName)
+                .containsOnly(team.getName());
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -933,6 +933,22 @@ class ProjectResourceTest extends ResourceTest {
         assertThat(qm.getProject("acme-app", null)).satisfies(project ->
                 assertThat(project.getAccessTeams()).extracting(Team::getName).containsOnly(team.getName()));
     }
+
+    @Test
+    void createProjectWithAclDisabledAddsApiKeyTeamTest() {
+        // ACL is not enabled - updateNewProjectACL should still add the API key's team
+        Project project = new Project();
+        project.setName("acme-app-acl-disabled");
+        project.setVersion("1.0");
+        Response response = jersey.target(V1_PROJECT)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(project, MediaType.APPLICATION_JSON));
+        assertThat(response.getStatus()).isEqualTo(201);
+        assertThat(qm.getProject("acme-app-acl-disabled", "1.0")).satisfies(created ->
+                assertThat(created.getAccessTeams()).extracting(Team::getName).containsOnly(team.getName()));
+    }
+
     @Test
     void createProjectAsLatestTest() {
         Project project = new Project();


### PR DESCRIPTION
## Summary

`updateNewProjectACL` now always adds the API key's team to newly created projects, regardless of whether the portfolio access control feature is enabled.

## Motivation

The behaviour now matches what `createProject` does with `accessTeams`: when creating a project via the Project API, teams passed in `accessTeams` are applied to the project's ACL even if the access control feature is disabled. The BOM upload auto-create and `updateNewProjectACL` path previously only set ACL when the feature was enabled, causing inconsistent behaviour.

With this change, the team that uploads a BOM or creates a project retains access once the ACL feature is later enabled, without requiring manual ACL assignment.

This is useful/needed when users/admins are preparing for the ACL to be enabled but have not enabled it yet.

## Changes

- **ProjectQueryManager**: Removed the `ACCESS_MANAGEMENT_ACL_ENABLED` check from `updateNewProjectACL`. The API key's team is now always added when the principal is an API key with at least one team.
- **Tests**: Added `uploadBomAutoCreateWithAclDisabledAddsApiKeyTeamTest` and `createProjectWithAclDisabledAddsApiKeyTeamTest` to verify ACL assignment when the feature is disabled.