### PR TITLE
Analysis: support resolved_with_pedigree

### DIFF
--- a/src/main/java/org/dependencytrack/model/AnalysisState.java
+++ b/src/main/java/org/dependencytrack/model/AnalysisState.java
@@ -30,5 +30,6 @@ public enum AnalysisState {
     FALSE_POSITIVE,
     NOT_AFFECTED,
     RESOLVED,
-    NOT_SET
+    RESOLVED_WITH_PEDIGREE,
+    NOT_SET,
 }

--- a/src/main/java/org/dependencytrack/notification/NotificationConstants.java
+++ b/src/main/java/org/dependencytrack/notification/NotificationConstants.java
@@ -51,6 +51,7 @@ public class NotificationConstants {
         public static final String ANALYSIS_DECISION_SUPPRESSED = "Analysis Decision: Finding Suppressed";
         public static final String ANALYSIS_DECISION_UNSUPPRESSED = "Analysis Decision: Finding UnSuppressed";
         public static final String ANALYSIS_DECISION_RESOLVED = "Analysis Decision: Finding Resolved";
+        public static final String ANALYSIS_DECISION_RESOLVED_WITH_PEDIGREE = "Analysis Decision: Finding Resolved By Pedigree";
         public static final String VIOLATIONANALYSIS_DECISION_APPROVED = "Violation Analysis Decision: Approved";
         public static final String VIOLATIONANALYSIS_DECISION_REJECTED = "Violation Analysis Decision: Rejected";
         public static final String VIOLATIONANALYSIS_DECISION_NOT_SET = "Violation Analysis Decision: Marking Finding as NOT SET";

--- a/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporter.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporter.java
@@ -152,7 +152,7 @@ public class CycloneDXVexImporter {
         }
         if (cdxVuln.getAnalysis().getState() != null) {
             analysisState = ModelConverter.convertCdxVulnAnalysisStateToDtAnalysisState(cdxVuln.getAnalysis().getState());
-            suppress = (AnalysisState.FALSE_POSITIVE == analysisState || AnalysisState.NOT_AFFECTED == analysisState || AnalysisState.RESOLVED == analysisState);
+            suppress = (AnalysisState.FALSE_POSITIVE == analysisState || AnalysisState.NOT_AFFECTED == analysisState || AnalysisState.RESOLVED == analysisState || AnalysisState.RESOLVED_WITH_PEDIGREE == analysisState);
             AnalysisCommentUtil.makeStateComment(qm, analysis, analysisState, COMMENTER);
         }
         if (cdxVuln.getAnalysis().getJustification() != null) {

--- a/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
@@ -1107,6 +1107,8 @@ public class ModelConverter {
                 return org.cyclonedx.model.vulnerability.Vulnerability.Analysis.State.NOT_AFFECTED;
             case RESOLVED:
                 return org.cyclonedx.model.vulnerability.Vulnerability.Analysis.State.RESOLVED;
+            case RESOLVED_WITH_PEDIGREE:
+                return org.cyclonedx.model.vulnerability.Vulnerability.Analysis.State.RESOLVED_WITH_PEDIGREE;
             default:
                 return null;
         }
@@ -1127,6 +1129,8 @@ public class ModelConverter {
                 return AnalysisState.NOT_AFFECTED;
             case RESOLVED:
                 return AnalysisState.RESOLVED;
+            case RESOLVED_WITH_PEDIGREE:
+                return AnalysisState.RESOLVED_WITH_PEDIGREE;
             default:
                 return AnalysisState.NOT_SET;
         }

--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -171,6 +171,9 @@ public final class NotificationUtil {
                     case RESOLVED:
                         title = NotificationConstants.Title.ANALYSIS_DECISION_RESOLVED;
                         break;
+                    case RESOLVED_WITH_PEDIGREE:
+                        title = NotificationConstants.Title.ANALYSIS_DECISION_RESOLVED_WITH_PEDIGREE;
+                        break;
                 }
             } else if (suppressionChange) {
                 if (analysis.isSuppressed()) {

--- a/src/test/java/org/dependencytrack/notification/NotificationConstantsTest.java
+++ b/src/test/java/org/dependencytrack/notification/NotificationConstantsTest.java
@@ -47,5 +47,6 @@ class NotificationConstantsTest {
         Assertions.assertEquals("Analysis Decision: Finding Suppressed", NotificationConstants.Title.ANALYSIS_DECISION_SUPPRESSED);
         Assertions.assertEquals("Analysis Decision: Finding UnSuppressed", NotificationConstants.Title.ANALYSIS_DECISION_UNSUPPRESSED);
         Assertions.assertEquals("Analysis Decision: Finding Resolved", NotificationConstants.Title.ANALYSIS_DECISION_RESOLVED);
+        Assertions.assertEquals("Analysis Decision: Finding Resolved By Pedigree", NotificationConstants.Title.ANALYSIS_DECISION_RESOLVED_WITH_PEDIGREE);
     }
 }


### PR DESCRIPTION
### Description

An SBOM we're using produces an analysis with resolved_with_pedigree, which does not correctly end up marking the vulnerability as resolved.

I have not tested this patch, but tried my best to pattern match my way to success.

### Addressed Issue

n/a

### Additional Details

We've updated our intake tooling in the meantime to replace resolved_with_pedigree with resolved.

### Checklist


- [ ] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
