### PR TITLE
Fix missing fields from GET /api/v1/project response

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
@@ -27,6 +27,7 @@ import org.dependencytrack.common.pagination.Page.TotalCount;
 import org.dependencytrack.exception.AlreadyExistsException;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectCollectionLogic;
+import org.dependencytrack.model.ProjectMetadata;
 import org.dependencytrack.model.ProjectMetrics;
 import org.dependencytrack.model.Tag;
 import org.dependencytrack.persistence.jdbi.command.CloneProjectCommand;
@@ -477,6 +478,7 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
                  , "PROJECT"."GROUP"
                  , "PROJECT"."LAST_BOM_IMPORTED" AS "lastBomImport"
                  , "PROJECT"."LAST_BOM_IMPORTED_FORMAT" AS "lastBomImportFormat"
+                 , "PROJECT"."LAST_VULNERABILITY_ANALYSIS" AS "lastVulnerabilityAnalysis"
                  , CASE
                      WHEN "PROJECT"."COLLECTION_LOGIC" IS NOT NULL
                      THEN cm."inheritedRiskScore"
@@ -494,6 +496,7 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
                  , "PROJECT"."IS_LATEST" AS "isLatest"
                  , "PROJECT"."INACTIVE_SINCE" AS "inactiveSince"
                  , "PROJECT"."COLLECTION_LOGIC" AS "collectionLogic"
+                 , collection_tag."NAME" AS "collectionTagName"
                  , (
                      SELECT JSONB_AGG(JSONB_BUILD_OBJECT('id', "ID", 'name', "NAME"))
                        FROM "TAG"
@@ -508,6 +511,15 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
                          ON "PROJECT_ACCESS_TEAMS"."TEAM_ID" = "TEAM"."ID"
                       WHERE "PROJECT_ACCESS_TEAMS"."PROJECT_ID" = "PROJECT"."ID"
                    ) AS "teamsJson"
+                 , (
+                     SELECT JSONB_STRIP_NULLS(JSONB_BUILD_OBJECT(
+                              'supplier', "SUPPLIER"::JSONB,
+                              'authors', "AUTHORS"::JSONB,
+                              'tools', "TOOLS"::JSONB
+                            ))
+                       FROM "PROJECT_METADATA"
+                      WHERE "PROJECT_METADATA"."PROJECT_ID" = "PROJECT"."ID"
+                   ) AS "metadataJson"
             <#if includeMetrics>
                  , CASE
                      WHEN "PROJECT"."COLLECTION_LOGIC" IS NOT NULL
@@ -515,6 +527,9 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
                      ELSE (SELECT TO_JSONB(m) FROM (${leafMetricsSubquery}) AS m)
                    END AS "metricsJson"
             </#if>
+                 , parent."UUID" AS "parentUuid"
+                 , parent."NAME" AS "parentName"
+                 , parent."VERSION" AS "parentVersion"
               FROM "PROJECT"
             <#--
                 NB: We are forced to do this lateral join unconditionally, because callers expect
@@ -522,8 +537,13 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
                 LAST_RISKSCORE column. In a future query backing a hypothetical API v2 endpoint,
                 lastInheritedRiskScore should be an expandable field to work around this.
             -->
+              LEFT JOIN "PROJECT" AS parent
+                ON "PROJECT"."PARENT_PROJECT_ID" IS NOT NULL
+               AND parent."ID" = "PROJECT"."PARENT_PROJECT_ID"
               LEFT JOIN LATERAL (${collectionMetricsSubquery}) AS cm
                 ON "PROJECT"."COLLECTION_LOGIC" IS NOT NULL
+              LEFT JOIN "TAG" AS collection_tag
+                ON collection_tag."ID" = "PROJECT"."COLLECTION_TAG_ID"
              WHERE ${apiProjectAclCondition}
                AND ${whereConditions?join(" AND ")}
             <#if apiOrderByClause??>
@@ -826,6 +846,8 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
         };
         private static final TypeReference<ProjectMetrics> METRICS_TYPE_REF = new TypeReference<>() {
         };
+        private static final TypeReference<ProjectMetadata> METADATA_TYPE_REF = new TypeReference<>() {
+        };
 
         private final RowMapper<Project> projectMapper = BeanMapper.of(Project.class);
 
