### PR TITLE
Backport: Fix potentially wrong version being used for CPE comparison

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/scanners/AbstractVulnerableSoftwareAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/AbstractVulnerableSoftwareAnalysisTask.java
@@ -58,19 +58,22 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
      *
      * @param qm            the QueryManager to use
      * @param vsList        a list of VulnerableSoftware objects
-     * @param targetVersion the version of the component
      * @param component     the component being analyzed
      */
-    protected void analyzeVersionRange(final QueryManager qm, final List<VulnerableSoftware> vsList,
-            final Cpe targetCpe, final PackageURL targetPURL, final String targetVersion, final Component component,
-            final VulnerabilityAnalysisLevel vulnerabilityAnalysisLevel) {
+    protected void analyzeVersionRange(
+            QueryManager qm,
+            List<VulnerableSoftware> vsList,
+            Cpe targetCpe,
+            PackageURL targetPURL,
+            Component component,
+            VulnerabilityAnalysisLevel vulnerabilityAnalysisLevel) {
         boolean ran = false;
         if (targetCpe != null) {
-            analyzeCpeVersionRange(qm, vsList, targetCpe, targetVersion, component, vulnerabilityAnalysisLevel);
+            analyzeCpeVersionRange(qm, vsList, targetCpe, component, vulnerabilityAnalysisLevel);
             ran = true;
         }
         if (targetPURL != null) {
-            analyzePurlVersionRange(qm, vsList, targetPURL, targetVersion, component, vulnerabilityAnalysisLevel);
+            analyzePurlVersionRange(qm, vsList, targetPURL, component, vulnerabilityAnalysisLevel);
             ran = true;
         }
         if (!ran) {
@@ -84,11 +87,10 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
             QueryManager qm,
             List<VulnerableSoftware> vsList,
             PackageURL targetPurl,
-            String targetVersion,
             Component component,
             VulnerabilityAnalysisLevel vulnerabilityAnalysisLevel) {
         for (final VulnerableSoftware vs : vsList) {
-            if (matchesPurl(vs, targetPurl) && comparePurlVersions(targetPurl, vs, targetVersion)) {
+            if (matchesPurl(vs, targetPurl) && comparePurlVersions(targetPurl, vs)) {
                 if (vs.getVulnerabilities() != null) {
                     for (final Vulnerability vulnerability : vs.getVulnerabilities()) {
                         NotificationUtil.analyzeNotificationCriteria(qm, vulnerability, component,
@@ -104,11 +106,10 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
             QueryManager qm,
             List<VulnerableSoftware> vsList,
             Cpe targetCpe,
-            String targetVersion,
             Component component,
             VulnerabilityAnalysisLevel vulnerabilityAnalysisLevel) {
         for (final VulnerableSoftware vs : vsList) {
-            if (matchesCpe(vs, targetCpe, targetVersion) && compareCpeVersions(vs, targetVersion, component)) {
+            if (matchesCpe(vs, targetCpe) && compareCpeVersions(vs, targetCpe, component)) {
                 if (vs.getVulnerabilities() != null) {
                     for (final Vulnerability vulnerability : vs.getVulnerabilities()) {
                         NotificationUtil.analyzeNotificationCriteria(qm, vulnerability, component, vulnerabilityAnalysisLevel);
@@ -123,7 +124,7 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
         return string == null ? null : string.toLowerCase();
     }
 
-    private boolean matchesCpe(final VulnerableSoftware vs, final Cpe targetCpe, final String targetVersion) {
+    private boolean matchesCpe(final VulnerableSoftware vs, final Cpe targetCpe) {
         if (targetCpe == null || vs.getCpe23() == null) {
             return false;
         }
@@ -132,7 +133,7 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
                 Cpe.compareAttribute(vs.getPart(), toLowerCaseNullable(targetCpe.getPart().getAbbreviation())),
                 Cpe.compareAttribute(vs.getVendor(), toLowerCaseNullable(targetCpe.getVendor())),
                 Cpe.compareAttribute(vs.getProduct(), toLowerCaseNullable(targetCpe.getProduct())),
-                Cpe.compareAttribute(vs.getVersion(), targetVersion),
+                Cpe.compareAttribute(vs.getVersion(), targetCpe.getVersion()),
                 Cpe.compareAttribute(vs.getUpdate(), targetCpe.getUpdate()),
                 Cpe.compareAttribute(vs.getEdition(), targetCpe.getEdition()),
                 Cpe.compareAttribute(vs.getLanguage(), targetCpe.getLanguage()),
@@ -171,7 +172,11 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
                 && Objects.equals(vs.getPurlName(), purl.getName());
     }
 
-    private boolean comparePurlVersions(PackageURL componentPurl, VulnerableSoftware vs, String targetVersion) {
+    private boolean comparePurlVersions(PackageURL componentPurl, VulnerableSoftware vs) {
+        if (componentPurl.getVersion() == null) {
+            return false;
+        }
+
         final String componentDistroQualifier = PurlUtil.getDistroQualifier(componentPurl);
         final String vsDistroQualifier = PurlUtil.getDistroQualifier(vs.getPurl());
 
@@ -209,7 +214,7 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
                 .flatMap(KnownVersioningSchemes::fromPurl)
                 .orElse(KnownVersioningSchemes.SCHEME_GENERIC);
 
-        return compareWithVers(vs, targetVersion, versioningScheme);
+        return compareWithVers(vs, componentPurl.getVersion(), versioningScheme);
     }
 
     /**
@@ -218,19 +223,19 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
      * versionStartIncluding.
      *
      * @param vs            a reference to the vulnerable software to compare
-     * @param targetVersion the version to compare
+     * @param targetCpe the CPE to compare against
      * @return <code>true</code> if the target version is matched; otherwise
      * <code>false</code>
      * <p>
      * Ported from Dependency-Check v5.2.1
      */
-    private boolean compareCpeVersions(VulnerableSoftware vs, String targetVersion, Component component) {
+    private boolean compareCpeVersions(VulnerableSoftware vs, Cpe targetCpe, Component component) {
         // Modified from original by @nscuro.
         // Special cases for CPE matching of ANY (*) and NA (*) versions.
         // These don't make sense to use for version range comparison and
         // can be dealt with upfront based on the matching documentation:
         // https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7696.pdf
-        if ("*".equals(targetVersion)) {
+        if ("*".equals(targetCpe.getVersion())) {
             // | No. | Source A-V     | Target A-V | Relation |
             // | :-- | :------------- | :--------- | :------- |
             // | 1   | ANY            | ANY        | EQUAL    |
@@ -238,7 +243,7 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
             // | 13  | i              | ANY        | SUBSET   |
             // | 15  | m + wild cards | ANY        | SUBSET   |
             return true;
-        } else if ("-".equals(targetVersion)) {
+        } else if ("-".equals(targetCpe.getVersion())) {
             // | No. | Source A-V     | Target A-V | Relation |
             // | :-- | :------------- | :--------- | :------- |
             // | 2   | ANY            | NA         | SUPERSET |
@@ -252,7 +257,7 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
 
         // Modified from original by Steve Springett
         // Added null check: vs.getVersion() != null as purl sources that use version ranges may not have version populated.
-        if (!result && vs.getVersion() != null && Cpe.compareAttribute(vs.getVersion(), targetVersion) != Relation.DISJOINT) {
+        if (!result && vs.getVersion() != null && Cpe.compareAttribute(vs.getVersion(), targetCpe.getVersion()) != Relation.DISJOINT) {
             return true;
         }
 
@@ -262,7 +267,7 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
                 .flatMap(KnownVersioningSchemes::fromPurl)
                 .orElse(KnownVersioningSchemes.SCHEME_GENERIC);
 
-        return compareWithVers(vs, targetVersion, versioningScheme);
+        return compareWithVers(vs, targetCpe.getVersion(), versioningScheme);
     }
 
     private boolean compareWithVers(VulnerableSoftware vs, String targetVersion, String versioningScheme) {

--- a/src/main/java/org/dependencytrack/tasks/scanners/InternalAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/InternalAnalysisTask.java
@@ -21,6 +21,7 @@ package org.dependencytrack.tasks.scanners;
 import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
+import com.github.packageurl.PackageURL;
 import org.dependencytrack.event.InternalAnalysisEvent;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ConfigPropertyConstants;
@@ -28,10 +29,10 @@ import org.dependencytrack.model.VulnerabilityAnalysisLevel;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.search.FuzzyVulnerableSoftwareSearchManager;
+import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.CpeParser;
 import us.springett.parsers.cpe.exceptions.CpeParsingException;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -98,8 +99,8 @@ public class InternalAnalysisTask extends AbstractVulnerableSoftwareAnalysisTask
                 (!component.isInternal() || !super.isEnabled(ConfigPropertyConstants.SCANNER_INTERNAL_FUZZY_EXCLUDE_INTERNAL));
         final boolean excludeComponentsWithPurl = super.isEnabled(ConfigPropertyConstants.SCANNER_INTERNAL_FUZZY_EXCLUDE_PURL);
 
-        com.github.packageurl.PackageURL parsedPurl = null;
-        us.springett.parsers.cpe.Cpe parsedCpe = null;
+        PackageURL parsedPurl = null;
+        Cpe parsedCpe = null;
 
         if (component.getCpe() != null) {
             try {
@@ -112,37 +113,7 @@ public class InternalAnalysisTask extends AbstractVulnerableSoftwareAnalysisTask
             parsedPurl = component.getPurl();
         }
 
-        List<VulnerableSoftware> vsList = Collections.emptyList();
-
-        String componentVersion = component.getVersion();
-        if (componentVersion == null || componentVersion.isBlank()) {
-            if (parsedCpe != null && parsedCpe.getVersion() != null && !parsedCpe.getVersion().isBlank()) {
-                componentVersion = parsedCpe.getVersion();
-            } else if (parsedPurl != null && parsedPurl.getVersion() != null && !parsedPurl.getVersion().isBlank()) {
-                componentVersion = parsedPurl.getVersion();
-            } else {
-                LOGGER.debug("Neither CPE, PURL, nor component version provide a version - skipping analysis");
-                return;
-            }
-        }
-        // In some cases, componentVersion may be null, such as when a Package URL does not have a version specified
-        if (componentVersion == null) {
-            return;
-        }
-        // https://github.com/DependencyTrack/dependency-track/issues/1574
-        // Some ecosystems use the "v" version prefix (e.g. v1.2.3) for their components.
-        // However, both the NVD and GHSA store versions without that prefix.
-        // For this reason, the prefix is stripped before running analyzeVersionRange.
-        //
-        // REVISIT THIS WHEN ADDING NEW VULNERABILITY SOURCES!
-        if (componentVersion.length() > 1 && componentVersion.startsWith("v")) {
-            if (componentVersion.matches("v0.0.0-\\d{14}-[a-f0-9]{12}")) {
-                componentVersion = componentVersion.substring(7,11) + "-" + componentVersion.substring(11,13) + "-" + componentVersion.substring(13,15);
-            } else {
-                componentVersion = componentVersion.substring(1);
-            }
-        }
-        
+        List<VulnerableSoftware> vsList;
         if (parsedCpe != null) {
             vsList = qm.getAllVulnerableSoftware(parsedCpe.getPart().getAbbreviation(), parsedCpe.getVendor(),
                     parsedCpe.getProduct(), component.getPurl());
@@ -154,7 +125,8 @@ public class InternalAnalysisTask extends AbstractVulnerableSoftwareAnalysisTask
             FuzzyVulnerableSoftwareSearchManager fm = new FuzzyVulnerableSoftwareSearchManager(excludeComponentsWithPurl);
             vsList = fm.fuzzyAnalysis(qm, component, parsedCpe);
         }
-        super.analyzeVersionRange(qm, vsList, parsedCpe, parsedPurl, componentVersion, component, vulnerabilityAnalysisLevel);
+
+        super.analyzeVersionRange(qm, vsList, parsedCpe, parsedPurl, component, vulnerabilityAnalysisLevel);
     }
 
 }

--- a/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskTest.java
@@ -134,6 +134,164 @@ class InternalAnalysisTaskTest extends PersistenceCapableTest {
     }
 
     @Test
+    void testCpeVersionDiffersFromComponentVersion() throws Exception {
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.createProject(project, Collections.emptyList(), false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("stm32l4_firmware");
+        component.setVersion("1.2.3");
+        component.setCpe("cpe:2.3:o:st:stm32l4_firmware:-:*:*:*:*:*:*:*");
+        component = qm.createComponent(component, false);
+
+        var vs = ModelConverter.convertCpe23UriToVulnerableSoftware(
+                "cpe:2.3:o:st:stm32l4_firmware:-:*:*:*:*:*:*:*");
+        vs = qm.persist(vs);
+
+        var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-2023-00001");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln = qm.createVulnerability(vuln, false);
+        vuln.setVulnerableSoftware(List.of(vs));
+
+        new InternalAnalysisTask().analyze(List.of(component));
+
+        final PaginatedResult vulns = qm.getVulnerabilities(component);
+        assertThat(vulns.getTotal()).isEqualTo(1);
+        assertThat(vulns.getList(Vulnerability.class).getFirst().getVulnId()).isEqualTo("CVE-2023-00001");
+    }
+
+    @Test
+    void testCpeVersionUsedInsteadOfComponentVersion() throws Exception {
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.createProject(project, Collections.emptyList(), false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("product");
+        component.setVersion("1.5.0");
+        component.setCpe("cpe:2.3:a:vendor:product:5.0:*:*:*:*:*:*:*");
+        component = qm.createComponent(component, false);
+
+        var vs = ModelConverter.convertCpe23UriToVulnerableSoftware(
+                "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*");
+        vs.setVersionStartIncluding("1.0.0");
+        vs.setVersionEndExcluding("2.0.0");
+        vs = qm.persist(vs);
+
+        var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-2023-00002");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln = qm.createVulnerability(vuln, false);
+        vuln.setVulnerableSoftware(List.of(vs));
+
+        new InternalAnalysisTask().analyze(List.of(component));
+
+        final PaginatedResult vulns = qm.getVulnerabilities(component);
+        assertThat(vulns.getTotal()).isEqualTo(0);
+    }
+
+    @Test
+    void testPurlVersionDiffersFromComponentVersion() {
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.createProject(project, Collections.emptyList(), false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("lib");
+        component.setVersion("1.0-SNAPSHOT");
+        component.setPurl("pkg:maven/com.example/lib@1.0.0");
+        component = qm.createComponent(component, false);
+
+        var vs = new VulnerableSoftware();
+        vs.setPurlType("maven");
+        vs.setPurlNamespace("com.example");
+        vs.setPurlName("lib");
+        vs.setVersionEndExcluding("1.0.1");
+        vs.setVulnerable(true);
+        vs = qm.persist(vs);
+
+        var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-2023-00003");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln = qm.createVulnerability(vuln, false);
+        vuln.setVulnerableSoftware(List.of(vs));
+
+        new InternalAnalysisTask().analyze(List.of(component));
+
+        final PaginatedResult vulns = qm.getVulnerabilities(component);
+        assertThat(vulns.getTotal()).isEqualTo(1);
+        assertThat(vulns.getList(Vulnerability.class).getFirst().getVulnId()).isEqualTo("CVE-2023-00003");
+    }
+
+    @Test
+    void testCpeWithAnyVersionMatchesEverything() throws Exception {
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.createProject(project, Collections.emptyList(), false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("product");
+        component.setVersion("2.5.0");
+        component.setCpe("cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*");
+        component = qm.createComponent(component, false);
+
+        var vs = ModelConverter.convertCpe23UriToVulnerableSoftware(
+                "cpe:2.3:a:vendor:product:2.5.0:*:*:*:*:*:*:*");
+        vs = qm.persist(vs);
+
+        var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-2023-00004");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln = qm.createVulnerability(vuln, false);
+        vuln.setVulnerableSoftware(List.of(vs));
+
+        new InternalAnalysisTask().analyze(List.of(component));
+
+        final PaginatedResult vulns = qm.getVulnerabilities(component);
+        assertThat(vulns.getTotal()).isEqualTo(1);
+        assertThat(vulns.getList(Vulnerability.class).getFirst().getVulnId()).isEqualTo("CVE-2023-00004");
+    }
+
+    @Test
+    void testPurlWithNullVersionNoMatch() {
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.createProject(project, Collections.emptyList(), false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("lib");
+        component.setVersion("1.0.0");
+        component.setPurl("pkg:maven/com.example/lib");
+        component = qm.createComponent(component, false);
+
+        var vs = new VulnerableSoftware();
+        vs.setPurlType("maven");
+        vs.setPurlNamespace("com.example");
+        vs.setPurlName("lib");
+        vs.setVersionEndExcluding("2.0.0");
+        vs.setVulnerable(true);
+        vs = qm.persist(vs);
+
+        var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-2023-00005");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln = qm.createVulnerability(vuln, false);
+        vuln.setVulnerableSoftware(List.of(vs));
+
+        new InternalAnalysisTask().analyze(List.of(component));
+
+        final PaginatedResult vulns = qm.getVulnerabilities(component);
+        assertThat(vulns.getTotal()).isEqualTo(0);
+    }
+
+    @Test
     void testExactMatchWithNAUpdate() throws CpeParsingException, CpeEncodingException {
         var project = new Project();
         project.setName("acme-app");


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes potentially wrong version being used for CPE comparison.

The internal analyzer used to determine a "normalized" component version from:

1. The component's dedicated "version" field
2. The component's CPE version
3. The component's PURL version

in exactly that order. This version would then be used for analysis against CPEs and PURLs in the database.

This gets problematic when components have different versions than what is declared in their CPE (or PURL). For example, a component may have the version "1.2.3", but the CPE "cpe:2.3:o:st:stm32l4_firmware:-:*:*:*:*:*:*:*" (version is "-"). In those cases, CPE comparison would have been erroneously performed with "1.2.3" instead of "-".

This change skips the error-prone attempt to find *the* version of a component. Instead, we use the CPE version for CPE comparison and the PURL version for PURL comparison.

Also, leftover normalization that stripped "v" prefixed and normalized Go dev versions (v0.0.0-...) is removed. Since we can do ecosystem-aware version matching now, all this is handled implicitly.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports https://github.com/DependencyTrack/dependency-track/pull/5944

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
