### PR TITLE
Delete NVD feed timestamp files during v4.14.0 upgrade

### DIFF
--- a/src/main/java/org/dependencytrack/upgrade/v4140/v4140Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v4140/v4140Updater.java
@@ -20,9 +20,14 @@ package org.dependencytrack.upgrade.v4140;
 
 import alpine.persistence.AlpineQueryManager;
 import alpine.server.upgrade.AbstractUpgradeItem;
+import org.dependencytrack.tasks.NistMirrorTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -39,6 +44,27 @@ public class v4140Updater extends AbstractUpgradeItem {
     @Override
     public void executeUpgrade(AlpineQueryManager qm, Connection connection) throws Exception {
         resetVulnSourceWatermarks(connection);
+        deleteNvdFeedTimestampFiles();
+    }
+
+    private void deleteNvdFeedTimestampFiles() {
+        final Path nvdMirrorDir = NistMirrorTask.DEFAULT_NVD_MIRROR_DIR;
+        if (!Files.isDirectory(nvdMirrorDir)) {
+            return;
+        }
+
+        LOGGER.info("Deleting NVD feed timestamp files to force re-download");
+        try (final DirectoryStream<Path> stream = Files.newDirectoryStream(nvdMirrorDir, "*.json.gz.ts")) {
+            for (final Path tsFile : stream) {
+                LOGGER.info("Deleting {}", tsFile.getFileName());
+                Files.delete(tsFile);
+            }
+        } catch (IOException e) {
+            LOGGER.warn("""
+                    Failed to delete NVD feed timestamp files. \
+                    You may need to delete them manually and restart Dependency-Track \
+                    to force a re-download.""", e);
+        }
     }
 
     private void resetVulnSourceWatermarks(Connection connection) throws SQLException {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Deletes NVD feed timestamp files during v4.14.0 upgrade.

This is a continuation of the existing watermark reset logic. Since the feed-based NVD mirroring does not keep watermarks in the database, we need to delete its timestamp files instead.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/dependency-track/issues/4707

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
