### PR TITLE
Fix LocalFileStorageTest flakiness

### DIFF
--- a/file-storage/provider-local/src/main/java/org/dependencytrack/filestorage/local/LocalFileStorage.java
+++ b/file-storage/provider-local/src/main/java/org/dependencytrack/filestorage/local/LocalFileStorage.java
@@ -40,6 +40,8 @@ import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 import static java.util.Objects.requireNonNull;
 import static org.dependencytrack.filestorage.api.FileStorage.requireValidFileName;
@@ -122,17 +124,34 @@ final class LocalFileStorage implements FileStorage {
         return deleted;
     }
 
+    @SuppressWarnings("BusyWait")
     private OutputStream openOutputStream(Path filePath) throws IOException {
-        // Concurrent directory cleanup from delete() can race with directory creation
-        // and file open, causing various FileSystemExceptions. Retry a bounded number
-        // of times to handle these transient race conditions.
-        final int maxAttempts = 3;
-        for (int attempt = 1; ; attempt++) {
+        final long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+
+        int attempt = 0;
+        while (true) {
             try {
                 Files.createDirectories(filePath.getParent());
                 return Files.newOutputStream(filePath);
             } catch (FileSystemException e) {
-                if (attempt >= maxAttempts) {
+                // It's possible that we're trying to create a file in a directory that was
+                // deleted by a concurrent deleteEmptyParentDirectories call.
+                // Retry up to 5 seconds with an exponential backoff of 1-16ms.
+                //
+                // Note that we can't use (arguably more correct) file locks here,
+                // because the underlying storage may use a network filesystem.
+
+                if (System.nanoTime() >= deadlineNanos) {
+                    throw e;
+                }
+
+                final long backoffCapMillis = Math.min(16L, 1L << Math.min(attempt++, 4));
+                final long backoffMillis = ThreadLocalRandom.current().nextLong(1, backoffCapMillis + 1);
+
+                try {
+                    Thread.sleep(backoffMillis);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
                     throw e;
                 }
             }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Uses a time-based retry cap for creating files instead of an attempt-based one. Makes the retry mechanism more resilient to many concurrent cleanup / create operations.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
