### PR TITLE
fix: dispatch metrics update for collection parent on project delete

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -1019,6 +1019,16 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
             throw ProjectOperationException.forDeletion(errorByUUID);
         }
 
+        // Collect parent collection projects that need metrics updates after deletion.
+        // Exclude parents that are themselves being deleted.
+        final Set<UUID> collectionParentUuids = projects.stream()
+                .map(Project::getParent)
+                .filter(parent -> parent != null
+                        && parent.getCollectionLogic() != ProjectCollectionLogic.NONE
+                        && uuids.stream().noneMatch(u -> u.equals(parent.getUuid())))
+                .map(Project::getUuid)
+                .collect(Collectors.toSet());
+
         Long[] projectIDsArray = accessibleProjectIds.toArray(Long[]::new);
         String commaSeparatedProjectIDs = accessibleProjectIds.stream().map(String::valueOf).collect(Collectors.joining(","));
         var queryParameter = DbUtil.isMssql() ? commaSeparatedProjectIDs : projectIDsArray;
@@ -1325,6 +1335,10 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                 executeAndCloseWithArray(sqlQuery, queryParameter);
             }
         });
+
+        for (final UUID parentUuid : collectionParentUuids) {
+            Event.dispatch(new ProjectMetricsUpdateEvent(parentUuid));
+        }
     }
 
     /**

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -1037,11 +1037,12 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
 
         // Collect parent collection projects that need metrics updates after deletion.
         // Exclude parents that are themselves being deleted.
+        final Set<UUID> deleteUuids = uuids instanceof Set ? (Set<UUID>) uuids : Set.copyOf(uuids);
         final Set<UUID> collectionParentUuids = projects.stream()
                 .map(Project::getParent)
                 .filter(parent -> parent != null
                         && parent.getCollectionLogic() != ProjectCollectionLogic.NONE
-                        && uuids.stream().noneMatch(u -> u.equals(parent.getUuid())))
+                        && !deleteUuids.contains(parent.getUuid()))
                 .map(Project::getUuid)
                 .collect(Collectors.toSet());
 

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -516,9 +516,16 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         final Project project = getObjectByUuid(Project.class, transientProject.getUuid());
 
         Project oldParent = project.getParent();
+        // Resolve the new parent from DB before making scheduling decisions.
+        // transientProject.getParent() is a stub from the API request with only UUID populated,
+        // so getCollectionLogic() on it always returns NONE.
+        Project resolvedNewParent = null;
+        if (transientProject.getParent() != null && transientProject.getParent().getUuid() != null) {
+            resolvedNewParent = getObjectByUuid(Project.class, transientProject.getParent().getUuid());
+        }
         boolean scheduleProjectMetricsUpdate = this.needScheduleProjectMetricsUpdate(project, transientProject);
-        boolean scheduleParentMetricsUpdate = this.needScheduleParentMetricsUpdate(transientProject, scheduleProjectMetricsUpdate);
-        boolean scheduleOldParentMetricsUpdate = this.needScheduleOldParentMetricsUpdate(oldParent, transientProject);
+        boolean scheduleParentMetricsUpdate = this.needScheduleParentMetricsUpdate(resolvedNewParent, scheduleProjectMetricsUpdate);
+        boolean scheduleOldParentMetricsUpdate = this.needScheduleOldParentMetricsUpdate(oldParent, resolvedNewParent);
 
         project.setAuthors(transientProject.getAuthors());
         project.setPublisher(transientProject.getPublisher());
@@ -557,20 +564,19 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         }
         project.setIsLatest(transientProject.isLatest());
 
-        if (transientProject.getParent() != null && transientProject.getParent().getUuid() != null) {
-            if (project.getUuid().equals(transientProject.getParent().getUuid())){
+        if (resolvedNewParent != null) {
+            if (project.getUuid().equals(resolvedNewParent.getUuid())){
                 throw new IllegalArgumentException("A project cannot select itself as a parent");
             }
-            Project parent = getObjectByUuid(Project.class, transientProject.getParent().getUuid());
-            if (!Boolean.TRUE.equals(parent.isActive())){
+            if (!Boolean.TRUE.equals(resolvedNewParent.isActive())){
                 throw new IllegalArgumentException("An inactive project cannot be selected as a parent");
-            } else if (isChildOf(parent, transientProject.getUuid())){
+            } else if (isChildOf(resolvedNewParent, transientProject.getUuid())){
                 throw new IllegalArgumentException("The new parent project cannot be a child of the current project.");
             } else {
-                project.setParent(parent);
+                project.setParent(resolvedNewParent);
             }
-            project.setParent(parent);
-        }else {
+            project.setParent(resolvedNewParent);
+        } else {
             project.setParent(null);
         }
 
@@ -621,17 +627,17 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
     /**
      * if parent is collection schedule an update, unless this project itself is scheduled already since that will trigger a parent update, too
      */
