### PR TITLE
Make latest version publish timestamp available to CEL policy engine

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyComponentRowMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyComponentRowMapper.java
@@ -58,6 +58,7 @@ public final class CelPolicyComponentRowMapper implements RowMapper<Component> {
         maybeSet(rs, "license_expression", ResultSet::getString, builder::setLicenseExpression);
         maybeSet(rs, "published_at", RowMapperUtil::nullableTimestamp, builder::setPublishedAt);
         maybeSet(rs, "latest_version", ResultSet::getString, builder::setLatestVersion);
+        maybeSet(rs, "latest_version_published_at", RowMapperUtil::nullableTimestamp, builder::setLatestVersionPublishedAt);
         maybeSet(rs, "package_artifact_md5", ResultSet::getString, builder::setPackageArtifactMd5);
         maybeSet(rs, "package_artifact_sha1", ResultSet::getString, builder::setPackageArtifactSha1);
         maybeSet(rs, "package_artifact_sha256", ResultSet::getString, builder::setPackageArtifactSha256);

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
@@ -88,7 +88,9 @@ public final class CelPolicyDao {
             fetchColumns.add("c.\"LICENSE_ID\" AS resolved_license_id");
         }
 
-        final boolean shouldJoinPm = protoFieldNames.contains("latest_version");
+        final boolean shouldJoinPm =
+                protoFieldNames.contains("latest_version")
+                        || protoFieldNames.contains("latest_version_published_at");
         final boolean shouldJoinPam =
                 shouldJoinPm
                         || protoFieldNames.contains("published_at")
@@ -666,7 +668,9 @@ public final class CelPolicyDao {
 
         final List<String> fetchColumns = new ArrayList<>(selectColumns(COMPONENT_FIELDS, componentRequirements));
 
-        final boolean shouldJoinPm = componentRequirements.contains("latest_version");
+        final boolean shouldJoinPm =
+                componentRequirements.contains("latest_version")
+                        || componentRequirements.contains("latest_version_published_at");
         final boolean shouldJoinPam =
                 shouldJoinPm
                         || componentRequirements.contains("published_at")

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyFieldMappingRegistry.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyFieldMappingRegistry.java
@@ -55,6 +55,7 @@ public final class CelPolicyFieldMappingRegistry {
             new FieldMapping("license_expression", "c.\"LICENSE_EXPRESSION\""),
             new FieldMapping("published_at", "pam.\"PUBLISHED_AT\""),
             new FieldMapping("latest_version", "pm.\"LATEST_VERSION\""),
+            new FieldMapping("latest_version_published_at", "pm.\"LATEST_VERSION_PUBLISHED_AT\""),
             new FieldMapping("package_artifact_md5", "pam.\"HASH_MD5\""),
             new FieldMapping("package_artifact_sha1", "pam.\"HASH_SHA1\""),
             new FieldMapping("package_artifact_sha256", "pam.\"HASH_SHA256\""),

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
@@ -202,8 +202,8 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
             new PackageMetadataDao(handle).upsertAll(List.of(
                     new PackageMetadata(
                             new PackageURL("pkg:maven/componentGroup/componentName"),
-                            "1.0.0",
-                            null,
+                            /* latestVersion */ "1.0.0",
+                            /* latestVersionPublishedAt */ Instant.ofEpochMilli(666),
                             Instant.now(),
                             null,
                             null)));
@@ -304,6 +304,8 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
                   && component.package_artifact_sha1 == "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"
                   && component.package_artifact_sha256 == "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
                   && component.package_artifact_sha512 == "f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7"
+                  && component.latest_version == "1.0.0"
+                  && component.latest_version_published_at == timestamp("1970-01-01T00:00:00.666Z")
                   && component.properties.all(property,
                        property.group == "componentPropertyGroup"
                          && property.name == "componentPropertyName"

--- a/proto/src/main/proto/org/dependencytrack/policy/v1/policy.proto
+++ b/proto/src/main/proto/org/dependencytrack/policy/v1/policy.proto
@@ -66,21 +66,41 @@ message Component {
   optional string license_name = 50;
   optional string license_expression = 51;
   optional License resolved_license = 52;
-  // When the component current version last modified.
+
+  // When the current version was published.
+  // NOTE: The platform resolves this information asynchronously, so it is not guaranteed to be
+  // available immediately. Policies should explicitly check presence using the has() macro.
   optional google.protobuf.Timestamp published_at = 53;
+
+  // Latest available version.
+  // NOTE: The platform resolves this information asynchronously, so it is not guaranteed to be
+  // available immediately. Policies should explicitly check presence using the has() macro.
   optional string latest_version = 54;
 
   // MD5 hash of the corresponding package artifact as reported by its upstream repository.
+  // NOTE: The platform resolves this information asynchronously, so it is not guaranteed to be
+  // available immediately. Policies should explicitly check presence using the has() macro.
   optional string package_artifact_md5 = 55;
 
   // SHA-1 hash of the corresponding package artifact as reported by its upstream repository.
+  // NOTE: The platform resolves this information asynchronously, so it is not guaranteed to be
+  // available immediately. Policies should explicitly check presence using the has() macro.
   optional string package_artifact_sha1 = 56;
 
   // SHA-256 hash of the corresponding package artifact as reported by its upstream repository.
+  // NOTE: The platform resolves this information asynchronously, so it is not guaranteed to be
+  // available immediately. Policies should explicitly check presence using the has() macro.
   optional string package_artifact_sha256 = 57;
 
   // SHA-512 hash of the corresponding package artifact as reported by its upstream repository.
+  // NOTE: The platform resolves this information asynchronously, so it is not guaranteed to be
+  // available immediately. Policies should explicitly check presence using the has() macro.
   optional string package_artifact_sha512 = 58;
+
+  // When the latest version was published.
+  // NOTE: The platform resolves this information asynchronously, so it is not guaranteed to be
+  // available immediately. Policies should explicitly check presence using the has() macro.
+  optional google.protobuf.Timestamp latest_version_published_at = 59;
 
   message Property {
     string group = 1;


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Makes latest version publish timestamp available to CEL policy engine.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #5290

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
