### PR TITLE
dex: Prevent possible deadlock when creating task queues

### DIFF
--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/ActivityDao.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/ActivityDao.java
@@ -46,6 +46,8 @@ import static java.util.Objects.requireNonNull;
 
 public final class ActivityDao extends AbstractDao {
 
+    private static final int ACTIVITY_TASK_QUEUE_LOCK_NAMESPACE = 1616084939;
+
     public ActivityDao(Handle jdbiHandle) {
         super(jdbiHandle);
     }
@@ -53,9 +55,15 @@ public final class ActivityDao extends AbstractDao {
     public boolean createActivityTaskQueue(CreateTaskQueueRequest request) {
         return jdbiHandle
                 .createQuery("""
+                        with lock as materialized (
+                          select pg_advisory_xact_lock(:lockNamespace, :lockKey)
+                        )
                         select dex_create_activity_task_queue(:name, cast(:capacity as smallint))
+                          from lock
                         """)
                 .bindMethods(request)
+                .bind("lockNamespace", ACTIVITY_TASK_QUEUE_LOCK_NAMESPACE)
+                .bind("lockKey", request.name().hashCode())
                 .mapTo(boolean.class)
                 .one();
     }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/WorkflowDao.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/WorkflowDao.java
@@ -64,6 +64,8 @@ import static org.jdbi.v3.core.generic.GenericTypes.parameterizeClass;
 
 public final class WorkflowDao extends AbstractDao {
 
+    private static final int WORKFLOW_TASK_QUEUE_LOCK_NAMESPACE = 657204660;
+
     public WorkflowDao(Handle jdbiHandle) {
         super(jdbiHandle);
     }
@@ -71,9 +73,15 @@ public final class WorkflowDao extends AbstractDao {
     public boolean createWorkflowTaskQueue(CreateTaskQueueRequest request) {
         return jdbiHandle
                 .createQuery("""
+                        with lock as materialized (
+                          select pg_advisory_xact_lock(:lockNamespace, :lockKey)
+                        )
                         select dex_create_workflow_task_queue(:name, cast(:capacity as smallint))
+                          from lock
                         """)
                 .bindMethods(request)
+                .bind("lockNamespace", WORKFLOW_TASK_QUEUE_LOCK_NAMESPACE)
+                .bind("lockKey", request.name().hashCode())
                 .mapTo(boolean.class)
                 .one();
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Prevents possible deadlock when creating dex task queues.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Task queue creation involves both DML (recording the queue in a table) and DDL (creating and attaching a partition). If multiple nodes of a new cluster boot for the first time in parallel, they can try to create the same queues at the same time. That can lead to deadlocks. Acquire advisory locks to prevent that.

Note that the worst case of this happening is a node failing to start and getting rescheduled by the orchestrator, since we only create queues on startup, not at runtime.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
