### PR TITLE
Add project filters to component identity search

### DIFF
--- a/docs/_docs/usage/impact-analysis.md
+++ b/docs/_docs/usage/impact-analysis.md
@@ -33,4 +33,4 @@ Two toggles on the Components search page narrow results during incident respons
 - **Only active projects**: hides components from inactive projects (usually archived).
 - **Only latest project versions**: hides components from older project versions.
 
-Combine both to scope to active, latest-version projects only. They map to the `onlyActive` and `onlyLatestVersion` query parameters on `GET /api/v1/component/identity`.
+Combine both to scope to active, latest-version projects only. They map to the `excludeInactiveProjects` and `onlyLatestProjectVersion` query parameters on `GET /api/v1/component/identity`.

--- a/docs/_docs/usage/impact-analysis.md
+++ b/docs/_docs/usage/impact-analysis.md
@@ -27,3 +27,10 @@ Alternatively, if the component name and version are known, then performing a se
 reveal a list of vulnerabilities, as well as a list of all projects that have a dependency on the component.
 
 ![incident response](/images/screenshots/vulnerable-component.png)
+
+The Components search page exposes two project-scope toggles to narrow results during incident response:
+
+- **Only active projects**: hides components that belong to projects flagged as inactive (typically used for archived projects).
+- **Only latest project versions**: hides components that belong to project versions other than the one flagged as latest.
+
+The toggles can be combined. They map to the `onlyActive` and `onlyLatestVersion` query parameters on `GET /api/v1/component/identity`.

--- a/docs/_docs/usage/impact-analysis.md
+++ b/docs/_docs/usage/impact-analysis.md
@@ -30,7 +30,7 @@ reveal a list of vulnerabilities, as well as a list of all projects that have a 
 
 Two toggles on the Components search page narrow results during incident response:
 
-- **Only active projects**: hides components from inactive projects (usually archived).
-- **Only latest project versions**: hides components from older project versions.
+- **Show inactive projects**: when off, hides components from inactive projects (usually archived). On by default.
+- **Show all project versions**: when off, hides components from project versions not flagged as the latest. On by default.
 
-Combine both to scope to active, latest-version projects only. They map to the `excludeInactiveProjects` and `onlyLatestProjectVersion` query parameters on `GET /api/v1/component/identity`.
+Switch both off to scope to active, latest-version projects only. They map to the `excludeInactiveProjects` and `onlyLatestProjectVersion` query parameters on `GET /api/v1/component/identity`.

--- a/docs/_docs/usage/impact-analysis.md
+++ b/docs/_docs/usage/impact-analysis.md
@@ -31,6 +31,6 @@ reveal a list of vulnerabilities, as well as a list of all projects that have a 
 Two toggles on the Components search page narrow results during incident response:
 
 - **Show inactive projects**: when off, hides components from inactive projects (usually archived). On by default.
-- **Show non-latest project versions**: when off, hides components from project versions not flagged as the latest. On by default.
+- **Only show latest project versions**: when on, hides components from project versions not flagged as the latest. Off by default.
 
-Switch both off to scope to active, latest-version projects only. They map to the `excludeInactiveProjects` and `onlyLatestProjectVersion` query parameters on `GET /api/v1/component/identity`.
+Combine with **Show inactive projects** (off) and **Only show latest project versions** (on) to scope to active, latest-version projects only. They map to the `excludeInactiveProjects` and `onlyLatestProjectVersions` query parameters on `GET /api/v1/component/identity`.

--- a/docs/_docs/usage/impact-analysis.md
+++ b/docs/_docs/usage/impact-analysis.md
@@ -28,9 +28,9 @@ reveal a list of vulnerabilities, as well as a list of all projects that have a 
 
 ![incident response](/images/screenshots/vulnerable-component.png)
 
-The Components search page exposes two project-scope toggles to narrow results during incident response:
+Two toggles on the Components search page narrow results during incident response:
 
-- **Only active projects**: hides components that belong to projects flagged as inactive (typically used for archived projects).
-- **Only latest project versions**: hides components that belong to project versions other than the one flagged as latest.
+- **Only active projects**: hides components from inactive projects (usually archived).
+- **Only latest project versions**: hides components from older project versions.
 
