### PR TITLE
Apply OWASP rating from VEX import

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporter.java
@@ -34,6 +34,7 @@ import org.dependencytrack.persistence.command.MakeAnalysisCommand;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -142,9 +143,9 @@ public class CycloneDXVexImporter {
                         vexVulnSource, vexVulnId, vexVulnPos);
                 continue;
             }
-            if (vexVuln.getAnalysis() == null) {
+            if (vexVuln.getAnalysis() == null && findOwaspRating(vexVuln) == null) {
                 LOGGER.debug(
-                        "VEX vulnerability {}/{} at position #{} does not have an analysis; Skipping it",
+                        "VEX vulnerability {}/{} at position #{} does not have an analysis or OWASP rating; Skipping it",
                         vexVulnSource, vexVulnId, vexVulnPos);
                 continue;
             }
@@ -195,38 +196,66 @@ public class CycloneDXVexImporter {
 
     private static void updateAnalysis(final QueryManager qm, final Component component, final Vulnerability vuln,
                                        final org.cyclonedx.model.vulnerability.Vulnerability cdxVuln) {
-        final AnalysisState state =
-                convertCdxVulnAnalysisStateToDtAnalysisState(cdxVuln.getAnalysis().getState());
-        final AnalysisJustification justification =
-                convertCdxVulnAnalysisJustificationToDtAnalysisJustification(cdxVuln.getAnalysis().getJustification());
+        MakeAnalysisCommand command = new MakeAnalysisCommand(component, vuln).withCommenter(COMMENTER);
 
-        // CycloneDX supports multiple responses, DT only one.
-        // The decision to effectively pick the last one is legacy behavior,
-        // there's no other particular reason for doing it.
-        final AnalysisResponse response;
-        if (cdxVuln.getAnalysis().getResponses() != null
-                && !cdxVuln.getAnalysis().getResponses().isEmpty()) {
-            response = cdxVuln.getAnalysis().getResponses().stream()
-                    .map(ModelConverter::convertCdxVulnAnalysisResponseToDtAnalysisResponse)
-                    .toList()
-                    .getLast();
-        } else {
-            response = null;
+        if (cdxVuln.getAnalysis() != null) {
+            final AnalysisState state =
+                    convertCdxVulnAnalysisStateToDtAnalysisState(cdxVuln.getAnalysis().getState());
+            final AnalysisJustification justification =
+                    convertCdxVulnAnalysisJustificationToDtAnalysisJustification(cdxVuln.getAnalysis().getJustification());
+
+            // CycloneDX supports multiple responses, DT only one.
+            // The decision to effectively pick the last one is legacy behavior,
+            // there's no other particular reason for doing it.
+            final AnalysisResponse response;
+            if (cdxVuln.getAnalysis().getResponses() != null
+                    && !cdxVuln.getAnalysis().getResponses().isEmpty()) {
+                response = cdxVuln.getAnalysis().getResponses().stream()
+                        .map(ModelConverter::convertCdxVulnAnalysisResponseToDtAnalysisResponse)
+                        .toList()
+                        .getLast();
+            } else {
+                response = null;
+            }
+
+            final boolean isSuppressed =
+                    state == AnalysisState.FALSE_POSITIVE
+                            || state == AnalysisState.NOT_AFFECTED
+                            || state == AnalysisState.RESOLVED;
+
+            command = command
+                    .withState(state)
+                    .withJustification(justification)
+                    .withResponse(response)
+                    .withDetails(cdxVuln.getAnalysis().getDetail())
+                    .withSuppress(isSuppressed);
         }
 
-        final boolean isSuppressed =
-                state == AnalysisState.FALSE_POSITIVE
-                        || state == AnalysisState.NOT_AFFECTED
-                        || state == AnalysisState.RESOLVED;
+        final org.cyclonedx.model.vulnerability.Vulnerability.Rating owaspRating = findOwaspRating(cdxVuln);
+        if (owaspRating != null) {
+            final BigDecimal score = owaspRating.getScore() != null
+                    ? BigDecimal.valueOf(owaspRating.getScore())
+                    : null;
+            command = command.withOwasp(owaspRating.getVector(), score);
+        }
 
-        qm.makeAnalysis(
-                new MakeAnalysisCommand(component, vuln)
-                        .withState(state)
-                        .withJustification(justification)
-                        .withResponse(response)
-                        .withDetails(cdxVuln.getAnalysis().getDetail())
-                        .withCommenter(COMMENTER)
-                        .withSuppress(isSuppressed));
+        qm.makeAnalysis(command);
+    }
+
+    private static org.cyclonedx.model.vulnerability.Vulnerability.Rating findOwaspRating(
+            final org.cyclonedx.model.vulnerability.Vulnerability cdxVuln) {
+        if (cdxVuln.getRatings() == null) {
+            return null;
+        }
+
+        for (final org.cyclonedx.model.vulnerability.Vulnerability.Rating rating : cdxVuln.getRatings()) {
+            if (rating.getMethod() == org.cyclonedx.model.vulnerability.Vulnerability.Rating.Method.OWASP
+                    && (rating.getVector() != null || rating.getScore() != null)) {
+                return rating;
+            }
+        }
+
+        return null;
     }
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/AnalysisQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/AnalysisQueryManager.java
@@ -31,6 +31,7 @@ import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.notification.JdoNotificationEmitter;
 import org.dependencytrack.notification.NotificationModelConverter;
 import org.dependencytrack.persistence.command.MakeAnalysisCommand;
+import org.dependencytrack.util.AnalysisCommentFormatter.AnalysisCommentField;
 
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
@@ -39,6 +40,7 @@ import java.util.Date;
 import java.util.List;
 
 import static org.dependencytrack.notification.api.NotificationFactory.createVulnerabilityAnalysisDecisionChangeNotification;
+import static org.dependencytrack.util.AnalysisCommentFormatter.formatComment;
 import static org.dependencytrack.util.PersistenceUtil.assertPersistent;
 
 public class AnalysisQueryManager extends QueryManager {
@@ -123,6 +125,15 @@ public class AnalysisQueryManager extends QueryManager {
                 auditTrailComments.add(command.suppress() ? "Suppressed" : "Unsuppressed");
                 analysis.setSuppressed(command.suppress());
                 suppressionChanged = true;
+            }
+            if (command.owaspVector() != null && !command.owaspVector().equals(analysis.getOwaspVector())) {
+                auditTrailComments.add(formatComment(AnalysisCommentField.OWASP_VECTOR, analysis.getOwaspVector(), command.owaspVector()));
+                analysis.setOwaspVector(command.owaspVector());
+            }
+            if (command.owaspScore() != null
+                    && (analysis.getOwaspScore() == null || command.owaspScore().compareTo(analysis.getOwaspScore()) != 0)) {
+                auditTrailComments.add(formatComment(AnalysisCommentField.OWASP_SCORE, analysis.getOwaspScore(), command.owaspScore()));
+                analysis.setOwaspScore(command.owaspScore());
             }
 
             final List<String> comments =

--- a/apiserver/src/main/java/org/dependencytrack/persistence/command/MakeAnalysisCommand.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/command/MakeAnalysisCommand.java
@@ -25,6 +25,7 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.notification.proto.v1.Group;
 
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Set;
 
@@ -40,6 +41,8 @@ import static java.util.Objects.requireNonNull;
  * @param suppress      Whether to suppress the finding
  * @param commenter     Name of the principal on which behalf audit trail entries will be created
  * @param comment       The comment to add to the audit trail
+ * @param owaspVector   The OWASP Risk Rating vector to set
+ * @param owaspScore    The OWASP Risk Rating score to set
  * @param options       Additional options
  * @since 5.0.0
  */
@@ -53,6 +56,8 @@ public record MakeAnalysisCommand(
         Boolean suppress,
         String commenter,
         String comment,
+        String owaspVector,
+        BigDecimal owaspScore,
         Set<Option> options) {
 
     public enum Option {
@@ -77,39 +82,43 @@ public record MakeAnalysisCommand(
     }
 
     public MakeAnalysisCommand(final Component component, final Vulnerability vulnerability) {
-        this(component, vulnerability, null, null, null, null, null, null, null, Collections.emptySet());
+        this(component, vulnerability, null, null, null, null, null, null, null, null, null, Collections.emptySet());
     }
 
     public MakeAnalysisCommand withState(final AnalysisState state) {
-        return new MakeAnalysisCommand(this.component, this.vulnerability, state, this.justification, this.response, this.details, this.suppress, this.commenter, this.comment, this.options);
+        return new MakeAnalysisCommand(this.component, this.vulnerability, state, this.justification, this.response, this.details, this.suppress, this.commenter, this.comment, this.owaspVector, this.owaspScore, this.options);
     }
 
     public MakeAnalysisCommand withJustification(final AnalysisJustification justification) {
-        return new MakeAnalysisCommand(this.component, this.vulnerability, this.state, justification, this.response, this.details, this.suppress, this.commenter, this.comment, this.options);
+        return new MakeAnalysisCommand(this.component, this.vulnerability, this.state, justification, this.response, this.details, this.suppress, this.commenter, this.comment, this.owaspVector, this.owaspScore, this.options);
     }
 
     public MakeAnalysisCommand withResponse(final AnalysisResponse response) {
-        return new MakeAnalysisCommand(this.component, this.vulnerability, this.state, this.justification, response, this.details, this.suppress, this.commenter, this.comment, this.options);
+        return new MakeAnalysisCommand(this.component, this.vulnerability, this.state, this.justification, response, this.details, this.suppress, this.commenter, this.comment, this.owaspVector, this.owaspScore, this.options);
     }
 
     public MakeAnalysisCommand withDetails(final String detail) {
-        return new MakeAnalysisCommand(this.component, this.vulnerability, this.state, this.justification, this.response, detail, this.suppress, this.commenter, this.comment, this.options);
+        return new MakeAnalysisCommand(this.component, this.vulnerability, this.state, this.justification, this.response, detail, this.suppress, this.commenter, this.comment, this.owaspVector, this.owaspScore, this.options);
     }
 
     public MakeAnalysisCommand withSuppress(final Boolean suppress) {
-        return new MakeAnalysisCommand(this.component, this.vulnerability, this.state, this.justification, this.response, this.details, suppress, this.commenter, this.comment, this.options);
+        return new MakeAnalysisCommand(this.component, this.vulnerability, this.state, this.justification, this.response, this.details, suppress, this.commenter, this.comment, this.owaspVector, this.owaspScore, this.options);
     }
 
     public MakeAnalysisCommand withCommenter(final String commenter) {
-        return new MakeAnalysisCommand(this.component, this.vulnerability, this.state, this.justification, this.response, this.details, this.suppress, commenter, this.comment, this.options);
+        return new MakeAnalysisCommand(this.component, this.vulnerability, this.state, this.justification, this.response, this.details, this.suppress, commenter, this.comment, this.owaspVector, this.owaspScore, this.options);
     }
 
     public MakeAnalysisCommand withComment(final String comment) {
-        return new MakeAnalysisCommand(this.component, this.vulnerability, this.state, this.justification, this.response, this.details, this.suppress, this.commenter, comment, this.options);
+        return new MakeAnalysisCommand(this.component, this.vulnerability, this.state, this.justification, this.response, this.details, this.suppress, this.commenter, comment, this.owaspVector, this.owaspScore, this.options);
+    }
+
+    public MakeAnalysisCommand withOwasp(final String owaspVector, final BigDecimal owaspScore) {
+        return new MakeAnalysisCommand(this.component, this.vulnerability, this.state, this.justification, this.response, this.details, this.suppress, this.commenter, this.comment, owaspVector, owaspScore, this.options);
     }
 
     public MakeAnalysisCommand withOptions(final Set<Option> options) {
-        return new MakeAnalysisCommand(this.component, this.vulnerability, this.state, this.justification, this.response, this.details, this.suppress, this.commenter, this.comment, options);
+        return new MakeAnalysisCommand(this.component, this.vulnerability, this.state, this.justification, this.response, this.details, this.suppress, this.commenter, this.comment, this.owaspVector, this.owaspScore, options);
     }
 
 }

--- a/apiserver/src/test/java/org/dependencytrack/notification/ProcessScheduledNotificationRuleActivityTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/notification/ProcessScheduledNotificationRuleActivityTest.java
@@ -102,7 +102,7 @@ class ProcessScheduledNotificationRuleActivityTest extends PersistenceCapableTes
                 null, null, Date.from(afterRuleLastFiredAt));
         qm.makeAnalysis(new MakeAnalysisCommand(
                 parentProjectComponent, vulnB, AnalysisState.FALSE_POSITIVE,
-                null, null, null, true, null, null, Set.of()));
+                null, null, null, true, null, null, null, null, Set.of()));
 
         // Child project affected by vulnA (BEFORE) and vulnB (AFTER).
         final var childProject = new Project();

--- a/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporterTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporterTest.java
@@ -35,6 +35,7 @@ import org.dependencytrack.model.Vulnerability;
 import org.junit.jupiter.api.Test;
 
 import javax.jdo.Query;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -201,6 +202,171 @@ public class CycloneDXVexImporterTest extends PersistenceCapableTest {
         Assertions.assertThat(analysis.getAnalysisComments())
                 .extracting(AnalysisComment::getComment)
                 .containsExactly("Vendor Response: NOT_SET → UPDATE");
+    }
+
+    private static final String OWASP_VECTOR =
+            "OWASP/SL:1/M:1/O:0/S:2/ED:1/EE:1/A:1/ID:1/LC:2/LI:1/LAV:1/LAC:1/FD:1/RD:1/NC:2/PV:3";
+
+    @Test
+    public void shouldApplyOwaspRatingFromVex() throws ParseException {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("Acme Component");
+        component.setVersion("1.0");
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-2099-0001");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setSeverity(Severity.HIGH);
+        vuln.setComponents(List.of(component));
+        qm.persist(vuln);
+
+        qm.addVulnerability(vuln, component, "none");
+
+        final byte[] vexBytes = /* language=JSON */ """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.4",
+                  "version": 1,
+                  "metadata": {
+                    "component": { "type": "application", "bom-ref": "project", "name": "Acme Example", "version": "1.0" }
+                  },
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2099-0001",
+                      "source": { "name": "NVD" },
+                      "analysis": { "state": "exploitable" },
+                      "ratings": [
+                        { "method": "OWASP", "vector": "%s", "score": 7.5 }
+                      ],
+                      "affects": [{ "ref": "project" }]
+                    }
+                  ]
+                }
+                """.formatted(OWASP_VECTOR).getBytes(StandardCharsets.UTF_8);
+        final var vex = BomParserFactory.createParser(vexBytes).parse(vexBytes);
+
+        vexImporter.applyVex(qm, vex, project);
+
+        final Analysis analysis = qm.getAnalysis(component, vuln);
+        Assertions.assertThat(analysis.getOwaspVector()).isEqualTo(OWASP_VECTOR);
+        Assertions.assertThat(analysis.getOwaspScore()).isEqualByComparingTo(new BigDecimal("7.5"));
+        // An OWASP rating import must not override the finding severity; it falls back to the vulnerability.
+        Assertions.assertThat(analysis.getSeverity()).isNull();
+        Assertions.assertThat(analysis.getAnalysisComments())
+                .extracting(AnalysisComment::getComment)
+                .contains(
+                        "OWASP Vector: (None) → " + OWASP_VECTOR,
+                        "OWASP Score: (None) → 7.5");
+    }
+
+    @Test
+    public void shouldApplyOwaspRatingWithoutAnalysisBlock() throws ParseException {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("Acme Component");
+        component.setVersion("1.0");
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-2099-0002");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setSeverity(Severity.HIGH);
+        vuln.setComponents(List.of(component));
+        qm.persist(vuln);
+
+        qm.addVulnerability(vuln, component, "none");
+
+        final byte[] vexBytes = /* language=JSON */ """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.4",
+                  "version": 1,
+                  "metadata": {
+                    "component": { "type": "application", "bom-ref": "project", "name": "Acme Example", "version": "1.0" }
+                  },
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2099-0002",
+                      "source": { "name": "NVD" },
+                      "ratings": [
+                        { "method": "OWASP", "vector": "%s", "score": 4.2 }
+                      ],
+                      "affects": [{ "ref": "project" }]
+                    }
+                  ]
+                }
+                """.formatted(OWASP_VECTOR).getBytes(StandardCharsets.UTF_8);
+        final var vex = BomParserFactory.createParser(vexBytes).parse(vexBytes);
+
+        vexImporter.applyVex(qm, vex, project);
+
+        final Analysis analysis = qm.getAnalysis(component, vuln);
+        Assertions.assertThat(analysis).isNotNull();
+        Assertions.assertThat(analysis.getOwaspVector()).isEqualTo(OWASP_VECTOR);
+        Assertions.assertThat(analysis.getOwaspScore()).isEqualByComparingTo(new BigDecimal("4.2"));
+        Assertions.assertThat(analysis.getAnalysisState()).isEqualTo(AnalysisState.NOT_SET);
+        Assertions.assertThat(analysis.isSuppressed()).isFalse();
+    }
+
+    @Test
+    public void shouldIgnoreNonOwaspRatings() throws ParseException {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("Acme Component");
+        component.setVersion("1.0");
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-2099-0003");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setSeverity(Severity.HIGH);
+        vuln.setComponents(List.of(component));
+        qm.persist(vuln);
+
+        qm.addVulnerability(vuln, component, "none");
+
+        final byte[] vexBytes = /* language=JSON */ """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.4",
+                  "version": 1,
+                  "metadata": {
+                    "component": { "type": "application", "bom-ref": "project", "name": "Acme Example", "version": "1.0" }
+                  },
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2099-0003",
+                      "source": { "name": "NVD" },
+                      "analysis": { "state": "exploitable" },
+                      "ratings": [
+                        { "method": "CVSSv3", "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", "score": 9.8 }
+                      ],
+                      "affects": [{ "ref": "project" }]
+                    }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+        final var vex = BomParserFactory.createParser(vexBytes).parse(vexBytes);
+
+        vexImporter.applyVex(qm, vex, project);
+
+        final Analysis analysis = qm.getAnalysis(component, vuln);
+        Assertions.assertThat(analysis.getOwaspVector()).isNull();
+        Assertions.assertThat(analysis.getOwaspScore()).isNull();
     }
 
 }


### PR DESCRIPTION
### Description

Re-targeting DependencyTrack/hyades-apiserver#1928 here, since v5 dev moved to this repo (asked by @nscuro: https://github.com/DependencyTrack/hyades-apiserver/pull/1928#issuecomment-4577290072).

Same change as the original PR, just rebased on main. Only thing that changed: renamed the migration so it runs after the latest one on main instead of in the middle.

### Addressed Issue

No separate issue — this is the re-target of DependencyTrack/hyades-apiserver#1928 onto this repo, as requested by @nscuro for the v5 GA move.

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
