### PR TITLE
Send composer package names with "/" separator to Trivy

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTask.java
@@ -212,8 +212,9 @@ public class TrivyAnalysisTask extends BaseComponentAnalyzerTask implements Subs
                 var name = component.getPurl().getName();
 
                 if (component.getPurl().getNamespace() != null) {
-                    if (PackageURL.StandardTypes.GOLANG.equals(component.getPurl().getType()) || 
-                            PackageURL.StandardTypes.NPM.equals(component.getPurl().getType())) {
+                    if (PackageURL.StandardTypes.GOLANG.equals(component.getPurl().getType()) ||
+                            PackageURL.StandardTypes.NPM.equals(component.getPurl().getType()) ||
+                            PackageURL.StandardTypes.COMPOSER.equals(component.getPurl().getType())) {
                         name = component.getPurl().getNamespace() + "/" + name;
                     } else {
                         name = component.getPurl().getNamespace() + ":" + name;

--- a/src/test/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/TrivyAnalysisTaskTest.java
@@ -494,6 +494,55 @@ class TrivyAnalysisTaskTest extends PersistenceCapableTest {
         assertThat(scanRequest.getOptions().getPkgTypes(0)).isEqualTo("library");
     }
 
+    @Test
+    void testAnalyzeComposerComponentUsesSlashSeparator() throws InvalidProtocolBufferException {
+        stubFor(post(urlPathEqualTo("/twirp/trivy.cache.v1.Cache/PutBlob"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/protobuf")));
+
+        stubFor(post(urlPathEqualTo("/twirp/trivy.scanner.v1.Scanner/Scan"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/protobuf")
+                        .withBody(ScanResponse.newBuilder().build().toByteArray())));
+
+        stubFor(post(urlPathEqualTo("/twirp/trivy.cache.v1.Cache/DeleteBlobs"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")));
+
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.createProject(project, null, false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setGroup("symfony");
+        component.setName("http-foundation");
+        component.setVersion("6.4.15");
+        component.setPurl("pkg:composer/symfony/http-foundation@6.4.15");
+        component = qm.createComponent(component, false);
+
+        new TrivyAnalysisTask().inform(new TrivyAnalysisEvent(
+                List.of(component), VulnerabilityAnalysisLevel.BOM_UPLOAD_ANALYSIS));
+
+        // The PutBlob request body carries the composer coordinate sent to
+        // Trivy. Packagist indexes composer packages as "vendor/package"
+        // (slash), so DT must transmit "symfony/http-foundation" rather than
+        // "symfony:http-foundation" for the Trivy server to match.
+        var putBlobRequests = WireMock.findAll(postRequestedFor(
+                urlPathEqualTo("/twirp/trivy.cache.v1.Cache/PutBlob")));
+        assertThat(putBlobRequests).hasSize(1);
+
+        final trivy.proto.cache.v1.PutBlobRequest putBlobRequest =
+                trivy.proto.cache.v1.PutBlobRequest.parseFrom(putBlobRequests.get(0).getBody());
+        assertThat(putBlobRequest.getBlobInfo().getApplicationsList())
+                .anySatisfy(app -> assertThat(app.getPackagesList())
+                        .anySatisfy(pkg -> assertThat(pkg.getName())
+                                .isEqualTo("symfony/http-foundation")));
+    }
+
     private static final ConcurrentLinkedQueue<Notification> NOTIFICATIONS = new ConcurrentLinkedQueue<>();
 
     public static class NotificationSubscriber implements Subscriber {


### PR DESCRIPTION
Fixes #6054.

  Trivy analyzer was sending composer package coordinates as `vendor:package` (colon) while Packagist and the Trivy composer vulnerability database index them as `vendor/package` (slash). Result: every composer component silently yielded zero vulnerabilities.
                                                                                                                                                                                         
This PR extends the slash-separator handling in `TrivyAnalysisTask` to the `composer` PURL type, mirroring the fix applied to npm in #5679.                                            
   
  ## Changes                                                                                                                                                                             
                  
  - `TrivyAnalysisTask.java`: add `PackageURL.StandardTypes.COMPOSER` to the set of PURL types that use `/` as the namespace/name separator when constructing the name sent to the Trivy server.
  - `TrivyAnalysisTaskTest.java`: add `testAnalyzeComposerComponentUsesSlashSeparator`, which captures the `PutBlob` request body and asserts that the composer coordinate is transmitted as `symfony/http-foundation`, not `symfony:http-foundation`.                                                                                                                          
   
  ## Before / After                                                                                                                                                                      
                  
  Given a single composer component `pkg:composer/symfony/http-foundation@6.4.15` ingested from a CycloneDX BOM:                                                                         
   
  | | Name sent to Trivy | Trivy result |                                                                                                                                                
  |---|---|---|   
  | Before | `symfony:http-foundation` | 0 vulnerabilities |                                                                                                                             
  | After | `symfony/http-foundation` | CVE-2025-64500 matched |                                                                                                                         
                                                                                                                                                                                         
  Verified end-to-end against a production Trivy server (v0.69.3) and Dependency-Track 4.14.1 + this patch applied.                                                                      
                                                                                                                                                                                         
  ## Test plan                                                                                                                                                                           
                  
  - [x] `mvn test -Dtest=TrivyAnalysisTaskTest` passes, including the new test.                                                                                                          
  - [x] Manual upload of a composer-only BOM to a patched DT instance: `analyzerIdentity` is now set to `TRIVY_ANALYZER` and the expected CVE is attached to the component.
  - [x] Regression check on npm-only and maven-only BOMs: no change in behavior for those ecosystems.                                                                                    
                                                                                                                                                                                         