@@ -839,6 +861,20 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
                     deserializeJson(rs, columnName, TAGS_TYPE_REF), project::setTags);
             maybeSet(rs, "metricsJson", (_, columnName) ->
                     deserializeJson(rs, columnName, METRICS_TYPE_REF), project::setMetrics);
+            maybeSet(rs, "metadataJson", (_, columnName) ->
+                    deserializeJson(rs, columnName, METADATA_TYPE_REF), project::setMetadata);
+            maybeSet(rs, "collectionTagName", ResultSet::getString,
+                    collectionTagName -> project.setCollectionTag(new Tag(collectionTagName)));
+
+            final var parentUuid = rs.getObject("parentUuid", UUID.class);
+            if (parentUuid != null) {
+                final var parent = new Project();
+                parent.setUuid(parentUuid);
+                parent.setName(rs.getString("parentName"));
+                parent.setVersion(rs.getString("parentVersion"));
+                project.setParent(parent);
+            }
+
             return project;
         }
     }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -152,9 +152,10 @@ class ProjectResourceTest extends ResourceTest {
         project.setClassifier(Classifier.APPLICATION);
         project.setDescription("project description");
         project.setExternalReferences(List.of(new ExternalReference()));
-        project.setLastBomImport(new java.util.Date());
+        project.setLastBomImport(new Date());
         project.setLastBomImportFormat("projectBomFormat");
         project.setLastInheritedRiskScore(7.7);
+        project.setLastVulnerabilityAnalysis(new Date());
         project.setPublisher("projectPublisher");
 
         final var projectContact = new OrganizationalContact();
@@ -173,13 +174,23 @@ class ProjectResourceTest extends ResourceTest {
 
         qm.bind(project, List.of(qm.createTag("foo")));
 
+        final var metadataAuthor = new OrganizationalContact();
+        metadataAuthor.setName("metadataAuthorName");
+        final var metadataSupplier = new OrganizationalEntity();
+        metadataSupplier.setName("metadataSupplierName");
+        final var metadata = new ProjectMetadata();
+        metadata.setProject(project);
+        metadata.setAuthors(List.of(metadataAuthor));
+        metadata.setSupplier(metadataSupplier);
+        qm.persist(metadata);
+
         final Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assertions.assertEquals(200, response.getStatus(), 0);
         Assertions.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
-        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
                 [ {
                    "publisher" : "projectPublisher",
                    "manufacturer" : {
@@ -208,7 +219,16 @@ class ProjectResourceTest extends ResourceTest {
                    "lastBomImport" : "${json-unit.any-number}",
                    "lastBomImportFormat" : "projectBomFormat",
                    "lastInheritedRiskScore" : 7.7,
+                   "lastVulnerabilityAnalysis" : "${json-unit.any-number}",
                    "externalReferences" : [ { } ],
+                   "metadata" : {
+                     "supplier" : {
+                       "name" : "metadataSupplierName"
+                     },
+                     "authors" : [ {
+                       "name" : "metadataAuthorName"
+                     } ]
+                   },
                    "isLatest" : false,
                    "active" : true
                  } ]
@@ -523,7 +543,7 @@ class ProjectResourceTest extends ResourceTest {
                 .get();
         assertThat(response.getStatus()).isEqualTo(200);
         assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("2");
-        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
                 [ {
                    "name" : "acme-app-a",
                    "uuid" : "${json-unit.any-string}",
@@ -531,6 +551,10 @@ class ProjectResourceTest extends ResourceTest {
                    "isLatest" : false,
                    "active" : true
                  }, {
+                   "parent": {
+                     "uuid": "${json-unit.any-string}",
+                     "name": "acme-app-a"
+                   },
                    "name" : "acme-app-b",
                    "uuid" : "${json-unit.any-string}",
                    "inactiveSince" : "${json-unit.any-number}",
@@ -548,7 +572,7 @@ class ProjectResourceTest extends ResourceTest {
                 .get();
         assertThat(response.getStatus()).isEqualTo(200);
         assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
-        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
                 [ {
                    "name" : "acme-app-a",
                    "uuid" : "${json-unit.any-string}",


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Restores `parent`, `metadata`, `lastVulnerabilityAnalysis`, and `collectionTag` fields.

Note that `children` is intentionally not restored, because returning nested collections in a collection resource has atrocious performance implications. Also, there is a dedicated `/children` resource with pagination support and all. Will document this as breaking API change instead.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6272 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
