### PR TITLE
v4-migrator: Dedupe components before join with repo meta component table

### DIFF
--- a/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/TableRegistry.java
+++ b/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/TableRegistry.java
@@ -2730,14 +2730,20 @@ public final class TableRegistry {
     /**
      * Derived {@code PACKAGE_METADATA} per schema-changes §7.7 / Liquibase changeset
      * v5.7.0-52. Joins {@code REPOSITORY_META_COMPONENT} to {@code COMPONENT} on
-     * {@code (NAME, NAMESPACE/GROUP)} with symmetric NULL match and a PURL scheme match by
-     * repository type. Output {@code PURL} is the PURL coordinates with the {@code @version}
-     * suffix stripped. Rows whose resulting PURL contains any of {@code @ ? & #} are skipped
-     * to satisfy the v5 {@code PACKAGE_METADATA_PURL_CHECK} constraint. {@code DISTINCT ON
-     * (PURL)} keeps the newest {@code LAST_CHECK} per PURL. {@code RESOLVED_BY},
-     * {@code RESOLVED_FROM}, {@code LATEST_VERSION_PUBLISHED_AT} have no v4 source and are
-     * left NULL, matching the Liquibase changeset which only projects PURL, LATEST_VERSION,
-     * and RESOLVED_AT (= LAST_CHECK).
+     * {@code (NAME, NAMESPACE/GROUP, repository type)} with symmetric NULL match. Output
+     * {@code PURL} is the PURL coordinates with the {@code @version} suffix stripped. Rows
+     * whose resulting PURL contains any of {@code @ ? & #} are skipped to satisfy the v5
+     * {@code PACKAGE_METADATA_PURL_CHECK} constraint. {@code DISTINCT ON (PURL)} keeps the
+     * newest {@code LAST_CHECK} per PURL. {@code RESOLVED_BY}, {@code RESOLVED_FROM},
+     * {@code LATEST_VERSION_PUBLISHED_AT} have no v4 source and are left NULL, matching the
+     * Liquibase changeset which only projects PURL, LATEST_VERSION, and RESOLVED_AT (=
+     * LAST_CHECK).
+     *
+     * <p>{@code src_component} is pre-deduplicated to one row per
+     * {@code (NAME, GROUP, type, stripped PURL)} tuple before the join. Without this, the
+     * equality on {@code NAME} alone is non-selective in multi-project deployments where the
+     * same package appears in thousands of components, producing a multi-million-row
+     * intermediate result that {@code DISTINCT ON} then has to sort to disk.
      */
     private static final TableMigration PACKAGE_METADATA = new TableMigration(
         "PACKAGE_METADATA",
@@ -2762,28 +2768,33 @@ public final class TableRegistry {
           , "RESOLVED_FROM"
           , "RESOLVED_AT"
         )
-        SELECT DISTINCT ON (t."PURL") t."PURL"
-             , t."LATEST_VERSION"
+        WITH c_unique AS (
+            SELECT DISTINCT
+                   c."NAME"
+                 , c."GROUP"
+                 , substring(lower(c."PURL") FROM '^pkg:([^/]+)/') AS "TYPE"
+                 , split_part(c."PURLCOORDINATES", '@', 1) AS "PURL"
+              FROM "%1$s".src_component c
+             WHERE c."PURLCOORDINATES" IS NOT NULL
+               AND lower(c."PURL") LIKE 'pkg:%%'
+        )
+        SELECT DISTINCT ON (cu."PURL") cu."PURL"
+             , rmc."LATEST_VERSION"
              , NULL
              , NULL
              , NULL
-             , t."LAST_CHECK"
-          FROM (
-            SELECT split_part(c."PURLCOORDINATES", '@', 1) AS "PURL"
-                 , rmc."LATEST_VERSION"
-                 , rmc."LAST_CHECK"
-              FROM "%1$s".src_repository_meta_component rmc
-              JOIN "%1$s".src_component c
-                ON c."NAME" = rmc."NAME"
-               AND (c."GROUP" = rmc."NAMESPACE"
-                    OR (c."GROUP" IS NULL AND rmc."NAMESPACE" IS NULL))
-               AND LOWER(c."PURL") LIKE ('pkg:' || LOWER(rmc."REPOSITORY_TYPE") || '/%%')
-          ) t
-         WHERE t."PURL" NOT LIKE '%%@%%'
-           AND t."PURL" NOT LIKE '%%?%%'
-           AND t."PURL" NOT LIKE '%%&%%'
-           AND t."PURL" NOT LIKE '%%#%%'
-         ORDER BY t."PURL", t."LAST_CHECK" DESC NULLS LAST
+             , rmc."LAST_CHECK"
+          FROM c_unique cu
+          JOIN "%1$s".src_repository_meta_component rmc
+            ON cu."NAME" = rmc."NAME"
+           AND (cu."GROUP" = rmc."NAMESPACE"
+                OR (cu."GROUP" IS NULL AND rmc."NAMESPACE" IS NULL))
+           AND cu."TYPE" = lower(rmc."REPOSITORY_TYPE")
+         WHERE cu."PURL" NOT LIKE '%%@%%'
+           AND cu."PURL" NOT LIKE '%%?%%'
+           AND cu."PURL" NOT LIKE '%%&%%'
+           AND cu."PURL" NOT LIKE '%%#%%'
+         ORDER BY cu."PURL", rmc."LAST_CHECK" DESC NULLS LAST
         """,
         """
         INSERT INTO "PACKAGE_METADATA" (

--- a/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/PackageMetadataIT.java
+++ b/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/PackageMetadataIT.java
@@ -66,7 +66,9 @@ class PackageMetadataIT {
         source.jdbi().useHandle(h -> {
             h.execute("""
                 INSERT INTO "PROJECT" ("ID", "NAME", "VERSION", "UUID")
-                VALUES (1, 'P', '1.0', '00000000-0000-0000-0000-000000000001')
+                VALUES (1, 'P', '1.0', '00000000-0000-0000-0000-000000000001'),
+                       (2, 'Q', '1.0', '00000000-0000-0000-0000-000000000002'),
+                       (3, 'R', '1.0', '00000000-0000-0000-0000-000000000003')
                 """);
 
             // Good Maven component: PURLCOORDINATES -> 'pkg:maven/com.example/foo' after @-split.
@@ -79,6 +81,37 @@ class PackageMetadataIT {
                     '00000000-0000-0000-0000-000000000010', 1,
                     'pkg:maven/com.example/foo@1.0.0',
                     'pkg:maven/com.example/foo@1.0.0'
+                )
+                """);
+
+            // Duplicate of component 1 in a different project: identical NAME/GROUP/PURL.
+            // Exercises the c_unique pre-dedup path — multi-project portfolios commonly have
+            // the same package repeated thousands of times, and we must not let that fan out
+            // into a multi-million-row join. Expected: collapses to the same single
+            // PACKAGE_METADATA row as component 1.
+            h.execute("""
+                INSERT INTO "COMPONENT" (
+                    "ID", "NAME", "GROUP", "UUID", "PROJECT_ID", "PURL", "PURLCOORDINATES"
+                )
+                VALUES (
+                    3, 'foo', 'com.example',
+                    '00000000-0000-0000-0000-000000000030', 2,
+                    'pkg:maven/com.example/foo@1.0.0',
+                    'pkg:maven/com.example/foo@1.0.0'
+                )
+                """);
+
+            // Same package, different version: the @-strip yields the same stripped PURL,
+            // so dedup must still collapse this into one row regardless of version variance.
+            h.execute("""
+                INSERT INTO "COMPONENT" (
+                    "ID", "NAME", "GROUP", "UUID", "PROJECT_ID", "PURL", "PURLCOORDINATES"
+                )
+                VALUES (
+                    4, 'foo', 'com.example',
+                    '00000000-0000-0000-0000-000000000040', 3,
+                    'pkg:maven/com.example/foo@2.0.0',
+                    'pkg:maven/com.example/foo@2.0.0'
                 )
                 """);
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Dedupes components before the join with repo meta component table.

Drastically reduces the row count that needs to be joined and later deduplicated by `DISTINCT ON "PURL"`.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #6246

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
