### PR TITLE
docs: add permissions roles table and enterprise OIDC mapping guidance

### DIFF
--- a/docs/_docs/getting-started/openidconnect-configuration.md
+++ b/docs/_docs/getting-started/openidconnect-configuration.md
@@ -30,6 +30,52 @@ When someone authenticates using OIDC, the claims provided in the ID token or `/
 2. Create a group with the name used in the OIDC team claim configured below. The value _must_ match exactly, including case.
 3. If the team you want members of the OIDC group to join already exists, use the _Mapped Teams_ menu to select it. If the team does not exist, open _Administration_ -> _Access Management_ -> _Teams_ to create it and, after having done so, add the OIDC group to the _Mapped OpenID Connect Groups_ list.
 
+## Dependency-Track Permission Roles
+
+When mapping OIDC groups to Dependency-Track teams, it is important to understand what permissions each role grants. The following table describes 
+all available permissions in Dependency-Track and their purpose:
+
+| Permission | Description |
+|---|---|
+| ACCESS_MANAGEMENT | Allows management of users, teams, and permissions |
+| BOM_UPLOAD | Allows uploading of Bill of Materials (BOM) files |
+| POLICY_MANAGEMENT | Allows creation and management of security policies |
+| POLICY_VIOLATION_ANALYSIS | Allows analysis and auditing of policy violations |
+| PORTFOLIO_MANAGEMENT | Allows management of projects and portfolio structure |
+| PROJECT_CREATION_UPLOAD | Allows creation of new projects and upload of BOMs |
+| SYSTEM_CONFIGURATION | Allows modification of system-wide configuration settings |
+| TAG_MANAGEMENT | Allows creation and management of tags |
+| VIEW_BADGES | Allows viewing of project badges |
+| VIEW_POLICY_VIOLATION | Allows viewing of policy violations without auditing them |
+| VULNERABILITY_ANALYSIS | Allows analysis and auditing of vulnerabilities |
+| VULNERABILITY_MANAGEMENT | Allows management of vulnerabilities and findings |
+
+### Recommended Enterprise Role Structure
+
+For enterprise deployments, consider mapping OIDC groups to the following team structure:
+
+| Team | Recommended Permissions |
+|---|---|
+| Security Administrators | ACCESS_MANAGEMENT, SYSTEM_CONFIGURATION, POLICY_MANAGEMENT, PORTFOLIO_MANAGEMENT |
+| Security Analysts | VULNERABILITY_ANALYSIS, POLICY_VIOLATION_ANALYSIS, VIEW_POLICY_VIOLATION |
+| Developers | BOM_UPLOAD, PROJECT_CREATION_UPLOAD, VIEW_BADGES, VIEW_POLICY_VIOLATION |
+| Read Only | VIEW_BADGES, VIEW_POLICY_VIOLATION |
+
+### Mapping Roles in Common Identity Providers
+
+#### Microsoft Entra ID
+
+In Entra ID, create security groups matching your team names (e.g. `DT-Security-Admins`, `DT-Developers`) and assign users to them. 
+In Dependency-Track, navigate to _Administration_ -> _Access Management_ -> _OpenID Connect Groups_ and map each Entra group name to the corresponding Dependency-Track team. Note that Entra ID returns group UUIDs by default — ensure you configure group claims to return group names or use the UUID as the group name in Dependency-Track.
+
+#### Keycloak
+
+In Keycloak, create groups matching your desired team names and assign users accordingly. Use the protocol mapper configuration described in the Keycloak example below to include group memberships in the `groups` claim. Map these group names in Dependency-Track under _Administration_ -> _Access Management_ -> _OpenID Connect Groups_.
+
+#### Okta
+
+In Okta, create groups and assign users. Configure the groups claim in your Okta application to include group memberships. Map the Okta group names to Dependency-Track teams under _Administration_ -> _Access Management_ -> _OpenID Connect Groups_.
+
 ### Example Configurations
 
 Generally, Dependency-Track can be used with any identity provider that implements the [OpenID Connect](https://openid.net/connect/) standard.

--- a/docs/_docs/getting-started/openidconnect-configuration.md
+++ b/docs/_docs/getting-started/openidconnect-configuration.md
@@ -32,45 +32,18 @@ When someone authenticates using OIDC, the claims provided in the ID token or `/
 
 ## Dependency-Track Permission Roles
 
-When mapping OIDC groups to Dependency-Track teams, it is important to understand what permissions each role grants. The following table describes 
-all available permissions in Dependency-Track and their purpose:
+When mapping OIDC groups to Dependency-Track teams, it is important to understand what permissions each role grants. For a full list of available permissions and their descriptions, refer to the [Users and Permissions](../administration/users-and-permissions.md) documentation.
 
