### PR TITLE
Enforce separate limits for compressed and uncompressed repository responses

### DIFF
--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cache/CachingHttpClient.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cache/CachingHttpClient.java
@@ -55,35 +55,77 @@ import java.util.zip.GZIPOutputStream;
 
 import static java.util.Objects.requireNonNull;
 
-/**
- * @since 5.0.0
- */
+/// @since 5.0.0
 public final class CachingHttpClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CachingHttpClient.class);
 
+    public static final Duration DEFAULT_FRESHNESS_CAP = Duration.ofHours(12);
+    public static final long DEFAULT_MAX_COMPRESSED_BYTES = 16L * 1024 * 1024;
+    public static final long DEFAULT_MAX_DECODED_BYTES = 64L * 1024 * 1024;
+
     private final HttpClient httpClient;
     private final Cache cache;
     private final Duration freshnessCap;
-    private final long maxBytes;
+    private final long maxCompressedBytes;
+    private final long maxDecodedBytes;
     private final Clock clock;
     private final RateLimitGate rateLimitGate;
 
-    public CachingHttpClient(HttpClient httpClient, Cache cache, Duration freshnessCap, long maxBytes) {
-        this(httpClient, cache, freshnessCap, maxBytes, Clock.systemUTC());
+    public CachingHttpClient(HttpClient httpClient, Cache cache) {
+        this(httpClient, cache, DEFAULT_FRESHNESS_CAP, DEFAULT_MAX_COMPRESSED_BYTES, DEFAULT_MAX_DECODED_BYTES);
     }
 
-    CachingHttpClient(HttpClient httpClient, Cache cache, Duration freshnessCap, long maxBytes, Clock clock) {
+    public CachingHttpClient(HttpClient httpClient, Cache cache, Duration freshnessCap) {
+        this(httpClient, cache, freshnessCap, DEFAULT_MAX_COMPRESSED_BYTES, DEFAULT_MAX_DECODED_BYTES);
+    }
+
+    public CachingHttpClient(
+            HttpClient httpClient,
+            Cache cache,
+            Duration freshnessCap,
+            long maxCompressedBytes,
+            long maxDecodedBytes) {
+        this(httpClient, cache, freshnessCap, maxCompressedBytes, maxDecodedBytes, Clock.systemUTC());
+    }
+
+    CachingHttpClient(HttpClient httpClient, Cache cache, Duration freshnessCap, Clock clock) {
+        this(httpClient, cache, freshnessCap, DEFAULT_MAX_COMPRESSED_BYTES, DEFAULT_MAX_DECODED_BYTES, clock);
+    }
+
+    /// @param httpClient         The [HttpClient] to execute requests with.
+    /// @param cache              The [Cache] to store responses in.
+    /// @param freshnessCap       For how long cache entries are considered fresh.
+    /// Entries outside this freshness window will be revalidated.
+    /// @param maxCompressedBytes Maximum number of bytes that compressed repository
+    /// responses are allowed to have. Responses exceeding this limit will be dropped.
+    /// @param maxDecodedBytes    Maximum number of bytes that decoded / decompressed
+    /// responses are allowed to have. Responses exceeding this limit will be dropped.
+    /// @param clock              The [Clock] to use for rate limit gating.
+    CachingHttpClient(
+            HttpClient httpClient,
+            Cache cache,
+            Duration freshnessCap,
+            long maxCompressedBytes,
+            long maxDecodedBytes,
+            Clock clock) {
         this.httpClient = requireNonNull(httpClient, "httpClient must not be null");
         this.cache = requireNonNull(cache, "cache must not be null");
         this.freshnessCap = requireNonNull(freshnessCap, "freshnessCap must not be null");
         if (freshnessCap.isNegative() || freshnessCap.isZero()) {
             throw new IllegalArgumentException("freshnessCap must be positive: " + freshnessCap);
         }
-        if (maxBytes <= 0 || maxBytes > Integer.MAX_VALUE) {
-            throw new IllegalArgumentException("maxBytes must be in (0, %d]: %d".formatted(Integer.MAX_VALUE, maxBytes));
+        if (maxCompressedBytes <= 0 || maxCompressedBytes > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException(
+                    "maxCompressedBytes must be in (0, %d]: %d".formatted(Integer.MAX_VALUE, maxCompressedBytes));
         }
-        this.maxBytes = maxBytes;
+        if (maxDecodedBytes < maxCompressedBytes || maxDecodedBytes > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException(
+                    "maxDecodedBytes must be in [%d, %d]: %d".formatted(
+                            maxCompressedBytes, Integer.MAX_VALUE, maxDecodedBytes));
+        }
+        this.maxCompressedBytes = maxCompressedBytes;
+        this.maxDecodedBytes = maxDecodedBytes;
         this.clock = requireNonNull(clock, "clock must not be null");
         this.rateLimitGate = new RateLimitGate(clock);
     }
@@ -114,7 +156,7 @@ public final class CachingHttpClient {
         return sendWithStaleFallback(uri, entry, this::staleBody, () -> {
             final HttpResponse<byte[]> response = httpClient.send(
                     requestBuilderCopy.build(),
-                    _ -> new LimitedBodySubscriber(maxBytes));
+                    _ -> new LimitedBodySubscriber(maxCompressedBytes));
             return handleGetResponse(response, entry, cacheKey);
         });
     }
@@ -528,11 +570,11 @@ public final class CachingHttpClient {
     }
 
     private byte[] gunzipBounded(byte[] gzipped) {
-        final int limit = (int) Math.min(Integer.MAX_VALUE, maxBytes + 1);
+        final int limit = (int) Math.min(Integer.MAX_VALUE, maxDecodedBytes + 1);
         try (var in = new GZIPInputStream(new ByteArrayInputStream(gzipped))) {
             final byte[] decoded = in.readNBytes(limit);
-            if (decoded.length > maxBytes) {
-                throw new IOException("Decoded body exceeds %d bytes".formatted(maxBytes));
+            if (decoded.length > maxDecodedBytes) {
+                throw new IOException("Decoded body exceeds %d bytes".formatted(maxDecodedBytes));
             }
             return decoded;
         } catch (IOException e) {

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolverFactory.java
@@ -30,14 +30,10 @@ import org.dependencytrack.plugin.api.ServiceRegistry;
 import org.jspecify.annotations.Nullable;
 
 import java.net.http.HttpClient;
-import java.time.Duration;
 
 import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 
 public final class CargoPackageMetadataResolverFactory implements PackageMetadataResolverFactory {
-
-    private static final Duration FRESH_FOR = Duration.ofHours(12);
-    private static final long MAX_BYTES = 8L * 1024 * 1024;
 
     private @Nullable ObjectMapper objectMapper;
     private @Nullable CachingHttpClient cachingHttpClient;
@@ -83,9 +79,7 @@ public final class CargoPackageMetadataResolverFactory implements PackageMetadat
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         cachingHttpClient = new CachingHttpClient(
                 serviceRegistry.require(HttpClient.class),
-                serviceRegistry.require(CacheManager.class).getCache("responses"),
-                FRESH_FOR,
-                MAX_BYTES);
+                serviceRegistry.require(CacheManager.class).getCache("responses"));
     }
 
     @Override

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/composer/ComposerPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/composer/ComposerPackageMetadataResolverFactory.java
@@ -30,14 +30,10 @@ import org.dependencytrack.plugin.api.ServiceRegistry;
 import org.jspecify.annotations.Nullable;
 
 import java.net.http.HttpClient;
-import java.time.Duration;
 
 import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 
 public final class ComposerPackageMetadataResolverFactory implements PackageMetadataResolverFactory {
-
-    private static final Duration FRESH_FOR = Duration.ofHours(12);
-    private static final long MAX_BYTES = 16L * 1024 * 1024;
 
     private @Nullable ObjectMapper objectMapper;
     private @Nullable CachingHttpClient cachingHttpClient;
@@ -84,9 +80,7 @@ public final class ComposerPackageMetadataResolverFactory implements PackageMeta
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         cachingHttpClient = new CachingHttpClient(
                 serviceRegistry.require(HttpClient.class),
-                serviceRegistry.require(CacheManager.class).getCache("responses"),
-                FRESH_FOR,
-                MAX_BYTES);
+                serviceRegistry.require(CacheManager.class).getCache("responses"));
     }
 
     @Override

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cpan/CpanPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cpan/CpanPackageMetadataResolverFactory.java
@@ -30,14 +30,10 @@ import org.dependencytrack.plugin.api.ServiceRegistry;
 import org.jspecify.annotations.Nullable;
 
 import java.net.http.HttpClient;
-import java.time.Duration;
 
 import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 
 public final class CpanPackageMetadataResolverFactory implements PackageMetadataResolverFactory {
-
-    private static final Duration FRESH_FOR = Duration.ofHours(12);
-    private static final long MAX_BYTES = 4L * 1024 * 1024;
 
     private @Nullable ObjectMapper objectMapper;
     private @Nullable CachingHttpClient cachingHttpClient;
@@ -83,9 +79,7 @@ public final class CpanPackageMetadataResolverFactory implements PackageMetadata
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         cachingHttpClient = new CachingHttpClient(
                 serviceRegistry.require(HttpClient.class),
-                serviceRegistry.require(CacheManager.class).getCache("responses"),
-                FRESH_FOR,
-                MAX_BYTES);
+                serviceRegistry.require(CacheManager.class).getCache("responses"));
     }
 
     @Override

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gem/GemPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gem/GemPackageMetadataResolverFactory.java
@@ -30,14 +30,10 @@ import org.dependencytrack.plugin.api.ServiceRegistry;
 import org.jspecify.annotations.Nullable;
 
 import java.net.http.HttpClient;
-import java.time.Duration;
 
 import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 
 public final class GemPackageMetadataResolverFactory implements PackageMetadataResolverFactory {
-
-    private static final Duration FRESH_FOR = Duration.ofHours(12);
-    private static final long MAX_BYTES = 4L * 1024 * 1024;
 
     private @Nullable ObjectMapper objectMapper;
     private @Nullable CachingHttpClient cachingHttpClient;
@@ -83,9 +79,7 @@ public final class GemPackageMetadataResolverFactory implements PackageMetadataR
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         cachingHttpClient = new CachingHttpClient(
                 serviceRegistry.require(HttpClient.class),
-                serviceRegistry.require(CacheManager.class).getCache("responses"),
-                FRESH_FOR,
-                MAX_BYTES);
+                serviceRegistry.require(CacheManager.class).getCache("responses"));
     }
 
     @Override

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/github/GithubPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/github/GithubPackageMetadataResolverFactory.java
@@ -30,14 +30,10 @@ import org.dependencytrack.plugin.api.ServiceRegistry;
 import org.jspecify.annotations.Nullable;
 
 import java.net.http.HttpClient;
-import java.time.Duration;
 
 import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 
 public final class GithubPackageMetadataResolverFactory implements PackageMetadataResolverFactory {
-
-    private static final Duration FRESH_FOR = Duration.ofHours(12);
-    private static final long MAX_BYTES = 4L * 1024 * 1024;
 
     private @Nullable ObjectMapper objectMapper;
     private @Nullable CachingHttpClient cachingHttpClient;
@@ -84,9 +80,7 @@ public final class GithubPackageMetadataResolverFactory implements PackageMetada
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         cachingHttpClient = new CachingHttpClient(
                 serviceRegistry.require(HttpClient.class),
-                serviceRegistry.require(CacheManager.class).getCache("responses"),
-                FRESH_FOR,
-                MAX_BYTES);
+                serviceRegistry.require(CacheManager.class).getCache("responses"));
     }
 
     @Override

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gomodules/GoModulesPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gomodules/GoModulesPackageMetadataResolverFactory.java
@@ -30,14 +30,10 @@ import org.dependencytrack.plugin.api.ServiceRegistry;
 import org.jspecify.annotations.Nullable;
 
 import java.net.http.HttpClient;
