### PR TITLE
Restore legacy behavior of LICENSE and LICENSE_GROUP policy conditions

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/compat/LicenseCelPolicyScriptSourceBuilder.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/compat/LicenseCelPolicyScriptSourceBuilder.java
@@ -19,37 +19,109 @@
 package org.dependencytrack.policy.cel.compat;
 
 import org.dependencytrack.model.PolicyCondition;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 import static org.dependencytrack.policy.cel.compat.CelPolicyScriptSourceBuilder.escapeQuotes;
 
-public class LicenseCelPolicyScriptSourceBuilder implements CelPolicyScriptSourceBuilder {
+public final class LicenseCelPolicyScriptSourceBuilder implements CelPolicyScriptSourceBuilder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LicenseCelPolicyScriptSourceBuilder.class);
+
+    /// Expression to determine the effective component license expression
+    /// to evaluate, matching v4's LicensePolicyEvaluator.
+    ///
+    /// Users should generally be steered to writing the CEL expressions
+    /// themselves, and making the field selection explicit.
+    static final String EFFECTIVE_COMPONENT_LICENSE_EXPR = """
+            (component.resolved_license.id != ""
+              ? component.resolved_license.id
+              : (component.resolved_license.name != ""
+                  ? component.resolved_license.name
+                  : (component.license_expression != ""
+                      ? component.license_expression
+                      : (component.license_name != ""
+                          ? component.license_name
+                          : "unresolved"))))""";
+
+    /// Expression to determine whether the component should be treated
+    /// as having an unresolved license. Again, this matches v4's
+    /// LicensePolicyEvaluator, which doesn't mean it's strictly correct.
+    private static final String IS_COMPONENT_LICENSE_UNRESOLVED_EXPR = """
+            !has(component.resolved_license) \
+              && component.license_expression == "" \
+              && component.license_name == ""\
+            """;
 
     @Override