-The toggles can be combined. They map to the `onlyActive` and `onlyLatestVersion` query parameters on `GET /api/v1/component/identity`.
+Combine both to scope to active, latest-version projects only. They map to the `onlyActive` and `onlyLatestVersion` query parameters on `GET /api/v1/component/identity`.

--- a/docs/_docs/usage/impact-analysis.md
+++ b/docs/_docs/usage/impact-analysis.md
@@ -31,6 +31,6 @@ reveal a list of vulnerabilities, as well as a list of all projects that have a 
 Two toggles on the Components search page narrow results during incident response:
 
 - **Show inactive projects**: when off, hides components from inactive projects (usually archived). On by default.
-- **Show all project versions**: when off, hides components from project versions not flagged as the latest. On by default.
+- **Show non-latest project versions**: when off, hides components from project versions not flagged as the latest. On by default.
 
 Switch both off to scope to active, latest-version projects only. They map to the `excludeInactiveProjects` and `onlyLatestProjectVersion` query parameters on `GET /api/v1/component/identity`.

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -251,6 +251,21 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
      * @return a list of components
      */
     public PaginatedResult getComponents(ComponentIdentity identity, Project project, boolean includeMetrics) {
+        return getComponents(identity, project, includeMetrics, false, false);
+    }
+
+    /**
+     * Returns Components by their identity, optionally restricting matches to components whose
+     * project is active and/or flagged as the latest version.
+     * @param identity the ComponentIdentity to query against
+     * @param project The {@link Project} the {@link Component}s shall belong to
+     * @param includeMetrics whether or not to include component metrics or not
+     * @param onlyActive when {@code true}, only components belonging to active projects are returned
+     * @param onlyLatestVersion when {@code true}, only components belonging to projects flagged as latest are returned
+     * @return a list of components
+     */
+    public PaginatedResult getComponents(ComponentIdentity identity, Project project, boolean includeMetrics,
+                                         boolean onlyActive, boolean onlyLatestVersion) {
         if (identity == null) {
             return null;
         }
@@ -261,6 +276,12 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
         if (project != null) {
             queryFilterElements.add(" project == :project ");
             queryParams.put("project", project);
+        }
+        if (onlyActive) {
+            queryFilterElements.add(" project.active == true ");
+        }
+        if (onlyLatestVersion) {
+            queryFilterElements.add(" project.isLatest == true ");
         }
 
         final PaginatedResult result;

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -261,11 +261,11 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
      * @param project the {@link Project} the {@link Component}s belong to
      * @param includeMetrics whether to include component metrics
      * @param excludeInactiveProjects when {@code true}, return only components from active projects
-     * @param onlyLatestProjectVersion when {@code true}, return only components from projects flagged as the latest version
+     * @param onlyLatestProjectVersions when {@code true}, return only components from projects flagged as the latest version
      * @return a list of components
      */
     public PaginatedResult getComponents(ComponentIdentity identity, Project project, boolean includeMetrics,
-                                         boolean excludeInactiveProjects, boolean onlyLatestProjectVersion) {
+                                         boolean excludeInactiveProjects, boolean onlyLatestProjectVersions) {
         if (identity == null) {
             return null;
         }
@@ -280,7 +280,7 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
         if (excludeInactiveProjects) {
             queryFilterElements.add(" project.active == true ");
         }
-        if (onlyLatestProjectVersion) {
+        if (onlyLatestProjectVersions) {
             queryFilterElements.add(" project.isLatest == true ");
         }
 

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -260,12 +260,12 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
      * @param identity the ComponentIdentity to query against
      * @param project the {@link Project} the {@link Component}s belong to
      * @param includeMetrics whether to include component metrics
-     * @param onlyActive when {@code true}, return only components from active projects
-     * @param onlyLatestVersion when {@code true}, return only components from projects flagged as the latest version
+     * @param excludeInactiveProjects when {@code true}, return only components from active projects
+     * @param onlyLatestProjectVersion when {@code true}, return only components from projects flagged as the latest version
      * @return a list of components
      */
     public PaginatedResult getComponents(ComponentIdentity identity, Project project, boolean includeMetrics,
-                                         boolean onlyActive, boolean onlyLatestVersion) {
+                                         boolean excludeInactiveProjects, boolean onlyLatestProjectVersion) {
         if (identity == null) {
             return null;
         }
@@ -277,10 +277,10 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             queryFilterElements.add(" project == :project ");
             queryParams.put("project", project);
         }
-        if (onlyActive) {
+        if (excludeInactiveProjects) {
             queryFilterElements.add(" project.active == true ");
         }
-        if (onlyLatestVersion) {
+        if (onlyLatestProjectVersion) {
             queryFilterElements.add(" project.isLatest == true ");
         }
 

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -255,13 +255,13 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
     }
 
     /**
-     * Returns Components by their identity, optionally restricting matches to components whose
-     * project is active and/or flagged as the latest version.
+     * Returns components by their identity, optionally scoped to active projects, latest-version
+     * projects, or both.
      * @param identity the ComponentIdentity to query against
-     * @param project The {@link Project} the {@link Component}s shall belong to
-     * @param includeMetrics whether or not to include component metrics or not
-     * @param onlyActive when {@code true}, only components belonging to active projects are returned
-     * @param onlyLatestVersion when {@code true}, only components belonging to projects flagged as latest are returned
+     * @param project the {@link Project} the {@link Component}s belong to
+     * @param includeMetrics whether to include component metrics
+     * @param onlyActive when {@code true}, return only components from active projects
+     * @param onlyLatestVersion when {@code true}, return only components from projects flagged as the latest version
      * @return a list of components
      */
     public PaginatedResult getComponents(ComponentIdentity identity, Project project, boolean includeMetrics,

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -568,8 +568,8 @@ public class QueryManager extends AlpineQueryManager {
     }
 
     public PaginatedResult getComponents(ComponentIdentity identity, Project project, boolean includeMetrics,
-                                         boolean excludeInactiveProjects, boolean onlyLatestProjectVersion) {
-        return getComponentQueryManager().getComponents(identity, project, includeMetrics, excludeInactiveProjects, onlyLatestProjectVersion);
+                                         boolean excludeInactiveProjects, boolean onlyLatestProjectVersions) {
+        return getComponentQueryManager().getComponents(identity, project, includeMetrics, excludeInactiveProjects, onlyLatestProjectVersions);
     }
 
     public Component createComponent(Component component, boolean commitIndex) {

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -568,8 +568,8 @@ public class QueryManager extends AlpineQueryManager {
     }
 
     public PaginatedResult getComponents(ComponentIdentity identity, Project project, boolean includeMetrics,
-                                         boolean onlyActive, boolean onlyLatestVersion) {
-        return getComponentQueryManager().getComponents(identity, project, includeMetrics, onlyActive, onlyLatestVersion);
+                                         boolean excludeInactiveProjects, boolean onlyLatestProjectVersion) {
+        return getComponentQueryManager().getComponents(identity, project, includeMetrics, excludeInactiveProjects, onlyLatestProjectVersion);
     }
 
     public Component createComponent(Component component, boolean commitIndex) {

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -567,6 +567,11 @@ public class QueryManager extends AlpineQueryManager {
         return getComponentQueryManager().getComponents(identity, project, includeMetrics);
     }
 
+    public PaginatedResult getComponents(ComponentIdentity identity, Project project, boolean includeMetrics,
+                                         boolean onlyActive, boolean onlyLatestVersion) {
+        return getComponentQueryManager().getComponents(identity, project, includeMetrics, onlyActive, onlyLatestVersion);
+    }
+
     public Component createComponent(Component component, boolean commitIndex) {
         return getComponentQueryManager().createComponent(component, commitIndex);
     }

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -206,7 +206,7 @@ public class ComponentResource extends AlpineResource {
                                            @Parameter(description = "When true, only return components from active projects")
                                            @QueryParam("excludeInactiveProjects") boolean excludeInactiveProjects,
                                            @Parameter(description = "When true, only return components from projects flagged as the latest version")
-                                           @QueryParam("onlyLatestProjectVersion") boolean onlyLatestProjectVersion) {
+                                           @QueryParam("onlyLatestProjectVersions") boolean onlyLatestProjectVersions) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             Project project = null;
             if (projectUuid != null) {
@@ -233,7 +233,7 @@ public class ComponentResource extends AlpineResource {
                     && identity.getPurl() == null && identity.getCpe() == null && identity.getSwidTagId() == null) {
                 return Response.ok().header(TOTAL_COUNT_HEADER, 0).build();
             } else {
-                final PaginatedResult result = qm.getComponents(identity, project, true, excludeInactiveProjects, onlyLatestProjectVersion);
+                final PaginatedResult result = qm.getComponents(identity, project, true, excludeInactiveProjects, onlyLatestProjectVersions);
                 return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
             }
         }

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -202,7 +202,11 @@ public class ComponentResource extends AlpineResource {
                                            @Parameter(description = "The swidTagId of the component")
                                            @QueryParam("swidTagId") String swidTagId,
                                            @Parameter(description = "The project the component belongs to", schema = @Schema(type = "string", format = "uuid"))
-                                           @QueryParam("project") @ValidUuid String projectUuid) {
+                                           @QueryParam("project") @ValidUuid String projectUuid,
+                                           @Parameter(description = "Optionally restrict results to components belonging to active projects only")
+                                           @QueryParam("onlyActive") boolean onlyActive,
+                                           @Parameter(description = "Optionally restrict results to components belonging to projects flagged as latest version only")
+                                           @QueryParam("onlyLatestVersion") boolean onlyLatestVersion) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             Project project = null;
             if (projectUuid != null) {
@@ -229,7 +233,7 @@ public class ComponentResource extends AlpineResource {
                     && identity.getPurl() == null && identity.getCpe() == null && identity.getSwidTagId() == null) {
                 return Response.ok().header(TOTAL_COUNT_HEADER, 0).build();
             } else {
-                final PaginatedResult result = qm.getComponents(identity, project, true);
+                final PaginatedResult result = qm.getComponents(identity, project, true, onlyActive, onlyLatestVersion);
                 return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
             }
         }

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -204,9 +204,9 @@ public class ComponentResource extends AlpineResource {
                                            @Parameter(description = "The project the component belongs to", schema = @Schema(type = "string", format = "uuid"))
                                            @QueryParam("project") @ValidUuid String projectUuid,
                                            @Parameter(description = "When true, only return components from active projects")
-                                           @QueryParam("onlyActive") boolean onlyActive,
+                                           @QueryParam("excludeInactiveProjects") boolean excludeInactiveProjects,
                                            @Parameter(description = "When true, only return components from projects flagged as the latest version")
-                                           @QueryParam("onlyLatestVersion") boolean onlyLatestVersion) {
+                                           @QueryParam("onlyLatestProjectVersion") boolean onlyLatestProjectVersion) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             Project project = null;
             if (projectUuid != null) {
@@ -233,7 +233,7 @@ public class ComponentResource extends AlpineResource {
                     && identity.getPurl() == null && identity.getCpe() == null && identity.getSwidTagId() == null) {
                 return Response.ok().header(TOTAL_COUNT_HEADER, 0).build();
             } else {
-                final PaginatedResult result = qm.getComponents(identity, project, true, onlyActive, onlyLatestVersion);
+                final PaginatedResult result = qm.getComponents(identity, project, true, excludeInactiveProjects, onlyLatestProjectVersion);
                 return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
             }
         }

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -203,9 +203,9 @@ public class ComponentResource extends AlpineResource {
                                            @QueryParam("swidTagId") String swidTagId,
                                            @Parameter(description = "The project the component belongs to", schema = @Schema(type = "string", format = "uuid"))
                                            @QueryParam("project") @ValidUuid String projectUuid,
-                                           @Parameter(description = "Optionally restrict results to components belonging to active projects only")
+                                           @Parameter(description = "When true, only return components from active projects")
                                            @QueryParam("onlyActive") boolean onlyActive,
-                                           @Parameter(description = "Optionally restrict results to components belonging to projects flagged as latest version only")
+                                           @Parameter(description = "When true, only return components from projects flagged as the latest version")
                                            @QueryParam("onlyLatestVersion") boolean onlyLatestVersion) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             Project project = null;

--- a/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
@@ -519,7 +519,7 @@ class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    void getComponentByIdentityOnlyActiveTest() {
+    void getComponentByIdentityExcludeInactiveProjectsTest() {
         final Project activeProject = qm.createProject("activeProject", null, "1.0", null, null, null, true, false);
         var activeComponent = new Component();
         activeComponent.setProject(activeProject);
@@ -540,7 +540,7 @@ class ComponentResourceTest extends ResourceTest {
 
         final Response response = jersey.target(V1_COMPONENT + "/identity")
                 .queryParam("name", "library")
-                .queryParam("onlyActive", "true")
+                .queryParam("excludeInactiveProjects", "true")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -553,7 +553,7 @@ class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    void getComponentByIdentityOnlyLatestVersionTest() {
+    void getComponentByIdentityOnlyLatestProjectVersionTest() {
         final Project latestProject = qm.createProject("latestProject", null, "2.0", null, null, null, true, true, false);
         var latestComponent = new Component();
         latestComponent.setProject(latestProject);
@@ -574,7 +574,7 @@ class ComponentResourceTest extends ResourceTest {
 
         final Response response = jersey.target(V1_COMPONENT + "/identity")
                 .queryParam("name", "library")
-                .queryParam("onlyLatestVersion", "true")
+                .queryParam("onlyLatestProjectVersion", "true")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -587,7 +587,7 @@ class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
-    void getComponentByIdentityOnlyActiveAndLatestVersionTest() {
+    void getComponentByIdentityExcludeInactiveAndOnlyLatestProjectVersionTest() {
         final Project activeLatest = qm.createProject("activeLatest", null, "2.0", null, null, null, true, true, false);
         var activeLatestComponent = new Component();
         activeLatestComponent.setProject(activeLatest);
@@ -617,8 +617,8 @@ class ComponentResourceTest extends ResourceTest {
 
         final Response response = jersey.target(V1_COMPONENT + "/identity")
                 .queryParam("name", "library")
-                .queryParam("onlyActive", "true")
-                .queryParam("onlyLatestVersion", "true")
+                .queryParam("excludeInactiveProjects", "true")
+                .queryParam("onlyLatestProjectVersion", "true")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);

--- a/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
@@ -519,6 +519,118 @@ class ComponentResourceTest extends ResourceTest {
     }
 
     @Test
+    void getComponentByIdentityOnlyActiveTest() {
+        final Project activeProject = qm.createProject("activeProject", null, "1.0", null, null, null, true, false);
+        var activeComponent = new Component();
+        activeComponent.setProject(activeProject);
+        activeComponent.setGroup("acme");
+        activeComponent.setName("library");
+        activeComponent.setVersion("1.0");
+        activeComponent.setPurl("pkg:maven/acme/library@1.0");
+        activeComponent = qm.createComponent(activeComponent, false);
+
+        final Project inactiveProject = qm.createProject("inactiveProject", null, "1.0", null, null, null, false, false);
+        var inactiveComponent = new Component();
+        inactiveComponent.setProject(inactiveProject);
+        inactiveComponent.setGroup("acme");
+        inactiveComponent.setName("library");
+        inactiveComponent.setVersion("1.0");
+        inactiveComponent.setPurl("pkg:maven/acme/library@1.0");
+        qm.createComponent(inactiveComponent, false);
+
+        final Response response = jersey.target(V1_COMPONENT + "/identity")
+                .queryParam("name", "library")
+                .queryParam("onlyActive", "true")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+
+        final JsonArray json = parseJsonArray(response);
+        assertThat(json).hasSize(1);
+        assertThat(json.getJsonObject(0).getString("uuid")).isEqualTo(activeComponent.getUuid().toString());
+    }
+
+    @Test
+    void getComponentByIdentityOnlyLatestVersionTest() {
+        final Project latestProject = qm.createProject("latestProject", null, "2.0", null, null, null, true, true, false);
+        var latestComponent = new Component();
+        latestComponent.setProject(latestProject);
+        latestComponent.setGroup("acme");
+        latestComponent.setName("library");
+        latestComponent.setVersion("1.0");
+        latestComponent.setPurl("pkg:maven/acme/library@1.0");
+        latestComponent = qm.createComponent(latestComponent, false);
+
+        final Project olderProject = qm.createProject("olderProject", null, "1.0", null, null, null, true, false);
+        var olderComponent = new Component();
+        olderComponent.setProject(olderProject);
+        olderComponent.setGroup("acme");
+        olderComponent.setName("library");
+        olderComponent.setVersion("1.0");
+        olderComponent.setPurl("pkg:maven/acme/library@1.0");
+        qm.createComponent(olderComponent, false);
+
+        final Response response = jersey.target(V1_COMPONENT + "/identity")
+                .queryParam("name", "library")
+                .queryParam("onlyLatestVersion", "true")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+
+        final JsonArray json = parseJsonArray(response);
+        assertThat(json).hasSize(1);
+        assertThat(json.getJsonObject(0).getString("uuid")).isEqualTo(latestComponent.getUuid().toString());
+    }
+
+    @Test
+    void getComponentByIdentityOnlyActiveAndLatestVersionTest() {
+        final Project activeLatest = qm.createProject("activeLatest", null, "2.0", null, null, null, true, true, false);
+        var activeLatestComponent = new Component();
+        activeLatestComponent.setProject(activeLatest);
+        activeLatestComponent.setGroup("acme");
+        activeLatestComponent.setName("library");
+        activeLatestComponent.setVersion("1.0");
+        activeLatestComponent.setPurl("pkg:maven/acme/library@1.0");
+        activeLatestComponent = qm.createComponent(activeLatestComponent, false);
+
+        final Project activeOlder = qm.createProject("activeOlder", null, "1.0", null, null, null, true, false);
+        var activeOlderComponent = new Component();
+        activeOlderComponent.setProject(activeOlder);
+        activeOlderComponent.setGroup("acme");
+        activeOlderComponent.setName("library");
+        activeOlderComponent.setVersion("1.0");
+        activeOlderComponent.setPurl("pkg:maven/acme/library@1.0");
+        qm.createComponent(activeOlderComponent, false);
+
+        final Project inactiveLatest = qm.createProject("inactiveLatest", null, "2.0", null, null, null, false, true, false);
+        var inactiveLatestComponent = new Component();
+        inactiveLatestComponent.setProject(inactiveLatest);
+        inactiveLatestComponent.setGroup("acme");
+        inactiveLatestComponent.setName("library");
+        inactiveLatestComponent.setVersion("1.0");
+        inactiveLatestComponent.setPurl("pkg:maven/acme/library@1.0");
+        qm.createComponent(inactiveLatestComponent, false);
+
+        final Response response = jersey.target(V1_COMPONENT + "/identity")
+                .queryParam("name", "library")
+                .queryParam("onlyActive", "true")
+                .queryParam("onlyLatestVersion", "true")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+
+        final JsonArray json = parseJsonArray(response);
+        assertThat(json).hasSize(1);
+        assertThat(json.getJsonObject(0).getString("uuid")).isEqualTo(activeLatestComponent.getUuid().toString());
+    }
+
+    @Test
     void getComponentByHashTest() {
         Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         Component component = new Component();

--- a/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
@@ -574,7 +574,7 @@ class ComponentResourceTest extends ResourceTest {
 
         final Response response = jersey.target(V1_COMPONENT + "/identity")
                 .queryParam("name", "library")
-                .queryParam("onlyLatestProjectVersion", "true")
+                .queryParam("onlyLatestProjectVersions", "true")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -618,7 +618,7 @@ class ComponentResourceTest extends ResourceTest {
         final Response response = jersey.target(V1_COMPONENT + "/identity")
                 .queryParam("name", "library")
                 .queryParam("excludeInactiveProjects", "true")
-                .queryParam("onlyLatestProjectVersion", "true")
+                .queryParam("onlyLatestProjectVersions", "true")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);


### PR DESCRIPTION
### Description

Adds `excludeInactiveProjects` and `onlyLatestProjectVersions` query parameters to `GET /v1/component/identity` so the Components page can filter out archived projects and older versions during portfolio-wide search.

### Addressed Issue

Closes #4570

### Additional Details

The new parameters combine with the existing `project` UUID filter and with all search modes (name, purl, cpe, swidTagId). Both default to `false`, so existing callers see no change.

Naming follows existing conventions in the codebase:

- `excludeInactiveProjects` mirrors `excludeInactive` from `ProjectResource`, `AccessControlResource`, and `VulnerabilityResource`. The `Projects` suffix disambiguates on this `/component` endpoint, where `excludeInactive` could otherwise read as filtering on component state.
- `onlyLatestProjectVersions` mirrors the existing `Policy.onlyLatestProjectVersion` field used by `PolicyEngine` for the same "scope to latest project versions" semantic, in plural form per PR review feedback.

Frontend toggle UI: DependencyTrack/frontend#1505

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~~This PR introduces changes to the database model, and I have added corresponding update logic~~
- [x] This PR introduces new or alters existing behavior, and I have updated the documentation accordingly