-import java.time.Duration;
 
 import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 
 public final class GoModulesPackageMetadataResolverFactory implements PackageMetadataResolverFactory {
-
-    private static final Duration FRESH_FOR = Duration.ofHours(12);
-    private static final long MAX_BYTES = 4L * 1024 * 1024;
 
     private @Nullable ObjectMapper objectMapper;
     private @Nullable CachingHttpClient cachingHttpClient;
@@ -83,9 +79,7 @@ public final class GoModulesPackageMetadataResolverFactory implements PackageMet
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         cachingHttpClient = new CachingHttpClient(
                 serviceRegistry.require(HttpClient.class),
-                serviceRegistry.require(CacheManager.class).getCache("responses"),
-                FRESH_FOR,
-                MAX_BYTES);
+                serviceRegistry.require(CacheManager.class).getCache("responses"));
     }
 
     @Override

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/hackage/HackagePackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/hackage/HackagePackageMetadataResolverFactory.java
@@ -30,14 +30,10 @@ import org.dependencytrack.plugin.api.ServiceRegistry;
 import org.jspecify.annotations.Nullable;
 
 import java.net.http.HttpClient;
-import java.time.Duration;
 
 import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 
 public final class HackagePackageMetadataResolverFactory implements PackageMetadataResolverFactory {
-
-    private static final Duration FRESH_FOR = Duration.ofHours(12);
-    private static final long MAX_BYTES = 4L * 1024 * 1024;
 
     private @Nullable ObjectMapper objectMapper;
     private @Nullable CachingHttpClient cachingHttpClient;
@@ -83,9 +79,7 @@ public final class HackagePackageMetadataResolverFactory implements PackageMetad
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         cachingHttpClient = new CachingHttpClient(
                 serviceRegistry.require(HttpClient.class),
-                serviceRegistry.require(CacheManager.class).getCache("responses"),
-                FRESH_FOR,
-                MAX_BYTES);
+                serviceRegistry.require(CacheManager.class).getCache("responses"));
     }
 
     @Override

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/hex/HexPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/hex/HexPackageMetadataResolverFactory.java
@@ -30,14 +30,10 @@ import org.dependencytrack.plugin.api.ServiceRegistry;
 import org.jspecify.annotations.Nullable;
 
 import java.net.http.HttpClient;
