### PR TITLE
Fix BOM ref values in dependency graph warning log

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -721,7 +721,7 @@ public class BomUploadProcessingTask implements Subscriber {
                 LOGGER.warn("""
                         Unable to resolve BOM ref %s to a component identity while processing direct \
                         dependencies of BOM ref %s; As a result, the dependency graph will likely be incomplete\
-                        """.formatted(dependencyBomRef, directDependencyBomRef));
+                        """.formatted(directDependencyBomRef, dependencyBomRef));
             }
         }
 


### PR DESCRIPTION
### Description

Fixes the warning log emitted when a direct dependency BOM ref cannot be resolved during dependency graph processing.

The warning message in `resolveDirectDependenciesJson(...)` currently formats the parent BOM ref and the direct dependency BOM ref in reverse order. This makes troubleshooting more difficult because the unresolved reference appears in the wrong position in the log output.

This change corrects the formatting order so the unresolved direct dependency BOM ref is reported first, followed by the BOM ref whose dependencies are being processed.

### Addressed Issue

N/A – Logging clarity improvement.

### Additional Details

In `resolveDirectDependenciesJson(...)`, the warning currently uses:
.formatted(dependencyBomRef, directDependencyBomRef)

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
