### PR TITLE
Fix EPSS < and <= policy conditions matching when vuln has no EPSS score

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/compat/EpssCelPolicyScriptSourceBuilder.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/compat/EpssCelPolicyScriptSourceBuilder.java
@@ -40,12 +40,12 @@ public class EpssCelPolicyScriptSourceBuilder implements CelPolicyScriptSourceBu
         }
 
         final String scriptSrcTemplate = switch (policyCondition.getOperator()) {
-            case NUMERIC_GREATER_THAN -> "vulns.exists(vuln, vuln.epss_score > %s)";
-            case NUMERIC_GREATER_THAN_OR_EQUAL -> "vulns.exists(vuln, vuln.epss_score >= %s)";
-            case NUMERIC_EQUAL -> "vulns.exists(vuln, vuln.epss_score == %s)";
-            case NUMERIC_NOT_EQUAL -> "vulns.exists(vuln, vuln.epss_score != %s)";
-            case NUMERIC_LESSER_THAN_OR_EQUAL -> "vulns.exists(vuln, vuln.epss_score <= %s)";
-            case NUMERIC_LESS_THAN -> "vulns.exists(vuln, vuln.epss_score < %s)";
+            case NUMERIC_GREATER_THAN -> "vulns.exists(vuln, has(vuln.epss_score) && vuln.epss_score > %s)";
+            case NUMERIC_GREATER_THAN_OR_EQUAL -> "vulns.exists(vuln, has(vuln.epss_score) && vuln.epss_score >= %s)";
+            case NUMERIC_EQUAL -> "vulns.exists(vuln, has(vuln.epss_score) && vuln.epss_score == %s)";
+            case NUMERIC_NOT_EQUAL -> "vulns.exists(vuln, has(vuln.epss_score) && vuln.epss_score != %s)";
+            case NUMERIC_LESSER_THAN_OR_EQUAL -> "vulns.exists(vuln, has(vuln.epss_score) && vuln.epss_score <= %s)";
+            case NUMERIC_LESS_THAN -> "vulns.exists(vuln, has(vuln.epss_score) && vuln.epss_score < %s)";
             default -> null;
         };
         if (scriptSrcTemplate == null) {

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/EpssConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/EpssConditionTest.java
@@ -78,8 +78,11 @@ public class EpssConditionTest extends PersistenceCapableTest {
                 new Object[]{MATCHES, "0.666", 0.666, false},
                 // Vulnerability without EPSS score.
                 new Object[]{NUMERIC_EQUAL, "0.666", null, false},
+                new Object[]{NUMERIC_NOT_EQUAL, "0.666", null, false},
+                new Object[]{NUMERIC_GREATER_THAN, "0.666", null, false},
+                new Object[]{NUMERIC_GREATER_THAN_OR_EQUAL, "0.666", null, false},
                 new Object[]{NUMERIC_LESSER_THAN_OR_EQUAL, "0.666", null, false},
-                new Object[]{NUMERIC_LESS_THAN, "0.666", null, false},
+                new Object[]{NUMERIC_LESS_THAN, "0.666", null, false}
                 // No condition value.
                 new Object[]{NUMERIC_EQUAL, "", 0.666, false},
                 // Invalid condition value.

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/EpssConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/EpssConditionTest.java
@@ -78,6 +78,8 @@ public class EpssConditionTest extends PersistenceCapableTest {
                 new Object[]{MATCHES, "0.666", 0.666, false},
                 // Vulnerability without EPSS score.
                 new Object[]{NUMERIC_EQUAL, "0.666", null, false},
+                new Object[]{NUMERIC_LESSER_THAN_OR_EQUAL, "0.666", null, false},
+                new Object[]{NUMERIC_LESS_THAN, "0.666", null, false},
                 // No condition value.
                 new Object[]{NUMERIC_EQUAL, "", 0.666, false},
                 // Invalid condition value.

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/EpssConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/EpssConditionTest.java
@@ -82,7 +82,7 @@ public class EpssConditionTest extends PersistenceCapableTest {
                 new Object[]{NUMERIC_GREATER_THAN, "0.666", null, false},
                 new Object[]{NUMERIC_GREATER_THAN_OR_EQUAL, "0.666", null, false},
                 new Object[]{NUMERIC_LESSER_THAN_OR_EQUAL, "0.666", null, false},
-                new Object[]{NUMERIC_LESS_THAN, "0.666", null, false}
+                new Object[]{NUMERIC_LESS_THAN, "0.666", null, false},
                 // No condition value.
                 new Object[]{NUMERIC_EQUAL, "", 0.666, false},
                 // Invalid condition value.


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds missing existence checks to avoid Protobuf's default value behavior from causing matches when the respective vulnerability does not have an EPSS score at all.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
