### PR TITLE
Add age and version distance to operational policy criteria in the policy compliance usage documentation

### DIFF
--- a/docs/_docs/usage/policy-compliance.md
+++ b/docs/_docs/usage/policy-compliance.md
@@ -48,11 +48,13 @@ will not result in a policy violation.
 
 ## Operational Violation
 Policy conditions can specify zero or more:
+* Age (publish date of the package version)
 * Coordinates (group, name, version)
 * Package URL
 * CPE
 * SWID Tag ID
 * Hash (MD5, SHA, SHA3, Blake2b, Blake3)
+* Version distance (used version vs latest available version)
 
 This allows organizations to create lists of allowable and/or prohibited components. Future versions
 of Dependency-Track will incorporate additional operational parameters into the policy framework.


### PR DESCRIPTION
### Description
Added age and version distance to the listed operational policy criteria in the documentation, as well as a clarification on what the `AGE` operand refers to as this seems to be a frequent misunderstanding e.g. #5948.

### Addressed Issue

related to #5948

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