-import java.time.Duration;
 
 import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 
 public final class HexPackageMetadataResolverFactory implements PackageMetadataResolverFactory {
-
-    private static final Duration FRESH_FOR = Duration.ofHours(12);
-    private static final long MAX_BYTES = 4L * 1024 * 1024;
 
     private @Nullable ObjectMapper objectMapper;
     private @Nullable CachingHttpClient cachingHttpClient;
@@ -83,9 +79,7 @@ public final class HexPackageMetadataResolverFactory implements PackageMetadataR
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         cachingHttpClient = new CachingHttpClient(
                 serviceRegistry.require(HttpClient.class),
-                serviceRegistry.require(CacheManager.class).getCache("responses"),
-                FRESH_FOR,
-                MAX_BYTES);
+                serviceRegistry.require(CacheManager.class).getCache("responses"));
     }
 
     @Override

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolverFactory.java
@@ -29,13 +29,9 @@ import org.dependencytrack.plugin.api.ServiceRegistry;
 import org.jspecify.annotations.Nullable;
 
 import java.net.http.HttpClient;
-import java.time.Duration;
 import java.util.Map;
 
 public final class MavenPackageMetadataResolverFactory implements PackageMetadataResolverFactory {
-
-    private static final Duration FRESH_FOR = Duration.ofHours(12);
-    private static final long MAX_BYTES = 4L * 1024 * 1024;
 
     private @Nullable CachingHttpClient cachingHttpClient;
 
@@ -90,9 +86,7 @@ public final class MavenPackageMetadataResolverFactory implements PackageMetadat
     public void init(ServiceRegistry serviceRegistry) {
         cachingHttpClient = new CachingHttpClient(
                 serviceRegistry.require(HttpClient.class),
-                serviceRegistry.require(CacheManager.class).getCache("responses"),
-                FRESH_FOR,
-                MAX_BYTES);
+                serviceRegistry.require(CacheManager.class).getCache("responses"));
     }
 
     @Override

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/npm/NpmPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/npm/NpmPackageMetadataResolverFactory.java
@@ -31,14 +31,10 @@ import org.dependencytrack.plugin.api.ServiceRegistry;
 import org.jspecify.annotations.Nullable;
 
 import java.net.http.HttpClient;
