### PR TITLE
Improve escaping of quoted strings for CEL policy inputs

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/compat/CelPolicyScriptSourceBuilder.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/compat/CelPolicyScriptSourceBuilder.java
@@ -21,14 +21,11 @@ package org.dependencytrack.policy.cel.compat;
 import org.dependencytrack.model.PolicyCondition;
 
 import java.util.function.Function;
-import java.util.regex.Pattern;
 
 public interface CelPolicyScriptSourceBuilder extends Function<PolicyCondition, String> {
 
-    Pattern QUOTES_PATTERN = Pattern.compile("\"");
-
-    static String escapeQuotes(final String value) {
-        return QUOTES_PATTERN.matcher(value).replaceAll("\\\\\"");
+    static String escapeQuotes(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
 }

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/CelPolicyScriptSourceBuilderTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/CelPolicyScriptSourceBuilderTest.java
@@ -23,11 +23,31 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.policy.cel.compat.CelPolicyScriptSourceBuilder.escapeQuotes;
 
-public class CelPolicyScriptSourceBuilderTest {
+class CelPolicyScriptSourceBuilderTest {
 
     @Test
-    public void testEscapeQuotes() {
+    void shouldEscapeQuote() {
         assertThat(escapeQuotes("\"foobar")).isEqualTo("\\\"foobar");
+    }
+
+    @Test
+    void shouldEscapeBackslash() {
+        assertThat(escapeQuotes("foo\\bar")).isEqualTo("foo\\\\bar");
+    }
+
+    @Test
+    void shouldEscapeBackslashBeforeQuote() {
+        assertThat(escapeQuotes("foo\\\"bar")).isEqualTo("foo\\\\\\\"bar");
+    }
+
+    @Test
+    void shouldEscapeTrailingBackslash() {
+        assertThat(escapeQuotes("foo\\")).isEqualTo("foo\\\\");
+    }
+
+    @Test
+    void shouldReturnInputWhenNothingToEscape() {
+        assertThat(escapeQuotes("foobar")).isEqualTo("foobar");
     }
 
 }

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/CpeConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/CpeConditionTest.java
@@ -38,7 +38,7 @@ public class CpeConditionTest extends PersistenceCapableTest {
                 // MATCHES with exact match
                 new Object[]{MATCHES, "cpe:/a:acme:application:1.0.0", "cpe:/a:acme:application:1.0.0", true},
                 // MATCHES with regex match
-                new Object[]{MATCHES, "cpe:/a:acme:\\\\w+:[0-9].0.0", "cpe:/a:acme:application:1.0.0", true},
+                new Object[]{MATCHES, "cpe:/a:acme:\\w+:[0-9].0.0", "cpe:/a:acme:application:1.0.0", true},
                 // MATCHES with no match
                 new Object[]{MATCHES, "cpe:/a:acme:application:1.0.0", "cpe:/a:acme:application:9.9.9", false},
                 // NO_MATCH with no match


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Improves escaping of quoted strings for CEL policy inputs.

We did not correctly escape backslashes, which could cause broken CEL expressions.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Identified as necessary via #6273

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
