### PR TITLE
Send groupby to defect dojo

### DIFF
--- a/docs/_docs/integrations/defectdojo.md
+++ b/docs/_docs/integrations/defectdojo.md
@@ -101,3 +101,25 @@ The DefectDojo documentation says 'If no test_title is provided, the latest test
 * Dependency-Track v4.6.0 or higher
 ![Configure Project](/images/screenshots/defectdojo_global_reimport.png)
 Alternatively, you can turn on the above reimport feature for all projects in one click, by checking on 'Enable reimport' box as shown in the screenshot above.
+
+### Step 11: Add per project configuration for finding groups
+
+* Not supported in any release yet
+
+You can define how findings should be grouped into Finding Groups in DefectDojo on import/reimport. This is particularly useful when pushing findings to an issue tracker like Jira, as it allows multiple related findings (e.g. all vulnerabilities in the same component) to be consolidated into a single ticket instead of one ticket per finding.
+
+If this property is not set, no grouping is applied and DefectDojo's default behavior is used.
+
+Supported values are defined by DefectDojo (see [`GROUP_BY_OPTIONS`](https://github.com/DefectDojo/django-DefectDojo/blob/6eab87386d504c4bc164f87b6aae58a8e0c1b8d2/dojo/models.py#L3703) in the DefectDojo source), and currently include:
+
+* `component_name`
+* `component_name+component_version`
+* `file_path`
+* `finding_title`
+
+| Attribute      | Value                                                         |
+|----------------|---------------------------------------------------------------|
+| Group Name     | `integrations`                                                |
+| Property Name  | `defectdojo.groupBy`                                          |
+| Property Value | One of the supported `group_by` values, e.g. `component_name` |
+| Property Type  | `STRING`                                                      |

--- a/docs/_docs/integrations/defectdojo.md
+++ b/docs/_docs/integrations/defectdojo.md
@@ -102,7 +102,7 @@ The DefectDojo documentation says 'If no test_title is provided, the latest test
 ![Configure Project](/images/screenshots/defectdojo_global_reimport.png)
 Alternatively, you can turn on the above reimport feature for all projects in one click, by checking on 'Enable reimport' box as shown in the screenshot above.
 
-### Step 11: Add per project configuration for finding groups
+#### Step 11: Add per project configuration for finding groups
 
 * Not supported in any release yet
 

--- a/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoClient.java
+++ b/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoClient.java
@@ -185,8 +185,7 @@ public class DefectDojoClient {
                 .addPart("push_to_jira", new StringBody("false", ContentType.MULTIPART_FORM_DATA))
                 .addPart("do_not_reactivate", new StringBody(doNotReactivate.toString(), ContentType.MULTIPART_FORM_DATA))
                 .addPart("test", new StringBody(testId, ContentType.MULTIPART_FORM_DATA))
-                .addPart("scan_date", new StringBody(DATE_FORMAT.format(new Date()), ContentType.MULTIPART_FORM_DATA))
-                .build();
+                .addPart("scan_date", new StringBody(DATE_FORMAT.format(new Date()), ContentType.MULTIPART_FORM_DATA));
         if (testTitle != null) {
             builder.addPart("test_title", new StringBody(testTitle, ContentType.MULTIPART_FORM_DATA));
         }

--- a/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoClient.java
+++ b/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoClient.java
@@ -55,7 +55,7 @@ public class DefectDojoClient {
         this.baseURL = baseURL;
     }
 
-    public void uploadDependencyTrackFindings(final String token, final String engagementId, final InputStream findingsJson, final Boolean verifyFindings, final String testTitle) {
+    public void uploadDependencyTrackFindings(final String token, final String engagementId, final InputStream findingsJson, final Boolean verifyFindings, final String testTitle, final String groupBy) {
         LOGGER.debug("Uploading Dependency-Track findings to DefectDojo");
         HttpPost request = new HttpPost(baseURL + "/api/v2/import-scan/");
         InputStreamBody inputStreamBody = new InputStreamBody(findingsJson, ContentType.APPLICATION_OCTET_STREAM, "findings.json");
@@ -72,8 +72,11 @@ public class DefectDojoClient {
                 .addPart("close_old_findings", new StringBody("true", ContentType.MULTIPART_FORM_DATA))
                 .addPart("push_to_jira", new StringBody("false", ContentType.MULTIPART_FORM_DATA))
                 .addPart("scan_date", new StringBody(DATE_FORMAT.format(new Date()), ContentType.MULTIPART_FORM_DATA));
-        if(testTitle != null) {
+        if (testTitle != null) {
             builder.addPart("test_title", new StringBody(testTitle, ContentType.MULTIPART_FORM_DATA));
+        }
+        if (groupBy != null) {
+            builder.addPart("group_by", new StringBody(groupBy, ContentType.MULTIPART_FORM_DATA));
         }
         request.setEntity(builder.build());
         try (CloseableHttpResponse response = HttpClientPool.getClient().execute(request)) {
@@ -164,7 +167,7 @@ public class DefectDojoClient {
      * A Reimport will reuse (overwrite) the existing test, instead of create a new test.
      * The Successfully reimport will also  increase the reimport counter by 1.
      */
-    public void reimportDependencyTrackFindings(final String token, final String engagementId, final InputStream findingsJson, final String testId, final Boolean doNotReactivate, final Boolean verifyFindings, final String testTitle) {
+    public void reimportDependencyTrackFindings(final String token, final String engagementId, final InputStream findingsJson, final String testId, final Boolean doNotReactivate, final Boolean verifyFindings, final String testTitle, final String groupBy) {
         LOGGER.debug("Re-reimport Dependency-Track findings to DefectDojo per Engagement");
         HttpPost request = new HttpPost(baseURL + "/api/v2/reimport-scan/");
         request.addHeader("accept", "application/json");
@@ -184,8 +187,11 @@ public class DefectDojoClient {
                 .addPart("test", new StringBody(testId, ContentType.MULTIPART_FORM_DATA))
                 .addPart("scan_date", new StringBody(DATE_FORMAT.format(new Date()), ContentType.MULTIPART_FORM_DATA))
                 .build();
-        if(testTitle != null) {
+        if (testTitle != null) {
             builder.addPart("test_title", new StringBody(testTitle, ContentType.MULTIPART_FORM_DATA));
+        }
+        if (groupBy != null) {
+            builder.addPart("group_by", new StringBody(groupBy, ContentType.MULTIPART_FORM_DATA));
         }
         request.setEntity(builder.build());
         try (CloseableHttpResponse response = HttpClientPool.getClient().execute(request)) {

--- a/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploader.java
+++ b/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploader.java
@@ -47,6 +47,7 @@ public class DefectDojoUploader extends AbstractIntegrationPoint implements Proj
     private static final String DO_NOT_REACTIVATE_PROPERTY = "defectdojo.doNotReactivate";
     private static final String VERIFIED_PROPERTY = "defectdojo.verified";
     private static final String TEST_TITLE_PROPERTY = "defectdojo.testTitle";
+    private static final String GROUP_BY_PROPERTY = "defectdojo.groupBy";
 
     public boolean isReimportConfigured(final Project project) {
         final ProjectProperty reimport = qm.getProjectProperty(project, DEFECTDOJO_ENABLED.getGroupName(), REIMPORT_PROPERTY);
@@ -80,6 +81,14 @@ public class DefectDojoUploader extends AbstractIntegrationPoint implements Proj
         final ProjectProperty testName = qm.getProjectProperty(project, DEFECTDOJO_ENABLED.getGroupName(), TEST_TITLE_PROPERTY);
         if (testName != null && testName.getPropertyValue() != null) {
             return testName.getPropertyValue();
+        }
+        return null;
+    }
+
+    public String getGroupBy(final Project project) {
+        final ProjectProperty groupBy = qm.getProjectProperty(project, DEFECTDOJO_ENABLED.getGroupName(), GROUP_BY_PROPERTY);
+        if (groupBy != null && groupBy.getPropertyValue() != null) {
+            return groupBy.getPropertyValue();
         }
         return null;
     }
@@ -119,19 +128,21 @@ public class DefectDojoUploader extends AbstractIntegrationPoint implements Proj
         final boolean globalReimportEnabled = qm.isEnabled(DEFECTDOJO_REIMPORT_ENABLED);
         final ProjectProperty engagementId = qm.getProjectProperty(project, DEFECTDOJO_ENABLED.getGroupName(), ENGAGEMENTID_PROPERTY);
         final boolean verifyFindings = isVerifiedConfigured(project);
+        final String testTitle = getTestTitle(project);
+        final String groupBy = getGroupBy(project);
         try {
             final DefectDojoClient client = new DefectDojoClient(this, URI.create(defectDojoUrl.getPropertyValue()).toURL());
             if (isReimportConfigured(project) || globalReimportEnabled) {
                 final ArrayList<String> testsIds = client.getDojoTestIds(apiKey.getPropertyValue(), engagementId.getPropertyValue());
-                final String testId = client.getDojoTestId(engagementId.getPropertyValue(), testsIds, getTestTitle(project));
+                final String testId = client.getDojoTestId(engagementId.getPropertyValue(), testsIds, testTitle);
                 LOGGER.debug("Found existing test Id: " + testId);
                 if (testId.equals("")) {
-                    client.uploadDependencyTrackFindings(apiKey.getPropertyValue(), engagementId.getPropertyValue(), payload, verifyFindings, getTestTitle(project));
+                    client.uploadDependencyTrackFindings(apiKey.getPropertyValue(), engagementId.getPropertyValue(), payload, verifyFindings, testTitle, groupBy);
                 } else {
-                    client.reimportDependencyTrackFindings(apiKey.getPropertyValue(), engagementId.getPropertyValue(), payload, testId, isDoNotReactivateConfigured(project), verifyFindings, getTestTitle(project));
+                    client.reimportDependencyTrackFindings(apiKey.getPropertyValue(), engagementId.getPropertyValue(), payload, testId, isDoNotReactivateConfigured(project), verifyFindings, testTitle, groupBy);
                 }
             } else {
-                client.uploadDependencyTrackFindings(apiKey.getPropertyValue(), engagementId.getPropertyValue(), payload, verifyFindings, getTestTitle(project));
+                client.uploadDependencyTrackFindings(apiKey.getPropertyValue(), engagementId.getPropertyValue(), payload, verifyFindings, testTitle, groupBy);
             }
         } catch (Exception e) {
             LOGGER.error("An error occurred attempting to upload findings to DefectDojo", e);

--- a/src/test/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploaderTest.java
+++ b/src/test/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploaderTest.java
@@ -68,4 +68,28 @@ class DefectDojoUploaderTest extends PersistenceCapableTest {
         Assertions.assertFalse(extension.isProjectConfigured(project));
     }
 
+    @Test
+    void testGetGroupByReturnsNullWhenNotConfigured() {
+        Project project = qm.createProject("ACME Example", null, "1.0", null, null, null, true, false);
+        DefectDojoUploader extension = new DefectDojoUploader();
+        extension.setQueryManager(qm);
+        Assertions.assertNull(extension.getGroupBy(project));
+    }
+
+    @Test
+    void testGetGroupByReturnsValueWhenConfigured() {
+        Project project = qm.createProject("ACME Example", null, "1.0", null, null, null, true, false);
+        qm.createProjectProperty(
+                project,
+                DEFECTDOJO_ENABLED.getGroupName(),
+                "defectdojo.groupBy",
+                "component_name",
+                IConfigProperty.PropertyType.STRING,
+                null
+        );
+        DefectDojoUploader extension = new DefectDojoUploader();
+        extension.setQueryManager(qm);
+        Assertions.assertEquals("component_name", extension.getGroupBy(project));
+    }
+
 }

--- a/src/test/java/org/dependencytrack/tasks/DefectDojoUploadTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/DefectDojoUploadTaskTest.java
@@ -909,6 +909,184 @@ class DefectDojoUploadTaskTest extends PersistenceCapableTest {
                                 """, true, false))));
     }
 
+    @Test
+    void testUploadWithGroupBy() {
+        qm.createConfigProperty(
+                DEFECTDOJO_ENABLED.getGroupName(),
+                DEFECTDOJO_ENABLED.getPropertyName(),
+                "true",
+                DEFECTDOJO_ENABLED.getPropertyType(),
+                null
+        );
+        qm.createConfigProperty(
+                DEFECTDOJO_URL.getGroupName(),
+                DEFECTDOJO_URL.getPropertyName(),
+                wmRuntimeInfo.getHttpBaseUrl(),
+                DEFECTDOJO_URL.getPropertyType(),
+                null
+        );
+        qm.createConfigProperty(
+                DEFECTDOJO_API_KEY.getGroupName(),
+                DEFECTDOJO_API_KEY.getPropertyName(),
+                "dojoApiKey",
+                DEFECTDOJO_API_KEY.getPropertyType(),
+                null
+        );
+        qm.createConfigProperty(
+                DEFECTDOJO_REIMPORT_ENABLED.getGroupName(),
+                DEFECTDOJO_REIMPORT_ENABLED.getPropertyName(),
+                DEFECTDOJO_REIMPORT_ENABLED.getDefaultPropertyValue(),
+                DEFECTDOJO_REIMPORT_ENABLED.getPropertyType(),
+                null
+        );
+
+        stubFor(post(urlPathEqualTo("/api/v2/import-scan/"))
+                .willReturn(aResponse()
+                        .withStatus(201)));
+
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("1.2.3");
+        qm.persist(component);
+
+        qm.createProjectProperty(project, "integrations", "defectdojo.engagementId",
+                "666", IConfigProperty.PropertyType.STRING, null);
+        qm.createProjectProperty(project, "integrations", "defectdojo.groupBy",
+                "component_name", IConfigProperty.PropertyType.STRING, null);
+
+        new DefectDojoUploadTask().inform(new DefectDojoUploadEventAbstract());
+
+        verify(postRequestedFor(urlPathEqualTo("/api/v2/import-scan/"))
+                .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Token dojoApiKey"))
+                .withAnyRequestBodyPart(aMultipart()
+                        .withName("engagement")
+                        .withBody(equalTo("666")))
+                .withAnyRequestBodyPart(aMultipart()
+                        .withName("group_by")
+                        .withBody(equalTo("component_name"))));
+    }
+
+    @Test
+    void testUploadWithReimportAndGroupBy() {
+        qm.createConfigProperty(
+                DEFECTDOJO_ENABLED.getGroupName(),
+                DEFECTDOJO_ENABLED.getPropertyName(),
+                "true",
+                DEFECTDOJO_ENABLED.getPropertyType(),
+                null
+        );
+        qm.createConfigProperty(
+                DEFECTDOJO_URL.getGroupName(),
+                DEFECTDOJO_URL.getPropertyName(),
+                wmRuntimeInfo.getHttpBaseUrl(),
+                DEFECTDOJO_URL.getPropertyType(),
+                null
+        );
+        qm.createConfigProperty(
+                DEFECTDOJO_API_KEY.getGroupName(),
+                DEFECTDOJO_API_KEY.getPropertyName(),
+                "dojoApiKey",
+                DEFECTDOJO_API_KEY.getPropertyType(),
+                null
+        );
+        qm.createConfigProperty(
+                DEFECTDOJO_REIMPORT_ENABLED.getGroupName(),
+                DEFECTDOJO_REIMPORT_ENABLED.getPropertyName(),
+                "false",
+                DEFECTDOJO_REIMPORT_ENABLED.getPropertyType(),
+                null
+        );
+
+        stubFor(get(urlPathEqualTo("/api/v2/tests/"))
+                .withQueryParam("engagement", equalTo("666"))
+                .withQueryParam("limit", equalTo("100"))
+                .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Token dojoApiKey"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                        .withBody("""
+                                {
+                                   "count": 1,
+                                   "next": null,
+                                   "previous": null,
+                                   "results": [
+                                     {
+                                       "id": 1,
+                                       "tags": [],
+                                       "test_type_name": "Dependency Track Finding Packaging Format (FPF) Export",
+                                       "finding_groups": [],
+                                       "scan_type": "Dependency Track Finding Packaging Format (FPF) Export",
+                                       "title": null,
+                                       "description": null,
+                                       "target_start": "2023-04-29T00:00:00Z",
+                                       "target_end": "2023-04-29T21:39:21.513481Z",
+                                       "estimated_time": null,
+                                       "actual_time": null,
+                                       "percent_complete": 100,
+                                       "updated": "2023-04-29T21:39:21.617857Z",
+                                       "created": "2023-04-29T21:39:21.516216Z",
+                                       "version": "",
+                                       "build_id": "",
+                                       "commit_hash": "",
+                                       "branch_tag": "",
+                                       "engagement": 666,
+                                       "lead": 1,
+                                       "test_type": 63,
+                                       "environment": 7,
+                                       "api_scan_configuration": null,
+                                       "notes": [],
+                                       "files": []
+                                     }
+                                   ],
+                                   "prefetch": {}
+                                 }
+                                """)));
+
+        stubFor(post(urlPathEqualTo("/api/v2/reimport-scan/"))
+                .willReturn(aResponse()
+                        .withStatus(201)));
+
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("1.2.3");
+        qm.persist(component);
+
+        qm.createProjectProperty(project, "integrations", "defectdojo.engagementId",
+                "666", IConfigProperty.PropertyType.STRING, null);
+        qm.createProjectProperty(project, "integrations", "defectdojo.reimport",
+                "true", IConfigProperty.PropertyType.BOOLEAN, null);
+        qm.createProjectProperty(project, "integrations", "defectdojo.groupBy",
+                "component_name+component_version", IConfigProperty.PropertyType.STRING, null);
+
+        new DefectDojoUploadTask().inform(new DefectDojoUploadEventAbstract());
+
+        verify(1, getRequestedFor(urlPathEqualTo("/api/v2/tests/")));
+
+        verify(postRequestedFor(urlPathEqualTo("/api/v2/reimport-scan/"))
+                .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Token dojoApiKey"))
+                .withAnyRequestBodyPart(aMultipart()
+                        .withName("engagement")
+                        .withBody(equalTo("666")))
+                .withAnyRequestBodyPart(aMultipart()
+                        .withName("test")
+                        .withBody(equalTo("1")))
+                .withAnyRequestBodyPart(aMultipart()
+                        .withName("group_by")
+                        .withBody(equalTo("component_name+component_version"))));
+    }
+
     /**
      * Un-ignore this test to test the integration against a local DefectDojo deployment.
      * <p>


### PR DESCRIPTION
### Description

DefectDojo's import-scan and reimport-scan endpoints accept a `group_by` parameter that clusters findings into Finding Groups on import, but Dependency-Track never forwarded it. This adds a new per-project property `defectdojo.groupBy` that, when set, is sent as `group_by` in the multipart form for both import and reimport requests.

Also removes a pre-existing dead `.build()` call at the end of the `reimportDependencyTrackFindings` fluent chain whose return value was discarded before `request.setEntity()` was called.

I have verified that after the findings groups are created in Defect Dojo in my own local test environment.

<img width="1692" height="547" alt="bild" src="https://github.com/user-attachments/assets/2477255a-4feb-4723-9e22-8aae9a65bf2f" />
<img width="1832" height="343" alt="bild" src="https://github.com/user-attachments/assets/988a9015-972b-4a03-85d4-2362b59591bf" />


### Addressed Issue

Closes #6061 

### Additional Details

The implementation follows the same pattern as `defectdojo.testTitle` (#4796): a per-project `ProjectProperty` is read in `DefectDojoUploader` and forwarded as a multipart form field in `DefectDojoClient`. No new abstraction was introduced.

The fix to `reimportDependencyTrackFindings` (removing the dangling `.build()` call at the end of the fluent `MultipartEntityBuilder` chain) is included here because it was discovered while adding `group_by` support to that method. It was pre-existing dead code, the return value was discarded and the actual entity was set correctly via a later `builder.build()` call, so it had no runtime effect.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