-import java.time.Duration;
 
 import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 
 public final class NpmPackageMetadataResolverFactory implements PackageMetadataResolverFactory {
-
-    private static final Duration FRESH_FOR = Duration.ofHours(12);
-    private static final long MAX_BYTES = 16L * 1024 * 1024;
 
     private @Nullable ObjectMapper objectMapper;
     private @Nullable CachingHttpClient cachingHttpClient;
@@ -85,9 +81,7 @@ public final class NpmPackageMetadataResolverFactory implements PackageMetadataR
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         cachingHttpClient = new CachingHttpClient(
                 serviceRegistry.require(HttpClient.class),
-                serviceRegistry.require(CacheManager.class).getCache("responses"),
-                FRESH_FOR,
-                MAX_BYTES);
+                serviceRegistry.require(CacheManager.class).getCache("responses"));
     }
 
     @Override

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nuget/NugetPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nuget/NugetPackageMetadataResolverFactory.java
@@ -30,14 +30,10 @@ import org.dependencytrack.plugin.api.ServiceRegistry;
 import org.jspecify.annotations.Nullable;
 
 import java.net.http.HttpClient;
-import java.time.Duration;
 
 import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 
 public final class NugetPackageMetadataResolverFactory implements PackageMetadataResolverFactory {
-
-    private static final Duration FRESH_FOR = Duration.ofHours(12);
-    private static final long MAX_BYTES = 16L * 1024 * 1024;
 
     private @Nullable ObjectMapper objectMapper;
     private @Nullable CachingHttpClient cachingHttpClient;
@@ -83,9 +79,7 @@ public final class NugetPackageMetadataResolverFactory implements PackageMetadat
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         cachingHttpClient = new CachingHttpClient(
                 serviceRegistry.require(HttpClient.class),
-                serviceRegistry.require(CacheManager.class).getCache("responses"),
-                FRESH_FOR,
-                MAX_BYTES);
+                serviceRegistry.require(CacheManager.class).getCache("responses"));
     }
 
     @Override

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/pypi/PypiPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/pypi/PypiPackageMetadataResolverFactory.java
@@ -31,14 +31,10 @@ import org.dependencytrack.plugin.api.ServiceRegistry;
 import org.jspecify.annotations.Nullable;
 
 import java.net.http.HttpClient;
