### PR TITLE
Fix missing allowed permission for /api/v2/projects/{uuid}/clone

### DIFF
--- a/api/src/main/openapi/resources/projects/project-clone.yaml
+++ b/api/src/main/openapi/resources/projects/project-clone.yaml
@@ -17,7 +17,7 @@
 post:
   operationId: cloneProject
   summary: Clones a given project.
-  description: Requires permission `PORTFOLIO_MANAGEMENT`
+  description: Requires permission `PORTFOLIO_MANAGEMENT` or `PORTFOLIO_MANAGEMENT_CREATE`
   tags:
     - Projects
   parameters:

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/ProjectsResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/ProjectsResource.java
@@ -223,7 +223,10 @@ public class ProjectsResource extends AbstractApiResource implements ProjectsApi
     }
 
     @Override
-    @PermissionRequired(Permissions.Constants.PORTFOLIO_MANAGEMENT)
+    @PermissionRequired({
+            Permissions.Constants.PORTFOLIO_MANAGEMENT,
+            Permissions.Constants.PORTFOLIO_MANAGEMENT_CREATE
+    })
     public Response cloneProject(final UUID projectUuid, final CloneProjectRequest request) {
         final UUID clonedProjectUuid = inJdbiTransaction(getAlpineRequest(), handle -> {
             requireProjectAccess(handle, projectUuid);

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/ProjectsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/ProjectsResourceTest.java
@@ -491,7 +491,7 @@ public class ProjectsResourceTest extends ResourceTest {
 
     @Test
     public void cloneProjectShouldReturnUuidOfClonedProject() {
-        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_CREATE);
 
         final var project = new Project();
         project.setName("acme-app");
@@ -523,7 +523,7 @@ public class ProjectsResourceTest extends ResourceTest {
 
     @Test
     public void cloneProjectShouldMarkNewProjectAsLatestWhenRequested() {
-        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_CREATE);
 
         final var project = new Project();
         project.setName("acme-app");
@@ -563,7 +563,7 @@ public class ProjectsResourceTest extends ResourceTest {
     public void cloneProjectShouldReturnForbiddenWhenAclIsEnabledAndProjectIsNotAccessible() {
         enablePortfolioAccessControl();
 
-        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_CREATE);
 
         final var project = new Project();
         project.setName("acme-app");
@@ -591,7 +591,7 @@ public class ProjectsResourceTest extends ResourceTest {
 
     @Test
     public void cloneProjectShouldReturnNotFoundWhenProjectDoesNotExist() {
-        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_CREATE);
 
         final Response response = jersey.target("/projects/c5b13f13-f2f0-4a30-97b5-94d164a345f6/clone")
                 .request()
@@ -614,7 +614,7 @@ public class ProjectsResourceTest extends ResourceTest {
 
     @Test
     public void cloneProjectShouldReturnConflictWhenNewVersionAlreadyExists() {
-        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_CREATE);
 
         final var project = new Project();
         project.setName("acme-app");
@@ -643,7 +643,7 @@ public class ProjectsResourceTest extends ResourceTest {
 
     @Test
     public void cloneProjectShouldUpdateMetrics() {
-        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_CREATE);
 
         final Project project = qm.createProject("Example Project 1", "Description 1", "1.0", null, null, null, null, false, false);
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes missing allowed permission for `/api/v2/projects/{uuid}/clone`.

Should allow PORTFOLIO_MANAGEMENT_CREATE in addition to the umbrella PORTFOLIO_MANAGEMENT permission.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
