### PR TITLE
v4-migrator: Fix overly paranoid schema name validation

### DIFF
--- a/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/config/SchemaNameConverter.java
+++ b/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/config/SchemaNameConverter.java
@@ -25,22 +25,25 @@ import java.util.regex.Pattern;
 
 /**
  * Picocli converter for schema-name options. Schema names are splice-formatted into SQL
- * throughout the migrator, so anything outside the unquoted-identifier syntax would allow
- * injection.
+ * throughout the migrator, always inside a double-quoted identifier position ({@code "%s"}),
+ * and in a few preflight probes additionally inside a single-quoted string literal
+ * (e.g. {@code to_regclass('"%s"."PROJECT"')}). The validator therefore accepts the full
+ * quoted-identifier alphabet but rejects characters that could break out of either quoting
+ * layer: the double-quote, the single-quote / apostrophe, NUL, and other control characters.
  *
- * <p>PostgreSQL unquoted-identifier syntax minus the locale-dependent letter ranges: leading
- * letter or underscore, followed by letters, digits, underscores, or {@code $}. Max length
- * 63 bytes ({@code NAMEDATALEN - 1}).
+ * <p>Length is capped at 63 bytes ({@code NAMEDATALEN - 1} on PostgreSQL; SQL Server's 128
+ * limit is a superset).
  */
 public final class SchemaNameConverter implements ITypeConverter<String> {
 
-    private static final Pattern PATTERN = Pattern.compile("^[A-Za-z_][A-Za-z0-9_$]{0,62}$");
+    private static final Pattern PATTERN = Pattern.compile("^[^\"'\\x00-\\x1F\\x7F]{1,63}$");
 
     @Override
     public String convert(final String value) {
         if (value == null || !PATTERN.matcher(value).matches()) {
             throw new TypeConversionException(
-                "must match [A-Za-z_][A-Za-z0-9_$]* and be 1-63 characters; got '" + value + "'");
+                "must be 1-63 characters and contain no quote or control characters; got '"
+                    + value + "'");
         }
         return value;
     }

--- a/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/config/SchemaNameConverterTest.java
+++ b/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/config/SchemaNameConverterTest.java
@@ -30,7 +30,23 @@ class SchemaNameConverterTest {
     private final SchemaNameConverter converter = new SchemaNameConverter();
 
     @ParameterizedTest
-    @ValueSource(strings = {"public", "dbo", "_dt", "DependencyTrack", "a$b", "x1", "dt_v4_migration"})
+    @ValueSource(strings = {
+        "public",
+        "dbo",
+        "_dt",
+        "DependencyTrack",
+        "a$b",
+        "x1",
+        "dt_v4_migration",
+        "custom-schema",
+        "with-dash",
+        "with.dot",
+        "with space",
+        " ",
+        "1leading_digit",
+        "with;semicolon",
+        "foo;DROP TABLE x"
+    })
     void shouldAcceptValidName(final String value) {
         assertThat(converter.convert(value)).isEqualTo(value);
     }
@@ -38,14 +54,11 @@ class SchemaNameConverterTest {
     @ParameterizedTest
     @ValueSource(strings = {
         "",
-        " ",
-        "1leading_digit",
-        "with space",
         "with\"quote",
-        "with;semicolon",
-        "with-dash",
-        "with.dot",
-        "foo;DROP TABLE x",
+        "with'apostrophe",
+        "foo'); DROP TABLE x;--",
+        "with\ttab",
+        "with\nnewline",
         "a234567890123456789012345678901234567890123456789012345678901234"
     })
     void shouldRejectInvalidName(final String value) {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes overly paranoid schema name validation in v4-migrator.

Since we explicitly quote the schema name on all occasions, all special characters outside of `"`, `'`, and control characters are actually valid.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6216

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