-    public String apply(final PolicyCondition policyCondition) {
-        if ("unresolved".equals(policyCondition.getValue())) {
-            if (policyCondition.getOperator() == PolicyCondition.Operator.IS) {
-                return """
-                        !has(component.resolved_license)
-                        """;
-            } else if (policyCondition.getOperator() == PolicyCondition.Operator.IS_NOT) {
-                return """
-                        has(component.resolved_license)
-                        """;
-            }
-        } else {
-            final String escapedLicenseUuid = escapeQuotes(policyCondition.getValue());
-            if (policyCondition.getOperator() == PolicyCondition.Operator.IS) {
-                return """
-                        component.resolved_license.uuid == "%s"
-                        """.formatted(escapedLicenseUuid);
-            } else if (policyCondition.getOperator() == PolicyCondition.Operator.IS_NOT) {
-                return """
-                        component.resolved_license.uuid != "%s"
-                        """.formatted(escapedLicenseUuid);
-            }
+    public String apply(PolicyCondition policyCondition) {
+        final String value = policyCondition.getValue();
+        if (value == null) {
+            return null;
         }
 
-        return null;
+        if ("unresolved".equals(value)) {
+            return switch (policyCondition.getOperator()) {
+                case IS -> IS_COMPONENT_LICENSE_UNRESOLVED_EXPR;
+                case IS_NOT -> "!(%s)".formatted(IS_COMPONENT_LICENSE_UNRESOLVED_EXPR);
+                default -> null;
+            };
+        }
+
+        // Unfortunately, the legacy v4 behavior of this condition is a bit overloaded.
+        // It does not only check EQUALITY, but also applies SPDX expression logic.
+        // The condition as configured by users only gives us a license UUID,
+        // which ofc does not suffice for SPDX expression evaluation.
+        //
+        // We don't have another choice than do a DB lookup here to resolve the license ID.
+        // DO NOT REPEAT THIS PATTERN ELSEWHERE. Script builders were intended to be thin
+        // translation layers, and not do any I/O whatsoever.
+        final ConditionLicense conditionLicense = tryLookupLicense(value);
+        if (conditionLicense == null) {
+            LOGGER.warn(
+                    "No license with UUID {} exists; Skipping condition {}",
+                    value, policyCondition.getUuid());
+            return null;
+        }
+
+        final String escapedId = escapeQuotes(conditionLicense.licenseId());
+        final String escapedName = escapeQuotes(conditionLicense.name());
+        return switch (policyCondition.getOperator()) {
+            case IS -> """
+                    %1$s in ["%2$s", "%3$s"] || spdx_expr_requires_any(%1$s, ["%2$s"])\
+                    """.formatted(EFFECTIVE_COMPONENT_LICENSE_EXPR, escapedId, escapedName);
+            case IS_NOT -> """
+                    !(%1$s in ["%2$s", "%3$s"]) && !spdx_expr_allows(%1$s, ["%2$s"])\
+                    """.formatted(EFFECTIVE_COMPONENT_LICENSE_EXPR, escapedId, escapedName);
+            default -> null;
+        };
+    }
+
+    record ConditionLicense(@Nullable String licenseId, String name) {
+    }
+
+    private static @Nullable ConditionLicense tryLookupLicense(String licenseUuid) {
+        try {
+            return withJdbiHandle(
+                    handle -> handle
+                            .createQuery("""
+                                    SELECT COALESCE("LICENSEID", '')
+                                         , "NAME" -- NOT NULL
+                                      FROM "LICENSE"
+                                     WHERE "UUID" = CAST(:uuid AS UUID)
+                                    """)
+                            .bind("uuid", licenseUuid)
+                            .map((rs, _) -> new ConditionLicense(
+                                    rs.getString(1),
+                                    rs.getString(2)))
+                            .findOne()
+                            .orElse(null));
+        } catch (RuntimeException e) {
+            LOGGER.warn("Failed to look up license with UUID {}", licenseUuid, e);
+            return null;
+        }
     }
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/compat/LicenseGroupCelPolicyScriptSourceBuilder.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/compat/LicenseGroupCelPolicyScriptSourceBuilder.java
@@ -19,24 +19,84 @@
 package org.dependencytrack.policy.cel.compat;
 
 import org.dependencytrack.model.PolicyCondition;
+import org.dependencytrack.policy.cel.compat.LicenseCelPolicyScriptSourceBuilder.ConditionLicense;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import static org.dependencytrack.policy.cel.compat.CelPolicyScriptSourceBuilder.escapeQuotes;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
-public class LicenseGroupCelPolicyScriptSourceBuilder implements CelPolicyScriptSourceBuilder {
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
+import static org.dependencytrack.policy.cel.compat.LicenseCelPolicyScriptSourceBuilder.EFFECTIVE_COMPONENT_LICENSE_EXPR;
+
+public final class LicenseGroupCelPolicyScriptSourceBuilder implements CelPolicyScriptSourceBuilder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LicenseGroupCelPolicyScriptSourceBuilder.class);
 
     @Override
-    public String apply(final PolicyCondition policyCondition) {
-        final String scriptSrc = """
-                component.resolved_license.groups.exists(group, group.uuid == "%s")
-                """.formatted(escapeQuotes(policyCondition.getValue()));
-
-        if (policyCondition.getOperator() == PolicyCondition.Operator.IS) {
-            return scriptSrc;
-        } else if (policyCondition.getOperator() == PolicyCondition.Operator.IS_NOT) {
-            return "!" + scriptSrc;
+    public String apply(PolicyCondition policyCondition) {
+        final String value = policyCondition.getValue();
+        if (value == null) {
+            return null;
         }
 
-        return null;
+        final List<ConditionLicense> licensesInGroup = tryLookupLicensesOfGroup(value);
+        if (licensesInGroup == null) {
+            return null;
+        }
+        
+        final String licenseIds = licensesInGroup.stream()
+                .map(ConditionLicense::licenseId)
+                .filter(Objects::nonNull)
+                .map(CelPolicyScriptSourceBuilder::escapeQuotes)
+                .map("\"%s\""::formatted)
+                .collect(Collectors.joining(", ", "[", "]"));
+        final String licenseNames = licensesInGroup.stream()
+                .map(ConditionLicense::name)
+                .filter(Objects::nonNull)
+                .map(CelPolicyScriptSourceBuilder::escapeQuotes)
+                .map("\"%s\""::formatted)
+                .collect(Collectors.joining(", ", "[", "]"));
+
+        return switch (policyCondition.getOperator()) {
+            case IS -> """
+                    %1$s.exists(id, id == %3$s) \
+                    || %2$s.exists(name, name == %3$s) \
+                    || spdx_expr_requires_any(%3$s, %1$s)\
+                    """.formatted(licenseIds, licenseNames, EFFECTIVE_COMPONENT_LICENSE_EXPR);
+            case IS_NOT -> """
+                    !%1$s.exists(id, id == %3$s) \
+                    && !%2$s.exists(name, name == %3$s) \
+                    && !spdx_expr_allows(%3$s, %1$s)\
+                    """.formatted(licenseIds, licenseNames, EFFECTIVE_COMPONENT_LICENSE_EXPR);
+            default -> null;
+        };
+    }
+
+    private static List<ConditionLicense> tryLookupLicensesOfGroup(String groupUuid) {
+        try {
+            return withJdbiHandle(
+                    handle -> handle
+                            .createQuery("""
+                                    SELECT l."LICENSEID"
+                                         , l."NAME"
+                                      FROM "LICENSE" AS l
+                                     INNER JOIN "LICENSEGROUP_LICENSE" AS lgl
+                                        ON lgl."LICENSE_ID" = l."ID"
+                                     INNER JOIN "LICENSEGROUP" AS lg
+                                        ON lg."ID" = lgl."LICENSEGROUP_ID"
+                                     WHERE lg."UUID" = CAST(:uuid AS UUID)
+                                    """)
+                            .bind("uuid", groupUuid)
+                            .map((rs, _) -> new ConditionLicense(
+                                    rs.getString(1),
+                                    rs.getString(2)))
+                            .list());
+        } catch (RuntimeException e) {
+            LOGGER.warn("Failed to look up license group with UUID {}", groupUuid, e);
+            return null;
+        }
     }
 
 }

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/LicenseConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/LicenseConditionTest.java
@@ -104,6 +104,149 @@ public class LicenseConditionTest extends PersistenceCapableTest {
     }
 
     @Test
+    void shouldMatchByLicenseExpression() {
+        final var license = new License();
+        license.setName("MIT License");
+        license.setLicenseId("MIT");
+        license.setUuid(UUID.randomUUID());
+        qm.persist(license);
+
+        final Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.LICENSE, PolicyCondition.Operator.IS, license.getUuid().toString());
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setName("acme-app");
+        component.setLicenseExpression("MIT");
+        component.setProject(project);
+        qm.persist(component);
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+        assertThat(qm.getAllPolicyViolations(component)).hasSize(1);
+    }
+
+    @Test
+    void shouldMatchByLicenseName() {
+        final var license = new License();
+        license.setName("MIT License");
+        license.setLicenseId("MIT");
+        license.setUuid(UUID.randomUUID());
+        qm.persist(license);
+
+        final Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.LICENSE, PolicyCondition.Operator.IS, license.getUuid().toString());
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setName("acme-app");
+        component.setLicense("MIT");
+        component.setProject(project);
+        qm.persist(component);
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+        assertThat(qm.getAllPolicyViolations(component)).hasSize(1);
+    }
+
+    @Test
+    void shouldNotViolateIsNotWhenOrExpressionPermitsLicense() {
+        final var mit = new License();
+        mit.setName("MIT License");
+        mit.setLicenseId("MIT");
+        mit.setUuid(UUID.randomUUID());
+        qm.persist(mit);
+
+        final Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.LICENSE, PolicyCondition.Operator.IS_NOT, mit.getUuid().toString());
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setName("acme-app");
+        component.setLicenseExpression("MIT OR Apache-2.0");
+        component.setProject(project);
+        qm.persist(component);
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+        assertThat(qm.getAllPolicyViolations(component)).isEmpty();
+    }
+
+    @Test
+    void shouldViolateIsWhenAndExpressionContainsForbiddenLicense() {
+        final var gpl = new License();
+        gpl.setName("GNU General Public License v2.0");
+        gpl.setLicenseId("GPL-2.0");
+        gpl.setUuid(UUID.randomUUID());
+        qm.persist(gpl);
+
+        final Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.LICENSE, PolicyCondition.Operator.IS, gpl.getUuid().toString());
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setName("acme-app");
+        component.setLicenseExpression("MIT AND GPL-2.0");
+        component.setProject(project);
+        qm.persist(component);
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+        assertThat(qm.getAllPolicyViolations(component)).hasSize(1);
+    }
+
+    @Test
+    void shouldViolateIsNotUnresolvedWhenLicenseExpressionIsSet() {
+        final Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.LICENSE, PolicyCondition.Operator.IS_NOT, "unresolved");
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setName("acme-app");
+        component.setLicenseExpression("MIT");
+        component.setProject(project);
+        qm.persist(component);
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+        assertThat(qm.getAllPolicyViolations(component)).hasSize(1);
+    }
+
+    @Test
+    void shouldMatchCustomLicenseByUuid() {
+        final var custom = new License();
+        custom.setName("Acme Proprietary");
+        custom.setUuid(UUID.randomUUID());
+        qm.persist(custom);
+
+        final Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.LICENSE, PolicyCondition.Operator.IS, custom.getUuid().toString());
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setName("acme-app");
+        component.setResolvedLicense(custom);
+        component.setProject(project);
+        qm.persist(component);
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+        assertThat(qm.getAllPolicyViolations(component)).hasSize(1);
+    }
+
+    @Test
     public void valueIsUnresolved() {
         License license = new License();
         license.setName("Apache 2.0");

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/LicenseGroupConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/LicenseGroupConditionTest.java
@@ -144,6 +144,118 @@ public class LicenseGroupConditionTest extends PersistenceCapableTest {
     }
 
     @Test
+    void shouldMatchLicenseGroupByLicenseExpression() {
+        final var mit = new License();
+        mit.setName("MIT License");
+        mit.setLicenseId("MIT");
+        mit.setUuid(UUID.randomUUID());
+        qm.persist(mit);
+        LicenseGroup lg = qm.createLicenseGroup("Permissive");
+        lg.setLicenses(Collections.singletonList(mit));
+        lg = qm.persist(lg);
+
+        final Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.LICENSE_GROUP, PolicyCondition.Operator.IS, lg.getUuid().toString());
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setName("acme-app");
+        component.setLicenseExpression("MIT");
+        component.setProject(project);
+        qm.persist(component);
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+        assertThat(qm.getAllPolicyViolations(component)).hasSize(1);
+    }
+
+    @Test
+    void shouldMatchLicenseGroupByLicenseName() {
+        final var mit = new License();
+        mit.setName("MIT License");
+        mit.setLicenseId("MIT");
+        mit.setUuid(UUID.randomUUID());
+        qm.persist(mit);
+        LicenseGroup lg = qm.createLicenseGroup("Permissive");
+        lg.setLicenses(Collections.singletonList(mit));
+        lg = qm.persist(lg);
+
+        final Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.LICENSE_GROUP, PolicyCondition.Operator.IS, lg.getUuid().toString());
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setName("acme-app");
+        component.setLicense("MIT");
+        component.setProject(project);
+        qm.persist(component);
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+        assertThat(qm.getAllPolicyViolations(component)).hasSize(1);
+    }
+
+    @Test
+    void shouldNotViolateIsNotWhenOrExpressionPermitsGroupMember() {
+        final var mit = new License();
+        mit.setName("MIT License");
+        mit.setLicenseId("MIT");
+        mit.setUuid(UUID.randomUUID());
+        qm.persist(mit);
+        LicenseGroup lg = qm.createLicenseGroup("Permissive");
+        lg.setLicenses(Collections.singletonList(mit));
+        lg = qm.persist(lg);
+
+        final Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.LICENSE_GROUP, PolicyCondition.Operator.IS_NOT, lg.getUuid().toString());
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setName("acme-app");
+        component.setLicenseExpression("MIT OR Apache-2.0");
+        component.setProject(project);
+        qm.persist(component);
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+        assertThat(qm.getAllPolicyViolations(component)).isEmpty();
+    }
+
+    @Test
+    void shouldViolateIsWhenAndExpressionContainsGroupMember() {
+        final var gpl = new License();
+        gpl.setName("GNU General Public License v2.0");
+        gpl.setLicenseId("GPL-2.0");
+        gpl.setUuid(UUID.randomUUID());
+        qm.persist(gpl);
+        LicenseGroup lg = qm.createLicenseGroup("Copyleft");
+        lg.setLicenses(Collections.singletonList(gpl));
+        lg = qm.persist(lg);
+
+        final Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.LICENSE_GROUP, PolicyCondition.Operator.IS, lg.getUuid().toString());
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setName("acme-app");
+        component.setLicenseExpression("MIT AND GPL-2.0");
+        component.setProject(project);
+        qm.persist(component);
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+        assertThat(qm.getAllPolicyViolations(component)).hasSize(1);
+    }
+
+    @Test
     public void licenseGroupDoesNotExist() {
         License license = new License();
         license.setName("Apache 2.0");


### PR DESCRIPTION

### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Aligns the behavior of the `LICENSE` and `LICENSE_GROUP` policy conditions with v4, to avoid users migrating to v4 experiencing unexpected changes.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
