### PR TITLE
Warn on duplicate service BOM refs during BOM processing

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -675,7 +675,13 @@ public class BomUploadProcessingTask implements Subscriber {
         final var identitiesSeen = new HashSet<ComponentIdentity>();
         return service -> {
             final var componentIdentity = new ComponentIdentity(service);
-            identitiesByBomRef.putIfAbsent(service.getBomRef(), componentIdentity);
+            final boolean isBomRefUnique = identitiesByBomRef.putIfAbsent(service.getBomRef(), componentIdentity) == null;
+            if (!isBomRefUnique) {
+            LOGGER.warn("""
+                BOM ref %s is associated with multiple services in the BOM; \
+                BOM refs are required to be unique; Please report this to the vendor \
+                of the tool that generated the BOM""".formatted(service.getBomRef()));
+            }
             bomRefsByIdentity.put(componentIdentity, service.getBomRef());
             final boolean isSeenBefore = !identitiesSeen.add(componentIdentity);
             if (LOGGER.isDebugEnabled() && isSeenBefore) {


### PR DESCRIPTION
### Description

Adds a warning log for duplicate **service BOM references** during BOM ingestion.

The method `distinctComponentsByIdentity(...)` already logs a warning when duplicate BOM references are encountered for components. However, the equivalent logic in `distinctServicesByIdentity(...)` silently ignored duplicate BOM references for services.

This change aligns the behavior of service processing with component processing by logging a warning when multiple services share the same BOM reference.

This improves diagnostics when ingesting malformed or incorrectly generated SBOMs and helps operators identify issues with SBOM generators.

### Addressed Issue

No existing issue.  
Improves consistency and observability in BOM processing.

### Additional Details

During BOM ingestion, `BomUploadProcessingTask` deduplicates both components and services using their identity and BOM reference.

For components, the method `distinctComponentsByIdentity(...)` already detects and logs a warning when multiple components share the same BOM reference:

```java
final boolean isBomRefUnique = identitiesByBomRef.putIfAbsent(component.getBomRef(), componentIdentity) == null;
if (!isBomRefUnique) {
    LOGGER.warn("...");
}

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [~] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [~] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
