### PR TITLE
v4-migrator: Run ANALYZE on staging src tables before transform

### DIFF
--- a/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/transform/TransformPhase.java
+++ b/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/transform/TransformPhase.java
@@ -50,6 +50,15 @@ public final class TransformPhase {
         target.useHandle(h -> h.execute(
             "DELETE FROM \"%s\".migration_state WHERE phase = 'LOAD'"
                 .formatted(options.stagingSchema)));
+        // src_* tables are bulk-loaded via COPY into UNLOGGED tables and autovacuum may not
+        // analyze them in time. Without stats the planner defaults to nested-loop joins for
+        // transforms like PACKAGE_METADATA, which can stall for hours on production-sized
+        // datasets.
+        target.useHandle(h -> {
+            for (final TableMigration t : TableRegistry.extracted()) {
+                h.execute("ANALYZE \"%s\".src_%s".formatted(options.stagingSchema, t.name()));
+            }
+        });
         for (final TableMigration t : TableRegistry.transformed()) {
             transformOne(t);
         }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Runs `ANALYZE` on staging src tables before transform.

It's likely the query planner is choosing suboptimal plans during the transform phase because the bulk-imported source data is not analyzed in time, leaving the planner without any statistics to work with.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #6246 (unclear if it actually fixes the issue yet)

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