-import java.time.Duration;
 
 import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 
 public final class PypiPackageMetadataResolverFactory implements PackageMetadataResolverFactory {
-
-    private static final Duration FRESH_FOR = Duration.ofHours(12);
-    private static final long MAX_BYTES = 8L * 1024 * 1024;
 
     private @Nullable ObjectMapper objectMapper;
     private @Nullable CachingHttpClient cachingHttpClient;
@@ -90,9 +86,7 @@ public final class PypiPackageMetadataResolverFactory implements PackageMetadata
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         cachingHttpClient = new CachingHttpClient(
                 serviceRegistry.require(HttpClient.class),
-                serviceRegistry.require(CacheManager.class).getCache("responses"),
-                FRESH_FOR,
-                MAX_BYTES);
+                serviceRegistry.require(CacheManager.class).getCache("responses"));
     }
 
     @Override

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/cache/CachingHttpClientTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/cache/CachingHttpClientTest.java
@@ -69,7 +69,6 @@ class CachingHttpClientTest {
 
     private static final String CACHE_NAME = "test-cache";
     private static final String PATH = "/resource";
-    private static final long MAX_BYTES = 16L * 1024 * 1024;
 
     private CacheManager cacheManager;
     private Cache cache;
@@ -98,7 +97,7 @@ class CachingHttpClientTest {
                         .withHeader("Last-Modified", "Sat, 04 Nov 2023 12:00:00 GMT")
                         .withBody("hello")));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         final byte[] body = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
 
         assertThat(body).isEqualTo("hello".getBytes(StandardCharsets.UTF_8));
@@ -112,7 +111,7 @@ class CachingHttpClientTest {
                         .withHeader("ETag", "\"abc\"")
                         .withBody("hello")));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         final byte[] secondBody = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
 
@@ -136,7 +135,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(304)));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         clock.advance(Duration.ofMinutes(2));
         final byte[] body = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
@@ -162,7 +161,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(304)));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         clock.advance(Duration.ofMinutes(2));
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
@@ -189,7 +188,7 @@ class CachingHttpClientTest {
                         .withBody("second")));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         clock.advance(Duration.ofMinutes(2));
         final byte[] body = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
@@ -205,7 +204,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(200).withBody("hello")));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         clock.advance(Duration.ofMinutes(2));
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
@@ -220,7 +219,7 @@ class CachingHttpClientTest {
         stubFor(get(urlPathEqualTo(PATH))
                 .willReturn(aResponse().withStatus(503)));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         assertThatExceptionOfType(RetryableResolutionException.class)
                 .isThrownBy(() -> cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null));
     }
@@ -231,7 +230,7 @@ class CachingHttpClientTest {
         stubFor(get(urlPathEqualTo(PATH))
                 .willReturn(aResponse().withStatus(status)));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         assertThat(cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null)).isNull();
         assertThat(cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null)).isNull();
         verify(1, getRequestedFor(urlPathEqualTo(PATH)));
@@ -243,7 +242,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(404)));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         clock.advance(Duration.ofMinutes(2));
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
@@ -268,7 +267,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(410)));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         clock.advance(Duration.ofMinutes(2));
         final byte[] afterGone = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
@@ -286,7 +285,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(404)
                         .withHeader("Cache-Control", "no-store")));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
 
@@ -308,7 +307,7 @@ class CachingHttpClientTest {
                         .withBody("hello")));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         assertThat(cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null)).isNull();
         clock.advance(Duration.ofMinutes(2));
         final byte[] body = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
@@ -329,7 +328,7 @@ class CachingHttpClientTest {
                         .withBody("hello")));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(24), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(24), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
 
         // Within the upstream-declared max-age: served from cache.
@@ -354,7 +353,7 @@ class CachingHttpClientTest {
                         .withBody("hello")));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
 
         clock.advance(Duration.ofMinutes(2));
@@ -371,7 +370,7 @@ class CachingHttpClientTest {
                         .withBody("hello")));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         clock.advance(Duration.ofMinutes(30));
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
@@ -387,7 +386,7 @@ class CachingHttpClientTest {
                         .withHeader("Cache-Control", "no-store")
                         .withBody("hello")));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         final byte[] firstBody = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         final byte[] secondBody = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
 
@@ -412,7 +411,7 @@ class CachingHttpClientTest {
                 .whenScenarioStateIs("warmed")
                 .willReturn(aResponse().withStatus(304)));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
 
         // Without advancing the clock, the next call must still revalidate.
@@ -440,7 +439,7 @@ class CachingHttpClientTest {
                         .withHeader("Cache-Control", "max-age=600")));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
 
         clock.advance(Duration.ofMinutes(2));
@@ -469,7 +468,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(304)));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
 
         // Past the upstream max-age: triggers revalidation.
@@ -492,27 +491,32 @@ class CachingHttpClientTest {
     @Test
     void shouldRejectInvalidConstructorArguments() {
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> new CachingHttpClient(httpClient, cache, Duration.ZERO, MAX_BYTES));
+                .isThrownBy(() -> new CachingHttpClient(httpClient, cache, Duration.ZERO));
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> new CachingHttpClient(httpClient, cache, Duration.ofSeconds(-1), MAX_BYTES));
+                .isThrownBy(() -> new CachingHttpClient(httpClient, cache, Duration.ofSeconds(-1)));
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> new CachingHttpClient(httpClient, cache, Duration.ofHours(1), 0));
+                .isThrownBy(() -> new CachingHttpClient(httpClient, cache, Duration.ofHours(1), 0, 0));
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> new CachingHttpClient(httpClient, cache, Duration.ofHours(1), -1));
+                .isThrownBy(() -> new CachingHttpClient(httpClient, cache, Duration.ofHours(1), -1, -1));
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new CachingHttpClient(
-                        httpClient, cache, Duration.ofHours(1), (long) Integer.MAX_VALUE + 1));
+                        httpClient, cache, Duration.ofHours(1), (long) Integer.MAX_VALUE + 1, (long) Integer.MAX_VALUE + 1));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new CachingHttpClient(httpClient, cache, Duration.ofHours(1), 1024, 512));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new CachingHttpClient(
+                        httpClient, cache, Duration.ofHours(1), 1024, (long) Integer.MAX_VALUE + 1));
     }
 
     @Test
-    void shouldThrowWhenResponseBodyExceedsMaxBytes(WireMockRuntimeInfo wmRuntimeInfo) {
+    void shouldThrowWhenResponseBodyExceedsMaxCompressedBytes(WireMockRuntimeInfo wmRuntimeInfo) {
         final byte[] payload = new byte[2048];
         stubFor(get(urlPathEqualTo(PATH))
                 .willReturn(aResponse().withStatus(200)
                         .withHeader("ETag", "\"big\"")
                         .withBody(payload)));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), 1024);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), 1024, 1024);
 
         assertThatExceptionOfType(UncheckedIOException.class)
                 .isThrownBy(() -> cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null));
@@ -535,7 +539,7 @@ class CachingHttpClientTest {
                 .whenScenarioStateIs("recovered")
                 .willReturn(aResponse().withStatus(200).withBody("hello")));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
 
         assertThatExceptionOfType(UncheckedIOException.class)
                 .isThrownBy(() -> cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null));
@@ -567,7 +571,7 @@ class CachingHttpClientTest {
                 ? aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)
                 : retryAfterSeconds > 0
                   ? aResponse().withStatus(failureStatus)
-                    .withHeader("Retry-After", String.valueOf(retryAfterSeconds))
+                .withHeader("Retry-After", String.valueOf(retryAfterSeconds))
                   : aResponse().withStatus(failureStatus);
         stubFor(get(urlPathEqualTo(PATH))
                 .inScenario(label)
@@ -575,7 +579,7 @@ class CachingHttpClientTest {
                 .willReturn(failureResponse));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         clock.advance(Duration.ofMinutes(2));
 
@@ -600,7 +604,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(200).withFixedDelay(2_000).withBody("late")));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         clock.advance(Duration.ofMinutes(2));
 
