### PR TITLE
Support component hash mismatch policy conditions

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyFunctions.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyFunctions.java
@@ -555,6 +555,19 @@ final class CelPolicyFunctions {
         };
     }
 
+    static boolean hasPackageArtifactHashMismatch(Component component) {
+        return hashesDiffer(component.getMd5(), component.getPackageArtifactMd5())
+                || hashesDiffer(component.getSha1(), component.getPackageArtifactSha1())
+                || hashesDiffer(component.getSha256(), component.getPackageArtifactSha256())
+                || hashesDiffer(component.getSha512(), component.getPackageArtifactSha512());
+    }
+
+    private static boolean hashesDiffer(String componentHash, String pkgArtifactHash) {
+        return !componentHash.isEmpty()
+                && !pkgArtifactHash.isEmpty()
+                && !componentHash.equalsIgnoreCase(pkgArtifactHash);
+    }
+
     @SuppressWarnings("unchecked")
     static boolean spdxExprAllows(String expr, List<?> ids) {
         return SpdxExpressions.allows(expr, (List<String>) ids);

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyLibrary.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyLibrary.java
@@ -133,6 +133,17 @@ final class CelPolicyLibrary implements CelCompilerLibrary, CelRuntimeLibrary {
                         "matches_version_distance_bool",
                         List.of(Component.class, String.class, VersionDistance.class),
                         args -> CelPolicyFunctions.matchesVersionDistance((Component) args[0], (String) args[1], (VersionDistance) args[2]))),
