### PR TITLE
Tweak vulnerability persistence logic

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -84,6 +84,7 @@ import org.dependencytrack.notification.publisher.Publisher;
 import org.dependencytrack.resources.v1.vo.AffectedProject;
 import org.dependencytrack.resources.v1.vo.DependencyGraphResponse;
 import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
+import org.dependencytrack.util.PersistenceUtil;
 
 import javax.jdo.FetchPlan;
 import javax.jdo.PersistenceManager;
@@ -785,6 +786,10 @@ public class QueryManager extends AlpineQueryManager {
 
     public Vulnerability createVulnerability(Vulnerability vulnerability, boolean commitIndex) {
         return getVulnerabilityQueryManager().createVulnerability(vulnerability, commitIndex);
+    }
+
+    public Map<String, PersistenceUtil.Diff> updateVulnerabilityIfChanged(Vulnerability persistentVuln, Vulnerability transientVuln) {
+        return getVulnerabilityQueryManager().updateIfChanged(persistentVuln, transientVuln);
     }
 
     public Vulnerability updateVulnerability(Vulnerability transientVulnerability, boolean commitIndex) {

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -53,6 +53,8 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.dependencytrack.util.PersistenceUtil.assertPersistent;
+
 final class VulnerabilityQueryManager extends QueryManager implements IQueryManager {
     private static final Logger LOGGER = Logger.getLogger(VulnDbSyncTask.class);
     /**
@@ -79,14 +81,14 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
      * @return a new vulnerability object
      */
     public Vulnerability createVulnerability(Vulnerability vulnerability, boolean commitIndex) {
-        final Vulnerability result = persist(vulnerability);
-        Event.dispatch(new IndexEvent(IndexEvent.Action.CREATE, result));
+        var persistentVuln = new Vulnerability();
+        persistentVuln.setVulnId(vulnerability.getVulnId());
+        persistentVuln.setSource(vulnerability.getSource());
+        persistentVuln = persist(persistentVuln);
+        updateIfChanged(persistentVuln, vulnerability);
+        Event.dispatch(new IndexEvent(IndexEvent.Action.CREATE, persistentVuln));
         commitSearchIndex(commitIndex, Vulnerability.class);
-        return result;
-    }
-
-    private boolean hasChanges(Vulnerability vulnerability, Vulnerability transientVulnerability) {
-        return vulnerability.getUpdated() == null || transientVulnerability.getUpdated() == null || !vulnerability.getUpdated().equals(transientVulnerability.getUpdated());
+        return persistentVuln;
     }
 
     private Vulnerability getExistingVulnerability(Vulnerability transientVulnerability){
@@ -97,6 +99,46 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
             return getObjectById(Vulnerability.class, transientVulnerability.getId());
         }
         return getVulnerabilityByVulnId(transientVulnerability.getSource(), transientVulnerability.getVulnId());
+    }
+
+    Map<String, PersistenceUtil.Diff> updateIfChanged(Vulnerability persistentVuln, Vulnerability transientVuln) {
+        assertPersistent(persistentVuln, "persistentVuln must be persistent");
+
+        final var differ = new PersistenceUtil.Differ<>(persistentVuln, transientVuln);
+        differ.applyIfChanged("created", Vulnerability::getCreated, persistentVuln::setCreated);
+        differ.applyIfChanged("published", Vulnerability::getPublished, persistentVuln::setPublished);
+        differ.applyIfChanged("updated", Vulnerability::getUpdated, persistentVuln::setUpdated);
+        differ.applyIfChanged("vulnId", Vulnerability::getVulnId, persistentVuln::setVulnId);
+        differ.applyIfChanged("source", Vulnerability::getSource, persistentVuln::setSource);
+        differ.applyIfChanged("friendlyVulnId", Vulnerability::getFriendlyVulnId, persistentVuln::setFriendlyVulnId);
+        differ.applyIfChanged("credits", Vulnerability::getCredits, persistentVuln::setCredits);
+        differ.applyIfChanged("vulnerableVersions", Vulnerability::getVulnerableVersions, persistentVuln::setVulnerableVersions);
+        differ.applyIfChanged("patchedVersions", Vulnerability::getPatchedVersions, persistentVuln::setPatchedVersions);
+        differ.applyIfChanged("description", Vulnerability::getDescription, persistentVuln::setDescription);
+        differ.applyIfChanged("detail", Vulnerability::getDetail, persistentVuln::setDetail);
+        differ.applyIfChanged("title", Vulnerability::getTitle, persistentVuln::setTitle);
+        differ.applyIfChanged("subTitle", Vulnerability::getSubTitle, persistentVuln::setSubTitle);
+        differ.applyIfChanged("references", Vulnerability::getReferences, persistentVuln::setReferences);
+        differ.applyIfChanged("recommendation", Vulnerability::getRecommendation, persistentVuln::setRecommendation);
+        differ.applyIfChanged("severity", Vulnerability::getSeverity, persistentVuln::setSeverity);
+        differ.applyIfChanged("cvssV2Vector", Vulnerability::getCvssV2Vector, persistentVuln::setCvssV2Vector);
+        differ.applyIfChanged("cvssV2BaseScore", Vulnerability::getCvssV2BaseScore, persistentVuln::setCvssV2BaseScore);
+        differ.applyIfChanged("cvssV2ImpactSubScore", Vulnerability::getCvssV2ImpactSubScore, persistentVuln::setCvssV2ImpactSubScore);
+        differ.applyIfChanged("cvssV2ExploitabilitySubScore", Vulnerability::getCvssV2ExploitabilitySubScore, persistentVuln::setCvssV2ExploitabilitySubScore);
+        differ.applyIfChanged("cvssV3Vector", Vulnerability::getCvssV3Vector, persistentVuln::setCvssV3Vector);
+        differ.applyIfChanged("cvssV3BaseScore", Vulnerability::getCvssV3BaseScore, persistentVuln::setCvssV3BaseScore);
+        differ.applyIfChanged("cvssV3ImpactSubScore", Vulnerability::getCvssV3ImpactSubScore, persistentVuln::setCvssV3ImpactSubScore);
+        differ.applyIfChanged("cvssV3ExploitabilitySubScore", Vulnerability::getCvssV3ExploitabilitySubScore, persistentVuln::setCvssV3ExploitabilitySubScore);
+        differ.applyIfChanged("owaspRRLikelihoodScore", Vulnerability::getOwaspRRLikelihoodScore, persistentVuln::setOwaspRRLikelihoodScore);
+        differ.applyIfChanged("owaspRRBusinessImpactScore", Vulnerability::getOwaspRRBusinessImpactScore, persistentVuln::setOwaspRRBusinessImpactScore);
+        differ.applyIfChanged("owaspRRTechnicalImpactScore", Vulnerability::getOwaspRRTechnicalImpactScore, persistentVuln::setOwaspRRTechnicalImpactScore);
+        differ.applyIfChanged("owaspRRVector", Vulnerability::getOwaspRRVector, persistentVuln::setOwaspRRVector);
+        differ.applyIfChanged("cwes", Vulnerability::getCwes, persistentVuln::setCwes);
+        // EPSS is an additional enrichment that no source currently provides natively. We don't want EPSS scores of CVEs to be purged.
+        differ.applyIfNonNullAndChanged("epssScore", Vulnerability::getEpssScore, persistentVuln::setEpssScore);
+        differ.applyIfNonNullAndChanged("epssPercentile", Vulnerability::getEpssPercentile, persistentVuln::setEpssPercentile);
+
+        return differ.getDiffs();
     }
 
     /**
@@ -110,67 +152,40 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
         return callInTransaction(() -> {
             Vulnerability existingVulnerability = getExistingVulnerability(transientVulnerability);
             if (existingVulnerability != null) {
-                final PersistenceUtil.Differ<Vulnerability> differ = new PersistenceUtil.Differ<>(existingVulnerability, transientVulnerability);
-                differ.applyIfChanged("created", Vulnerability::getCreated, existingVulnerability::setCreated);
-                differ.applyIfChanged("published", Vulnerability::getPublished, existingVulnerability::setPublished);
-                differ.applyIfChanged("updated", Vulnerability::getUpdated, existingVulnerability::setUpdated);
-                differ.applyIfChanged("vulnId", Vulnerability::getVulnId, existingVulnerability::setVulnId);
-                differ.applyIfChanged("source", Vulnerability::getSource, existingVulnerability::setSource);
-                differ.applyIfChanged("credits", Vulnerability::getCredits, existingVulnerability::setCredits);
-                differ.applyIfChanged("vulnerableVersions", Vulnerability::getVulnerableVersions, existingVulnerability::setVulnerableVersions);
-                differ.applyIfChanged("patchedVersions", Vulnerability::getPatchedVersions, existingVulnerability::setPatchedVersions);
-                differ.applyIfChanged("description", Vulnerability::getDescription, existingVulnerability::setDescription);
-                differ.applyIfChanged("detail", Vulnerability::getDetail, existingVulnerability::setDetail);
-                differ.applyIfChanged("title", Vulnerability::getTitle, existingVulnerability::setTitle);
-                differ.applyIfChanged("subTitle", Vulnerability::getSubTitle, existingVulnerability::setSubTitle);
-                differ.applyIfChanged("references", Vulnerability::getReferences, existingVulnerability::setReferences);
-                differ.applyIfChanged("recommendation", Vulnerability::getRecommendation, existingVulnerability::setRecommendation);
-                differ.applyIfChanged("severity", Vulnerability::getSeverity, existingVulnerability::setSeverity);
-                differ.applyIfChanged("cvssV2Vector", Vulnerability::getCvssV2Vector, existingVulnerability::setCvssV2Vector);
-                differ.applyIfChanged("cvssV2BaseScore", Vulnerability::getCvssV2BaseScore, existingVulnerability::setCvssV2BaseScore);
-                differ.applyIfChanged("cvssV2ImpactSubScore", Vulnerability::getCvssV2ImpactSubScore, existingVulnerability::setCvssV2ImpactSubScore);
-                differ.applyIfChanged("cvssV2ExploitabilitySubScore", Vulnerability::getCvssV2ExploitabilitySubScore, existingVulnerability::setCvssV2ExploitabilitySubScore);
-                differ.applyIfChanged("cvssV3Vector", Vulnerability::getCvssV3Vector, existingVulnerability::setCvssV3Vector);
-                differ.applyIfChanged("cvssV3BaseScore", Vulnerability::getCvssV3BaseScore, existingVulnerability::setCvssV3BaseScore);
-                differ.applyIfChanged("cvssV3ImpactSubScore", Vulnerability::getCvssV3ImpactSubScore, existingVulnerability::setCvssV3ImpactSubScore);
-                differ.applyIfChanged("cvssV3ExploitabilitySubScore", Vulnerability::getCvssV3ExploitabilitySubScore, existingVulnerability::setCvssV3ExploitabilitySubScore);
-                differ.applyIfChanged("owaspRRLikelihoodScore", Vulnerability::getOwaspRRLikelihoodScore, existingVulnerability::setOwaspRRLikelihoodScore);
-                differ.applyIfChanged("owaspRRBusinessImpactScore", Vulnerability::getOwaspRRBusinessImpactScore, existingVulnerability::setOwaspRRBusinessImpactScore);
-                differ.applyIfChanged("owaspRRTechnicalImpactScore", Vulnerability::getOwaspRRTechnicalImpactScore, existingVulnerability::setOwaspRRTechnicalImpactScore);
-                differ.applyIfChanged("owaspRRVector", Vulnerability::getOwaspRRVector, existingVulnerability::setOwaspRRVector);
-                differ.applyIfChanged("cwes", Vulnerability::getCwes, existingVulnerability::setCwes);
-                differ.applyIfNonNullAndChanged("vulnerableSoftware", Vulnerability::getVulnerableSoftware, existingVulnerability::setVulnerableSoftware);
-            }
-            else {
-                // Handle cases where no existing vulnerability is found if needed (e.g., log an error)
+                final var diffs = updateIfChanged(existingVulnerability, transientVulnerability);
+                if (!diffs.isEmpty()) {
+                    Event.dispatch(new IndexEvent(IndexEvent.Action.UPDATE, existingVulnerability));
+                    commitSearchIndex(commitIndex, Vulnerability.class);
+                }
+            } else {
                 LOGGER.warn("No existing vulnerability found for update operation.");
             }
-            //return updated Vulnerability
             return existingVulnerability;
         });
     }
 
     /**
-     * Synchronizes a vulnerability. Method first checkes to see if the vulnerability already
+     * Synchronizes a vulnerability. Method first checks to see if the vulnerability already
      * exists and if so, updates the vulnerability. If the vulnerability does not already exist,
      * this method will create a new vulnerability.
      * @param vulnerability the vulnerability to synchronize
      * @param commitIndex specifies if the search index should be committed (an expensive operation)
-     * @return a Vulnerability object
+     * @return a Vulnerability object, or {@code null} if the vulnerability already exists and has no changes
      */
     @Override
     public Vulnerability synchronizeVulnerability(Vulnerability vulnerability, boolean commitIndex) {
         return callInTransaction(() -> {
-            Vulnerability existingVulnerability  = getExistingVulnerability(vulnerability);
+            Vulnerability existingVulnerability = getExistingVulnerability(vulnerability);
             if (existingVulnerability == null) {
-                // Create new vulnerability if it doesnt exist
-                return  createVulnerability(vulnerability, commitIndex);
-            } else {
-                // Update only if changes are detected
-                return hasChanges(existingVulnerability, vulnerability)
-                ? updateVulnerability(vulnerability, commitIndex)
-                : null;
+                return createVulnerability(vulnerability, commitIndex);
             }
+            final var diffs = updateIfChanged(existingVulnerability, vulnerability);
+            if (diffs.isEmpty()) {
+                return null;
+            }
+            Event.dispatch(new IndexEvent(IndexEvent.Action.UPDATE, existingVulnerability));
+            commitSearchIndex(commitIndex, Vulnerability.class);
+            return existingVulnerability;
         });
     }
 

--- a/src/main/java/org/dependencytrack/tasks/AbstractNistMirrorTask.java
+++ b/src/main/java/org/dependencytrack/tasks/AbstractNistMirrorTask.java
@@ -27,8 +27,6 @@ import org.dependencytrack.util.PersistenceUtil;
 import javax.jdo.Query;
 import java.util.Map;
 
-import static org.dependencytrack.util.PersistenceUtil.assertPersistent;
-
 /**
  * @since 4.11.0
  */
@@ -44,7 +42,7 @@ abstract class AbstractNistMirrorTask {
             if (persistentVuln == null) {
                 persistentVuln = qm.getPersistenceManager().makePersistent(vuln);
             } else {
-                final Map<String, PersistenceUtil.Diff> diffs = updateVulnerability(persistentVuln, vuln);
+                final var diffs = qm.updateVulnerabilityIfChanged(persistentVuln, vuln);
                 if (!diffs.isEmpty()) {
                     logger.debug("%s has changed: %s".formatted(vuln.getVulnId(), diffs));
                     return persistentVuln;
@@ -79,54 +77,6 @@ abstract class AbstractNistMirrorTask {
         } finally {
             query.closeAll();
         }
-    }
-
-    /**
-     * Update an existing, persistent {@link Vulnerability} with data as reported by the NVD.
-     * <p>
-     * It differs from {@link QueryManager#updateVulnerability(Vulnerability, boolean)} in that it keeps track of
-     * which fields are modified, and assumes the to-be-updated {@link Vulnerability} to be persistent, and enrolled
-     * in an active {@link javax.jdo.Transaction}.
-     *
-     * @param existingVuln The existing {@link Vulnerability} to update
-     * @param reportedVuln The {@link Vulnerability} as reported by the NVD
-     * @return A {@link Map} holding the differences of all updated fields
-     */
-    private static Map<String, PersistenceUtil.Diff> updateVulnerability(final Vulnerability existingVuln, final Vulnerability reportedVuln) {
-        assertPersistent(existingVuln, "existingVuln must be persistent in order for changes to be effective");
-
-        final var differ = new PersistenceUtil.Differ<>(existingVuln, reportedVuln);
-        differ.applyIfChanged("title", Vulnerability::getTitle, existingVuln::setTitle);
-        differ.applyIfChanged("subTitle", Vulnerability::getSubTitle, existingVuln::setSubTitle);
-        differ.applyIfChanged("description", Vulnerability::getDescription, existingVuln::setDescription);
-        differ.applyIfChanged("detail", Vulnerability::getDetail, existingVuln::setDetail);
-        differ.applyIfChanged("recommendation", Vulnerability::getRecommendation, existingVuln::setRecommendation);
-        differ.applyIfChanged("references", Vulnerability::getReferences, existingVuln::setReferences);
-        differ.applyIfChanged("credits", Vulnerability::getCredits, existingVuln::setCredits);
-        differ.applyIfChanged("created", Vulnerability::getCreated, existingVuln::setCreated);
-        differ.applyIfChanged("published", Vulnerability::getPublished, existingVuln::setPublished);
-        differ.applyIfChanged("updated", Vulnerability::getUpdated, existingVuln::setUpdated);
-        differ.applyIfNonEmptyAndChanged("cwes", Vulnerability::getCwes, existingVuln::setCwes);
-        differ.applyIfChanged("severity", Vulnerability::getSeverity, existingVuln::setSeverity);
-        differ.applyIfChanged("cvssV2BaseScore", Vulnerability::getCvssV2BaseScore, existingVuln::setCvssV2BaseScore);
-        differ.applyIfChanged("cvssV2ImpactSubScore", Vulnerability::getCvssV2ImpactSubScore, existingVuln::setCvssV2ImpactSubScore);
-        differ.applyIfChanged("cvssV2ExploitabilitySubScore", Vulnerability::getCvssV2ExploitabilitySubScore, existingVuln::setCvssV2ExploitabilitySubScore);
-        differ.applyIfChanged("cvssV2Vector", Vulnerability::getCvssV2Vector, existingVuln::setCvssV2Vector);
-        differ.applyIfChanged("cvssV3BaseScore", Vulnerability::getCvssV3BaseScore, existingVuln::setCvssV3BaseScore);
-        differ.applyIfChanged("cvssV3ImpactSubScore", Vulnerability::getCvssV3ImpactSubScore, existingVuln::setCvssV3ImpactSubScore);
-        differ.applyIfChanged("cvssV3ExploitabilitySubScore", Vulnerability::getCvssV3ExploitabilitySubScore, existingVuln::setCvssV3ExploitabilitySubScore);
-        differ.applyIfChanged("cvssV3Vector", Vulnerability::getCvssV3Vector, existingVuln::setCvssV3Vector);
-        differ.applyIfChanged("owaspRRLikelihoodScore", Vulnerability::getOwaspRRLikelihoodScore, existingVuln::setOwaspRRLikelihoodScore);
-        differ.applyIfChanged("owaspRRTechnicalImpactScore", Vulnerability::getOwaspRRTechnicalImpactScore, existingVuln::setOwaspRRTechnicalImpactScore);
-        differ.applyIfChanged("owaspRRBusinessImpactScore", Vulnerability::getOwaspRRBusinessImpactScore, existingVuln::setOwaspRRBusinessImpactScore);
-        differ.applyIfChanged("owaspRRVector", Vulnerability::getOwaspRRVector, existingVuln::setOwaspRRVector);
-        differ.applyIfChanged("vulnerableVersions", Vulnerability::getVulnerableVersions, existingVuln::setVulnerableVersions);
-        differ.applyIfChanged("patchedVersions", Vulnerability::getPatchedVersions, existingVuln::setPatchedVersions);
-        // EPSS is an additional enrichment that no source currently provides natively. We don't want EPSS scores of CVEs to be purged.
-        differ.applyIfNonNullAndChanged("epssScore", Vulnerability::getEpssScore, existingVuln::setEpssScore);
-        differ.applyIfNonNullAndChanged("epssPercentile", Vulnerability::getEpssPercentile, existingVuln::setEpssPercentile);
-
-        return differ.getDiffs();
     }
 
 }

--- a/src/test/java/org/dependencytrack/persistence/VulnerabilityQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/VulnerabilityQueryManagerTest.java
@@ -21,9 +21,9 @@ package org.dependencytrack.persistence;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
-import org.junit.jupiter.api.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.runner.RunWith;
@@ -31,8 +31,8 @@ import org.junit.runner.RunWith;
 import javax.jdo.Query;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -47,7 +47,7 @@ public class VulnerabilityQueryManagerTest {
     class SynchronizeVulnerabilityAliasTest extends PersistenceCapableTest {
 
         @Test
-        void updateVulnerabilityNoChangesInUpdated() {
+        void synchronizeVulnerabilityNoChanges() {
             Vulnerability vuln = new Vulnerability();
             final Date updated = new Date();
             vuln.setId(124L);
@@ -59,16 +59,39 @@ public class VulnerabilityQueryManagerTest {
             Vulnerability transientVuln = new Vulnerability();
             transientVuln.setId(vuln.getId());
             transientVuln.setVulnId("CVE-1234-123");
-            transientVuln.setSource(Vulnerability.Source.GITHUB);
-            transientVuln.setUpdated(updated); // same updated date
+            transientVuln.setSource(Vulnerability.Source.NVD);
+            transientVuln.setUpdated(updated);
 
             Vulnerability result = qm.synchronizeVulnerability(transientVuln, false);
             assertThat(result).isNull();
 
-            // check the database to see if the vulnerability was updated
             Vulnerability dbVuln = qm.getObjectById(Vulnerability.class, vuln.getId());
             assertThat(dbVuln.getUpdated()).isEqualTo(updated);
             assertThat(dbVuln.getSource()).isEqualTo("NVD");
+        }
+
+        @Test
+        void synchronizeVulnerabilityFieldChangesWithSameTimestamp() {
+            Vulnerability vuln = new Vulnerability();
+            final Date updated = new Date();
+            vuln.setId(124L);
+            vuln.setVulnId("CVE-1234-123");
+            vuln.setSource(Vulnerability.Source.NVD);
+            vuln.setUpdated(updated);
+            qm.persist(vuln);
+
+            Vulnerability transientVuln = new Vulnerability();
+            transientVuln.setId(vuln.getId());
+            transientVuln.setVulnId("CVE-1234-123");
+            transientVuln.setSource(Vulnerability.Source.NVD);
+            transientVuln.setUpdated(updated); // same timestamp
+            transientVuln.setDescription("A new description");
+
+            Vulnerability result = qm.synchronizeVulnerability(transientVuln, false);
+            assertThat(result).isNotNull();
+
+            Vulnerability dbVuln = qm.getObjectById(Vulnerability.class, vuln.getId());
+            assertThat(dbVuln.getDescription()).isEqualTo("A new description");
         }
 
         @Test

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -647,7 +647,7 @@ class VulnerabilityResourceTest extends ResourceTest {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
-        qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln, false);
         JsonObject payload = Json.createObjectBuilder()
                 .add("vulnId", "ACME-2")
                 .add("description", "Something is vulnerable")
@@ -1087,12 +1087,12 @@ class VulnerabilityResourceTest extends ResourceTest {
         final Component c1;
         final Component c2;
         final Component c3;
-        final Vulnerability v1;
-        final Vulnerability v2;
-        final Vulnerability v3;
-        final Vulnerability v4;
-        final Vulnerability v5;
-        final Vulnerability v6;
+        Vulnerability v1;
+        Vulnerability v2;
+        Vulnerability v3;
+        Vulnerability v4;
+        Vulnerability v5;
+        Vulnerability v6;
         final VulnerableSoftware vs1;
 
         SampleData() {
@@ -1133,11 +1133,6 @@ class VulnerabilityResourceTest extends ResourceTest {
             v1.setSeverity(Severity.CRITICAL);
             v1.setDescription("Description 1");
 
-            vs1 = new VulnerableSoftware();
-            qm.persist(vs1);
-            qm.persist(new AffectedVersionAttribution(Vulnerability.Source.INTERNAL, v1, vs1));
-            v1.setVulnerableSoftware(List.of(vs1));
-
             v2 = new Vulnerability();
             v2.setVulnId("INT-2");
             v2.setSource(Vulnerability.Source.INTERNAL);
@@ -1168,12 +1163,17 @@ class VulnerabilityResourceTest extends ResourceTest {
             v6.setSeverity(Severity.CRITICAL);
             v6.setDescription("Description 6");
 
-            qm.createVulnerability(v1, false);
-            qm.createVulnerability(v2, false);
-            qm.createVulnerability(v3, false);
-            qm.createVulnerability(v4, false);
-            qm.createVulnerability(v5, false);
-            qm.createVulnerability(v6, false);
+            v1 = qm.createVulnerability(v1, false);
+            v2 = qm.createVulnerability(v2, false);
+            v3 = qm.createVulnerability(v3, false);
+            v4 = qm.createVulnerability(v4, false);
+            v5 = qm.createVulnerability(v5, false);
+            v6 = qm.createVulnerability(v6, false);
+
+            vs1 = new VulnerableSoftware();
+            qm.persist(vs1);
+            qm.persist(new AffectedVersionAttribution(Vulnerability.Source.INTERNAL, v1, vs1));
+            v1.setVulnerableSoftware(List.of(vs1));
             qm.addVulnerability(v1, c1, AnalyzerIdentity.NONE);
             qm.addVulnerability(v2, c1, AnalyzerIdentity.NONE);
             qm.addVulnerability(v3, c1, AnalyzerIdentity.NONE);

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -25,6 +25,10 @@ import alpine.notification.Notification;
 import alpine.notification.NotificationLevel;
 import alpine.notification.NotificationService;
 import alpine.notification.Subscription;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
 import org.awaitility.core.ConditionTimeoutException;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.event.BomUploadEvent;
@@ -53,11 +57,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonReader;
 
 import javax.jdo.JDOObjectNotFoundException;
 import java.io.StringReader;
@@ -147,26 +146,27 @@ class BomUploadProcessingTaskTest extends PersistenceCapableTest {
 
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
-        final VulnerableSoftware vs = new VulnerableSoftware();
+        var vs = new VulnerableSoftware();
         vs.setPurlType("maven");
         vs.setPurlNamespace("com.example");
         vs.setPurlName("xmlutil");
         vs.setVersion("1.0.0");
         vs.setVulnerable(true);
+        vs = qm.persist(vs);
 
-        final var vulnerability1 = new Vulnerability();
+        var vulnerability1 = new Vulnerability();
         vulnerability1.setVulnId("INT-001");
         vulnerability1.setSource(Vulnerability.Source.INTERNAL);
         vulnerability1.setSeverity(Severity.HIGH);
+        vulnerability1 = qm.createVulnerability(vulnerability1, false);
         vulnerability1.setVulnerableSoftware(List.of(vs));
-        qm.createVulnerability(vulnerability1, false);
 
-        final var vulnerability2 = new Vulnerability();
+        var vulnerability2 = new Vulnerability();
         vulnerability2.setVulnId("INT-002");
         vulnerability2.setSource(Vulnerability.Source.INTERNAL);
         vulnerability2.setSeverity(Severity.HIGH);
+        vulnerability2 = qm.createVulnerability(vulnerability2, false);
         vulnerability2.setVulnerableSoftware(List.of(vs));
-        qm.createVulnerability(vulnerability2, false);
 
         final var bomUploadEvent = new BomUploadEvent(qm.detach(Project.class, project.getId()),
                 resourceToByteArray("/unit/bom-1.xml"));

--- a/src/test/java/org/dependencytrack/tasks/GitHubAdvisoryMirrorTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/GitHubAdvisoryMirrorTaskTest.java
@@ -231,8 +231,8 @@ class GitHubAdvisoryMirrorTaskTest extends PersistenceCapableTest {
         var existingVuln = new Vulnerability();
         existingVuln.setVulnId("GHSA-57j2-w4cx-62h2");
         existingVuln.setSource(Source.GITHUB);
-        existingVuln.setVulnerableSoftware(List.of(vs1, vs2, vs3));
         existingVuln = qm.createVulnerability(existingVuln, false);
+        existingVuln.setVulnerableSoftware(List.of(vs1, vs2, vs3));
         qm.updateAffectedVersionAttribution(existingVuln, vs1, Source.OSV);
         qm.updateAffectedVersionAttribution(existingVuln, vs2, Source.OSV);
         qm.updateAffectedVersionAttribution(existingVuln, vs3, Source.GITHUB);

--- a/src/test/java/org/dependencytrack/tasks/OsvDownloadTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/OsvDownloadTaskTest.java
@@ -58,10 +58,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.apache.commons.io.IOUtils.resourceToByteArray;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED;
-import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_BASE_URL;
-import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_NVD_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GITHUB_ADVISORIES_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_BASE_URL;
+import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_GOOGLE_OSV_ENABLED;
+import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_NVD_ENABLED;
 
 @WireMockTest
 class OsvDownloadTaskTest extends PersistenceCapableTest {
@@ -412,8 +412,8 @@ class OsvDownloadTaskTest extends PersistenceCapableTest {
         var existingVuln = new Vulnerability();
         existingVuln.setVulnId("GHSA-57j2-w4cx-62h2");
         existingVuln.setSource(Vulnerability.Source.GITHUB);
-        existingVuln.setVulnerableSoftware(List.of(vs1, vs2, vs3));
         existingVuln = qm.createVulnerability(existingVuln, false);
+        existingVuln.setVulnerableSoftware(List.of(vs1, vs2, vs3));
         qm.updateAffectedVersionAttribution(existingVuln, vs1, Vulnerability.Source.GITHUB);
         qm.updateAffectedVersionAttribution(existingVuln, vs2, Vulnerability.Source.GITHUB);
         qm.updateAffectedVersionAttribution(existingVuln, vs3, Vulnerability.Source.OSV);
@@ -685,8 +685,8 @@ class OsvDownloadTaskTest extends PersistenceCapableTest {
         existingVuln.setDescription("Initial description");
         existingVuln.setSource(Vulnerability.Source.NVD);
         existingVuln.setSeverity(Severity.CRITICAL);
-        existingVuln.setVulnerableSoftware(List.of(vulnerableSoftware));
         existingVuln = qm.createVulnerability(existingVuln, false);
+        existingVuln.setVulnerableSoftware(List.of(vulnerableSoftware));
         qm.updateAffectedVersionAttribution(existingVuln, vulnerableSoftware, Vulnerability.Source.NVD);
 
         OsvAdvisory advisory = parser.parse(jsonObject);
@@ -761,8 +761,8 @@ class OsvDownloadTaskTest extends PersistenceCapableTest {
         existingVuln.setDescription("Initial description");
         existingVuln.setSource(Vulnerability.Source.NVD);
         existingVuln.setSeverity(Severity.CRITICAL);
-        existingVuln.setVulnerableSoftware(List.of(vulnerableSoftware));
         existingVuln = qm.createVulnerability(existingVuln, false);
+        existingVuln.setVulnerableSoftware(List.of(vulnerableSoftware));
         qm.updateAffectedVersionAttribution(existingVuln, vulnerableSoftware, Vulnerability.Source.NVD);
 
         OsvAdvisory advisory = parser.parse(jsonObject);

--- a/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskTest.java
@@ -41,8 +41,8 @@ class InternalAnalysisTaskTest extends PersistenceCapableTest {
         var vulnerability = new Vulnerability();
         vulnerability.setVulnId("GHSA-wjm3-fq3r-5x46");
         vulnerability.setSource(Vulnerability.Source.GITHUB);
+        vulnerability = qm.createVulnerability(vulnerability, false);
         vulnerability.setVulnerableSoftware(List.of(vulnerableSoftware));
-        qm.createVulnerability(vulnerability, false);
 
         new InternalAnalysisTask().analyze(List.of(component));
 
@@ -70,8 +70,8 @@ class InternalAnalysisTaskTest extends PersistenceCapableTest {
         var vulnerability = new Vulnerability();
         vulnerability.setVulnId("CVE-2020-23904");
         vulnerability.setSource(Vulnerability.Source.NVD);
+        vulnerability = qm.createVulnerability(vulnerability, false);
         vulnerability.setVulnerableSoftware(List.of(vulnerableSoftware));
-        qm.createVulnerability(vulnerability, false);
 
         new InternalAnalysisTask().analyze(List.of(component));
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Tweaks vulnerability persistence logic.

* Removes preliminary update timestamp check. This prevents backfilling of existing vulnerabilities with new data (e.g. EPSS scores, CVSSv4).
* Uses a diff-based approach when updating existing vulnerability records to avoid unnecessary DB writes triggered by the ORM.
* Do not set vulnerableSoftware when updating or creating new vulnerability records. VS have their own lifecycle that requires attribution management. Passing them as-is to the ORM could cause undesired behaviour.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/dependency-track/pull/5829
Relates to https://github.com/DependencyTrack/dependency-track/pull/5456

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

A few tests used incorrect persistence patterns, i.e. they relied on cascading persistence performed by the ORM. Those patterns are not used in production code, so I opted for updating the tests instead of polluting the persistence logic with hacks.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
