### PR TITLE
Improve latest version detection for Cargo and Ruby Gems

### DIFF
--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoCrateDocument.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoCrateDocument.java
@@ -27,7 +27,9 @@ record CargoCrateDocument(
         @JsonProperty("crate") Crate crate,
         List<Version> versions) {
 
-    record Crate(@JsonProperty("newest_version") @Nullable String newestVersion) {
+    record Crate(
+            @JsonProperty("newest_version") @Nullable String newestVersion,
+            @JsonProperty("max_stable_version") @Nullable String maxStableVersion) {
     }
 
     record Version(

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolver.java
@@ -77,7 +77,9 @@ final class CargoPackageMetadataResolver implements PackageMetadataResolver {
 
         final CargoCrateDocument crateDoc = parseDocument(body);
         final String latestVersion = crateDoc.crate() != null
-                ? crateDoc.crate().newestVersion()
+                ? (crateDoc.crate().maxStableVersion() != null
+                        ? crateDoc.crate().maxStableVersion()
+                        : crateDoc.crate().newestVersion())
                 : null;
         if (latestVersion == null) {
             return null;

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gem/GemPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gem/GemPackageMetadataResolver.java
@@ -82,11 +82,28 @@ final class GemPackageMetadataResolver implements PackageMetadataResolver {
             return null;
         }
 
-        final String latestVersion = root.get(0).path("number").asText(null);
+        // rubygems.org returns versions ordered from newest to oldest,
+        // although that is not guaranteed per API contract (https://guides.rubygems.org/rubygems-org-api/).
+        // Prefer the first stable so we don't surface RC / alpha versions.
+        // Fall back to the first prerelease for packages that never published a stable version.
+        JsonNode latestEntry = null;
+        for (int i = 0; i < root.size(); i++) {
+            final JsonNode entry = root.get(i);
+            if (!entry.path("prerelease").asBoolean(false)) {
+                latestEntry = entry;
+                break;
+            }
+        }
+        if (latestEntry == null) {
+            latestEntry = root.get(0);
+        }
+
+        final String latestVersion = latestEntry.path("number").asText(null);
         if (latestVersion == null) {
             return null;
         }
-        Instant latestVersionPublishedAt = getCreatedAt(root.get(0));
+
+        Instant latestVersionPublishedAt = getCreatedAt(latestEntry);
 
         final String requestedVersion = purl.getVersion();
         JsonNode matchingEntry = null;

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolverTest.java
@@ -18,7 +18,6 @@
  */
 package org.dependencytrack.pkgmetadata.resolution.cargo;
 
-import com.github.packageurl.PackageURLBuilder;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.dependencytrack.cache.api.CacheManager;
@@ -41,6 +40,7 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.Map;
 
+import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -78,24 +78,24 @@ class CargoPackageMetadataResolverTest {
     void shouldResolveLatestVersionWithArtifactMetadata(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         stubFor(get(urlPathEqualTo("/api/v1/crates/serde"))
                 .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
-                {
-                  "crate": { "newest_version": "1.0.200" },
-                  "versions": [
-                    {
-                      "num": "1.0.200",
-                      "created_at": "2024-01-15T10:30:00Z",
-                      "checksum": "0e0580d37234d8aeb18c8d2ce6b5e093366c3a52fb7eb5a2f7d2100635122b07"
-                    },
-                    {
-                      "num": "1.0.199",
-                      "created_at": "2023-12-01T08:00:00Z",
-                      "checksum": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                    }
-                  ]
-                }
-                """)));
+                        {
+                          "crate": { "newest_version": "1.0.200" },
+                          "versions": [
+                            {
+                              "num": "1.0.200",
+                              "created_at": "2024-01-15T10:30:00Z",
+                              "checksum": "0e0580d37234d8aeb18c8d2ce6b5e093366c3a52fb7eb5a2f7d2100635122b07"
+                            },
+                            {
+                              "num": "1.0.199",
+                              "created_at": "2023-12-01T08:00:00Z",
+                              "checksum": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                            }
+                          ]
+                        }
+                        """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("cargo")
                 .withName("serde")
                 .withVersion("1.0.200")
@@ -120,24 +120,24 @@ class CargoPackageMetadataResolverTest {
     void shouldResolveOlderArtifactMetadata(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         stubFor(get(urlPathEqualTo("/api/v1/crates/serde"))
                 .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
-                {
-                  "crate": { "newest_version": "1.0.200" },
-                  "versions": [
-                    {
-                      "num": "1.0.200",
-                      "created_at": "2024-01-15T10:30:00Z",
-                      "checksum": "0e0580d37234d8aeb18c8d2ce6b5e093366c3a52fb7eb5a2f7d2100635122b07"
-                    },
-                    {
-                      "num": "1.0.150",
-                      "created_at": "2023-06-01T12:00:00Z",
-                      "checksum": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-                    }
-                  ]
-                }
-                """)));
+                        {
+                          "crate": { "newest_version": "1.0.200" },
+                          "versions": [
+                            {
+                              "num": "1.0.200",
+                              "created_at": "2024-01-15T10:30:00Z",
+                              "checksum": "0e0580d37234d8aeb18c8d2ce6b5e093366c3a52fb7eb5a2f7d2100635122b07"
+                            },
+                            {
+                              "num": "1.0.150",
+                              "created_at": "2023-06-01T12:00:00Z",
+                              "checksum": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                            }
+                          ]
+                        }
+                        """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("cargo")
                 .withName("serde")
                 .withVersion("1.0.150")
@@ -162,15 +162,15 @@ class CargoPackageMetadataResolverTest {
     void shouldReturnNullArtifactMetadataWhenVersionNotInResponse(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         stubFor(get(urlPathEqualTo("/api/v1/crates/serde"))
                 .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
-                {
-                  "crate": { "newest_version": "1.0.200" },
-                  "versions": [
-                    { "num": "1.0.200", "created_at": "2024-01-15T10:30:00Z", "checksum": "0e0580d37234d8aeb18c8d2ce6b5e093366c3a52fb7eb5a2f7d2100635122b07" }
-                  ]
-                }
-                """)));
+                        {
+                          "crate": { "newest_version": "1.0.200" },
+                          "versions": [
+                            { "num": "1.0.200", "created_at": "2024-01-15T10:30:00Z", "checksum": "0e0580d37234d8aeb18c8d2ce6b5e093366c3a52fb7eb5a2f7d2100635122b07" }
+                          ]
+                        }
+                        """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("cargo")
                 .withName("serde")
                 .withVersion("0.9.0")
@@ -187,11 +187,68 @@ class CargoPackageMetadataResolverTest {
     }
 
     @Test
+    void shouldPreferMaxStableVersionOverNewestVersion(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/api/v1/crates/bevy"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody(/* language=JSON */ """
+                                {
+                                  "crate": {
+                                    "newest_version": "0.19.0-rc.2",
+                                    "max_stable_version": "0.18.1"
+                                  },
+                                  "versions": [
+                                    { "num": "0.18.1", "created_at": "2025-01-10T10:00:00Z" }
+                                  ]
+                                }
+                                """)));
+
+        final var purl = aPackageURL()
+                .withType("cargo")
+                .withName("bevy")
+                .withVersion("0.18.1")
+                .build();
+
+        final var repo = new PackageRepository("crates-io", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.latestVersion()).isEqualTo("0.18.1");
+        assertThat(result.latestVersionPublishedAt())
+                .isEqualTo(Instant.parse("2025-01-10T10:00:00Z"));
+    }
+
+    @Test
+    void shouldFallBackToNewestVersionWhenNoStableExists(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/api/v1/crates/early-bird"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody(/* language=JSON */ """
+                                {
+                                  "crate": { "newest_version": "0.1.0-alpha", "max_stable_version": null },
+                                  "versions": []
+                                }
+                                """)));
+
+        final var purl = aPackageURL()
+                .withType("cargo")
+                .withName("early-bird")
+                .withVersion("0.1.0-alpha")
+                .build();
+
+        final var repo = new PackageRepository("crates-io", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.latestVersion()).isEqualTo("0.1.0-alpha");
+    }
+
+    @Test
     void shouldReturnNullWhenCrateNotFound(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         stubFor(get(urlPathEqualTo("/api/v1/crates/nonexistent"))
                 .willReturn(aResponse().withStatus(404)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("cargo")
                 .withName("nonexistent")
                 .withVersion("1.0.0")
@@ -205,7 +262,7 @@ class CargoPackageMetadataResolverTest {
 
     @Test
     void shouldThrowWhenRepositoryIsNull() throws Exception {
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("cargo")
                 .withName("serde")
                 .withVersion("1.0.0")
@@ -219,15 +276,15 @@ class CargoPackageMetadataResolverTest {
     void shouldHandleVersionWithoutChecksum(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         stubFor(get(urlPathEqualTo("/api/v1/crates/serde"))
                 .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
-                {
-                  "crate": { "newest_version": "1.0.200" },
-                  "versions": [
-                    { "num": "1.0.200", "created_at": "2024-01-15T10:30:00Z" }
-                  ]
-                }
-                """)));
+                        {
+                          "crate": { "newest_version": "1.0.200" },
+                          "versions": [
+                            { "num": "1.0.200", "created_at": "2024-01-15T10:30:00Z" }
+                          ]
+                        }
+                        """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("cargo")
                 .withName("serde")
                 .withVersion("1.0.200")
@@ -247,15 +304,15 @@ class CargoPackageMetadataResolverTest {
     void shouldHandleInvalidChecksum(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         stubFor(get(urlPathEqualTo("/api/v1/crates/serde"))
                 .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
-                {
-                  "crate": { "newest_version": "1.0.200" },
-                  "versions": [
-                    { "num": "1.0.200", "created_at": "2024-01-15T10:30:00Z", "checksum": "not-a-valid-hash" }
-                  ]
-                }
-                """)));
+                        {
+                          "crate": { "newest_version": "1.0.200" },
+                          "versions": [
+                            { "num": "1.0.200", "created_at": "2024-01-15T10:30:00Z", "checksum": "not-a-valid-hash" }
+                          ]
+                        }
+                        """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("cargo")
                 .withName("serde")
                 .withVersion("1.0.200")
@@ -276,7 +333,7 @@ class CargoPackageMetadataResolverTest {
         stubFor(get(urlPathEqualTo("/api/v1/crates/serde"))
                 .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "30")));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("cargo")
                 .withName("serde")
                 .withVersion("1.0.0")
@@ -293,7 +350,7 @@ class CargoPackageMetadataResolverTest {
         stubFor(get(urlPathEqualTo("/api/v1/crates/serde"))
                 .willReturn(aResponse().withStatus(503)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("cargo")
                 .withName("serde")
                 .withVersion("1.0.0")
@@ -308,13 +365,13 @@ class CargoPackageMetadataResolverTest {
     void shouldReturnNullNewestVersionWhenMissing(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         stubFor(get(urlPathEqualTo("/api/v1/crates/serde"))
                 .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
-                {
-                  "crate": {},
-                  "versions": []
-                }
-                """)));
+                        {
+                          "crate": {},
+                          "versions": []
+                        }
+                        """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("cargo")
                 .withName("serde")
                 .withVersion("1.0.0")
@@ -333,7 +390,7 @@ class CargoPackageMetadataResolverTest {
                         {"crate": {"newest_version": "1.0.0"}, "versions": []}
                         """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("cargo").withName("serde").withVersion("1.0.0").build();
 
         final var repo = new PackageRepository("crates", wmRuntimeInfo.getHttpBaseUrl(), "user", "secret");
@@ -352,7 +409,7 @@ class CargoPackageMetadataResolverTest {
                         {"crate": {"newest_version": "1.0.0"}, "versions": []}
                         """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("cargo").withName("serde").withVersion("1.0.0").build();
 
         final var repo = new PackageRepository("crates", wmRuntimeInfo.getHttpBaseUrl(), null, "token");

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/gem/GemPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/gem/GemPackageMetadataResolverTest.java
@@ -18,7 +18,6 @@
  */
 package org.dependencytrack.pkgmetadata.resolution.gem;
 
-import com.github.packageurl.PackageURLBuilder;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.dependencytrack.cache.api.CacheManager;
@@ -40,6 +39,7 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.Map;
 
+import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -84,7 +84,7 @@ class GemPackageMetadataResolverTest {
                         ]
                         """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("gem")
                 .withName("rails")
                 .withVersion("7.1.3")
@@ -103,11 +103,64 @@ class GemPackageMetadataResolverTest {
     }
 
     @Test
+    void shouldSkipPrereleaseWhenSelectingLatest(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/api/v1/versions/rails.json"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody(/* language=JSON */ """
+                                [
+                                  {"number": "8.0.0.rc1", "prerelease": true, "created_at": "2024-09-01T10:00:00Z"},
+                                  {"number": "7.1.3", "prerelease": false, "created_at": "2024-01-15T10:30:00Z"},
+                                  {"number": "7.1.2", "prerelease": false, "created_at": "2023-12-01T08:00:00Z"}
+                                ]
+                                """)));
+
+        final var purl = aPackageURL()
+                .withType("gem")
+                .withName("rails")
+                .withVersion("7.1.3")
+                .build();
+
+        final var repo = new PackageRepository("rubygems", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.latestVersion()).isEqualTo("7.1.3");
+        assertThat(result.latestVersionPublishedAt())
+                .isEqualTo(Instant.parse("2024-01-15T10:30:00Z"));
+    }
+
+    @Test
+    void shouldFallBackToFirstEntryWhenAllVersionsArePrerelease(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/api/v1/versions/early-gem.json"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody(/* language=JSON */ """
+                                [
+                                  {"number": "0.2.0.rc1", "prerelease": true, "created_at": "2024-05-01T10:00:00Z"},
+                                  {"number": "0.1.0.alpha", "prerelease": true, "created_at": "2024-02-01T10:00:00Z"}
+                                ]
+                                """)));
+
+        final var purl = aPackageURL()
+                .withType("gem")
+                .withName("early-gem")
+                .withVersion("0.2.0.rc1")
+                .build();
+
+        final var repo = new PackageRepository("rubygems", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.latestVersion()).isEqualTo("0.2.0.rc1");
+    }
+
+    @Test
     void shouldReturnNullWhenPackageNotFound(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         stubFor(get(urlPathEqualTo("/api/v1/versions/nonexistent.json"))
                 .willReturn(aResponse().withStatus(404)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("gem")
                 .withName("nonexistent")
                 .withVersion("1.0.0")
@@ -121,7 +174,7 @@ class GemPackageMetadataResolverTest {
 
     @Test
     void shouldThrowWhenRepositoryIsNull() throws Exception {
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("gem")
                 .withName("rails")
                 .withVersion("1.0.0")
@@ -142,7 +195,7 @@ class GemPackageMetadataResolverTest {
                         ]
                         """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("gem")
                 .withName("rails")
                 .withVersion("7.1.2")
@@ -171,7 +224,7 @@ class GemPackageMetadataResolverTest {
                         ]
                         """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("gem")
                 .withName("rails")
                 .withVersion("9.9.9")
@@ -192,7 +245,7 @@ class GemPackageMetadataResolverTest {
         stubFor(get(urlPathEqualTo("/api/v1/versions/rails.json"))
                 .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "30")));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("gem")
                 .withName("rails")
                 .withVersion("1.0.0")
@@ -209,7 +262,7 @@ class GemPackageMetadataResolverTest {
         stubFor(get(urlPathEqualTo("/api/v1/versions/rails.json"))
                 .willReturn(aResponse().withStatus(503)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("gem")
                 .withName("rails")
                 .withVersion("1.0.0")
@@ -227,7 +280,7 @@ class GemPackageMetadataResolverTest {
                         [{"number": "7.1.3", "created_at": "2024-01-15T10:30:00Z"}]
                         """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("gem")
                 .withName("rails")
                 .withVersion("7.1.3")


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Improves latest version detection for Cargo and Ruby Gems:

* Uses the dedicated `max_stable_version` field for Cargo packages if available. It's not documented in the API docs (https://doc.rust-lang.org/nightly/cargo/reference/registry-web-api.html), but the Cargo API returns it.
* Makes an attempt to not report unstable Ruby Gem versions as latest by inspecting the `prerelease` version field. Only reports unstable versions as latest when no version with `prerelease=false` exists.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