-    private boolean needScheduleParentMetricsUpdate(Project transientProject, boolean scheduleProjectMetricsUpdate) {
+    private boolean needScheduleParentMetricsUpdate(Project newParent, boolean scheduleProjectMetricsUpdate) {
         return !scheduleProjectMetricsUpdate
-                && transientProject.getParent() != null
-                && transientProject.getParent().getCollectionLogic() != ProjectCollectionLogic.NONE;
+                && newParent != null
+                && newParent.getCollectionLogic() != ProjectCollectionLogic.NONE;
     }
 
     /**
      * if project gets a new parent and old parent was collection, we need to update old parent's metrics
      */
-    private boolean needScheduleOldParentMetricsUpdate(Project oldParent, Project transientProject) {
-        return oldParent != transientProject.getParent()
+    private boolean needScheduleOldParentMetricsUpdate(Project oldParent, Project newParent) {
+        return oldParent != newParent
                 && oldParent != null
                 && oldParent.getCollectionLogic() != ProjectCollectionLogic.NONE;
     }

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -955,7 +955,17 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
      */
     @Override
     public void recursivelyDelete(final Project project, final boolean commitIndex) {
-        Project parent = project.getParent();
+        // Reload the parent with collectionLogic eagerly fetched before any deletions occur.
+        // collectionLogic is not in the default fetch group, so accessing it after the PM
+        // state is modified by cascading deletes risks a silent lazy-load failure (returning NONE).
+        final Project parent;
+        if (project.getParent() != null) {
+            try (var ignored = new ScopedCustomization(pm).withFetchGroup(Project.FetchGroup.METRICS_UPDATE.name())) {
+                parent = pm.getObjectById(Project.class, project.getParent().getId());
+            }
+        } else {
+            parent = null;
+        }
 
         if (project.getChildren() != null) {
             for (final Project child: project.getChildren()) {

--- a/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
@@ -32,7 +32,9 @@ import alpine.event.framework.Event;
 
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.times;
 
@@ -132,4 +134,42 @@ class ProjectQueryManagerTest extends PersistenceCapableTest {
         }
     }
 
+    @Test
+    void testDeleteProjectsByUUIDsDispatchesMetricsUpdateForCollectionParent() {
+        final Project collectionParent = qm.createProject("Collection", null, "1.0", null, null, null, true, false);
+        final Project detachedParent = qm.detach(Project.class, collectionParent.getId());
+        detachedParent.setCollectionLogic(ProjectCollectionLogic.AGGREGATE_DIRECT_CHILDREN);
+        qm.updateProject(detachedParent, false);
+
+        final Project child = qm.createProject("Child", null, "1.0", null, collectionParent, null, true, false);
+
+        try (MockedStatic<Event> mockedEvent = Mockito.mockStatic(Event.class)) {
+            qm.deleteProjectsByUUIDs(List.of(child.getUuid()));
+
+            final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+            mockedEvent.verify(() -> Event.dispatch(eventCaptor.capture()), times(1));
+
+            final List<UUID> dispatchedUuids = eventCaptor.getAllValues().stream()
+                    .filter(e -> e instanceof ProjectMetricsUpdateEvent)
+                    .map(e -> ((ProjectMetricsUpdateEvent) e).getUuid())
+                    .toList();
+            assertThat(dispatchedUuids).containsExactly(collectionParent.getUuid());
+        }
+    }
+
+    @Test
+    void testDeleteProjectsByUUIDsDoesNotDispatchMetricsUpdateWhenParentAlsoDeleted() {
+        final Project collectionParent = qm.createProject("Collection", null, "1.0", null, null, null, true, false);
+        final Project detachedParent = qm.detach(Project.class, collectionParent.getId());
+        detachedParent.setCollectionLogic(ProjectCollectionLogic.AGGREGATE_DIRECT_CHILDREN);
+        qm.updateProject(detachedParent, false);
+
+        final Project child = qm.createProject("Child", null, "1.0", null, collectionParent, null, true, false);
+
+        try (MockedStatic<Event> mockedEvent = Mockito.mockStatic(Event.class)) {
+            qm.deleteProjectsByUUIDs(List.of(collectionParent.getUuid(), child.getUuid()));
+
+            mockedEvent.verify(() -> Event.dispatch(Mockito.any(ProjectMetricsUpdateEvent.class)), times(0));
+        }
+    }
 }

--- a/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
@@ -135,6 +135,29 @@ class ProjectQueryManagerTest extends PersistenceCapableTest {
     }
 
     @Test
+    void testRecursivelyDeleteDispatchesMetricsUpdateForCollectionParent() {
+        final Project collectionParent = qm.createProject("Collection", null, "1.0", null, null, null, true, false);
+        final Project detachedParent = qm.detach(Project.class, collectionParent.getId());
+        detachedParent.setCollectionLogic(ProjectCollectionLogic.AGGREGATE_DIRECT_CHILDREN);
+        qm.updateProject(detachedParent, false);
+
+        final Project child = qm.createProject("Child", null, "1.0", null, collectionParent, null, true, false);
+
+        try (MockedStatic<Event> mockedEvent = Mockito.mockStatic(Event.class)) {
+            qm.recursivelyDelete(child, true);
+
+            final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+            mockedEvent.verify(() -> Event.dispatch(eventCaptor.capture()), Mockito.atLeastOnce());
+
+            final List<UUID> dispatchedUuids = eventCaptor.getAllValues().stream()
+                    .filter(e -> e instanceof ProjectMetricsUpdateEvent)
+                    .map(e -> ((ProjectMetricsUpdateEvent) e).getUuid())
+                    .toList();
+            assertThat(dispatchedUuids).contains(collectionParent.getUuid());
+        }
+    }
+
+    @Test
     void testDeleteProjectsByUUIDsDispatchesMetricsUpdateForCollectionParent() {
         final Project collectionParent = qm.createProject("Collection", null, "1.0", null, null, null, true, false);
         final Project detachedParent = qm.detach(Project.class, collectionParent.getId());

--- a/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
@@ -146,14 +146,11 @@ class ProjectQueryManagerTest extends PersistenceCapableTest {
         try (MockedStatic<Event> mockedEvent = Mockito.mockStatic(Event.class)) {
             qm.deleteProjectsByUUIDs(List.of(child.getUuid()));
 
-            final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+            final ArgumentCaptor<ProjectMetricsUpdateEvent> eventCaptor =
+                    ArgumentCaptor.forClass(ProjectMetricsUpdateEvent.class);
             mockedEvent.verify(() -> Event.dispatch(eventCaptor.capture()), times(1));
 
-            final List<UUID> dispatchedUuids = eventCaptor.getAllValues().stream()
-                    .filter(e -> e instanceof ProjectMetricsUpdateEvent)
-                    .map(e -> ((ProjectMetricsUpdateEvent) e).getUuid())
-                    .toList();
-            assertThat(dispatchedUuids).containsExactly(collectionParent.getUuid());
+            assertThat(eventCaptor.getValue().getUuid()).isEqualTo(collectionParent.getUuid());
         }
     }
 


### PR DESCRIPTION
## Problem

In my DT instance I am observing that collection projects without any children retain their metrics. Although I will probably update my integration scripts to remove these empty projects, I also think DT should handle this correctly w.r.t. the metrics.

When child projects are deleted, any parent collection project retains stale metrics indefinitely — showing non-zero vulnerability counts, risk scores, etc. even after the collection is empty.

## Root cause

Two separate bugs, both in `ProjectQueryManager`:

**1. `recursivelyDelete` (single delete path)**

`recursivelyDelete` captures `project.getParent()` before the cascade, but `collectionLogic` is `@Persistent` without `defaultFetchGroup = "true"` — it is not eagerly loaded. By the time `parent.getCollectionLogic()` is checked at the end of the method, the PM state has been heavily modified by cascading `pm.deletePersistentAll` calls (all joining the same outer transaction from `ProjectResource`). The lazy load silently fails, `getCollectionLogic()` normalises `null` to `NONE`, the condition is false, and `ProjectMetricsUpdateEvent` is never dispatched for the parent collection.

**2. `deleteProjectsByUUIDs` (bulk delete path)**

Uses bulk SQL to remove projects but never dispatches `ProjectMetricsUpdateEvent` for parent collection projects at all.

## Fix

**`recursivelyDelete`:** Reload the parent with the `METRICS_UPDATE` fetch group (which explicitly includes `collectionLogic`) before the deletion cascade begins, so the field is in memory and does not depend on lazy loading through a modified PM state.

**`deleteProjectsByUUIDs`:** Before the SQL deletion runs, collect the UUIDs of any parent collection projects whose children are being deleted (excluding parents that are themselves in the delete set). After the transaction completes, dispatch `ProjectMetricsUpdateEvent` for each of them.

## Why it does not self-correct

One might expect the periodic portfolio metrics recalculation to fix this automatically, but it explicitly **skips collection projects** ([`PortfolioMetricsUpdateTask:179`](src/main/java/org/dependencytrack/tasks/metrics/PortfolioMetricsUpdateTask.java#L179)):

```java
query.setFilter("active && (collectionLogic == null || collectionLogic == 'NONE')");
```

This exclusion is intentional — collection project numbers are derived from their children, not counted independently at portfolio level, to avoid double-counting. The side effect is that a collection project's own `ProjectMetrics` record is **only** updated when a `ProjectMetricsUpdateEvent` is explicitly dispatched for it.

This exclusion is doubtful as I think collection projects also need to have their metrics updated periodically. But it's not straightforward to fix as projects can be nested multiple levels deep.

## Tests

Three new tests added to `ProjectQueryManagerTest`, following the existing `MockedStatic<Event>` + `ArgumentCaptor` pattern:

- **`testRecursivelyDeleteDispatchesMetricsUpdateForCollectionParent`** — verifies that single-deleting a child dispatches a metrics update event for the collection parent.
- **`testDeleteProjectsByUUIDsDispatchesMetricsUpdateForCollectionParent`** — verifies that bulk-deleting a child dispatches a metrics update event for the collection parent.
- **`testDeleteProjectsByUUIDsDoesNotDispatchMetricsUpdateWhenParentAlsoDeleted`** — verifies that no spurious event is dispatched when the parent is also included in the same delete batch.

## Disclaimer
Claude Code was used in the process of creating this PR.