### PR TITLE
Remove leading whitespace from vulnerability badge SVG template

### DIFF
--- a/src/main/resources/templates/badge/project-vulns.peb
+++ b/src/main/resources/templates/badge/project-vulns.peb
@@ -1,7 +1,7 @@
-{% set width = 234 %}
-{% if unassigned equals "0" %}
-    {% set width = 204 %}
-{% endif %}
+{%- set width = 234 -%}
+{%- if unassigned equals "0" -%}
+    {%- set width = 204 -%}
+{%- endif -%}
 <svg width="{{ width }}" height="20" viewBox="0 0 {{ width }} 20" xmlns="http://www.w3.org/2000/svg">
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>


### PR DESCRIPTION
(cherry picked from commit f8910cc1a9ce0c2e31ac9512b37c73fa23bd49de)

### Description

Removes leading whitespace from the vulnerability badge SVG template output.

The SVG produced by `src/main/resources/templates/badge/project-vulns.peb` may include leading whitespace before the `<svg>` element, which can cause some consumers (for example Confluence) to treat the response as text rather than SVG.

This change trims whitespace around the initial Pebble template tags using `{%- ... -%}` so the rendered output begins directly with the `<svg>` element.

### Addressed Issue

Fixes #5897

### Additional Details

Pebble preserves whitespace by default. By changing the initial template tags to use whitespace trimming syntax, the generated SVG no longer starts with extra whitespace or blank lines.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