+        HAS_PACKAGE_ARTIFACT_HASH_MISMATCH(
+                CelFunctionDecl.newFunctionDeclaration(
+                        "has_package_artifact_hash_mismatch",
+                        CelOverloadDecl.newMemberOverload(
+                                "component_has_package_artifact_hash_mismatch_bool",
+                                SimpleType.BOOL,
+                                List.of(TYPE_COMPONENT))),
+                CelFunctionBinding.from(
+                        "component_has_package_artifact_hash_mismatch_bool",
+                        List.of(Component.class),
+                        args -> CelPolicyFunctions.hasPackageArtifactHashMismatch((Component) args[0]))),
         SPDX_EXPR_ALLOWS(
                 CelFunctionDecl.newFunctionDeclaration(
                         "spdx_expr_allows",

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyRequirements.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyRequirements.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import static org.dependencytrack.policy.cel.CelPolicyLibrary.Function.COMPARE_AGE;
 import static org.dependencytrack.policy.cel.CelPolicyLibrary.Function.DEPENDS_ON;
+import static org.dependencytrack.policy.cel.CelPolicyLibrary.Function.HAS_PACKAGE_ARTIFACT_HASH_MISMATCH;
 import static org.dependencytrack.policy.cel.CelPolicyLibrary.Function.IS_DEPENDENCY_OF;
 import static org.dependencytrack.policy.cel.CelPolicyLibrary.Function.IS_DIRECT_DEPENDENCY_OF;
 import static org.dependencytrack.policy.cel.CelPolicyLibrary.Function.IS_EXCLUSIVE_DEPENDENCY_OF;
@@ -43,7 +44,20 @@ final class CelPolicyRequirements {
             Map.entry(IS_DIRECT_DEPENDENCY_OF.functionName(), Map.of(TYPE_COMPONENT, List.of("uuid"))),
             Map.entry(MATCHES_RANGE.functionName(), Map.of(TYPE_PROJECT, List.of("version"), TYPE_COMPONENT, List.of("version"))),
             Map.entry(VERSION_DISTANCE.functionName(), Map.of(TYPE_COMPONENT, List.of("purl", "uuid", "version", "latest_version"))),
-            Map.entry(COMPARE_AGE.functionName(), Map.of(TYPE_COMPONENT, List.of("purl", "published_at"))));
+            Map.entry(COMPARE_AGE.functionName(), Map.of(TYPE_COMPONENT, List.of("purl", "published_at"))),
+            Map.entry(
+                    HAS_PACKAGE_ARTIFACT_HASH_MISMATCH.functionName(),
+                    Map.of(
+                            TYPE_COMPONENT,
+                            List.of(
+                                    "md5",
+                                    "sha1",
+                                    "sha256",
+                                    "sha512",
+                                    "package_artifact_md5",
+                                    "package_artifact_sha1",
+                                    "package_artifact_sha256",
+                                    "package_artifact_sha512"))));
 
     static final Map<CelType, Map<String, List<String>>> FIELD_EXPANSIONS = Map.of(
             TYPE_VULNERABILITY, Map.of(

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyComponentRowMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyComponentRowMapper.java
@@ -58,6 +58,10 @@ public final class CelPolicyComponentRowMapper implements RowMapper<Component> {
         maybeSet(rs, "license_expression", ResultSet::getString, builder::setLicenseExpression);
         maybeSet(rs, "published_at", RowMapperUtil::nullableTimestamp, builder::setPublishedAt);
         maybeSet(rs, "latest_version", ResultSet::getString, builder::setLatestVersion);
+        maybeSet(rs, "package_artifact_md5", ResultSet::getString, builder::setPackageArtifactMd5);
+        maybeSet(rs, "package_artifact_sha1", ResultSet::getString, builder::setPackageArtifactSha1);
+        maybeSet(rs, "package_artifact_sha256", ResultSet::getString, builder::setPackageArtifactSha256);
+        maybeSet(rs, "package_artifact_sha512", ResultSet::getString, builder::setPackageArtifactSha512);
         return builder.build();
     }
 }

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
@@ -88,23 +88,28 @@ public final class CelPolicyDao {
             fetchColumns.add("c.\"LICENSE_ID\" AS resolved_license_id");
         }
 
+        final boolean shouldJoinPm = protoFieldNames.contains("latest_version");
         final boolean shouldJoinPam =
-                protoFieldNames.contains("published_at")
-                        || protoFieldNames.contains("latest_version");
+                shouldJoinPm
+                        || protoFieldNames.contains("published_at")
+                        || protoFieldNames.contains("package_artifact_md5")
+                        || protoFieldNames.contains("package_artifact_sha1")
+                        || protoFieldNames.contains("package_artifact_sha256")
+                        || protoFieldNames.contains("package_artifact_sha512");
 
         final var componentRowMapper = new CelPolicyComponentRowMapper();
         return jdbiHandle
                 .createQuery(/* language=InjectedFreeMarker */ """
                         <#-- @ftlvariable name="fetchColumns" type="java.util.Collection<String>" -->
                         <#-- @ftlvariable name="shouldJoinPam" type="boolean" -->
-                        <#-- @ftlvariable name="shouldJoinLatestVersion" type="boolean" -->
+                        <#-- @ftlvariable name="shouldJoinPm" type="boolean" -->
                         SELECT ${fetchColumns?join(", ")}
                           FROM "COMPONENT" AS c
                         <#if shouldJoinPam!false>
                           LEFT JOIN "PACKAGE_ARTIFACT_METADATA" AS pam
                             ON pam."PURL" = c."PURL"
                         </#if>
-                        <#if shouldJoinLatestVersion!false>
+                        <#if shouldJoinPm!false>
                           LEFT JOIN "PACKAGE_METADATA" AS pm
                             ON pm."PURL" = pam."PACKAGE_PURL"
                         </#if>
@@ -112,7 +117,7 @@ public final class CelPolicyDao {
                         """)
                 .define("fetchColumns", fetchColumns)
                 .define("shouldJoinPam", shouldJoinPam)
-                .define("shouldJoinLatestVersion", protoFieldNames.contains("latest_version"))
+                .define("shouldJoinPm", shouldJoinPm)
                 .bind("projectId", projectId)
                 .reduceResultSet(
                         new HashMap<>(),
@@ -661,33 +666,38 @@ public final class CelPolicyDao {
 
         final List<String> fetchColumns = new ArrayList<>(selectColumns(COMPONENT_FIELDS, componentRequirements));
 
-        final boolean needsLatestVersion = componentRequirements.contains("latest_version");
-        final boolean needsPublishedAt = componentRequirements.contains("published_at");
-        final boolean needsPam = needsPublishedAt || needsLatestVersion;
+        final boolean shouldJoinPm = componentRequirements.contains("latest_version");
+        final boolean shouldJoinPam =
+                shouldJoinPm
+                        || componentRequirements.contains("published_at")
+                        || componentRequirements.contains("package_artifact_md5")
+                        || componentRequirements.contains("package_artifact_sha1")
+                        || componentRequirements.contains("package_artifact_sha256")
+                        || componentRequirements.contains("package_artifact_sha512");
 
         final var componentRowMapper = new CelPolicyComponentRowMapper();
         return jdbiHandle.createQuery(/* language=InjectedFreeMarker */ """
                         <#-- @ftlvariable name="fetchColumns" type="java.util.Collection<String>" -->
-                        <#-- @ftlvariable name="needsPam" type="boolean" -->
-                        <#-- @ftlvariable name="needsLatestVersion" type="boolean" -->
+                        <#-- @ftlvariable name="shouldJoinPam" type="boolean" -->
+                        <#-- @ftlvariable name="shouldJoinPm" type="boolean" -->
                         SELECT c."ID" AS db_id
                         <#if fetchColumns?size gt 0>
                              , ${fetchColumns?join(", ")}
                         </#if>
                           FROM "COMPONENT" AS c
-                        <#if needsPam!false>
+                        <#if shouldJoinPam!false>
                           LEFT JOIN "PACKAGE_ARTIFACT_METADATA" AS pam
                             ON pam."PURL" = c."PURL"
                         </#if>
-                        <#if needsLatestVersion!false>
+                        <#if shouldJoinPm!false>
                           LEFT JOIN "PACKAGE_METADATA" AS pm
                             ON pm."PURL" = pam."PACKAGE_PURL"
                         </#if>
                          WHERE c."ID" = ANY(:ids)
                         """)
                 .define("fetchColumns", fetchColumns)
-                .define("needsPam", needsPam)
-                .define("needsLatestVersion", needsLatestVersion)
+                .define("shouldJoinPam", shouldJoinPam)
+                .define("shouldJoinPm", shouldJoinPm)
                 .bindArray("ids", Long.class, componentIds)
                 .reduceResultSet(new HashMap<>(), (accumulator, rs, ctx) -> {
                     final long dbId = rs.getLong("db_id");

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyFieldMappingRegistry.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyFieldMappingRegistry.java
@@ -54,7 +54,11 @@ public final class CelPolicyFieldMappingRegistry {
             new FieldMapping("license_name", "c.\"LICENSE\""),
             new FieldMapping("license_expression", "c.\"LICENSE_EXPRESSION\""),
             new FieldMapping("published_at", "pam.\"PUBLISHED_AT\""),
-            new FieldMapping("latest_version", "pm.\"LATEST_VERSION\""));
+            new FieldMapping("latest_version", "pm.\"LATEST_VERSION\""),
+            new FieldMapping("package_artifact_md5", "pam.\"HASH_MD5\""),
+            new FieldMapping("package_artifact_sha1", "pam.\"HASH_SHA1\""),
+            new FieldMapping("package_artifact_sha256", "pam.\"HASH_SHA256\""),
+            new FieldMapping("package_artifact_sha512", "pam.\"HASH_SHA512\""));
 
     static final List<FieldMapping> COMPONENT_PROPERTY_FIELDS = List.of(
             new FieldMapping("group", "cp.\"GROUPNAME\""),

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
@@ -60,6 +60,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -88,16 +89,16 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
         project.setName("projectName");
         project.setVersion("projectVersion");
         project.setClassifier(Classifier.APPLICATION);
-        project.setInactiveSince(new java.util.Date(777));
+        project.setInactiveSince(new Date(777));
         project.setCpe("projectCpe");
         project.setPurl("projectPurl");
         project.setSwidTagId("projectSwidTagId");
-        project.setLastBomImport(new java.util.Date());
+        project.setLastBomImport(new Date());
         qm.persist(project);
 
         final var bom = new Bom();
         bom.setProject(project);
-        bom.setGenerated(new java.util.Date(999));
+        bom.setGenerated(new Date(999));
         bom.setImported(new Date());
         qm.persist(bom);
 
@@ -211,11 +212,11 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
                     new PackageArtifactMetadata(
                             new PackageURL("pkg:maven/componentGroup/componentName@componentVersion"),
                             new PackageURL("pkg:maven/componentGroup/componentName"),
-                            null,
-                            null,
-                            null,
-                            null,
-                            new java.util.Date(222).toInstant(),
+                            "acbd18db4cc2f85cedef654fccc4a4d8",
+                            "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
+                            "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+                            "f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7",
+                            Instant.ofEpochMilli(222),
                             null,
                             null,
                             Instant.now())));
@@ -226,9 +227,9 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
         vuln.setVulnId("CVE-001");
         vuln.setSource(Vulnerability.Source.NVD);
         vuln.setCwes(List.of(666, 777));
-        vuln.setCreated(new java.util.Date(666));
-        vuln.setPublished(new java.util.Date(777));
-        vuln.setUpdated(new java.util.Date(888));
+        vuln.setCreated(new Date(666));
+        vuln.setPublished(new Date(777));
+        vuln.setUpdated(new Date(888));
         vuln.setSeverity(Severity.INFO);
         vuln.setCvssV2BaseScore(BigDecimal.valueOf(6.0));
         vuln.setCvssV2ImpactSubScore(BigDecimal.valueOf(6.4));
@@ -299,6 +300,10 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
                          && licenseGroup.name == "licenseGroupName"
                      )
                   && component.published_at == timestamp("1970-01-01T00:00:00.222Z")
+                  && component.package_artifact_md5 == "acbd18db4cc2f85cedef654fccc4a4d8"
+                  && component.package_artifact_sha1 == "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"
+                  && component.package_artifact_sha256 == "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                  && component.package_artifact_sha512 == "f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7"
                   && component.properties.all(property,
                        property.group == "componentPropertyGroup"
                          && property.name == "componentPropertyName"
@@ -727,6 +732,100 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
         final var policyEngine = new CelPolicyEngine();
         policyEngine.evaluateProject(project.getUuid());
         assertThat(qm.getAllPolicyViolations(component)).isEmpty();
+    }
+
+    private static Stream<Arguments> shouldEvaluateHasPackageArtifactHashMismatch() {
+        return Stream.of(
+                Arguments.of(
+                        "sha256 differs",
+                        (Consumer<Component>) c -> c.setSha256("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                        new String[]{null, null, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", null},
+                        true),
+                Arguments.of(
+                        "sha256 matches case-insensitively",
+                        (Consumer<Component>) c -> c.setSha256("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                        new String[]{null, null, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", null},
+                        false),
+                Arguments.of(
+                        "no overlapping algorithm",
+                        (Consumer<Component>) c -> c.setSha256("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                        new String[]{null, "0123456789abcdef0123456789abcdef01234567", null, null},
+                        false),
+                Arguments.of(
+                        "component has no comparable hash",
+                        (Consumer<Component>) _ -> {
+                        },
+                        new String[]{null, null, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", null},
+                        false),
+                Arguments.of(
+                        "component only has non-comparable algorithm",
+                        (Consumer<Component>) c -> c.setSha3_512("c" + "0".repeat(127)),
+                        new String[]{null, null, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", null},
+                        false),
+                Arguments.of(
+                        "no package artifact metadata",
+                        (Consumer<Component>) c -> c.setSha256("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                        null,
+                        false),
+                Arguments.of(
+                        "package artifact metadata exists but all hash columns null",
+                        (Consumer<Component>) c -> c.setSha256("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                        new String[]{null, null, null, null},
+                        false));
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource
+    void shouldEvaluateHasPackageArtifactHashMismatch(
+            String displayName,
+            Consumer<Component> componentSetup,
+            String[] pkgArtifactHashes,
+            boolean expectViolation) throws Exception {
+        final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
+        qm.createPolicyCondition(
+                policy,
+                PolicyCondition.Subject.EXPRESSION,
+                PolicyCondition.Operator.MATCHES,
+                "component.has_package_artifact_hash_mismatch()",
+                PolicyViolation.Type.OPERATIONAL);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setPurl(new PackageURL("pkg:maven/acme/lib@1.0"));
+        componentSetup.accept(component);
+        qm.persist(component);
+
+        if (pkgArtifactHashes != null) {
+            useJdbiHandle(handle -> {
+                try {
+                    new PackageMetadataDao(handle).upsertAll(List.of(
+                            new PackageMetadata(
+                                    new PackageURL("pkg:maven/acme/lib"),
+                                    "1.0", null, Instant.now(), null, null)));
+                    new PackageArtifactMetadataDao(handle).upsertAll(List.of(
+                            new PackageArtifactMetadata(
+                                    new PackageURL("pkg:maven/acme/lib@1.0"),
+                                    new PackageURL("pkg:maven/acme/lib"),
+                                    pkgArtifactHashes[0], pkgArtifactHashes[1], pkgArtifactHashes[2], pkgArtifactHashes[3],
+                                    null, null, "central", Instant.now())));
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+
+        if (expectViolation) {
+            assertThat(qm.getAllPolicyViolations(component)).hasSize(1);
+        } else {
+            assertThat(qm.getAllPolicyViolations(component)).isEmpty();
+        }
     }
 
     @Test

--- a/docs/adr/028-hash-verification-computed-not-materialized.md
+++ b/docs/adr/028-hash-verification-computed-not-materialized.md
@@ -40,3 +40,15 @@ interpretation to clients. There is no status enum or per-algorithm sub-schema t
 A future server-side consumer can compute the status when needed from the existing tables. No
 data migration is required, and the result always reflects the current state of both inputs.
 Refreshing artifact metadata never triggers updates to the `COMPONENT` table.
+
+## Follow-up (2026-06-04)
+
+We added a new CEL function `component.has_package_artifact_hash_mismatch()`. Users author the
+policy with an `EXPRESSION` condition. The filter and metrics paths are not built yet.
+
+The function returns true only when the component hash and the upstream hash are both set and not equal.
+It checks MD5, SHA-1, SHA-256, and SHA-512, ignoring upper or lower case. If there is no upstream data,
+or no shared algorithm, it returns false.
+
+It fires only on real mismatches. Matches or "unknown" states are not a useful signal.
+Many packages have no upstream data, so flagging unknowns would just add noise.

--- a/proto/src/main/proto/org/dependencytrack/policy/v1/policy.proto
+++ b/proto/src/main/proto/org/dependencytrack/policy/v1/policy.proto
@@ -70,6 +70,18 @@ message Component {
   optional google.protobuf.Timestamp published_at = 53;
   optional string latest_version = 54;
 
+  // MD5 hash of the corresponding package artifact as reported by its upstream repository.
+  optional string package_artifact_md5 = 55;
+
+  // SHA-1 hash of the corresponding package artifact as reported by its upstream repository.
+  optional string package_artifact_sha1 = 56;
+
+  // SHA-256 hash of the corresponding package artifact as reported by its upstream repository.
+  optional string package_artifact_sha256 = 57;
+
+  // SHA-512 hash of the corresponding package artifact as reported by its upstream repository.
+  optional string package_artifact_sha512 = 58;
+
   message Property {
     string group = 1;
     string name = 2;


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Supports component hash mismatch policy conditions.

Adds a new `has_package_artifact_hash_mismatch` CEL policy function that evaluates to `true` if and only if at least one component hash does not match what is reported by the upstream repository.

This closes a gap where hash matching was previously only explicitly surfaced via UI, but not really actionable.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Frontend PR: https://github.com/DependencyTrack/frontend/pull/1573
Docs PR: https://github.com/DependencyTrack/docs/pull/128

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [x] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
