### PR TITLE
Extending length of PURL and PURLCOORDINATES columns from 786 to 4096

### DIFF
--- a/docs/_posts/2026-04-03-v4.14.1.md
+++ b/docs/_posts/2026-04-03-v4.14.1.md
@@ -21,6 +21,15 @@ type: patch
 * Avoid NPE when computing Trivy pkgType - [apiserver/#5987]
 * Remove leading whitespace from vulnerability badge SVG template - [apiserver/#6000]
 * Fix Japanese Trivy analyzer strings - [frontend/#1489]
+* Fix inability to store PURLs longer than 4096 characters - [apiserver/#6138]
+
+**Upgrade Notes:**
+
+* The types of the following columns are changed from `VARCHAR(786)` to `VARCHAR(4096)` automatically upon upgrade:
+  * `COMPONENT.PURL`
+  * `COMPONENT.PURLCOORDINATES`
+  * `COMPONENTANALYSISCACHE.TARGET`
+  * `PROJECT.PURL`
 
 For a complete list of changes, refer to the respective GitHub milestones:
 
@@ -70,6 +79,7 @@ Special thanks to everyone who contributed code to implement enhancements and fi
 [apiserver/#5995]: https://github.com/DependencyTrack/dependency-track/pull/5995
 [apiserver/#5996]: https://github.com/DependencyTrack/dependency-track/pull/5996
 [apiserver/#6000]: https://github.com/DependencyTrack/dependency-track/pull/6000
+[apiserver/#6138]: https://github.com/DependencyTrack/dependency-track/pull/6138
 
 [frontend/#1489]: https://github.com/DependencyTrack/frontend/pull/1489
 [frontend/#1490]: https://github.com/DependencyTrack/frontend/pull/1490

--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -305,8 +305,8 @@ public class Component implements Serializable {
 
     @Persistent(defaultFetchGroup = "true")
     @Index(name = "COMPONENT_PURL_IDX")
-    @Column(name = "PURL", length = 786)
-    @Size(max = 786)
+    @Column(name = "PURL", length = 4096)
+    @Size(max = 4096)
     @com.github.packageurl.validator.PackageURL
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Schema(type = "string")
@@ -314,8 +314,8 @@ public class Component implements Serializable {
 
     @Persistent(defaultFetchGroup = "true")
     @Index(name = "COMPONENT_PURL_COORDINATES_IDX")
-    @Column(name = "PURLCOORDINATES", length = 786)
-    @Size(max = 786)
+    @Column(name = "PURLCOORDINATES", length = 4096)
+    @Size(max = 4096)
     @com.github.packageurl.validator.PackageURL
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     private String purlCoordinates; // Field should contain only type, namespace, name, and version. Everything up to the qualifiers

--- a/src/main/java/org/dependencytrack/model/ComponentAnalysisCache.java
+++ b/src/main/java/org/dependencytrack/model/ComponentAnalysisCache.java
@@ -84,7 +84,7 @@ public class ComponentAnalysisCache implements Serializable {
     private String targetType;
 
     @Persistent
-    @Column(name = "TARGET", allowsNull = "false", length = 786)
+    @Column(name = "TARGET", allowsNull = "false", length = 4096)
     @NotNull
     private String target;
 

--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -239,8 +239,8 @@ public class Project implements Serializable {
 
     @Persistent
     @Index(name = "PROJECT_PURL_IDX")
-    @Column(name = "PURL", length = 786)
-    @Size(max = 786)
+    @Column(name = "PURL", length = 4096)
+    @Size(max = 4096)
     @com.github.packageurl.validator.PackageURL
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Schema(type = "string")

--- a/src/main/java/org/dependencytrack/upgrade/v4110/v4110Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v4110/v4110Updater.java
@@ -150,41 +150,41 @@ public class v4110Updater extends AbstractUpgradeItem {
     }
 
     private static void extendPurlColumnLengths(final Connection connection) throws Exception {
-        LOGGER.info("Extending length of PURL and PURLCOORDINATES columns from 255 to 786");
+        LOGGER.info("Extending length of PURL and PURLCOORDINATES columns from 786 to 4096");
         if (DbUtil.isH2() || DbUtil.isPostgreSQL()) {
             try (final Statement statement = connection.createStatement()) {
                 statement.addBatch("""
-                        ALTER TABLE "COMPONENT" ALTER COLUMN "PURL" SET DATA TYPE VARCHAR(786)""");
+                        ALTER TABLE "COMPONENT" ALTER COLUMN "PURL" SET DATA TYPE VARCHAR(4096)""");
                 statement.addBatch("""
-                        ALTER TABLE "COMPONENT" ALTER COLUMN "PURLCOORDINATES" SET DATA TYPE VARCHAR(786)""");
+                        ALTER TABLE "COMPONENT" ALTER COLUMN "PURLCOORDINATES" SET DATA TYPE VARCHAR(4096)""");
                 statement.addBatch("""
-                        ALTER TABLE "COMPONENTANALYSISCACHE" ALTER COLUMN "TARGET" SET DATA TYPE VARCHAR(786)""");
+                        ALTER TABLE "COMPONENTANALYSISCACHE" ALTER COLUMN "TARGET" SET DATA TYPE VARCHAR(4096)""");
                 statement.addBatch("""
-                        ALTER TABLE "PROJECT" ALTER COLUMN "PURL" SET DATA TYPE VARCHAR(786)""");
+                        ALTER TABLE "PROJECT" ALTER COLUMN "PURL" SET DATA TYPE VARCHAR(4096)""");
                 statement.executeBatch();
             }
         } else if (DbUtil.isMssql()) {
             try (final Statement statement = connection.createStatement()) {
                 statement.addBatch("""
-                        ALTER TABLE "COMPONENT" ALTER COLUMN "PURL" VARCHAR(786) NULL""");
+                        ALTER TABLE "COMPONENT" ALTER COLUMN "PURL" VARCHAR(4096) NULL""");
                 statement.addBatch("""
-                        ALTER TABLE "COMPONENT" ALTER COLUMN "PURLCOORDINATES" VARCHAR(786) NULL""");
+                        ALTER TABLE "COMPONENT" ALTER COLUMN "PURLCOORDINATES" VARCHAR(4096) NULL""");
                 statement.addBatch("""
-                        ALTER TABLE "COMPONENTANALYSISCACHE" ALTER COLUMN "TARGET" VARCHAR(786) NOT NULL""");
+                        ALTER TABLE "COMPONENTANALYSISCACHE" ALTER COLUMN "TARGET" VARCHAR(4096) NOT NULL""");
                 statement.addBatch("""
-                        ALTER TABLE "PROJECT" ALTER COLUMN "PURL" VARCHAR(786) NULL""");
+                        ALTER TABLE "PROJECT" ALTER COLUMN "PURL" VARCHAR(4096) NULL""");
                 statement.executeBatch();
             }
         } else if (DbUtil.isMysql()) {
             try (final Statement statement = connection.createStatement()) {
                 statement.addBatch("""
-                        ALTER TABLE "COMPONENT" MODIFY COLUMN "PURL" VARCHAR(786)""");
+                        ALTER TABLE "COMPONENT" MODIFY COLUMN "PURL" VARCHAR(4096)""");
                 statement.addBatch("""
-                        ALTER TABLE "COMPONENT" MODIFY COLUMN "PURLCOORDINATES" VARCHAR(786)""");
+                        ALTER TABLE "COMPONENT" MODIFY COLUMN "PURLCOORDINATES" VARCHAR(4096)""");
                 statement.addBatch("""
-                        ALTER TABLE "COMPONENTANALYSISCACHE" MODIFY COLUMN "TARGET" VARCHAR(786)""");
+                        ALTER TABLE "COMPONENTANALYSISCACHE" MODIFY COLUMN "TARGET" VARCHAR(4096)""");
                 statement.addBatch("""
-                        ALTER TABLE "PROJECT" MODIFY COLUMN "PURL" VARCHAR(786)""");
+                        ALTER TABLE "PROJECT" MODIFY COLUMN "PURL" VARCHAR(4096)""");
                 statement.executeBatch();
             }
         } else {


### PR DESCRIPTION
### Description

Increased the maximum length of the `PURL` and `PURLCOORDINATES` fields.

In some BOM files generated on Windows environments, the `PURL` value can become excessively long — in certain cases exceeding the current limit of 786 characters. As a result, importing such BOM files into DependencyTrack fails with the following error:

> `in column "PURLCOORDINATES" that has maximum length of 786. Please correct your data!`

This fix increases the allowed field length and resolves the issue when importing such BOM files.

A similar issue has also been discussed previously in `#3560`.

### Addressed Issue

fixes #3560

### Additional Details

The issue was reproducible with BOM files generated on Windows, where the path contained in the `PURL` became significantly longer than expected.

Due to the length limitation of the `PURLCOORDINATES` database field, the database rejected the record during BOM import.

This change is limited to increasing the allowed data size and does not affect the existing PURL processing logic.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly