### PR TITLE
Try to only report stable versions as latest for Maven

### DIFF
--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolver.java
@@ -19,6 +19,10 @@
 package org.dependencytrack.pkgmetadata.resolution.maven;
 
 import com.github.packageurl.PackageURL;
+import io.github.nscuro.versatile.VersionFactory;
+import io.github.nscuro.versatile.spi.InvalidVersionException;
+import io.github.nscuro.versatile.spi.Version;
+import io.github.nscuro.versatile.version.KnownVersioningSchemes;
 import org.dependencytrack.pkgmetadata.resolution.api.HashAlgorithm;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageArtifactMetadata;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadata;
@@ -54,6 +58,7 @@ final class MavenPackageMetadataResolver implements PackageMetadataResolver {
     private static final Logger LOGGER = LoggerFactory.getLogger(MavenPackageMetadataResolver.class);
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
     private static final Pattern LATEST_PATTERN = Pattern.compile("<latest>([^<]+)</latest>");
+    private static final Pattern RELEASE_PATTERN = Pattern.compile("<release>([^<]+)</release>");
     private static final Pattern VERSION_PATTERN = Pattern.compile("<version>([^<]+)</version>");
 
     private final CachingHttpClient cachingHttpClient;
@@ -155,20 +160,81 @@ final class MavenPackageMetadataResolver implements PackageMetadataResolver {
     }
 
     private static @Nullable String parseLatestVersion(String xml) {
-        final Matcher latestMatcher = LATEST_PATTERN.matcher(xml);
-        if (latestMatcher.find()) {
-            return latestMatcher.group(1);
-        }
+        // NB: <latest> and <release> do not reliably point to current stable versions.
+        // They may be out-of-date, or point to RC versions. So we walk the entire
+        // <versions> array, <latest>, AND <release>, and pick the highest stable
+        // among all of them.
+        final var candidate = new HighestStableVersionCandidate();
 
-        // Fall back to last <version> in <versions> list.
-        // Sometimes the latest version is not explicitly recorded.
-        String lastVersion = null;
         final Matcher versionMatcher = VERSION_PATTERN.matcher(xml);
         while (versionMatcher.find()) {
-            lastVersion = versionMatcher.group(1);
+            candidate.offer(versionMatcher.group(1));
         }
 
-        return lastVersion;
+        final String releaseRaw = firstMatch(xml, RELEASE_PATTERN);
+        candidate.offer(releaseRaw);
+
+        final String latestRaw = firstMatch(xml, LATEST_PATTERN);
+        candidate.offer(latestRaw);
+
+        if (candidate.highestStableRaw != null) {
+            return candidate.highestStableRaw;
+        }
+
+        if (releaseRaw != null) {
+            return releaseRaw;
+        }
+
+        if (latestRaw != null) {
+            return latestRaw;
+        }
+
+        return candidate.lastSeenRaw;
+    }
+
+    private static final class HighestStableVersionCandidate {
+
+        private @Nullable String highestStableRaw;
+        private @Nullable Version highestStableVersion;
+        private @Nullable String lastSeenRaw;
+
+        private void offer(@Nullable String raw) {
+            if (raw == null) {
+                return;
+            }
+
+            final String normalized = raw.strip();
+            if (normalized.isEmpty()) {
+                return;
+            }
+
+            lastSeenRaw = normalized;
+
+            final Version parsed;
+            try {
+                parsed = VersionFactory.forScheme(KnownVersioningSchemes.SCHEME_MAVEN, normalized);
+            } catch (InvalidVersionException e) {
+                LOGGER.debug("Skipping version because parsing it failed: {}", normalized, e);
+                return;
+            }
+
+            if (parsed.isStable()
+                    && (highestStableVersion == null || parsed.compareTo(highestStableVersion) > 0)) {
+                highestStableRaw = normalized;
+                highestStableVersion = parsed;
+            }
+        }
+
+    }
+
+    private static @Nullable String firstMatch(String input, Pattern pattern) {
+        final Matcher matcher = pattern.matcher(input);
+        if (!matcher.find()) {
+            return null;
+        }
+
+        final String match = matcher.group(1).strip();
+        return !match.isEmpty() ? match : null;
     }
 
     private @Nullable Instant resolvePublishedAt(

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolverTest.java
@@ -18,7 +18,6 @@
  */
 package org.dependencytrack.pkgmetadata.resolution.maven;
 
-import com.github.packageurl.PackageURLBuilder;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.smallrye.config.SmallRyeConfigBuilder;
@@ -47,6 +46,7 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.Map;
 
+import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -112,7 +112,7 @@ class MavenPackageMetadataResolverTest {
                 .willReturn(aResponse().withStatus(200)
                         .withBody("da39a3ee5e6b4b0d3255bfef95601890afd80709")));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -152,7 +152,7 @@ class MavenPackageMetadataResolverTest {
                 .willReturn(aResponse().withStatus(200)
                         .withBody("da39a3ee5e6b4b0d3255bfef95601890afd80709")));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -197,7 +197,7 @@ class MavenPackageMetadataResolverTest {
                 .willReturn(aResponse().withStatus(200)
                         .withHeader("Last-Modified", "Thu, 02 Mar 2023 10:00:00 GMT")));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -241,7 +241,7 @@ class MavenPackageMetadataResolverTest {
                 .willReturn(aResponse().withStatus(200)
                         .withBody("da39a3ee5e6b4b0d3255bfef95601890afd80709")));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -258,11 +258,86 @@ class MavenPackageMetadataResolverTest {
     }
 
     @Test
+    void shouldPreferHighestStableVersionOverUnstableLatest(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/io/micrometer/micrometer-observation/maven-metadata.xml"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody(/* language=XML */ """
+                                <?xml version="1.0" encoding="UTF-8"?>
+                                <metadata>
+                                  <groupId>io.micrometer</groupId>
+                                  <artifactId>micrometer-observation</artifactId>
+                                  <versioning>
+                                    <latest>1.17.0-RC1</latest>
+                                    <release>1.17.0-RC1</release>
+                                    <versions>
+                                      <version>1.16.4</version>
+                                      <version>1.16.5</version>
+                                      <version>1.17.0-M1</version>
+                                      <version>1.17.0-M2</version>
+                                      <version>1.17.0-RC1</version>
+                                    </versions>
+                                  </versioning>
+                                </metadata>
+                                """)));
+        stubFor(head(urlPathEqualTo("/io/micrometer/micrometer-observation/1.16.5/micrometer-observation-1.16.5.jar"))
+                .willReturn(aResponse().withStatus(200)
+                        .withHeader("Last-Modified", "Mon, 14 Apr 2025 09:00:00 GMT")));
+
+        final var purl = aPackageURL()
+                .withType("maven")
+                .withNamespace("io.micrometer")
+                .withName("micrometer-observation")
+                .build();
+
+        final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.latestVersion()).isEqualTo("1.16.5");
+        assertThat(result.latestVersionPublishedAt())
+                .isEqualTo(Instant.parse("2025-04-14T09:00:00Z"));
+    }
+
+    @Test
+    void shouldFallBackToLatestWhenAllVersionsAreUnstable(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/com/example/mylib/maven-metadata.xml"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=XML */ """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <metadata>
+                          <groupId>com.example</groupId>
+                          <artifactId>mylib</artifactId>
+                          <versioning>
+                            <latest>2.0.0-RC1</latest>
+                            <versions>
+                              <version>2.0.0-M1</version>
+                              <version>2.0.0-RC1</version>
+                            </versions>
+                          </versioning>
+                        </metadata>
+                        """)));
+        stubFor(head(urlPathEqualTo("/com/example/mylib/2.0.0-RC1/mylib-2.0.0-RC1.jar"))
+                .willReturn(aResponse().withStatus(404)));
+
+        final var purl = aPackageURL()
+                .withType("maven")
+                .withNamespace("com.example")
+                .withName("mylib")
+                .build();
+
+        final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.latestVersion()).isEqualTo("2.0.0-RC1");
+    }
+
+    @Test
     void shouldReturnNullWhenMetadataXmlNotFound(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         stubFor(get(urlPathEqualTo("/com/example/mylib/maven-metadata.xml"))
                 .willReturn(aResponse().withStatus(404)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -277,7 +352,7 @@ class MavenPackageMetadataResolverTest {
 
     @Test
     void shouldThrowWhenRepositoryIsNull() throws Exception {
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -307,7 +382,7 @@ class MavenPackageMetadataResolverTest {
                 .willReturn(aResponse().withStatus(200)
                         .withBody("da39a3ee5e6b4b0d3255bfef95601890afd80709  mylib-1.0.0.jar")));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -341,7 +416,7 @@ class MavenPackageMetadataResolverTest {
         stubFor(get(urlPathEqualTo("/com/example/mylib/1.0.0/mylib-1.0.0.jar.sha1"))
                 .willReturn(aResponse().withStatus(200).withBody("abc123")));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -376,7 +451,7 @@ class MavenPackageMetadataResolverTest {
                 .willReturn(aResponse().withStatus(200)
                         .withBody("da39a3ee5e6b4b0d3255bfef95601890afd80709")));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -403,7 +478,7 @@ class MavenPackageMetadataResolverTest {
         stubFor(get(urlPathEqualTo("/com/example/mylib/maven-metadata.xml"))
                 .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "20")));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -421,7 +496,7 @@ class MavenPackageMetadataResolverTest {
         stubFor(get(urlPathEqualTo("/com/example/mylib/maven-metadata.xml"))
                 .willReturn(aResponse().withStatus(503)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -453,7 +528,7 @@ class MavenPackageMetadataResolverTest {
                 .willReturn(aResponse().withStatus(200)
                         .withBody("da39a3ee5e6b4b0d3255bfef95601890afd80709")));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -491,7 +566,7 @@ class MavenPackageMetadataResolverTest {
                         </metadata>
                         """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -519,7 +594,7 @@ class MavenPackageMetadataResolverTest {
         stubFor(get(urlPathEqualTo("/com/example/mylib/1.0.0/mylib-1.0.0.jar.sha1"))
                 .willReturn(aResponse().withStatus(404)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -549,7 +624,7 @@ class MavenPackageMetadataResolverTest {
         stubFor(get(urlPathEqualTo("/com/example/mylib/1.0.0/mylib-1.0.0.jar.sha1"))
                 .willReturn(aResponse().withStatus(404)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -573,7 +648,7 @@ class MavenPackageMetadataResolverTest {
                         </metadata>
                         """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -614,7 +689,7 @@ class MavenPackageMetadataResolverTest {
                 .willReturn(aResponse().withStatus(200)
                         .withBody("da39a3ee5e6b4b0d3255bfef95601890afd80709")));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")
@@ -645,7 +720,7 @@ class MavenPackageMetadataResolverTest {
                 .willReturn(aResponse().withStatus(200)
                         .withBody("da39a3ee5e6b4b0d3255bfef95601890afd80709")));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("maven")
                 .withNamespace("com.example")
                 .withName("mylib")

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <lib.system-stubs.version>2.1.8</lib.system-stubs.version>
         <lib.testcontainers.version>2.0.5</lib.testcontainers.version>
         <lib.tink.version>1.21.0</lib.tink.version>
-        <lib.versatile.version>0.18.1</lib.versatile.version>
+        <lib.versatile.version>0.18.3</lib.versatile.version>
         <lib.wiremock.version>3.13.2</lib.wiremock.version>
         <lib.zstd-jni.version>1.5.7-9</lib.zstd-jni.version>
         <!-- Number of JVM processes to use for unit test parallelization -->


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Try to only report stable versions as latest for Maven.

This is best-effort but should catch most cases where we currently report unstable versions as latest.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
