### PR TITLE
Backport: Handle epoch PURL qualifier for version comparison

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/scanners/AbstractVulnerableSoftwareAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/scanners/AbstractVulnerableSoftwareAnalysisTask.java
@@ -173,7 +173,8 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
     }
 
     private boolean comparePurlVersions(PackageURL componentPurl, VulnerableSoftware vs) {
-        if (componentPurl.getVersion() == null) {
+        final String componentVersion = PurlUtil.getEffectiveVersion(componentPurl);
+        if (componentVersion == null) {
             return false;
         }
 
@@ -209,12 +210,10 @@ public abstract class AbstractVulnerableSoftwareAnalysisTask extends BaseCompone
             }
         }
 
-        final String versioningScheme = Optional
-                .ofNullable(componentPurl)
-                .flatMap(KnownVersioningSchemes::fromPurl)
+        final String versioningScheme = KnownVersioningSchemes.fromPurl(componentPurl)
                 .orElse(KnownVersioningSchemes.SCHEME_GENERIC);
 
-        return compareWithVers(vs, componentPurl.getVersion(), versioningScheme);
+        return compareWithVers(vs, componentVersion, versioningScheme);
     }
 
     /**

--- a/src/main/java/org/dependencytrack/util/PurlUtil.java
+++ b/src/main/java/org/dependencytrack/util/PurlUtil.java
@@ -24,10 +24,13 @@ import jakarta.json.Json;
 import org.jspecify.annotations.Nullable;
 
 import java.util.TreeMap;
+import java.util.regex.Pattern;
 
 import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 
 public class PurlUtil {
+
+    private static final Pattern EPOCH_PREFIX_PATTERN = Pattern.compile("^\\d+:");
 
     private PurlUtil() { }
 
@@ -100,6 +103,45 @@ public class PurlUtil {
         }
 
         return null;
+    }
+
+    /**
+     * Returns the PURL's version with any type-specific transformations applied to make it
+     * suitable for ecosystem-aware comparison. Returns the raw version when no transformation
+     * applies, or {@code null} if no version is set.
+     * <p>
+     * Applied transformations:
+     * <ul>
+     *   <li>{@code deb}/{@code rpm}: fold the {@code epoch} qualifier into the version as
+     *       {@code <epoch>:<version>} when not already encoded inline.</li>
+     * </ul>
+     */
+    public static @Nullable String getEffectiveVersion(@Nullable PackageURL purl) {
+        if (purl == null || purl.getVersion() == null) {
+            return null;
+        }
+
+        final String version = purl.getVersion();
+        final String type = purl.getType();
+        if (!PackageURL.StandardTypes.DEBIAN.equals(type)
+                && !PackageURL.StandardTypes.RPM.equals(type)) {
+            return version;
+        }
+
+        if (EPOCH_PREFIX_PATTERN.matcher(version).find()) {
+            return version;
+        }
+
+        if (purl.getQualifiers() == null) {
+            return version;
+        }
+
+        final String epoch = purl.getQualifiers().get("epoch");
+        if (epoch == null || epoch.isBlank()) {
+            return version;
+        }
+
+        return epoch + ":" + version;
     }
 
     public static @Nullable String getDistroQualifier(@Nullable String purl) {

--- a/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskPurlMatchingTest.java
+++ b/src/test/java/org/dependencytrack/tasks/scanners/InternalAnalysisTaskPurlMatchingTest.java
@@ -38,7 +38,9 @@ public class InternalAnalysisTaskPurlMatchingTest extends PersistenceCapableTest
                 Arguments.of("pkg:nuget/System.IO.Packaging", withRange().havingStartIncluding("8.0.0-preview.1.23110.8").havingEndIncluding("8.0.0"), DOES_NOT_MATCH, "pkg:nuget/System.IO.Packaging@8.0.1"),
                 Arguments.of("pkg:composer/typo3/cms-backend", withRange().havingStartIncluding("4.1.0").havingEndExcluding("4.1.13"), DOES_NOT_MATCH, "pkg:composer/typo3/cms-backend@v12.4.44"),
                 Arguments.of("pkg:composer/typo3/cms-backend", withRange().havingStartIncluding("4.3alpha1").havingEndExcluding("4.3beta2"), MATCHES, "pkg:composer/typo3/cms-backend@4.3beta1"),
-                Arguments.of("pkg:composer/typo3/cms-backend", withRange().havingStartIncluding("4.3alpha1").havingEndExcluding("4.3beta2"), DOES_NOT_MATCH, "pkg:composer/typo3/cms-backend@4.3.0")
+                Arguments.of("pkg:composer/typo3/cms-backend", withRange().havingStartIncluding("4.3alpha1").havingEndExcluding("4.3beta2"), DOES_NOT_MATCH, "pkg:composer/typo3/cms-backend@4.3.0"),
+                Arguments.of("pkg:deb/debian/busybox?arch=source&distro=debian-13", withRange().havingEndExcluding("1:1.37.0-1"), DOES_NOT_MATCH, "pkg:deb/debian/busybox@1.37.0-6%2Bb7?arch=amd64&distro=debian-13.4&epoch=1"),
+                Arguments.of("pkg:rpm/redhat/openssl", withRange().havingEndExcluding("1:1.1.1k-7"), DOES_NOT_MATCH, "pkg:rpm/redhat/openssl@1.1.1k-8?epoch=1")
         );
     }
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Handles epoch PURL qualifier for version comparison.

Some BOM generators, including Trivy, omit epochs from the PURLs version field, and instead provide it as `epoch` qualifier. Handle this by prepending the epoch before version comparison if necessary.

Note that we only do this for deb and rpm PURL types for now.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #6081

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
