### PR TITLE
Backport: Fix PURL-specific version matching being bypassed for components with CPE

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/scanners/AbstractVulnerableSoftwareAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/AbstractVulnerableSoftwareAnalysisTask.java
@@ -37,6 +37,7 @@ import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.util.Relation;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -87,7 +88,7 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
             Component component,
             VulnerabilityAnalysisLevel vulnerabilityAnalysisLevel) {
         for (final VulnerableSoftware vs : vsList) {
-            if (comparePurlVersions(targetPurl, vs, targetVersion)) {
+            if (matchesPurl(vs, targetPurl) && comparePurlVersions(targetPurl, vs, targetVersion)) {
                 if (vs.getVulnerabilities() != null) {
                     for (final Vulnerability vulnerability : vs.getVulnerabilities()) {
                         NotificationUtil.analyzeNotificationCriteria(qm, vulnerability, component,
@@ -107,8 +108,7 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
             Component component,
             VulnerabilityAnalysisLevel vulnerabilityAnalysisLevel) {
         for (final VulnerableSoftware vs : vsList) {
-            final Boolean isCpeMatch = maybeMatchCpe(vs, targetCpe, targetVersion);
-            if ((isCpeMatch == null || isCpeMatch) && compareCpeVersions(vs, targetVersion, component)) {
+            if (matchesCpe(vs, targetCpe, targetVersion) && compareCpeVersions(vs, targetVersion, component)) {
                 if (vs.getVulnerabilities() != null) {
                     for (final Vulnerability vulnerability : vs.getVulnerabilities()) {
                         NotificationUtil.analyzeNotificationCriteria(qm, vulnerability, component, vulnerabilityAnalysisLevel);
@@ -123,9 +123,9 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
         return string == null ? null : string.toLowerCase();
     }
 
-    private Boolean maybeMatchCpe(final VulnerableSoftware vs, final Cpe targetCpe, final String targetVersion) {
+    private boolean matchesCpe(final VulnerableSoftware vs, final Cpe targetCpe, final String targetVersion) {
         if (targetCpe == null || vs.getCpe23() == null) {
-            return null;
+            return false;
         }
 
         final List<Relation> relations = List.of(
@@ -159,6 +159,16 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
         }
 
         return isMatch;
+    }
+
+    private boolean matchesPurl(VulnerableSoftware vs, PackageURL purl) {
+        if (purl == null) {
+            return false;
+        }
+
+        return Objects.equals(vs.getPurlType(), purl.getType())
+                && Objects.equals(vs.getPurlNamespace(), purl.getNamespace())
+                && Objects.equals(vs.getPurlName(), purl.getName());
     }
 
     private boolean comparePurlVersions(PackageURL componentPurl, VulnerableSoftware vs, String targetVersion) {

--- a/src/main/java/org/dependencytrack/tasks/scanners/InternalAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/InternalAnalysisTask.java
@@ -107,9 +107,10 @@ public class InternalAnalysisTask extends AbstractVulnerableSoftwareAnalysisTask
             } catch (CpeParsingException e) {
                 LOGGER.warn("An error occurred while parsing: " + component.getCpe() + " - The CPE is invalid and will be discarded. " + e.getMessage());
             }
-        } else if (component.getPurl() != null) { 
+        }
+        if (component.getPurl() != null) {
             parsedPurl = component.getPurl();
-        } 
+        }
 
         List<VulnerableSoftware> vsList = Collections.emptyList();
 

--- a/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskTest.java
@@ -52,6 +52,88 @@ class InternalAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
+    void testPurlAnalysisNotSkippedWhenCpeIsInvalid() {
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.createProject(project, Collections.emptyList(), false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("jackson-databind");
+        component.setVersion("2.13.0");
+        component.setCpe("cpe:invalid");
+        component.setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.0");
+        component = qm.createComponent(component, false);
+
+        var purlVs = new VulnerableSoftware();
+        purlVs.setPurlType("maven");
+        purlVs.setPurlNamespace("com.fasterxml.jackson.core");
+        purlVs.setPurlName("jackson-databind");
+        purlVs.setVersionEndExcluding("2.13.1");
+        purlVs.setVulnerable(true);
+        purlVs = qm.persist(purlVs);
+
+        var ghsaVuln = new Vulnerability();
+        ghsaVuln.setVulnId("GHSA-0000-0000-0001");
+        ghsaVuln.setSource(Vulnerability.Source.GITHUB);
+        ghsaVuln = qm.createVulnerability(ghsaVuln, false);
+        ghsaVuln.setVulnerableSoftware(List.of(purlVs));
+
+        new InternalAnalysisTask().analyze(List.of(component));
+
+        final PaginatedResult vulnerabilities = qm.getVulnerabilities(component);
+        assertThat(vulnerabilities.getTotal()).isEqualTo(1);
+        assertThat(vulnerabilities.getList(Vulnerability.class).getFirst().getVulnId()).isEqualTo("GHSA-0000-0000-0001");
+    }
+
+    @Test
+    void testComponentWithBothValidCpeAndPurl() throws CpeParsingException, CpeEncodingException {
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.createProject(project, Collections.emptyList(), false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("jackson-databind");
+        component.setVersion("2.13.0");
+        component.setCpe("cpe:2.3:a:fasterxml:jackson-databind:2.13.0:*:*:*:*:*:*:*");
+        component.setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.0");
+        component = qm.createComponent(component, false);
+
+        var cpeVs = ModelConverter.convertCpe23UriToVulnerableSoftware(
+                "cpe:2.3:a:fasterxml:jackson-databind:2.13.0:*:*:*:*:*:*:*");
+        cpeVs = qm.persist(cpeVs);
+
+        var cveVuln = new Vulnerability();
+        cveVuln.setVulnId("CVE-2022-00001");
+        cveVuln.setSource(Vulnerability.Source.NVD);
+        cveVuln = qm.createVulnerability(cveVuln, false);
+        cveVuln.setVulnerableSoftware(List.of(cpeVs));
+
+        var purlVs = new VulnerableSoftware();
+        purlVs.setPurlType("maven");
+        purlVs.setPurlNamespace("com.fasterxml.jackson.core");
+        purlVs.setPurlName("jackson-databind");
+        purlVs.setVersionEndExcluding("2.13.1");
+        purlVs.setVulnerable(true);
+        purlVs = qm.persist(purlVs);
+
+        var ghsaVuln = new Vulnerability();
+        ghsaVuln.setVulnId("GHSA-0000-0000-0001");
+        ghsaVuln.setSource(Vulnerability.Source.GITHUB);
+        ghsaVuln = qm.createVulnerability(ghsaVuln, false);
+        ghsaVuln.setVulnerableSoftware(List.of(purlVs));
+
+        new InternalAnalysisTask().analyze(List.of(component));
+
+        final PaginatedResult vulnerabilities = qm.getVulnerabilities(component);
+        assertThat(vulnerabilities.getTotal()).isEqualTo(2);
+        assertThat(vulnerabilities.getList(Vulnerability.class))
+                .extracting(Vulnerability::getVulnId)
+                .containsExactlyInAnyOrder("CVE-2022-00001", "GHSA-0000-0000-0001");
+    }
+
+    @Test
     void testExactMatchWithNAUpdate() throws CpeParsingException, CpeEncodingException {
         var project = new Project();
         project.setName("acme-app");


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

The previous logic did not explicitly "parse" the component's PURL when the component also has a CPE. It would still go on to fetch VulnerableSoftware records for CPE *and* PURL as expected, but would not follow the PURL-specific version comparison algorithms.

A leftover logic that pre-dates the introduction of vers caused version range analysis to be performed against VulnerableSoftware records that had no CPE information (i.e. maybeMatchCpe returns null). VulnerableSoftware records with PURL information were thus still considered, but in a logic branch that doesn't leverage ecosystem-aware or distro-aware matching.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports https://github.com/DependencyTrack/dependency-track/pull/5903

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Credit to @xavier-calland for identifying this as per https://github.com/DependencyTrack/dependency-track/issues/5343#issuecomment-4046427496

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
