### PR TITLE
Fix e2e tests for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ in the software supply chain. Dependency-Track takes a unique and highly benefic
 capabilities of Software Bill of Materials (SBOM).
 
 [![Build Status](https://github.com/DependencyTrack/dependency-track/actions/workflows/ci-build.yaml/badge.svg)](https://github.com/DependencyTrack/dependency-track/actions/workflows/ci-build.yaml)
+[![Test Status](https://github.com/DependencyTrack/dependency-track/actions/workflows/ci-test.yaml/badge.svg)](https://github.com/DependencyTrack/dependency-track/actions/workflows/ci-test.yaml)
+[![E2E Test Status](https://github.com/DependencyTrack/dependency-track/actions/workflows/ci-test-e2e.yaml/badge.svg)](https://github.com/DependencyTrack/dependency-track/actions/workflows/ci-test-e2e.yaml)
 [![Documentation](https://img.shields.io/badge/docs-next-blue.svg)](https://dependencytrack.github.io/docs/next/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE.txt)
 

--- a/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
@@ -44,9 +44,11 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Collection;
@@ -128,6 +130,14 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
         // host.docker.internal may not always be available, so use testcontainer's
         // solution for host port exposure instead: https://www.testcontainers.org/features/networking/#exposing-host-ports-to-the-container
         Testcontainers.exposeHostPorts(wireMock.getRuntimeInfo().getHttpPort());
+
+        // NB: On Linux, bind mounts preserve host file permissions. @TempDir creates
+        // directories with owner-only perms, which blocks the unprivileged nginx
+        // user inside the container from reading the bundle and causes 403s.
+        // Relax perms where the filesystem supports POSIX.
+        if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+            Files.setPosixFilePermissions(bundleDir, PosixFilePermissions.fromString("rwxr-xr-x"));
+        }
 
         publishPolicyBundle(List.of(POLICY_A, POLICY_B));
 
@@ -344,7 +354,11 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
     private void publishPolicyBundle(final Collection<String> yamlPolicies) throws Exception {
         final Path policyBundlePath = createPolicyBundle(yamlPolicies);
         logger.info("Publishing policy bundle to {}", bundleDir);
-        Files.copy(policyBundlePath, bundleDir.resolve(BUNDLE_FILE_NAME), StandardCopyOption.REPLACE_EXISTING);
+        final Path target = bundleDir.resolve(BUNDLE_FILE_NAME);
+        Files.copy(policyBundlePath, target, StandardCopyOption.REPLACE_EXISTING);
+        if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+            Files.setPosixFilePermissions(target, PosixFilePermissions.fromString("rw-r--r--"));
+        }
     }
 
     private Path createPolicyBundle(final Collection<String> yamlPolicies) throws Exception {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes e2e tests for Linux.

In `VulnerabilityPolicyE2ET`, we mount a file from the host into an NGINX container. This works fine on macOS, but causes issues for Linux due to file permission mismatch between host user and NGINX user.

Also adds README badges for tests and e2e tests.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
