### PR TITLE
Fix lastRiskScore of collection projects missing from project list API endpoints

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/PaginationSupport.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/PaginationSupport.java
@@ -20,6 +20,7 @@ package org.dependencytrack.persistence.jdbi;
 
 import org.dependencytrack.common.pagination.Page.TotalCount;
 import org.jdbi.v3.core.statement.Query;
+import org.jdbi.v3.core.statement.SqlStatements;
 import org.jdbi.v3.sqlobject.SqlObject;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -117,10 +118,24 @@ public interface PaginationSupport extends SqlObject {
                 """);
 
         if (includeAcl) {
-            query.addCustomizer(new DefineApiProjectAclCondition.StatementCustomizer(
-                    JdbiAttributes.ATTRIBUTE_API_PROJECT_ACL_CONDITION,
-                    projectIdColumn));
+            // Only install the secondary ACL customizer when the chosen column
+            // differs from the default. Otherwise the existing condition defined
+            // by ApiRequestStatementCustomizer is already correct and no rewrite is needed.
+            final String defaultProjectIdColumn = getHandle()
+                    .getConfig(ApiRequestConfig.class)
+                    .projectAclProjectIdColumn();
+            if (!projectIdColumn.equals(defaultProjectIdColumn)) {
+                query.addCustomizer(
+                        new DefineApiProjectAclCondition.StatementCustomizer(
+                                JdbiAttributes.ATTRIBUTE_API_PROJECT_ACL_CONDITION,
+                                projectIdColumn));
+            }
         }
+
+        // NB: The count query inherits bindings from the handle's customizer chain
+        // (e.g. pagination offset / limit) and from the threshold bind even when the
+        // template doesn't reference them.
+        query.getConfig(SqlStatements.class).setUnusedBindingAllowed(true);
 
         final long count = query
                 .bindMap(whereParams)

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
@@ -20,8 +20,10 @@ package org.dependencytrack.persistence.jdbi;
 
 import alpine.model.Team;
 import alpine.persistence.PaginatedResult;
-import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.dependencytrack.common.pagination.Page;
+import org.dependencytrack.common.pagination.Page.TotalCount;
 import org.dependencytrack.exception.AlreadyExistsException;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectCollectionLogic;
@@ -36,6 +38,7 @@ import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.mapper.reflect.BeanMapper;
 import org.jdbi.v3.core.mapper.reflect.ColumnName;
 import org.jdbi.v3.core.statement.Query;
+import org.jdbi.v3.core.statement.SqlStatements;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.jdbi.v3.json.Json;
@@ -45,8 +48,8 @@ import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.AllowUnusedBindings;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.BindMap;
 import org.jdbi.v3.sqlobject.customizer.Define;
-import org.jdbi.v3.sqlobject.customizer.DefineNamedBindings;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -56,39 +59,183 @@ import org.postgresql.util.PSQLException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import java.util.function.Supplier;
 
 import static org.dependencytrack.persistence.jdbi.mapping.RowMapperUtil.deserializeJson;
 import static org.dependencytrack.persistence.jdbi.mapping.RowMapperUtil.maybeSet;
+import static org.dependencytrack.util.PersistenceUtil.escapeLikePattern;
 
 /**
  * @since 5.0.0
  */
 @RegisterConstructorMapper(ProjectDao.ConciseProjectListRow.class)
-public interface ProjectDao extends SqlObject {
+public interface ProjectDao extends SqlObject, PaginationSupport {
+
+    /// Aggregates `PROJECTMETRICS` rows of a single collection project's
+    /// descendants into one row. Intended to be embedded as the body of a
+    /// correlated LATERAL subquery.
+    ///
+    /// The outer query must alias the source project as `"PROJECT"` and is
+    /// responsible for the `LEFT JOIN LATERAL (...)` wrapper, as well as
+    /// enforcing portfolio ACL on `"PROJECT"`. Because ACLs are inherited,
+    /// this query does not perform additional ACL checks.
+    ///
+    /// When the outer row is not a collection (`COLLECTION_LOGIC IS NULL`),
+    /// the recursive seed short-circuits, making the impact negligible.
+    ///
+    /// Conceptually similar to [MetricsDao#getMostRecentCollectionProjectMetrics].
+    /// Keep them in sync when the recursion rules change.
+    String COLLECTION_METRICS_SUBQUERY = /* language=SQL */ """
+            WITH RECURSIVE collection_descendants AS (
+              SELECT "PROJECT"."ID" AS root_id
+                   , child."ID" AS project_id
+                   , child."COLLECTION_LOGIC"
+                   , child."COLLECTION_TAG_ID"
+                FROM "PROJECT_HIERARCHY" AS ph
+               INNER JOIN "PROJECT" AS child
+                  ON child."ID" = ph."CHILD_PROJECT_ID"
+                 AND child."INACTIVE_SINCE" IS NULL
+                 AND (
+                   "PROJECT"."COLLECTION_LOGIC" != 'AGGREGATE_DIRECT_CHILDREN_WITH_TAG'
+                   OR EXISTS (
+                     SELECT 1
+                       FROM "PROJECTS_TAGS" AS pt
+                      WHERE pt."PROJECT_ID" = child."ID"
+                        AND pt."TAG_ID" = "PROJECT"."COLLECTION_TAG_ID"
+                   )
+                 )
+                 AND (
+                   "PROJECT"."COLLECTION_LOGIC" != 'AGGREGATE_LATEST_VERSION_CHILDREN'
+                   OR child."IS_LATEST"
+                 )
+               WHERE "PROJECT"."COLLECTION_LOGIC" IS NOT NULL
+                 AND ph."PARENT_PROJECT_ID" = "PROJECT"."ID"
+                 AND ph."DEPTH" = 1
+               UNION ALL
+              SELECT cd.root_id
+                   , child."ID"
+                   , child."COLLECTION_LOGIC"
+                   , child."COLLECTION_TAG_ID"
+                FROM collection_descendants cd
+               INNER JOIN "PROJECT_HIERARCHY" AS ph
+                  ON ph."PARENT_PROJECT_ID" = cd.project_id
+                 AND ph."DEPTH" = 1
+               INNER JOIN "PROJECT" AS child
+                  ON child."ID" = ph."CHILD_PROJECT_ID"
+               WHERE cd."COLLECTION_LOGIC" IS NOT NULL
+                 AND child."INACTIVE_SINCE" IS NULL
+                 AND (
+                   cd."COLLECTION_LOGIC" != 'AGGREGATE_DIRECT_CHILDREN_WITH_TAG'
+                   OR EXISTS (
+                     SELECT 1
+                       FROM "PROJECTS_TAGS" AS pt
+                      WHERE pt."PROJECT_ID" = child."ID"
+                        AND pt."TAG_ID" = cd."COLLECTION_TAG_ID"
+                   )
+                 )
+                 AND (
+                   cd."COLLECTION_LOGIC" != 'AGGREGATE_LATEST_VERSION_CHILDREN'
+                   OR child."IS_LATEST"
+                 )
+            ) CYCLE project_id SET is_cycle USING path
+            SELECT COALESCE(SUM(pm."COMPONENTS"), 0) AS components
+                 , COALESCE(SUM(pm."VULNERABLECOMPONENTS"), 0) AS "vulnerableComponents"
+                 , COALESCE(SUM(pm."VULNERABILITIES"), 0) AS vulnerabilities
+                 , COALESCE(SUM(pm."CRITICAL"), 0) AS critical
+                 , COALESCE(SUM(pm."HIGH"), 0) AS high
+                 , COALESCE(SUM(pm."MEDIUM"), 0) AS medium
+                 , COALESCE(SUM(pm."LOW"), 0) AS low
+                 , COALESCE(SUM(pm."UNASSIGNED_SEVERITY"), 0) AS unassigned
+                 , COALESCE(SUM(pm."RISKSCORE"), 0) AS "inheritedRiskScore"
+                 , COALESCE(SUM(pm."FINDINGS_TOTAL"), 0) AS "findingsTotal"
+                 , COALESCE(SUM(pm."FINDINGS_AUDITED"), 0) AS "findingsAudited"
+                 , COALESCE(SUM(pm."FINDINGS_UNAUDITED"), 0) AS "findingsUnaudited"
+                 , COALESCE(SUM(pm."SUPPRESSED"), 0) AS suppressed
+                 , COALESCE(SUM(pm."POLICYVIOLATIONS_TOTAL"), 0) AS "policyViolationsTotal"
+                 , COALESCE(SUM(pm."POLICYVIOLATIONS_FAIL"), 0) AS "policyViolationsFail"
+                 , COALESCE(SUM(pm."POLICYVIOLATIONS_WARN"), 0) AS "policyViolationsWarn"
+                 , COALESCE(SUM(pm."POLICYVIOLATIONS_INFO"), 0) AS "policyViolationsInfo"
+                 , COALESCE(SUM(pm."POLICYVIOLATIONS_AUDITED"), 0) AS "policyViolationsAudited"
+                 , COALESCE(SUM(pm."POLICYVIOLATIONS_UNAUDITED"), 0) AS "policyViolationsUnaudited"
+                 , COALESCE(SUM(pm."POLICYVIOLATIONS_SECURITY_TOTAL"), 0) AS "policyViolationsSecurityTotal"
+                 , COALESCE(SUM(pm."POLICYVIOLATIONS_SECURITY_AUDITED"), 0) AS "policyViolationsSecurityAudited"
+                 , COALESCE(SUM(pm."POLICYVIOLATIONS_SECURITY_UNAUDITED"), 0) AS "policyViolationsSecurityUnaudited"
+                 , COALESCE(SUM(pm."POLICYVIOLATIONS_LICENSE_TOTAL"), 0) AS "policyViolationsLicenseTotal"
+                 , COALESCE(SUM(pm."POLICYVIOLATIONS_LICENSE_AUDITED"), 0) AS "policyViolationsLicenseAudited"
+                 , COALESCE(SUM(pm."POLICYVIOLATIONS_LICENSE_UNAUDITED"), 0) AS "policyViolationsLicenseUnaudited"
+                 , COALESCE(SUM(pm."POLICYVIOLATIONS_OPERATIONAL_TOTAL"), 0) AS "policyViolationsOperationalTotal"
+                 , COALESCE(SUM(pm."POLICYVIOLATIONS_OPERATIONAL_AUDITED"), 0) AS "policyViolationsOperationalAudited"
+                 , COALESCE(SUM(pm."POLICYVIOLATIONS_OPERATIONAL_UNAUDITED"), 0) AS "policyViolationsOperationalUnaudited"
+                 , MIN(pm."FIRST_OCCURRENCE") AS "firstOccurrence"
+                 , MAX(pm."LAST_OCCURRENCE") AS "lastOccurrence"
+              FROM collection_descendants cd
+              LEFT JOIN LATERAL (
+                SELECT *
+                  FROM "PROJECTMETRICS"
+                 WHERE "PROJECT_ID" = cd.project_id
+                 ORDER BY "LAST_OCCURRENCE" DESC
+                 LIMIT 1
+              ) pm ON TRUE
+             WHERE cd."COLLECTION_LOGIC" IS NULL
+            """;
+
+    /// Selects the most recent `PROJECTMETRICS` row for a single non-collection project.
+    /// Columns are aliased to match the [ProjectMetrics] property names.
+    ///
+    /// The outer query must alias the source project as `"PROJECT"`.
+    String LEAF_METRICS_SUBQUERY = /* language=SQL */ """
+            SELECT "COMPONENTS" AS components
+                 , "VULNERABLECOMPONENTS" AS "vulnerableComponents"
+                 , "VULNERABILITIES" AS vulnerabilities
+                 , "CRITICAL" AS critical
+                 , "HIGH" AS high
+                 , "MEDIUM" AS medium
+                 , "LOW" AS low
+                 , "UNASSIGNED_SEVERITY" AS unassigned
+                 , "RISKSCORE" AS "inheritedRiskScore"
+                 , "FINDINGS_TOTAL" AS "findingsTotal"
+                 , "FINDINGS_AUDITED" AS "findingsAudited"
+                 , "FINDINGS_UNAUDITED" AS "findingsUnaudited"
+                 , "SUPPRESSED" AS suppressed
+                 , "POLICYVIOLATIONS_TOTAL" AS "policyViolationsTotal"
+                 , "POLICYVIOLATIONS_FAIL" AS "policyViolationsFail"
+                 , "POLICYVIOLATIONS_WARN" AS "policyViolationsWarn"
+                 , "POLICYVIOLATIONS_INFO" AS "policyViolationsInfo"
+                 , "POLICYVIOLATIONS_AUDITED" AS "policyViolationsAudited"
+                 , "POLICYVIOLATIONS_UNAUDITED" AS "policyViolationsUnaudited"
+                 , "POLICYVIOLATIONS_SECURITY_TOTAL" AS "policyViolationsSecurityTotal"
+                 , "POLICYVIOLATIONS_SECURITY_AUDITED" AS "policyViolationsSecurityAudited"
+                 , "POLICYVIOLATIONS_SECURITY_UNAUDITED" AS "policyViolationsSecurityUnaudited"
+                 , "POLICYVIOLATIONS_LICENSE_TOTAL" AS "policyViolationsLicenseTotal"
+                 , "POLICYVIOLATIONS_LICENSE_AUDITED" AS "policyViolationsLicenseAudited"
+                 , "POLICYVIOLATIONS_LICENSE_UNAUDITED" AS "policyViolationsLicenseUnaudited"
+                 , "POLICYVIOLATIONS_OPERATIONAL_TOTAL" AS "policyViolationsOperationalTotal"
+                 , "POLICYVIOLATIONS_OPERATIONAL_AUDITED" AS "policyViolationsOperationalAudited"
+                 , "POLICYVIOLATIONS_OPERATIONAL_UNAUDITED" AS "policyViolationsOperationalUnaudited"
+                 , "FIRST_OCCURRENCE" AS "firstOccurrence"
+                 , "LAST_OCCURRENCE" AS "lastOccurrence"
+              FROM "PROJECTMETRICS"
+             WHERE "PROJECTMETRICS"."PROJECT_ID" = "PROJECT"."ID"
+             ORDER BY "PROJECTMETRICS"."LAST_OCCURRENCE" DESC
+             LIMIT 1
+            """;
 
     @SqlQuery(/* language=InjectedFreeMarker */ """
-            <#-- @ftlvariable name="nameFilter" type="Boolean" -->
-            <#-- @ftlvariable name="versionFilter" type="Boolean" -->
-            <#-- @ftlvariable name="classifierFilter" type="Boolean" -->
-            <#-- @ftlvariable name="tagFilter" type="Boolean" -->
-            <#-- @ftlvariable name="teamFilter" type="Boolean" -->
-            <#-- @ftlvariable name="activeFilter" type="Boolean" -->
-            <#-- @ftlvariable name="onlyRootFilter" type="Boolean" -->
-            <#-- @ftlvariable name="parentUuidFilter" type="Boolean" -->
-            <#-- @ftlvariable name="includeMetrics" type="Boolean" -->
-            <#-- @ftlvariable name="apiFilterParameter" type="String" -->
+            <#-- @ftlvariable name="includeMetrics" type="boolean" -->
+            <#-- @ftlvariable name="whereConditions" type="java.util.Collection<String>" -->
+            <#-- @ftlvariable name="collectionMetricsSubquery" type="String" -->
+            <#-- @ftlvariable name="leafMetricsSubquery" type="String" -->
             <#-- @ftlvariable name="apiOrderByClause" type="String" -->
             <#-- @ftlvariable name="apiOffsetLimitClause" type="String" -->
             <#-- @ftlvariable name="apiProjectAclCondition" type="String" -->
-            <#-- @ftlvariable name="apiParentProjectAclCondition" type="String" -->
             SELECT "PROJECT"."ID" AS "id"
                  , "PROJECT"."UUID" AS "uuid"
                  , "GROUP" AS "group"
@@ -99,108 +246,58 @@ public interface ProjectDao extends SqlObject {
                  , "PROJECT"."IS_LATEST" AS "isLatest"
                  , "PROJECT"."COLLECTION_LOGIC" AS "collectionLogic"
                  , "PROJECT"."COLLECTION_TAG_ID" AS "collectionTagId"
-                 , (SELECT ARRAY_AGG("TAG"."NAME")
-                      FROM "TAG"
-                     INNER JOIN "PROJECTS_TAGS"
-                        ON "PROJECTS_TAGS"."TAG_ID" = "TAG"."ID"
-                     WHERE "PROJECTS_TAGS"."PROJECT_ID" = "PROJECT"."ID") AS "tags"
-                 , (SELECT ARRAY_AGG("TEAM"."NAME")
-                      FROM "TEAM"
-                     INNER JOIN "PROJECT_ACCESS_TEAMS"
-                        ON "PROJECT_ACCESS_TEAMS"."TEAM_ID" = "TEAM"."ID"
-                     WHERE "PROJECT_ACCESS_TEAMS"."PROJECT_ID" = "PROJECT"."ID") AS "teams"
+                 , (
+                     SELECT ARRAY_AGG("TAG"."NAME")
+                       FROM "TAG"
+                      INNER JOIN "PROJECTS_TAGS"
+                         ON "PROJECTS_TAGS"."TAG_ID" = "TAG"."ID"
+                      WHERE "PROJECTS_TAGS"."PROJECT_ID" = "PROJECT"."ID"
+                   ) AS "tags"
+                 , (
+                     SELECT ARRAY_AGG("TEAM"."NAME")
+                       FROM "TEAM"
+                      INNER JOIN "PROJECT_ACCESS_TEAMS"
+                         ON "PROJECT_ACCESS_TEAMS"."TEAM_ID" = "TEAM"."ID"
+                      WHERE "PROJECT_ACCESS_TEAMS"."PROJECT_ID" = "PROJECT"."ID"
+                   ) AS "teams"
                  , "PROJECT"."LAST_BOM_IMPORTED" AS "lastBomImport"
                  , "PROJECT"."LAST_BOM_IMPORTED_FORMAT" AS "lastBomImportFormat"
-                 , "PROJECT"."LAST_RISKSCORE" AS "lastRiskScore"
-                 , (SELECT EXISTS(
-                     SELECT 1
-                       FROM "PROJECT" AS "CHILD_PROJECT"
-                      WHERE "CHILD_PROJECT"."PARENT_PROJECT_ID" = "PROJECT"."ID")) AS "hasChildren"
+                 , CASE
+                     WHEN "PROJECT"."COLLECTION_LOGIC" IS NOT NULL
+                     THEN cm."inheritedRiskScore"
+                     ELSE "PROJECT"."LAST_RISKSCORE"
+                   END AS "lastRiskScore"
+                 , (
+                     SELECT EXISTS(
+                       SELECT 1
+                         FROM "PROJECT" AS "CHILD_PROJECT"
+                        WHERE "CHILD_PROJECT"."PARENT_PROJECT_ID" = "PROJECT"."ID")
+                   ) AS "hasChildren"
             <#if includeMetrics>
-                 , (SELECT TO_JSONB(m)
-                      FROM (
-                        SELECT "COMPONENTS"
-                             , "CRITICAL"
-                             , "HIGH"
-                             , "LOW"
-                             , "MEDIUM"
-                             , "POLICYVIOLATIONS_FAIL"
-                             , "POLICYVIOLATIONS_INFO"
-                             , "POLICYVIOLATIONS_LICENSE_TOTAL"
-                             , "POLICYVIOLATIONS_OPERATIONAL_TOTAL"
-                             , "POLICYVIOLATIONS_SECURITY_TOTAL"
-                             , "POLICYVIOLATIONS_TOTAL"
-                             , "POLICYVIOLATIONS_WARN"
-                             , "RISKSCORE"
-                             , "UNASSIGNED_SEVERITY"
-                             , "VULNERABILITIES"
-                          FROM "PROJECTMETRICS"
-                         WHERE "PROJECTMETRICS"."PROJECT_ID" = "PROJECT"."ID"
-                           AND "PROJECT"."COLLECTION_LOGIC" IS NULL
-                         ORDER BY "PROJECTMETRICS"."LAST_OCCURRENCE" DESC
-                         LIMIT 1
-                      ) AS m
-                   ) AS "metrics"
+                 , CASE
+                     WHEN "PROJECT"."COLLECTION_LOGIC" IS NOT NULL
+                     THEN TO_JSONB(cm.*)
+                     ELSE (SELECT TO_JSONB(m) FROM (${leafMetricsSubquery}) AS m)
+                   END AS "metrics"
             </#if>
-                 , COUNT(*) OVER() AS "totalCount"
               FROM "PROJECT"
+            <#--
+                NB: We are forced to do this lateral join unconditionally, because callers expect
+                lastRiskScore to be returned, but collection projects have no precomputed
+                LAST_RISKSCORE column. In a future query backing a hypothetical API v2 endpoint,
+                lastRiskScore should be an expandable field to work around this.
+            -->
+              LEFT JOIN LATERAL (${collectionMetricsSubquery}) AS cm
+                ON "PROJECT"."COLLECTION_LOGIC" IS NOT NULL
              WHERE ${apiProjectAclCondition}
-            <#if nameFilter>
-               AND "PROJECT"."NAME" = :nameFilter
-            </#if>
-            <#if versionFilter>
-               AND "PROJECT"."VERSION" = :versionFilter
-            </#if>
-            <#if classifierFilter>
-               AND "PROJECT"."CLASSIFIER" = :classifierFilter
-            </#if>
-            <#if tagFilter>
-               AND EXISTS(
-                 SELECT 1
-                   FROM "PROJECTS_TAGS"
-                  INNER JOIN "TAG"
-                     ON "TAG"."ID" = "PROJECTS_TAGS"."TAG_ID"
-                  WHERE "PROJECTS_TAGS"."PROJECT_ID" = "PROJECT"."ID"
-                    AND "TAG"."NAME" = :tagFilter)
-            </#if>
-            <#if teamFilter>
-               AND EXISTS(
-                 SELECT 1
-                   FROM "PROJECT_ACCESS_TEAMS"
-                  INNER JOIN "TEAM"
-                     ON "TEAM"."ID" = "PROJECT_ACCESS_TEAMS"."TEAM_ID"
-                  WHERE "PROJECT_ACCESS_TEAMS"."PROJECT_ID" = "PROJECT"."ID"
-                    AND "TEAM"."NAME" = :teamFilter)
-            </#if>
-            <#if activeFilter && activeFilter == true>
-                AND "PROJECT"."INACTIVE_SINCE" IS NULL
-            </#if>
-            <#if onlyRootFilter>
-               AND (NOT :onlyRootFilter OR "PROJECT"."PARENT_PROJECT_ID" IS NULL)
-            <#elseif parentUuidFilter>
-               AND EXISTS(
-                     SELECT 1
-                       FROM "PROJECT" AS "PARENT_PROJECT"
-                      WHERE "PARENT_PROJECT"."ID" = "PROJECT"."PARENT_PROJECT_ID"
-                        AND "PARENT_PROJECT"."UUID" = :parentUuidFilter
-                        AND ${apiParentProjectAclCondition})
-            </#if>
-            <#if apiFilterParameter??>
-               AND (LOWER("PROJECT"."NAME") LIKE ('%' || LOWER(${apiFilterParameter}) || '%')
-                    OR EXISTS (SELECT 1 FROM "TAG" WHERE "TAG"."NAME" = ${apiFilterParameter}))
-            </#if>
+               AND ${whereConditions?join(" AND ")}
             <#if apiOrderByClause??>
               ${apiOrderByClause}
             <#else>
-             ORDER BY "name" ASC, "version" DESC
+             ORDER BY "name", "id"
             </#if>
             ${apiOffsetLimitClause!}
             """)
-    @DefineNamedBindings
-    @DefineApiProjectAclCondition(
-            name = "apiParentProjectAclCondition",
-            projectIdColumn = "\"PARENT_PROJECT\".\"ID\""
-    )
     @AllowApiOrdering(alwaysBy = "id", by = {
             @AllowApiOrdering.Column(name = "id"),
             @AllowApiOrdering.Column(name = "group"),
@@ -213,57 +310,115 @@ public interface ProjectDao extends SqlObject {
             @AllowApiOrdering.Column(name = "lastBomImportFormat"),
             @AllowApiOrdering.Column(name = "lastRiskScore")
     })
+    @AllowUnusedBindings
     List<ConciseProjectListRow> queryPageConcise(
-            @Bind String nameFilter,
-            @Bind String versionFilter,
-            @Bind String classifierFilter,
-            @Bind String tagFilter,
-            @Bind String teamFilter,
-            @Bind Boolean activeFilter,
-            @Bind Boolean onlyRootFilter,
-            @Bind UUID parentUuidFilter,
-            @Define boolean includeMetrics);
+            @Define ArrayList<String> whereConditions,
+            @BindMap Map<String, Object> queryParams,
+            @Define boolean includeMetrics,
+            @Define String collectionMetricsSubquery,
+            @Define String leafMetricsSubquery);
 
-    default List<ConciseProjectListRow> getPageConcise(ListProjectsConciseQuery query) {
-        List<ConciseProjectListRow> rows = queryPageConcise(
-                query.nameFilter(),
-                query.versionFilter(),
-                query.classifierFilter(),
-                query.tagFilter(),
-                query.teamFilter(),
-                query.activeFilter(),
-                query.onlyRootFilter(),
-                query.parentUuidFilter(),
-                query.includeMetrics());
-        if (!query.includeMetrics() || rows.isEmpty()) {
-            return rows;
+    default Page<ConciseProjectListRow> getPageConcise(ListProjectsConciseQuery query) {
+        if (query.parentUuidFilter() != null
+                && !Boolean.TRUE.equals(isAccessible(query.parentUuidFilter()))) {
+            return Page.empty();
         }
 
-        // Metrics of collection projects cannot reasonably be queried inline.
-        // If this result set contains collections, query their metrics separately.
-        // Note that collection metrics are retrieved in bulk, and does not cause N+1.
-        final Set<Long> collectionIds = rows.stream()
-                .filter(row -> row.collectionLogic() != null && row.metrics() == null)
-                .map(ConciseProjectListRow::id)
-                .collect(Collectors.toSet());
-        if (collectionIds.isEmpty()) {
-            return rows;
+        final var whereConditions = new ArrayList<String>();
+        final var queryParams = new HashMap<String, Object>();
+        whereConditions.add("TRUE");
+        if (query.nameFilter() != null) {
+            whereConditions.add("\"PROJECT\".\"NAME\" = :nameFilter");
+            queryParams.put("nameFilter", query.nameFilter());
+        }
+        if (query.versionFilter() != null) {
+            whereConditions.add("\"PROJECT\".\"VERSION\" = :versionFilter");
+            queryParams.put("versionFilter", query.versionFilter());
+        }
+        if (query.classifierFilter() != null) {
+            whereConditions.add("\"PROJECT\".\"CLASSIFIER\" = :classifierFilter");
+            queryParams.put("classifierFilter", query.classifierFilter());
+        }
+        if (query.tagFilter() != null) {
+            whereConditions.add(/* language=SQL */ """
+                    EXISTS (
+                      SELECT 1
+                        FROM "PROJECTS_TAGS"
+                       INNER JOIN "TAG"
+                          ON "TAG"."ID" = "PROJECTS_TAGS"."TAG_ID"
+                       WHERE "PROJECTS_TAGS"."PROJECT_ID" = "PROJECT"."ID"
+                         AND "TAG"."NAME" = :tagFilter
+                    )""");
+            queryParams.put("tagFilter", query.tagFilter());
+        }
+        if (query.teamFilter() != null) {
+            whereConditions.add(/* language=SQL */ """
+                    EXISTS (
+                      SELECT 1
+                        FROM "PROJECT_ACCESS_TEAMS"
+                       INNER JOIN "TEAM"
+                          ON "TEAM"."ID" = "PROJECT_ACCESS_TEAMS"."TEAM_ID"
+                       WHERE "PROJECT_ACCESS_TEAMS"."PROJECT_ID" = "PROJECT"."ID"
+                         AND "TEAM"."NAME" = :teamFilter
+                    )""");
+            queryParams.put("teamFilter", query.teamFilter());
+        }
+        if (Boolean.TRUE.equals(query.activeFilter())) {
+            whereConditions.add("\"PROJECT\".\"INACTIVE_SINCE\" IS NULL");
+        }
+        if (query.onlyRootFilter() != null) {
+            if (query.onlyRootFilter()) {
+                whereConditions.add("\"PROJECT\".\"PARENT_PROJECT_ID\" IS NULL");
+            }
+        } else if (query.parentUuidFilter() != null) {
+            whereConditions.add(/* language=SQL */ """
+                    EXISTS (
+                      SELECT 1
+                        FROM "PROJECT" AS "PARENT_PROJECT"
+                       WHERE "PARENT_PROJECT"."ID" = "PROJECT"."PARENT_PROJECT_ID"
+                         AND "PARENT_PROJECT"."UUID" = :parentUuidFilter
+                    )""");
+            queryParams.put("parentUuidFilter", query.parentUuidFilter());
+        }
+        if (query.searchText() != null) {
+            whereConditions.add(/* language=SQL */ """
+                    (
+                      LOWER("PROJECT"."NAME") LIKE ('%' || LOWER(:searchTextLike) || '%') ESCAPE '!'
+                      OR EXISTS (
+                        SELECT 1
+                          FROM "PROJECTS_TAGS"
+                         INNER JOIN "TAG"
+                            ON "TAG"."ID" = "PROJECTS_TAGS"."TAG_ID"
+                         WHERE "PROJECTS_TAGS"."PROJECT_ID" = "PROJECT"."ID"
+                           AND "TAG"."NAME" = :searchText
+                      )
+                    )""");
+            queryParams.put("searchText", query.searchText());
+            queryParams.put("searchTextLike", escapeLikePattern(query.searchText()));
         }
 
-        final Map<Long, ProjectMetrics> collectionMetricsById = getHandle()
-                .attach(MetricsDao.class)
-                .getMostRecentCollectionProjectMetrics(collectionIds)
-                .stream()
-                .collect(Collectors.toMap(ProjectMetrics::getProjectId, Function.identity()));
+        return withJitDisabled(() -> {
+            // NB: Count is executed separately from the main query, because including
+            // `COUNT(*) OVER()` in the main query forces Postgres to materialize all rows,
+            // including LATERAL joins *BEFORE* applying filters and limits.
+            //
+            // Since calculating metrics for collection projects requires recursive subqueries,
+            // this would be extremely expensive. Counting in a separate query bypasses this.
+            final TotalCount totalCount = getBoundedTotalCountWithProjectAcl(
+                    "FROM \"PROJECT\" WHERE " + String.join(" AND ", whereConditions),
+                    queryParams,
+                    /* threshold */ null,
+                    "\"PROJECT\".\"ID\"");
 
-        return rows.stream()
-                .map(row -> {
-                    final ProjectMetrics pm = collectionMetricsById.get(row.id());
-                    return pm != null
-                            ? row.withMetrics(ConciseProjectMetricsRow.of(pm))
-                            : row;
-                })
-                .toList();
+            final List<ConciseProjectListRow> rows = queryPageConcise(
+                    whereConditions,
+                    queryParams,
+                    query.includeMetrics(),
+                    COLLECTION_METRICS_SUBQUERY,
+                    LEAF_METRICS_SUBQUERY);
+
+            return new Page<>(rows, /* nextPageToken */ null, totalCount);
+        });
     }
 
     record ConciseProjectListRow(
@@ -283,86 +438,36 @@ public interface ProjectDao extends SqlObject {
             @Nullable String lastBomImportFormat,
             @Nullable Double lastRiskScore,
             boolean hasChildren,
-            @Nullable @Json ConciseProjectMetricsRow metrics,
-            long totalCount) {
-
-        ConciseProjectListRow withMetrics(@Nullable ConciseProjectMetricsRow metrics) {
-            return new ConciseProjectListRow(
-                    this.id,
-                    this.uuid,
-                    this.group,
-                    this.name,
-                    this.version,
-                    this.classifier,
-                    this.inactiveSince,
-                    this.isLatest,
-                    this.collectionLogic,
-                    this.collectionTagId,
-                    this.tags,
-                    this.teams,
-                    this.lastBomImport,
-                    this.lastBomImportFormat,
-                    this.lastRiskScore,
-                    this.hasChildren,
-                    metrics,
-                    this.totalCount);
-        }
-
+            @Nullable @Json ConciseProjectMetricsRow metrics) {
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     record ConciseProjectMetricsRow(
             int components,
             int critical,
             int high,
             int low,
             int medium,
-            @JsonAlias("policyviolations_fail") int policyViolationsFail,
-            @JsonAlias("policyviolations_info") int policyViolationsInfo,
-            @JsonAlias("policyviolations_license_total") int policyViolationsLicenseTotal,
-            @JsonAlias("policyviolations_operational_total") int policyViolationsOperationalTotal,
-            @JsonAlias("policyviolations_security_total") int policyViolationsSecurityTotal,
-            @JsonAlias("policyviolations_total") int policyViolationsTotal,
-            @JsonAlias("policyviolations_warn") int policyViolationsWarn,
-            @JsonAlias("riskscore") double riskScore,
-            @JsonAlias("unassigned_severity") int unassigned,
+            int policyViolationsFail,
+            int policyViolationsInfo,
+            int policyViolationsLicenseTotal,
+            int policyViolationsOperationalTotal,
+            int policyViolationsSecurityTotal,
+            int policyViolationsTotal,
+            int policyViolationsWarn,
+            double inheritedRiskScore,
+            int unassigned,
             int vulnerabilities) {
-
-        static ConciseProjectMetricsRow of(ProjectMetrics pm) {
-            return new ConciseProjectMetricsRow(
-                    pm.getComponents(),
-                    pm.getCritical(),
-                    pm.getHigh(),
-                    pm.getLow(),
-                    pm.getMedium(),
-                    pm.getPolicyViolationsFail(),
-                    pm.getPolicyViolationsInfo(),
-                    pm.getPolicyViolationsLicenseTotal(),
-                    pm.getPolicyViolationsOperationalTotal(),
-                    pm.getPolicyViolationsSecurityTotal(),
-                    pm.getPolicyViolationsTotal(),
-                    pm.getPolicyViolationsWarn(),
-                    pm.getInheritedRiskScore(),
-                    pm.getUnassigned(),
-                    pm.getVulnerabilities());
-        }
-
-    }
-
-    record ProjectListRow(Project project, long totalCount) {
     }
 
     @SqlQuery(/* language=InjectedFreeMarker */ """
-            <#-- @ftlvariable name="nameFilter" type="String" -->
-            <#-- @ftlvariable name="classifierFilter" type="Boolean" -->
-            <#-- @ftlvariable name="teamFilter" type="String" -->
-            <#-- @ftlvariable name="tagFilter" type="String" -->
-            <#-- @ftlvariable name="notAssignedToTeamWithUuid" type="String" -->
-            <#-- @ftlvariable name="onlyRoot" type="Boolean" -->
-            <#-- @ftlvariable name="apiFilterParameter" type="String" -->
+            <#-- @ftlvariable name="includeMetrics" type="boolean" -->
+            <#-- @ftlvariable name="whereConditions" type="java.util.Collection<String>" -->
+            <#-- @ftlvariable name="collectionMetricsSubquery" type="String" -->
+            <#-- @ftlvariable name="leafMetricsSubquery" type="String" -->
             <#-- @ftlvariable name="apiOrderByClause" type="String" -->
             <#-- @ftlvariable name="apiOffsetLimitClause" type="String" -->
             <#-- @ftlvariable name="apiProjectAclCondition" type="String" -->
-            <#-- @ftlvariable name="apiParentProjectAclCondition" type="String" -->
             SELECT "PROJECT"."ID" AS "id"
                  , "PROJECT"."CLASSIFIER"
                  , "PROJECT"."CPE"
@@ -372,7 +477,11 @@ public interface ProjectDao extends SqlObject {
                  , "PROJECT"."GROUP"
                  , "PROJECT"."LAST_BOM_IMPORTED" AS "lastBomImport"
                  , "PROJECT"."LAST_BOM_IMPORTED_FORMAT" AS "lastBomImportFormat"
-                 , "PROJECT"."LAST_RISKSCORE" AS "lastInheritedRiskScore"
+                 , CASE
+                     WHEN "PROJECT"."COLLECTION_LOGIC" IS NOT NULL
+                     THEN cm."inheritedRiskScore"
+                     ELSE "PROJECT"."LAST_RISKSCORE"
+                   END AS "lastInheritedRiskScore"
                  , "PROJECT"."NAME" AS "name"
                  , "PROJECT"."PUBLISHER"
                  , "PROJECT"."PURL" AS "projectPurl"
@@ -385,64 +494,38 @@ public interface ProjectDao extends SqlObject {
                  , "PROJECT"."IS_LATEST" AS "isLatest"
                  , "PROJECT"."INACTIVE_SINCE" AS "inactiveSince"
                  , "PROJECT"."COLLECTION_LOGIC" AS "collectionLogic"
-                 , (SELECT JSONB_AGG(JSONB_BUILD_OBJECT('id', "ID", 'name', "NAME"))
-                        FROM "TAG"
-                        INNER JOIN "PROJECTS_TAGS"
-                            ON "PROJECTS_TAGS"."PROJECT_ID" = "PROJECT"."ID"
-                        WHERE "TAG"."ID" = "PROJECTS_TAGS"."TAG_ID"
-                    ) AS "tagsJson"
-                 , (SELECT JSONB_AGG(JSONB_BUILD_OBJECT('id', "ID", 'name', "NAME"))
-                        FROM "TEAM"
-                        INNER JOIN "PROJECT_ACCESS_TEAMS"
-                            ON "PROJECT_ACCESS_TEAMS"."TEAM_ID" = "TEAM"."ID"
-                        WHERE "PROJECT_ACCESS_TEAMS"."PROJECT_ID" = "PROJECT"."ID"
-                    ) AS "teamsJson"
-                 , COUNT(*) OVER() AS "totalCount"
+                 , (
+                     SELECT JSONB_AGG(JSONB_BUILD_OBJECT('id', "ID", 'name', "NAME"))
+                       FROM "TAG"
+                      INNER JOIN "PROJECTS_TAGS"
+                         ON "PROJECTS_TAGS"."PROJECT_ID" = "PROJECT"."ID"
+                      WHERE "TAG"."ID" = "PROJECTS_TAGS"."TAG_ID"
+                   ) AS "tagsJson"
+                 , (
+                     SELECT JSONB_AGG(JSONB_BUILD_OBJECT('id', "ID", 'name', "NAME"))
+                       FROM "TEAM"
+                      INNER JOIN "PROJECT_ACCESS_TEAMS"
+                         ON "PROJECT_ACCESS_TEAMS"."TEAM_ID" = "TEAM"."ID"
+                      WHERE "PROJECT_ACCESS_TEAMS"."PROJECT_ID" = "PROJECT"."ID"
+                   ) AS "teamsJson"
+            <#if includeMetrics>
+                 , CASE
+                     WHEN "PROJECT"."COLLECTION_LOGIC" IS NOT NULL
+                     THEN TO_JSONB(cm.*)
+                     ELSE (SELECT TO_JSONB(m) FROM (${leafMetricsSubquery}) AS m)
+                   END AS "metricsJson"
+            </#if>
               FROM "PROJECT"
+            <#--
+                NB: We are forced to do this lateral join unconditionally, because callers expect
+                lastInheritedRiskScore to be returned, but collection projects have no precomputed
+                LAST_RISKSCORE column. In a future query backing a hypothetical API v2 endpoint,
+                lastInheritedRiskScore should be an expandable field to work around this.
+            -->
+              LEFT JOIN LATERAL (${collectionMetricsSubquery}) AS cm
+                ON "PROJECT"."COLLECTION_LOGIC" IS NOT NULL
              WHERE ${apiProjectAclCondition}
-            <#if nameFilter>
-               AND "PROJECT"."NAME" = :nameFilter
-            </#if>
-            <#if classifierFilter>
-               AND "PROJECT"."CLASSIFIER" = :classifierFilter
-            </#if>
-            <#if tagFilter>
-               AND EXISTS(
-                 SELECT 1
-                   FROM "PROJECTS_TAGS"
-                  INNER JOIN "TAG"
-                     ON "TAG"."ID" = "PROJECTS_TAGS"."TAG_ID"
-                  WHERE "PROJECTS_TAGS"."PROJECT_ID" = "PROJECT"."ID"
-                    AND "TAG"."NAME" = :tagFilter)
-            </#if>
-            <#if teamFilter>
-               AND EXISTS(
-                 SELECT 1
-                   FROM "PROJECT_ACCESS_TEAMS"
-                  INNER JOIN "TEAM"
-                     ON "TEAM"."ID" = "PROJECT_ACCESS_TEAMS"."TEAM_ID"
-                  WHERE "PROJECT_ACCESS_TEAMS"."PROJECT_ID" = "PROJECT"."ID"
-                    AND "TEAM"."NAME" = :teamFilter)
-            </#if>
-            <#if notAssignedToTeamWithUuid>
-               AND NOT EXISTS(
-                 SELECT 1
-                   FROM "PROJECT_ACCESS_TEAMS"
-                  INNER JOIN "TEAM"
-                     ON "TEAM"."ID" = "PROJECT_ACCESS_TEAMS"."TEAM_ID"
-                  WHERE "PROJECT_ACCESS_TEAMS"."PROJECT_ID" = "PROJECT"."ID"
-                    AND "TEAM"."UUID" = :notAssignedToTeamWithUuid)
-            </#if>
-            <#if excludeInactive>
-                AND "PROJECT"."INACTIVE_SINCE" IS NULL
-            </#if>
-            <#if onlyRoot>
-               AND ("PROJECT"."PARENT_PROJECT_ID" IS NULL)
-            </#if>
-            <#if apiFilterParameter??>
-               AND (LOWER("PROJECT"."NAME") LIKE ('%' || LOWER(${apiFilterParameter}) || '%')
-                    OR EXISTS (SELECT 1 FROM "TAG" WHERE "TAG"."NAME" = ${apiFilterParameter}))
-            </#if>
+               AND ${whereConditions?join(" AND ")}
             <#if apiOrderByClause??>
                 ${apiOrderByClause}
             <#else>
@@ -450,30 +533,29 @@ public interface ProjectDao extends SqlObject {
             </#if>
             ${apiOffsetLimitClause!}
             """)
-    @DefineNamedBindings
-    @AllowUnusedBindings
-    @DefineApiProjectAclCondition(
-            name = "apiParentProjectAclCondition",
-            projectIdColumn = "\"PARENT_PROJECT\".\"ID\""
-    )
     @AllowApiOrdering(alwaysBy = "id", by = {
             @AllowApiOrdering.Column(name = "id"),
+            @AllowApiOrdering.Column(name = "group"),
             @AllowApiOrdering.Column(name = "name"),
-            @AllowApiOrdering.Column(name = "version")
+            @AllowApiOrdering.Column(name = "version"),
+            @AllowApiOrdering.Column(name = "classifier"),
+            @AllowApiOrdering.Column(name = "inactiveSince"),
+            @AllowApiOrdering.Column(name = "isLatest"),
+            @AllowApiOrdering.Column(name = "lastBomImport"),
+            @AllowApiOrdering.Column(name = "lastBomImportFormat"),
+            @AllowApiOrdering.Column(name = "lastInheritedRiskScore")
     })
     @RegisterColumnMapper(ExternalReferenceMapper.class)
     @RegisterColumnMapper(OrganizationalEntityMapper.class)
     @RegisterColumnMapper(OrganizationalContactMapper.class)
     @RegisterRowMapper(ProjectListRowMapper.class)
-    List<ProjectListRow> getProjects(
-            @Bind String nameFilter,
-            @Bind String classifierFilter,
-            @Bind String tagFilter,
-            @Bind String teamFilter,
-            @Bind String notAssignedToTeamWithUuid,
-            @Define boolean excludeInactive,
-            @Define boolean onlyRoot
-    );
+    @AllowUnusedBindings
+    List<Project> getProjects(
+            @Define ArrayList<String> whereConditions,
+            @BindMap Map<String, Object> queryParams,
+            @Define boolean includeMetrics,
+            @Define String collectionMetricsSubquery,
+            @Define String leafMetricsSubquery);
 
     default PaginatedResult getProjects(
             String nameFilter,
@@ -481,57 +563,100 @@ public interface ProjectDao extends SqlObject {
             String tagFilter,
             String teamFilter,
             String notAssignedToTeamWithUuid,
+            String searchText,
             boolean excludeInactive,
             boolean onlyRoot,
             boolean includeMetrics) {
-        final List<ProjectListRow> projectListRows = getProjects(
-                nameFilter,
-                classifierFilter,
-                tagFilter,
-                teamFilter,
-                notAssignedToTeamWithUuid,
-                excludeInactive,
-                onlyRoot);
-        final long totalCount = !projectListRows.isEmpty()
-                ? projectListRows.getFirst().totalCount()
-                : 0;
-        final List<Project> projects = projectListRows.stream()
-                .map(ProjectListRow::project)
-                .toList();
-
-        if (includeMetrics) {
-            final Map<Long, Project> projectById = projects.stream()
-                    .filter(project -> project.getCollectionLogic() == null)
-                    .collect(Collectors.toMap(Project::getId, Function.identity()));
-            final List<ProjectMetrics> metricsList = getHandle()
-                    .attach(MetricsDao.class)
-                    .getMostRecentProjectMetrics(projectById.keySet());
-
-            for (final ProjectMetrics metrics : metricsList) {
-                final Project project = projectById.get(metrics.getProjectId());
-                if (project != null) {
-                    project.setMetrics(metrics);
-                }
-            }
-
-            final Map<Long, Project> collectionById = projects.stream()
-                    .filter(project -> project.getCollectionLogic() != null)
-                    .collect(Collectors.toMap(Project::getId, Function.identity()));
-            if (!collectionById.isEmpty()) {
-                final List<ProjectMetrics> collectionMetrics = getHandle()
-                        .attach(MetricsDao.class)
-                        .getMostRecentCollectionProjectMetrics(collectionById.keySet());
-
-                for (final ProjectMetrics metrics : collectionMetrics) {
-                    final Project collection = collectionById.get(metrics.getProjectId());
-                    if (collection != null) {
-                        collection.setMetrics(metrics);
-                    }
-                }
-            }
+        final var whereConditions = new ArrayList<String>();
+        final var queryParams = new HashMap<String, Object>();
+        whereConditions.add("TRUE");
+        if (nameFilter != null) {
+            whereConditions.add("\"PROJECT\".\"NAME\" = :nameFilter");
+            queryParams.put("nameFilter", nameFilter);
+        }
+        if (classifierFilter != null) {
+            whereConditions.add("\"PROJECT\".\"CLASSIFIER\" = :classifierFilter");
+            queryParams.put("classifierFilter", classifierFilter);
+        }
+        if (tagFilter != null) {
+            whereConditions.add(/* language=SQL */ """
+                    EXISTS (
+                      SELECT 1
+                        FROM "PROJECTS_TAGS"
+                       INNER JOIN "TAG"
+                          ON "TAG"."ID" = "PROJECTS_TAGS"."TAG_ID"
+                       WHERE "PROJECTS_TAGS"."PROJECT_ID" = "PROJECT"."ID"
+                         AND "TAG"."NAME" = :tagFilter
+                    )""");
+            queryParams.put("tagFilter", tagFilter);
+        }
+        if (teamFilter != null) {
+            whereConditions.add(/* language=SQL */ """
+                    EXISTS (
+                      SELECT 1
+                        FROM "PROJECT_ACCESS_TEAMS"
+                       INNER JOIN "TEAM"
+                          ON "TEAM"."ID" = "PROJECT_ACCESS_TEAMS"."TEAM_ID"
+                       WHERE "PROJECT_ACCESS_TEAMS"."PROJECT_ID" = "PROJECT"."ID"
+                         AND "TEAM"."NAME" = :teamFilter
+                    )""");
+            queryParams.put("teamFilter", teamFilter);
+        }
+        if (notAssignedToTeamWithUuid != null) {
+            whereConditions.add(/* language=SQL */ """
+                    NOT EXISTS (
+                      SELECT 1
+                        FROM "PROJECT_ACCESS_TEAMS"
+                       INNER JOIN "TEAM"
+                          ON "TEAM"."ID" = "PROJECT_ACCESS_TEAMS"."TEAM_ID"
+                       WHERE "PROJECT_ACCESS_TEAMS"."PROJECT_ID" = "PROJECT"."ID"
+                         AND "TEAM"."UUID" = :notAssignedToTeamWithUuid
+                    )""");
+            queryParams.put("notAssignedToTeamWithUuid", notAssignedToTeamWithUuid);
+        }
+        if (excludeInactive) {
+            whereConditions.add("\"PROJECT\".\"INACTIVE_SINCE\" IS NULL");
+        }
+        if (onlyRoot) {
+            whereConditions.add("\"PROJECT\".\"PARENT_PROJECT_ID\" IS NULL");
+        }
+        if (searchText != null) {
+            whereConditions.add(/* language=SQL */ """
+                    (
+                      LOWER("PROJECT"."NAME") LIKE ('%' || LOWER(:searchTextLike) || '%') ESCAPE '!'
+                      OR EXISTS (
+                        SELECT 1
+                          FROM "PROJECTS_TAGS"
+                         INNER JOIN "TAG"
+                            ON "TAG"."ID" = "PROJECTS_TAGS"."TAG_ID"
+                         WHERE "PROJECTS_TAGS"."PROJECT_ID" = "PROJECT"."ID"
+                           AND "TAG"."NAME" = :searchText
+                      )
+                    )""");
+            queryParams.put("searchText", searchText);
+            queryParams.put("searchTextLike", escapeLikePattern(searchText));
         }
 
-        return (new PaginatedResult()).objects(projects).total(totalCount);
+        return withJitDisabled(() -> {
+            // Count is run separately so the LATERAL fan-out and per-row SubPlans
+            // in the page query stay bounded to the page rows. Without this, the
+            // `COUNT(*) OVER()` window function would force materialization of
+            // every filtered row through the LATERAL.
+            final TotalCount totalCount = getBoundedTotalCountWithProjectAcl(
+                    "FROM \"PROJECT\" WHERE " + String.join(" AND ", whereConditions),
+                    queryParams,
+                    /* threshold */ null,
+                    "\"PROJECT\".\"ID\"");
+
+            final List<Project> projects = getProjects(
+                    whereConditions,
+                    queryParams,
+                    includeMetrics,
+                    COLLECTION_METRICS_SUBQUERY,
+                    LEAF_METRICS_SUBQUERY);
+
+            return (new PaginatedResult()).objects(projects).total(totalCount.value());
+        });
     }
 
     @SqlUpdate("""
@@ -693,25 +818,40 @@ public interface ProjectDao extends SqlObject {
             """)
     void updateLastVulnAnalysis(@Bind UUID uuid);
 
-    class ProjectListRowMapper implements RowMapper<ProjectListRow> {
+    class ProjectListRowMapper implements RowMapper<Project> {
 
         private static final TypeReference<Set<Tag>> TAGS_TYPE_REF = new TypeReference<>() {
         };
         private static final TypeReference<Set<Team>> TEAMS_TYPE_REF = new TypeReference<>() {
         };
+        private static final TypeReference<ProjectMetrics> METRICS_TYPE_REF = new TypeReference<>() {
+        };
 
         private final RowMapper<Project> projectMapper = BeanMapper.of(Project.class);
 
         @Override
-        public ProjectListRow map(final ResultSet rs, final StatementContext ctx) throws SQLException {
+        public Project map(final ResultSet rs, final StatementContext ctx) throws SQLException {
             final Project project = projectMapper.map(rs, ctx);
             maybeSet(rs, "projectPurl", ResultSet::getString, project::setPurl);
             maybeSet(rs, "teamsJson", (_, columnName) ->
                     deserializeJson(rs, columnName, TEAMS_TYPE_REF), project::setAccessTeams);
             maybeSet(rs, "tagsJson", (_, columnName) ->
                     deserializeJson(rs, columnName, TAGS_TYPE_REF), project::setTags);
-            final ProjectListRow projectListRow = new ProjectListRow(project, rs.getInt("totalCount"));
-            return projectListRow;
+            maybeSet(rs, "metricsJson", (_, columnName) ->
+                    deserializeJson(rs, columnName, METRICS_TYPE_REF), project::setMetrics);
+            return project;
         }
     }
+
+    default <T> T withJitDisabled(Supplier<T> supplier) {
+        return getHandle().inTransaction(trx -> {
+            trx.createUpdate("SET LOCAL jit = OFF")
+                    // The handle may carry bindings from ApiRequestStatementCustomizer
+                    // (e.g. pagination offset / limit) that this statement doesn't consume.
+                    .configure(SqlStatements.class, cfg -> cfg.setUnusedBindingAllowed(true))
+                    .execute();
+            return supplier.get();
+        });
+    }
+
 }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/query/ListProjectsConciseQuery.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/query/ListProjectsConciseQuery.java
@@ -34,10 +34,11 @@ public record ListProjectsConciseQuery(
         @Nullable Boolean activeFilter,
         @Nullable Boolean onlyRootFilter,
         @Nullable UUID parentUuidFilter,
+        @Nullable String searchText,
         boolean includeMetrics) {
 
     public ListProjectsConciseQuery() {
-        this(null, null, null, null, null, null, null, null, false);
+        this(null, null, null, null, null, null, null, null, null, false);
     }
 
     public ListProjectsConciseQuery withNameFilter(@Nullable String nameFilter) {
@@ -50,6 +51,7 @@ public record ListProjectsConciseQuery(
                 this.activeFilter,
                 this.onlyRootFilter,
                 this.parentUuidFilter,
+                this.searchText,
                 this.includeMetrics);
     }
 
@@ -63,6 +65,7 @@ public record ListProjectsConciseQuery(
                 this.activeFilter,
                 this.onlyRootFilter,
                 this.parentUuidFilter,
+                this.searchText,
                 this.includeMetrics);
     }
 
@@ -76,6 +79,7 @@ public record ListProjectsConciseQuery(
                 this.activeFilter,
                 this.onlyRootFilter,
                 this.parentUuidFilter,
+                this.searchText,
                 this.includeMetrics);
     }
 
@@ -89,6 +93,7 @@ public record ListProjectsConciseQuery(
                 this.activeFilter,
                 this.onlyRootFilter,
                 this.parentUuidFilter,
+                this.searchText,
                 this.includeMetrics);
     }
 
@@ -102,6 +107,7 @@ public record ListProjectsConciseQuery(
                 this.activeFilter,
                 this.onlyRootFilter,
                 this.parentUuidFilter,
+                this.searchText,
                 this.includeMetrics);
     }
 
@@ -115,6 +121,7 @@ public record ListProjectsConciseQuery(
                 activeFilter,
                 this.onlyRootFilter,
                 this.parentUuidFilter,
+                this.searchText,
                 this.includeMetrics);
     }
 
@@ -128,6 +135,7 @@ public record ListProjectsConciseQuery(
                 this.activeFilter,
                 onlyRootFilter,
                 this.parentUuidFilter,
+                this.searchText,
                 this.includeMetrics);
     }
 
@@ -141,6 +149,21 @@ public record ListProjectsConciseQuery(
                 this.activeFilter,
                 this.onlyRootFilter,
                 parentUuidFilter,
+                this.searchText,
+                this.includeMetrics);
+    }
+
+    public ListProjectsConciseQuery withSearchText(@Nullable String searchText) {
+        return new ListProjectsConciseQuery(
+                this.nameFilter,
+                this.versionFilter,
+                this.classifierFilter,
+                this.tagFilter,
+                this.teamFilter,
+                this.activeFilter,
+                this.onlyRootFilter,
+                this.parentUuidFilter,
+                searchText,
                 this.includeMetrics);
     }
 
@@ -154,6 +177,7 @@ public record ListProjectsConciseQuery(
                 this.activeFilter,
                 this.onlyRootFilter,
                 this.parentUuidFilter,
+                this.searchText,
                 includeMetrics);
     }
 

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/AccessControlResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/AccessControlResource.java
@@ -99,8 +99,20 @@ public class AccessControlResource extends AbstractApiResource {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final Team team = qm.getObjectByUuid(Team.class, uuid);
             if (team != null) {
-                final PaginatedResult projectPages = withJdbiHandle(getAlpineRequest(), handle ->
-                        handle.attach(ProjectDao.class).getProjects(null, null, null, team.getName(), null, excludeInactive, onlyRoot, false));
+                final PaginatedResult projectPages = withJdbiHandle(
+                        getAlpineRequest(),
+                        handle -> handle
+                                .attach(ProjectDao.class)
+                                .getProjects(
+                                        /* nameFilter */ null,
+                                        /* classifierFilter */ null,
+                                        /* tagFilter */ null,
+                                        team.getName(),
+                                        /* notAssignedToTeamWithUuid */ null,
+                                        getAlpineRequest().getFilter(),
+                                        excludeInactive,
+                                        onlyRoot,
+                                        /* includeMetrics */ false));
                 return Response.ok(projectPages.getObjects()).header(TOTAL_COUNT_HEADER, projectPages.getTotal()).build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the team could not be found.").build();

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -51,6 +51,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.common.pagination.Page;
 import org.dependencytrack.model.Classifier;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectCollectionLogic;
@@ -61,7 +62,6 @@ import org.dependencytrack.notification.NotificationModelConverter;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.persistence.jdbi.MetricsDao;
 import org.dependencytrack.persistence.jdbi.ProjectDao;
-import org.dependencytrack.persistence.jdbi.ProjectDao.ConciseProjectListRow;
 import org.dependencytrack.persistence.jdbi.command.CloneProjectCommand;
 import org.dependencytrack.persistence.jdbi.query.ListProjectsConciseQuery;
 import org.dependencytrack.resources.AbstractApiResource;
@@ -150,9 +150,18 @@ public class ProjectResource extends AbstractApiResource {
                     return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the team could not be found.").build();
                 }
             }
-            final PaginatedResult projectPages = withJdbiHandle(getAlpineRequest(), handle ->
-                    (name != null) ? handle.attach(ProjectDao.class).getProjects(name, null, null, null, notAssignedToTeamWithUuid, excludeInactive, onlyRoot, false)
-                            : handle.attach(ProjectDao.class).getProjects(null, null, null, null, notAssignedToTeamWithUuid, excludeInactive, onlyRoot, true));
+            final PaginatedResult projectPages = withJdbiHandle(getAlpineRequest(), handle -> handle
+                    .attach(ProjectDao.class)
+                    .getProjects(
+                            name,
+                            /* classifierFilter */ null,
+                            /* tagFilter */ null,
+                            /* teamFilter */ null,
+                            notAssignedToTeamWithUuid,
+                            getAlpineRequest().getFilter(),
+                            excludeInactive,
+                            onlyRoot,
+                            /* includeMetrics */ true));
             return Response.ok(projectPages.getObjects()).header(TOTAL_COUNT_HEADER, projectPages.getTotal()).build();
         }
     }
@@ -193,7 +202,7 @@ public class ProjectResource extends AbstractApiResource {
             @Parameter(description = "Whether to include metrics in the response.")
             @QueryParam("includeMetrics") final boolean includeMetrics
     ) {
-        final List<ConciseProjectListRow> projectRows = withJdbiHandle(
+        final Page<ProjectDao.ConciseProjectListRow> page = withJdbiHandle(
                 getAlpineRequest(),
                 handle -> handle
                         .attach(ProjectDao.class)
@@ -205,11 +214,11 @@ public class ProjectResource extends AbstractApiResource {
                                 .withTeamFilter(teamFilter)
                                 .withActiveFilter(activeFilter)
                                 .withOnlyRootFilter(onlyRootFilter)
+                                .withSearchText(getAlpineRequest().getFilter())
                                 .withIncludeMetrics(includeMetrics)));
 
-        final long totalCount = projectRows.isEmpty() ? 0 : projectRows.getFirst().totalCount();
-        final List<ConciseProject> projects = projectRows.stream().map(ConciseProject::new).toList();
-        return Response.ok(projects).header(TOTAL_COUNT_HEADER, totalCount).build();
+        final List<ConciseProject> projects = page.items().stream().map(ConciseProject::new).toList();
+        return Response.ok(projects).header(TOTAL_COUNT_HEADER, page.totalCount().value()).build();
     }
 
     @GET
@@ -248,7 +257,7 @@ public class ProjectResource extends AbstractApiResource {
             @Parameter(description = "Whether to include metrics in the response.")
             @QueryParam("includeMetrics") final boolean includeMetrics
     ) {
-        final List<ConciseProjectListRow> projectRows = withJdbiHandle(
+        final Page<ProjectDao.ConciseProjectListRow> page = withJdbiHandle(
                 getAlpineRequest(),
                 handle -> handle
                         .attach(ProjectDao.class)
@@ -260,11 +269,11 @@ public class ProjectResource extends AbstractApiResource {
                                 .withTeamFilter(teamFilter)
                                 .withActiveFilter(activeFilter)
                                 .withParentUuidFilter(UUID.fromString(parentUuid))
+                                .withSearchText(getAlpineRequest().getFilter())
                                 .withIncludeMetrics(includeMetrics)));
 
-        final long totalCount = projectRows.isEmpty() ? 0 : projectRows.getFirst().totalCount();
-        final List<ConciseProject> projects = projectRows.stream().map(ConciseProject::new).toList();
-        return Response.ok(projects).header(TOTAL_COUNT_HEADER, totalCount).build();
+        final List<ConciseProject> projects = page.items().stream().map(ConciseProject::new).toList();
+        return Response.ok(projects).header(TOTAL_COUNT_HEADER, page.totalCount().value()).build();
     }
 
     @GET
@@ -410,7 +419,7 @@ public class ProjectResource extends AbstractApiResource {
             @Parameter(description = "Optionally excludes children projects from being returned")
             @QueryParam("onlyRoot") boolean onlyRoot) {
         final PaginatedResult projectPages = withJdbiHandle(getAlpineRequest(), handle -> handle.attach(ProjectDao.class)
-                .getProjects(null, null, tagString, null, null, excludeInactive, onlyRoot, true));
+                .getProjects(null, null, tagString, null, null, getAlpineRequest().getFilter(), excludeInactive, onlyRoot, true));
         return Response.ok(projectPages.getObjects()).header(TOTAL_COUNT_HEADER, projectPages.getTotal()).build();
     }
 
@@ -442,7 +451,7 @@ public class ProjectResource extends AbstractApiResource {
         try {
             final Classifier classifier = Classifier.valueOf(classifierString);
             final PaginatedResult projectPages = withJdbiHandle(getAlpineRequest(), handle -> handle.attach(ProjectDao.class)
-                    .getProjects(null, classifier.name(), null, null, null, excludeInactive, onlyRoot, true));
+                    .getProjects(null, classifier.name(), null, null, null, getAlpineRequest().getFilter(), excludeInactive, onlyRoot, true));
             return Response.ok(projectPages.getObjects()).header(TOTAL_COUNT_HEADER, projectPages.getTotal()).build();
         } catch (IllegalArgumentException e) {
             return Response.status(Response.Status.BAD_REQUEST).entity("The classifier type specified is not valid.").build();

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/ConciseProjectMetrics.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/ConciseProjectMetrics.java
@@ -40,14 +40,25 @@ public record ConciseProjectMetrics(
         @Schema(description = "Number of policy violations with status WARN", requiredMode = Schema.RequiredMode.REQUIRED) int policyViolationsWarn,
         @Schema(description = "The inherited risk score", requiredMode = Schema.RequiredMode.REQUIRED) double inheritedRiskScore,
         @Schema(description = "Number of vulnerabilities with unassigned severity", requiredMode = Schema.RequiredMode.REQUIRED) int unassigned,
-        @Schema(description = "Total number of vulnerabilities", requiredMode = Schema.RequiredMode.REQUIRED) int vulnerabilities
-) {
+        @Schema(description = "Total number of vulnerabilities", requiredMode = Schema.RequiredMode.REQUIRED) int vulnerabilities) {
 
     public ConciseProjectMetrics(final ConciseProjectMetricsRow row) {
-        this(row.components(), row.critical(), row.high(), row.low(), row.medium(),
-                row.policyViolationsFail(), row.policyViolationsInfo(), row.policyViolationsLicenseTotal(),
-                row.policyViolationsOperationalTotal(), row.policyViolationsSecurityTotal(), row.policyViolationsTotal(),
-                row.policyViolationsWarn(), row.riskScore(), row.unassigned(), row.vulnerabilities());
+        this(
+                row.components(),
+                row.critical(),
+                row.high(),
+                row.low(),
+                row.medium(),
+                row.policyViolationsFail(),
+                row.policyViolationsInfo(),
+                row.policyViolationsLicenseTotal(),
+                row.policyViolationsOperationalTotal(),
+                row.policyViolationsSecurityTotal(),
+                row.policyViolationsTotal(),
+                row.policyViolationsWarn(),
+                row.inheritedRiskScore(),
+                row.unassigned(),
+                row.vulnerabilities());
     }
 
 }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -664,6 +664,68 @@ class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
+    void shouldSortProjectsByLastInheritedRiskScoreIncludingCollectionProjects() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+
+        final var projectA = new Project();
+        projectA.setName("acme-app-a");
+        projectA.setLastInheritedRiskScore(10.0);
+        qm.persist(projectA);
+
+        final var projectB = new Project();
+        projectB.setName("acme-app-b");
+        projectB.setCollectionLogic(ProjectCollectionLogic.AGGREGATE_DIRECT_CHILDREN);
+        qm.createProject(projectB, List.of(), false);
+
+        final var projectC = new Project();
+        projectC.setName("acme-app-c");
+        projectC.setParent(projectB);
+        projectC.setLastInheritedRiskScore(6.0);
+        qm.persist(projectC);
+
+        final var projectD = new Project();
+        projectD.setName("acme-app-d");
+        projectD.setLastInheritedRiskScore(5.0);
+        qm.persist(projectD);
+
+        useJdbiHandle(handle -> {
+            final var testDao = handle.attach(MetricsTestDao.class);
+            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
+            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
+
+            final var childMetrics = new ProjectMetrics();
+            childMetrics.setProjectId(projectC.getId());
+            childMetrics.setInheritedRiskScore(7.0);
+            childMetrics.setFirstOccurrence(Date.from(dbNow));
+            childMetrics.setLastOccurrence(Date.from(dbNow));
+            testDao.createProjectMetrics(childMetrics);
+        });
+
+        final Response response = jersey
+                .target(V1_PROJECT)
+                .queryParam(ORDER_BY, "lastInheritedRiskScore")
+                .queryParam(SORT, SORT_DESC)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("4");
+
+        final JsonArray json = parseJsonArray(response);
+        assertThat(json)
+                .extracting(value -> ((JsonObject) value).getString("name"))
+                .containsExactly(
+                        "acme-app-a",
+                        "acme-app-b",
+                        "acme-app-c",
+                        "acme-app-d");
+        assertThat(json)
+                .extracting(value -> ((JsonObject) value).getJsonNumber("lastInheritedRiskScore").doubleValue())
+                .containsExactly(10.0, 7.0, 6.0, 5.0);
+    }
+
+    @Test
     void getProjectsConciseTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
         final var project = new Project();
@@ -4428,6 +4490,188 @@ class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
+    void shouldSortConciseListByLastRiskScoreIncludingCollectionProjects() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+
+        final var projectA = new Project();
+        projectA.setName("acme-app-a");
+        projectA.setLastInheritedRiskScore(10.0);
+        qm.persist(projectA);
+
+        final var projectB = new Project();
+        projectB.setName("acme-app-b");
+        projectB.setCollectionLogic(ProjectCollectionLogic.AGGREGATE_DIRECT_CHILDREN);
+        qm.createProject(projectB, List.of(), false);
+
+        final var projectC = new Project();
+        projectC.setName("acme-app-c");
+        projectC.setParent(projectB);
+        projectC.setLastInheritedRiskScore(6.0);
+        qm.persist(projectC);
+
+        final var projectD = new Project();
+        projectD.setName("acme-app-d");
+        projectD.setLastInheritedRiskScore(5.0);
+        qm.persist(projectD);
+
+        useJdbiHandle(handle -> {
+            final var testDao = handle.attach(MetricsTestDao.class);
+            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
+            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
+
+            final var childMetrics = new ProjectMetrics();
+            childMetrics.setProjectId(projectC.getId());
+            childMetrics.setInheritedRiskScore(7.0);
+            childMetrics.setFirstOccurrence(Date.from(dbNow));
+            childMetrics.setLastOccurrence(Date.from(dbNow));
+            testDao.createProjectMetrics(childMetrics);
+        });
+
+        final Response response = jersey
+                .target(V1_PROJECT + "/concise")
+                .queryParam("sortName", "lastRiskScore")
+                .queryParam("sortOrder", "desc")
+                .queryParam("includeMetrics", "true")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("4");
+
+        final JsonArray jsonArray = parseJsonArray(response);
+        assertThat(jsonArray).hasSize(4);
+        assertThat(jsonArray)
+                .extracting(value -> ((JsonObject) value).getString("name"))
+                .containsExactly(
+                        "acme-app-a",
+                        "acme-app-b",
+                        "acme-app-c",
+                        "acme-app-d");
+        assertThat(jsonArray)
+                .extracting(value -> ((JsonObject) value).getJsonNumber("lastRiskScore").doubleValue())
+                .containsExactly(10.0, 7.0, 6.0, 5.0);
+
+        final JsonObject collectionObj = jsonArray.getJsonObject(1);
+        assertThatJson(collectionObj.getJsonObject("metrics").toString())
+                .withOptions(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo(/* language=JSON */ """
+                        {
+                          "inheritedRiskScore": 7.0
+                        }
+                        """);
+    }
+
+    @Test
+    void shouldSortConciseListByLastRiskScoreWithoutMetricsExpansion() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+
+        final var projectA = new Project();
+        projectA.setName("acme-app-a");
+        projectA.setLastInheritedRiskScore(3.0);
+        qm.persist(projectA);
+
+        final var projectB = new Project();
+        projectB.setName("acme-app-b");
+        projectB.setCollectionLogic(ProjectCollectionLogic.AGGREGATE_DIRECT_CHILDREN);
+        qm.createProject(projectB, List.of(), false);
+
+        final var projectC = new Project();
+        projectC.setName("acme-app-c");
+        projectC.setParent(projectB);
+        projectC.setLastInheritedRiskScore(2.0);
+        qm.persist(projectC);
+
+        useJdbiHandle(handle -> {
+            final var testDao = handle.attach(MetricsTestDao.class);
+            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
+            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
+
+            final var childMetrics = new ProjectMetrics();
+            childMetrics.setProjectId(projectC.getId());
+            childMetrics.setInheritedRiskScore(8.0);
+            childMetrics.setFirstOccurrence(Date.from(dbNow));
+            childMetrics.setLastOccurrence(Date.from(dbNow));
+            testDao.createProjectMetrics(childMetrics);
+        });
+
+        final Response response = jersey
+                .target(V1_PROJECT + "/concise")
+                .queryParam("sortName", "lastRiskScore")
+                .queryParam("sortOrder", "desc")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("3");
+
+        final JsonArray jsonArray = parseJsonArray(response);
+        assertThat(jsonArray)
+                .extracting(value -> ((JsonObject) value).getString("name"))
+                .containsExactly("acme-app-b", "acme-app-a", "acme-app-c");
+        assertThat(jsonArray.getJsonObject(0).containsKey("metrics")).isFalse();
+    }
+
+    @Test
+    void shouldReturnCollectionProjectMetricsForChildrenConciseEndpoint() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+
+        final var parent = new Project();
+        parent.setName("parent-collection");
+        parent.setCollectionLogic(ProjectCollectionLogic.AGGREGATE_DIRECT_CHILDREN);
+        qm.createProject(parent, List.of(), false);
+
+        final var nestedCollection = new Project();
+        nestedCollection.setName("nested-collection");
+        nestedCollection.setCollectionLogic(ProjectCollectionLogic.AGGREGATE_DIRECT_CHILDREN);
+        nestedCollection.setParent(parent);
+        qm.createProject(nestedCollection, List.of(), false);
+
+        final var leafGrandchild = new Project();
+        leafGrandchild.setName("leaf-grandchild");
+        leafGrandchild.setParent(nestedCollection);
+        qm.persist(leafGrandchild);
+
+        useJdbiHandle(handle -> {
+            final var testDao = handle.attach(MetricsTestDao.class);
+            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
+            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
+
+            final var grandchildMetrics = new ProjectMetrics();
+            grandchildMetrics.setProjectId(leafGrandchild.getId());
+            grandchildMetrics.setInheritedRiskScore(4.0);
+            grandchildMetrics.setCritical(2);
+            grandchildMetrics.setFirstOccurrence(Date.from(dbNow));
+            grandchildMetrics.setLastOccurrence(Date.from(dbNow));
+            testDao.createProjectMetrics(grandchildMetrics);
+        });
+
+        final Response response = jersey.target(V1_PROJECT + "/concise/" + parent.getUuid() + "/children")
+                .queryParam("includeMetrics", "true")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+
+        final JsonArray jsonArray = parseJsonArray(response);
+        assertThat(jsonArray).hasSize(1);
+        final JsonObject nested = jsonArray.getJsonObject(0);
+        assertThat(nested.getString("name")).isEqualTo("nested-collection");
+        // The nested collection's metrics aggregate recursively from its leaf descendant.
+        assertThatJson(nested.getJsonObject("metrics").toString())
+                .withOptions(Option.IGNORING_EXTRA_FIELDS)
+                .isEqualTo(/* language=JSON */ """
+                        {
+                          "critical": 2,
+                          "inheritedRiskScore": 4.0
+                        }
+                        """);
+    }
+
+    @Test
     void shouldCreateCollectionProjectWithoutClassifier() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_CREATE);
 
@@ -4717,6 +4961,122 @@ class ProjectResourceTest extends ResourceTest {
                 .inPath("$.versions[*].uuid")
                 .isArray()
                 .containsExactly(accessibleVersion.getUuid().toString());
+    }
+
+    @Test
+    void shouldFilterProjectsBySearchTextOnNameAndTag() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+
+        final var projectA = new Project();
+        projectA.setName("acme-app-a");
+        qm.persist(projectA);
+
+        final var projectB = new Project();
+        projectB.setName("acme-app-b");
+        qm.persist(projectB);
+        qm.bind(projectB, List.of(qm.createTag("tag-foo")));
+
+        final var projectC = new Project();
+        projectC.setName("acme-app-c");
+        qm.persist(projectC);
+        qm.bind(projectC, List.of(qm.createTag("tag-bar")));
+
+        Response response = jersey
+                .target(V1_PROJECT)
+                .queryParam("searchText", "acme-app-a")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].name")
+                .isArray()
+                .containsExactlyInAnyOrder("acme-app-a");
+
+        response = jersey
+                .target(V1_PROJECT)
+                .queryParam("searchText", "tag-foo")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].name")
+                .isArray()
+                .containsExactlyInAnyOrder("acme-app-b");
+
+        response = jersey
+                .target(V1_PROJECT)
+                .queryParam("searchText", "tag-bar")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].name")
+                .isArray()
+                .containsExactlyInAnyOrder("acme-app-c");
+    }
+
+    @Test
+    void shouldFilterConciseProjectsBySearchTextOnNameAndTag() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+
+        final var projectA = new Project();
+        projectA.setName("acme-app-a");
+        qm.persist(projectA);
+
+        final var projectB = new Project();
+        projectB.setName("acme-app-b");
+        qm.persist(projectB);
+        qm.bind(projectB, List.of(qm.createTag("tag-foo")));
+
+        final var projectC = new Project();
+        projectC.setName("acme-app-c");
+        qm.persist(projectC);
+        qm.bind(projectC, List.of(qm.createTag("tag-bar")));
+
+        Response response = jersey
+                .target(V1_PROJECT + "/concise")
+                .queryParam("searchText", "acme-app-a")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].name")
+                .isArray()
+                .containsExactlyInAnyOrder("acme-app-a");
+
+        response = jersey
+                .target(V1_PROJECT + "/concise")
+                .queryParam("searchText", "tag-foo")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].name")
+                .isArray()
+                .containsExactlyInAnyOrder("acme-app-b");
+
+        response = jersey
+                .target(V1_PROJECT + "/concise")
+                .queryParam("searchText", "tag-bar")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].name")
+                .isArray()
+                .containsExactlyInAnyOrder("acme-app-c");
     }
 
 }

--- a/apiserver/src/test/java/org/dependencytrack/tasks/maintenance/ProjectMaintenanceTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/maintenance/ProjectMaintenanceTaskTest.java
@@ -68,7 +68,7 @@ class ProjectMaintenanceTaskTest extends PersistenceCapableTest {
         assertThatNoException().isThrownBy(() -> task.run());
 
         final PaginatedResult projects = withJdbiHandle(handle ->
-                handle.attach(ProjectDao.class).getProjects(null, null, null, null, null, false, false, false));
+                handle.attach(ProjectDao.class).getProjects(null, null, null, null, null, null, false, false, false));
 
         assertThat(projects.getList(Project.class)).satisfiesExactly(
                 retainedProject -> assertThat(retainedProject.getName()).isEqualTo("acme-app-B")
@@ -124,7 +124,7 @@ class ProjectMaintenanceTaskTest extends PersistenceCapableTest {
         final var task = new ProjectMaintenanceTask();
         assertThatNoException().isThrownBy(() -> task.run());
         final PaginatedResult projects = withJdbiHandle(handle ->
-                handle.attach(ProjectDao.class).getProjects(null, null, null, null, null, false, false, false));
+                handle.attach(ProjectDao.class).getProjects(null, null, null, null, null, null, false, false, false));
         assertThat(projects.getList(Project.class)).satisfiesExactly(
                 retainedProject -> assertThat(retainedProject.getVersion()).isEqualTo("5.0.0"),
                 retainedProject -> assertThat(retainedProject.getVersion()).isEqualTo("4.0.0"),
@@ -181,7 +181,7 @@ class ProjectMaintenanceTaskTest extends PersistenceCapableTest {
         final var task = new ProjectMaintenanceTask();
         assertThatNoException().isThrownBy(() -> task.run());
         final PaginatedResult projects = withJdbiHandle(handle ->
-                handle.attach(ProjectDao.class).getProjects(null, null, null, null, null, false, false, false));
+                handle.attach(ProjectDao.class).getProjects(null, null, null, null, null, null, false, false, false));
         assertThat(projects.getList(Project.class)).satisfiesExactlyInAnyOrder(
                 retainedProject -> {
                     assertThat(retainedProject.getName()).isEqualTo("acme-app-A");
@@ -216,7 +216,7 @@ class ProjectMaintenanceTaskTest extends PersistenceCapableTest {
         final var task = new ProjectMaintenanceTask();
         assertThatNoException().isThrownBy(() -> task.run());
         final PaginatedResult projects = withJdbiHandle(handle ->
-                handle.attach(ProjectDao.class).getProjects(null, null, null, null, null, false, false, false));
+                handle.attach(ProjectDao.class).getProjects(null, null, null, null, null, null, false, false, false));
         assertThat(projects).isNotNull();
     }
 
@@ -238,7 +238,7 @@ class ProjectMaintenanceTaskTest extends PersistenceCapableTest {
         final var task = new ProjectMaintenanceTask();
         assertThatNoException().isThrownBy(() -> task.run());
         final PaginatedResult projects = withJdbiHandle(handle ->
-                handle.attach(ProjectDao.class).getProjects(null, null, null, null, null, false, false, false));
+                handle.attach(ProjectDao.class).getProjects(null, null, null, null, null, null, false, false, false));
         assertThat(projects).isNotNull();
     }
 }

--- a/apiserver/src/test/resources/archunit_store/abb951d9-b11c-45d0-a35c-0d8977fd78e3
+++ b/apiserver/src/test/resources/archunit_store/abb951d9-b11c-45d0-a35c-0d8977fd78e3
@@ -15,6 +15,7 @@ org.dependencytrack.persistence.jdbi.MetricsDao.getMostRecentProjectMetrics(long
 org.dependencytrack.persistence.jdbi.MetricsDao.getPortfolioMetricsForDays(int) returns model class org.dependencytrack.model.PortfolioMetrics
 org.dependencytrack.persistence.jdbi.MetricsDao.getProjectMetricsSince(long, java.time.Instant) returns model class org.dependencytrack.model.ProjectMetrics
 org.dependencytrack.persistence.jdbi.MetricsDao.getVulnerabilityMetrics() returns model class org.dependencytrack.model.VulnerabilityMetrics
+org.dependencytrack.persistence.jdbi.ProjectDao.getProjects(java.util.ArrayList, java.util.Map, boolean, java.lang.String, java.lang.String) returns model class org.dependencytrack.model.Project
 org.dependencytrack.persistence.jdbi.ScheduledNotificationDao.getScheduledNotificationRuleByName(java.lang.String) returns model class org.dependencytrack.model.NotificationRule
 org.dependencytrack.persistence.jdbi.VulnerabilityDao.getByUuid(java.util.UUID) returns model class org.dependencytrack.model.Vulnerability
 org.dependencytrack.persistence.jdbi.VulnerabilityDao.getByUuidOrVulnIdAndSource(java.util.UUID, java.lang.String, java.lang.String) returns model class org.dependencytrack.model.Vulnerability

--- a/apiserver/src/test/resources/archunit_store/f3b37c20-3a23-4355-a1a0-626adddec514
+++ b/apiserver/src/test/resources/archunit_store/f3b37c20-3a23-4355-a1a0-626adddec514
@@ -1,4 +1,5 @@
 org.dependencytrack.persistence.jdbi.mapping.AnalysisRowMapper maps to model class org.dependencytrack.model.Analysis
 org.dependencytrack.persistence.jdbi.mapping.NotificationRuleRowMapper maps to model class org.dependencytrack.model.NotificationRule
+org.dependencytrack.persistence.jdbi.ProjectDao$ProjectListRowMapper maps to model class org.dependencytrack.model.Project
 org.dependencytrack.persistence.jdbi.mapping.VulnerabilityRowMapper maps to model class org.dependencytrack.model.Vulnerability
 org.dependencytrack.persistence.jdbi.mapping.VulnerableSoftwareRowMapper maps to model class org.dependencytrack.model.VulnerableSoftware


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes `lastRiskScore` of collection projects missing from project list API endpoints.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

In contrast to v4, collection project metrics are calculated ad-hoc. This approach was chosen because pre-computing them is a coordination nightmare (would require re-computing on project hierarchy changes, project deletions, isLatest, and tag assignment changes, and all that recursively).

As a side effect of that, the `LAST_RISKSCORE` column of collection projects no longer gets populated, which is confusing, and also makes it impossible to sort collection projects by risk score.

To fix this, the computation of collection metrics is inlined in the project listing queries. Definitely not optimal, but still miles better than trying to coordinate the write path.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