@@ -619,7 +623,7 @@ class CachingHttpClientTest {
         stubFor(get(urlPathEqualTo(PATH))
                 .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
 
         assertThatExceptionOfType(UncheckedIOException.class)
                 .isThrownBy(() -> cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null));
@@ -638,7 +642,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(503)));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         assertThat(cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null)).isNull();
         clock.advance(Duration.ofMinutes(2));
 
@@ -666,7 +670,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(304)));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         clock.advance(Duration.ofMinutes(2));
 
@@ -696,7 +700,7 @@ class CachingHttpClientTest {
                         .withHeader("Content-Length", "1234")
                         .withHeader("Server", "nginx")));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         final HttpHeaders headers = cachingHttpClient.head(
                 headRequestBuilderFor(wmRuntimeInfo), null, "content-length"::equalsIgnoreCase);
 
@@ -723,7 +727,7 @@ class CachingHttpClientTest {
                         .withHeader("ETag", "\"v1\"")
                         .withHeader("Last-Modified", "Sat, 04 Nov 2023 12:00:00 GMT")));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         final HttpHeaders headers = cachingHttpClient.head(
                 headRequestBuilderFor(wmRuntimeInfo), null, name -> false);
 
@@ -746,7 +750,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(304)));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         cachingHttpClient.head(headRequestBuilderFor(wmRuntimeInfo), null, "content-length"::equalsIgnoreCase);
         clock.advance(Duration.ofMinutes(2));
         final HttpHeaders headers = cachingHttpClient.head(
@@ -764,7 +768,7 @@ class CachingHttpClientTest {
         stubFor(head(urlPathEqualTo(PATH))
                 .willReturn(aResponse().withStatus(404)));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         assertThat(cachingHttpClient.head(headRequestBuilderFor(wmRuntimeInfo), null, name -> false)).isNull();
         assertThat(cachingHttpClient.head(headRequestBuilderFor(wmRuntimeInfo), null, name -> false)).isNull();
 
@@ -786,7 +790,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(503)));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         cachingHttpClient.head(headRequestBuilderFor(wmRuntimeInfo), null, "content-length"::equalsIgnoreCase);
         clock.advance(Duration.ofMinutes(2));
 
@@ -802,7 +806,7 @@ class CachingHttpClientTest {
         stubFor(head(urlPathEqualTo(PATH))
                 .willReturn(aResponse().withStatus(304)));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         assertThatExceptionOfType(UncheckedIOException.class)
                 .isThrownBy(() -> cachingHttpClient.head(
                         headRequestBuilderFor(wmRuntimeInfo), null, name -> false));
@@ -819,7 +823,7 @@ class CachingHttpClientTest {
                         .withHeader("ETag", "\"head\"")
                         .withHeader("Content-Length", "5")));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         final HttpHeaders headers = cachingHttpClient.head(
                 headRequestBuilderFor(wmRuntimeInfo), null, "content-length"::equalsIgnoreCase);
@@ -834,7 +838,7 @@ class CachingHttpClientTest {
         stubFor(get(urlPathEqualTo(PATH))
                 .willReturn(aResponse().withStatus(200).withBody("hello")));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
 
         verify(getRequestedFor(urlPathEqualTo(PATH))
@@ -846,7 +850,7 @@ class CachingHttpClientTest {
         stubFor(get(urlPathEqualTo(PATH))
                 .willReturn(aResponse().withStatus(200).withBody("hello")));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         cachingHttpClient.get(
                 HttpRequest.newBuilder()
                         .uri(URI.create(wmRuntimeInfo.getHttpBaseUrl() + PATH))
@@ -876,7 +880,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(304)));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         clock.advance(Duration.ofMinutes(2));
         final byte[] body = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
@@ -885,7 +889,7 @@ class CachingHttpClientTest {
     }
 
     @Test
-    void shouldRejectGzipDecodedBodyExceedingMaxBytes(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+    void shouldRejectGzipDecodedBodyExceedingMaxDecodedBytes(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         // 64 KiB of zeros compresses to ~80 bytes.
         // Well below the wire cap but above the decoded cap.
         final byte[] payload = new byte[64 * 1024];
@@ -895,10 +899,29 @@ class CachingHttpClientTest {
                         .withHeader("Content-Encoding", "gzip")
                         .withBody(gzipped)));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), 1024);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), 8 * 1024, 8 * 1024);
 
         assertThatExceptionOfType(UncheckedIOException.class)
                 .isThrownBy(() -> cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null));