-| Permission | Description |
-|---|---|
-| ACCESS_MANAGEMENT | Allows management of users, teams, and permissions |
-| BOM_UPLOAD | Allows uploading of Bill of Materials (BOM) files |
-| POLICY_MANAGEMENT | Allows creation and management of security policies |
-| POLICY_VIOLATION_ANALYSIS | Allows analysis and auditing of policy violations |
-| PORTFOLIO_MANAGEMENT | Allows management of projects and portfolio structure |
-| PROJECT_CREATION_UPLOAD | Allows creation of new projects and upload of BOMs |
-| SYSTEM_CONFIGURATION | Allows modification of system-wide configuration settings |
-| TAG_MANAGEMENT | Allows creation and management of tags |
-| VIEW_BADGES | Allows viewing of project badges |
-| VIEW_POLICY_VIOLATION | Allows viewing of policy violations without auditing them |
-| VULNERABILITY_ANALYSIS | Allows analysis and auditing of vulnerabilities |
-| VULNERABILITY_MANAGEMENT | Allows management of vulnerabilities and findings |
+### Example Enterprise Role Structure
 
-### Recommended Enterprise Role Structure
-
-For enterprise deployments, consider mapping OIDC groups to the following team structure:
+The following is an example role structure for enterprise deployments. Organizations should adapt this to their own needs, as roles may not map cleanly to every environment:
 
 | Team | Recommended Permissions |
 |---|---|
-| Security Administrators | ACCESS_MANAGEMENT, SYSTEM_CONFIGURATION, POLICY_MANAGEMENT, PORTFOLIO_MANAGEMENT |
-| Security Analysts | VULNERABILITY_ANALYSIS, POLICY_VIOLATION_ANALYSIS, VIEW_POLICY_VIOLATION |
-| Developers | BOM_UPLOAD, PROJECT_CREATION_UPLOAD, VIEW_BADGES, VIEW_POLICY_VIOLATION |
-| Read Only | VIEW_BADGES, VIEW_POLICY_VIOLATION |
-
-### Mapping Roles in Common Identity Providers
-
-#### Microsoft Entra ID
-
-In Entra ID, create security groups matching your team names (e.g. `DT-Security-Admins`, `DT-Developers`) and assign users to them. 
-In Dependency-Track, navigate to _Administration_ -> _Access Management_ -> _OpenID Connect Groups_ and map each Entra group name to the corresponding Dependency-Track team. Note that Entra ID returns group UUIDs by default — ensure you configure group claims to return group names or use the UUID as the group name in Dependency-Track.
-
-#### Keycloak
-
-In Keycloak, create groups matching your desired team names and assign users accordingly. Use the protocol mapper configuration described in the Keycloak example below to include group memberships in the `groups` claim. Map these group names in Dependency-Track under _Administration_ -> _Access Management_ -> _OpenID Connect Groups_.
+| Security Administrators | VIEW_PORTFOLIO, ACCESS_MANAGEMENT, SYSTEM_CONFIGURATION, POLICY_MANAGEMENT, PORTFOLIO_MANAGEMENT |
+| Security Analysts |  VIEW_PORTFOLIO, VULNERABILITY_ANALYSIS, POLICY_VIOLATION_ANALYSIS, VIEW_POLICY_VIOLATION |
+| Developers | VIEW_PORTFOLIO, BOM_UPLOAD, PROJECT_CREATION_UPLOAD, VIEW_BADGES, VIEW_POLICY_VIOLATION |
+| Read Only | VIEW_PORTFOLIO, VIEW_BADGES, VIEW_POLICY_VIOLATION |
 
 #### Okta
 
@@ -374,8 +347,7 @@ The following steps demonstrate how to setup OpenID Connect with Microsoft Entra
    - OpenId permissions -> profile
    - GroupMember -> GroupMember.Read.All
   
-5. Note that Entra will return the group UUID in the claims (not the group name). 
-
+5. Note that Entra ID returns group UUIDs in the claims (not the group name). To use group names instead, configure optional claims in your app registration to return `groups` as names. Alternatively, use the group UUID as the group name in Dependency-Track's _Administration_ -> _Access Management_ -> _OpenID Connect Groups_ configuration. 
 
 ### Example setup with AWS Cognito
 

--- a/docs/_docs/getting-started/openidconnect-configuration.md
+++ b/docs/_docs/getting-started/openidconnect-configuration.md
@@ -38,7 +38,7 @@ When mapping OIDC groups to Dependency-Track teams, it is important to understan
 
 The following is an example role structure for enterprise deployments. Organizations should adapt this to their own needs, as roles may not map cleanly to every environment:
 
-| Team | Recommended Permissions |
+| Team | Example Permissions |
 |---|---|
 | Security Administrators | VIEW_PORTFOLIO, ACCESS_MANAGEMENT, SYSTEM_CONFIGURATION, POLICY_MANAGEMENT, PORTFOLIO_MANAGEMENT |
 | Security Analysts |  VIEW_PORTFOLIO, VULNERABILITY_ANALYSIS, POLICY_VIOLATION_ANALYSIS, VIEW_POLICY_VIOLATION |


### PR DESCRIPTION
### Description

Adds a complete permissions roles table to the OIDC configuration documentation, explaining what each Dependency-Track permission grants to authenticated users. Also adds a recommended enterprise role structure and guidance on mapping OIDC groups in Microsoft Entra ID, Keycloak, and Okta.

### Addressed Issue

closes #5841

### Additional Details

The existing documentation explained how to configure OIDC but did not describe what permissions are available in Dependency-Track or how to structure teams for enterprise deployments. This left administrators without guidance on which permissions to assign when mapping identity provider groups to Dependency-Track teams.

This change is documentation only - no code changes.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
