### PR TITLE
Backport: Avoid NPE when computing Trivy pkgType (#5982)

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTask.java
@@ -245,15 +245,16 @@ public class TrivyAnalysisTask extends BaseComponentAnalyzerTask implements Subs
                         String arch = null;
                         Integer epoch = null;
 
-                        if (component.getPurl().getQualifiers() != null) {
-                            arch = component.getPurl().getQualifiers().get("arch");
+                        final var qualifiers = component.getPurl().getQualifiers();
+                        if (qualifiers != null) {
+                            arch = qualifiers.get("arch");
 
-                            String tmpEpoch = component.getPurl().getQualifiers().get("epoch");
+                            String tmpEpoch = qualifiers.get("epoch");
                             if (tmpEpoch != null) {
                                 epoch = Integer.parseInt(tmpEpoch);
                             }
 
-                            String distro = component.getPurl().getQualifiers().get("distro");
+                            String distro = qualifiers.get("distro");
 
                             if (distro != null) {
                                 pkgType = URLDecoder.decode(distro, StandardCharsets.UTF_8);
@@ -272,7 +273,7 @@ public class TrivyAnalysisTask extends BaseComponentAnalyzerTask implements Subs
                             } else if (!pkgType.contains("-") && property.getPropertyName().equals("trivy:PkgType")) {
                                 pkgType = property.getPropertyValue();
 
-                                String distro = component.getPurl().getQualifiers().get("distro");
+                                String distro = qualifiers == null ? null : qualifiers.get("distro");
 
                                 if (distro != null) {
                                     pkgType += "-" + URLDecoder.decode(distro, StandardCharsets.UTF_8);


### PR DESCRIPTION
(cherry picked from commit d3ff4c102e19801484aac63eb4c73e4e2f5fa76b)

### Description

Backports #5982

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
