### PR TITLE
Expose project created date via API

### DIFF
--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -282,6 +282,14 @@ public class Project implements Serializable {
     private Set<Tag> tags;
 
     /**
+     * Date when the project was created.
+     */
+    @Persistent
+    @Column(name = "CREATED", allowsNull = "true") // New column, must allow nulls on existing databases
+    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.NOT_REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    private Date created;
+
+    /**
      * Convenience field which will contain the date of the last entry in the {@link Bom} table
      */
     @Persistent
@@ -545,6 +553,14 @@ public class Project implements Serializable {
 
     public void setTags(Set<Tag> tags) {
         this.tags = tags;
+    }
+
+    public Date getCreated() {
+        return created;
+    }
+
+    public void setCreated(Date created) {
+        this.created = created;
     }
 
     public Date getLastBomImport() {

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -463,6 +463,9 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         if (project.getParent() != null && !Boolean.TRUE.equals(project.getParent().isActive())){
             throw new IllegalArgumentException("An inactive Parent cannot be selected as parent");
         }
+        if (project.getCreated() == null) {
+            project.setCreated(new Date());
+        }
         final Project oldLatestProject = project.isLatest() ? getLatestProjectVersion(project.getName()) : null;
         final Project result = callInTransaction(() -> {
             // Remove isLatest flag from current latest project version, if the new project will be the latest
@@ -685,6 +688,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                 oldLatestProject.set(null);
             }
             Project project = new Project();
+            project.setCreated(new Date());
             project.setAuthors(source.getAuthors());
             project.setManufacturer(source.getManufacturer());
             project.setSupplier(source.getSupplier());

--- a/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
@@ -33,10 +33,38 @@ import alpine.event.framework.Event;
 import java.util.Date;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.times;
 
 class ProjectQueryManagerTest extends PersistenceCapableTest {
+
+    @Test
+    void testCreateProjectSetsCreatedDate() {
+        final Date before = new Date();
+        Project project = qm.createProject("Example Project", null, "1.0", null, null, null, true, false);
+        final Date after = new Date();
+        assertThat(project.getCreated())
+                .isNotNull()
+                .isBetween(before, after);
+    }
+
+    @Test
+    void testCloneProjectSetsCreatedDate() throws Exception {
+        Project source = qm.createProject("Source", null, "1.0", null, null, null, true, false);
+        // Force an older created date on the source to verify the clone is independent.
+        source.setCreated(new Date(1700000000000L));
+        qm.persist(source);
+
+        final Date before = new Date();
+        Project cloned = qm.clone(source.getUuid(), "1.1.0", false, false,
+                false, false, false, false, false, false);
+        final Date after = new Date();
+
+        assertThat(cloned.getCreated())
+                .isNotNull()
+                .isBetween(before, after);
+    }
 
     @Test
     void testCloneProjectPreservesVulnerabilityAttributionDate() throws Exception {

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -384,6 +384,25 @@ class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
+    void getProjectByUuidExposesCreatedDateTest() {
+        // Issue #6094: GET /api/v1/project/<uuid> must return the project's creation timestamp.
+        final long beforeCreate = System.currentTimeMillis();
+        final Project project = qm.createProject("acme-app", null, "1.0.0", null, null, null, true, false);
+        final long afterCreate = System.currentTimeMillis();
+
+        final Response response = jersey.target(V1_PROJECT + "/" + project.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        final JsonObject json = parseJsonObject(response);
+        assertThat(json.containsKey("created")).isTrue();
+        final long created = json.getJsonNumber("created").longValueExact();
+        assertThat(created).isBetween(beforeCreate, afterCreate);
+    }
+
+    @Test
     void getProjectByUuidNotPermittedTest() {
         enablePortfolioAccessControl();
 
@@ -643,7 +662,8 @@ class ProjectResourceTest extends ResourceTest {
                           "properties": [],
                           "tags": [],
                           "active": true,
-                          "isLatest":false
+                          "isLatest":false,
+                          "created": "${json-unit.any-number}"
                         }
                         """);
 
@@ -690,7 +710,8 @@ class ProjectResourceTest extends ResourceTest {
                           "properties": [],
                           "tags": [],
                           "active": true,
-                          "isLatest":false
+                          "isLatest":false,
+                          "created": "${json-unit.any-number}"
                         }
                         """);
 
@@ -732,7 +753,8 @@ class ProjectResourceTest extends ResourceTest {
                           "properties": [],
                           "tags": [],
                           "active": true,
-                          "isLatest":false
+                          "isLatest":false,
+                          "created": "${json-unit.any-number}"
                         }
                         """);
 
@@ -815,7 +837,8 @@ class ProjectResourceTest extends ResourceTest {
                           "properties": [],
                           "tags": [],
                           "active": true,
-                          "isLatest":false
+                          "isLatest":false,
+                          "created": "${json-unit.any-number}"
                         }
                         """);
 
@@ -926,7 +949,8 @@ class ProjectResourceTest extends ResourceTest {
                           "properties": [],
                           "tags": [],
                           "active": true,
-                          "isLatest":false
+                          "isLatest":false,
+                          "created": "${json-unit.any-number}"
                         }
                         """);
 
@@ -1606,7 +1630,8 @@ class ProjectResourceTest extends ResourceTest {
                           "active": false,
                           "isLatest":false,
                           "children": [],
-                          "collectionLogic":"NONE"
+                          "collectionLogic":"NONE",
+                          "created": "${json-unit.any-number}"
                         }
                         """);
     }
@@ -1680,7 +1705,8 @@ class ProjectResourceTest extends ResourceTest {
                           "tags": [],
                           "active": true,
                           "isLatest":false,
-                          "collectionLogic":"NONE"
+                          "collectionLogic":"NONE",
+                          "created": "${json-unit.any-number}"
                         }
                         """);
 
@@ -2311,7 +2337,8 @@ class ProjectResourceTest extends ResourceTest {
                       "uuid": "${json-unit.any-string}",
                       "active": true,
                       "isLatest":false,
-                      "collectionLogic":"NONE"
+                      "collectionLogic":"NONE",
+                      "created": "${json-unit.any-number}"
                     }
                   ],
                   "properties": [],
@@ -2319,6 +2346,7 @@ class ProjectResourceTest extends ResourceTest {
                   "active": true,
                   "isLatest":false,
                   "collectionLogic":"NONE",
+                  "created": "${json-unit.any-number}",
                   "versions": [
                     {
                       "uuid": "${json-unit.any-string}",
@@ -2351,6 +2379,7 @@ class ProjectResourceTest extends ResourceTest {
                   "active": true,
                   "isLatest":false,
                   "collectionLogic":"NONE",
+                  "created": "${json-unit.any-number}",
                   "versions": [
                     {
                       "uuid": "${json-unit.any-string}",


### PR DESCRIPTION
Resolves #6094.

The `Project` entity did not track a creation timestamp, so `GET /api/v1/project/{uuid}` had no way to surface when a project was first created. This adds a `CREATED` column to the `PROJECT` table and serializes it as `created` (UNIX epoch milliseconds) on `Project` responses, matching the existing convention used by `lastBomImport` and `lastVulnerabilityAnalysis`.

### Changes

- `Project.java`: new `created` field with `@Column(name = "CREATED", allowsNull = "true")` and `@Schema` matching the other epoch-millis date fields. Nullable so existing rows are not affected on schema upgrade.
- `ProjectQueryManager#createProject(Project, Collection<Tag>, boolean)`: stamps `created = new Date()` if not already set.
- `ProjectQueryManager#clone(...)`: stamps `created` on the cloned project (the clone is a new project, so it gets its own creation timestamp rather than inheriting the source's).

No DB migration is included. The column is nullable, so DataNucleus' schema auto-update handles the column add for existing deployments. Existing rows will have `created = null` until they are next written; this is documented above and behaves the same way `lastInheritedRiskScore` and similar additive nullable columns have shipped historically (see `LAST_RISKSCORE` comment in `Project.java`). If maintainers prefer an explicit backfill via an `UpgradeItem`, happy to add one.

### Tests

- `ProjectQueryManagerTest#testCreateProjectSetsCreatedDate` — asserts `createProject(...)` sets `created` to the current time.
- `ProjectQueryManagerTest#testCloneProjectSetsCreatedDate` — asserts a cloned project gets a fresh `created`, not the source's.
- `ProjectResourceTest#getProjectByUuidExposesCreatedDateTest` — asserts `created` is present on `GET /api/v1/project/{uuid}` and is a number within the request window.
- Existing `createProject` and `patchProject` JSON assertions in `ProjectResourceTest` updated to include `"created": "${json-unit.any-number}"`.

Local: `mvn -P enhance test -Dtest='ProjectQueryManagerTest,ProjectResourceTest,ComponentResourceTest,BomResourceTest,BomUploadProcessingTaskTest,WebhookPublisherTest,JiraPublisherTest,ScheduledNotificationDispatchTaskTest'` — all 297 tests pass.

### DCO

Signed-off-by trailer present on the commit.