+    }
+
+    @Test
+    void shouldAcceptGzipDecodedBodyWhenWithinDecodedCapButExceedingCompressedCap(
+            WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        // 64 KiB of zeros compresses to ~80 bytes.
+        // Passes the 1 KiB wire cap, and the 128 KiB decoded
+        // cap accommodates the uncompressed payload.
+        final byte[] payload = new byte[64 * 1024];
+        final byte[] gzipped = gzip(payload);
+        stubFor(get(urlPathEqualTo(PATH))
+                .willReturn(aResponse().withStatus(200)
+                        .withHeader("Content-Encoding", "gzip")
+                        .withBody(gzipped)));
+
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), 1024, 128 * 1024);
+        final byte[] body = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
+
+        assertThat(body).isEqualTo(payload);
     }
 
     @ParameterizedTest(name = "[{index}] Content-Encoding={0}")
@@ -914,7 +937,7 @@ class CachingHttpClientTest {
         }
         stubFor(get(urlPathEqualTo(PATH)).willReturn(stub));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         final byte[] result = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
 
         assertThat(result).isEqualTo(body.getBytes(StandardCharsets.UTF_8));
@@ -928,7 +951,7 @@ class CachingHttpClientTest {
                         .withHeader("ETag", "\"v1\"")
                         .withBody(payload)));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         final byte[] body = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
 
         assertThat(body).isEqualTo(payload);
@@ -948,7 +971,7 @@ class CachingHttpClientTest {
                         .withHeader("ETag", "\"v1\"")
                         .withBody(gzipped)));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         final byte[] expected = "hello".getBytes(StandardCharsets.UTF_8);
         assertThat(cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null)).isEqualTo(expected);
         assertThat(cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null)).isEqualTo(expected);
@@ -973,7 +996,7 @@ class CachingHttpClientTest {
         stubFor(get(urlPathEqualTo(PATH))
                 .willReturn(aResponse().withStatus(304)));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         assertThat(cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null)).isNull();
 
         // Refreshed entry must remain bodyless, not a cached empty 200.
@@ -997,7 +1020,7 @@ class CachingHttpClientTest {
                         .withHeader("ETag", "\"v1\"")
                         .withBody("fresh")));
 
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
         final byte[] body = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
 
         assertThat(body).isEqualTo("fresh".getBytes(StandardCharsets.UTF_8));
@@ -1019,7 +1042,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "60")));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         clock.advance(Duration.ofMinutes(2));
 
@@ -1038,7 +1061,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "60")));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), clock);
         assertThatExceptionOfType(RetryableResolutionException.class)
                 .isThrownBy(() -> cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null));
 
@@ -1068,7 +1091,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(304)));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         clock.advance(Duration.ofMinutes(2));
 
@@ -1095,7 +1118,7 @@ class CachingHttpClientTest {
                 .willReturn(aResponse().withStatus(503)));
 
         final var clock = new MutableClock();
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), clock);
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
         clock.advance(Duration.ofMinutes(2));
 

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/composer/ComposerPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/composer/ComposerPackageMetadataResolverTest.java
@@ -28,6 +28,7 @@ import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadata;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadataResolver;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageRepository;
 import org.dependencytrack.pkgmetadata.resolution.api.RetryableResolutionException;
+import org.dependencytrack.pkgmetadata.resolution.cache.CachingHttpClient;
 import org.dependencytrack.plugin.api.MutableServiceRegistry;
 import org.dependencytrack.plugin.api.config.ConfigRegistry;
 import org.dependencytrack.plugin.api.storage.KeyValueStore;
@@ -40,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import java.io.UncheckedIOException;
 import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.Map;
 
@@ -831,10 +833,11 @@ class ComposerPackageMetadataResolverTest {
     void shouldRejectOversizedResponse(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         final var smallResolver = new ComposerPackageMetadataResolver(
                 new ObjectMapper(),
-                new org.dependencytrack.pkgmetadata.resolution.cache.CachingHttpClient(
+                new CachingHttpClient(
                         HttpClient.newHttpClient(),
                         cacheManager.getCache("small-test"),
-                        java.time.Duration.ofHours(1),
+                        Duration.ofHours(1),
+                        1024,
                         1024));
 
         stubJsonFile("/packages.json", "composer/packagist-v2-packages.json");


### PR DESCRIPTION




### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Enforces separate limits for compressed and uncompressed repository responses.

This change was prompted by NPM responses exceeding 16MiB uncompressed despite being small in their gzip-compressed form. We previously enforced the same limit for both, which turned out to be an issue for ecosystems like NPM.

Going forward we'll allow a higher limit for uncompressed responses (up to 64Mib) and a lower limit for compressed responses (up to 16MiB). Since we process responses serially, not concurrently, RAM usage should remain predictable.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
