### PR TITLE
v4-migrator: Grant SECRET_MANAGEMENT to principals with SYSTEM_CONFIGURATION permission

### DIFF
--- a/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/PermissionCatalog.java
+++ b/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/PermissionCatalog.java
@@ -28,8 +28,8 @@ import org.jdbi.v3.core.Jdbi;
  * <p>The migrator owns v5 PERMISSION seeding because downstream join-table loads
  * ({@code USERS_PERMISSIONS}, {@code TEAMS_PERMISSIONS}) need to FK-resolve v5
  * permission IDs (including v5-only entries such as
- * {@code PORTFOLIO_ACCESS_CONTROL_BYPASS}) before the apiserver runs its own
- * seeding step on first post-migration boot.
+ * {@code PORTFOLIO_ACCESS_CONTROL_BYPASS} and {@code SECRET_MANAGEMENT}) before
+ * the apiserver runs its own seeding step on first post-migration boot.
  *
  * <p>Seeding runs in {@code bootstrap} rather than {@code transform} so that a
  * documented "drop v5 schema, re-bootstrap, re-run load" recovery (see ADR-023

--- a/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/TableRegistry.java
+++ b/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/TableRegistry.java
@@ -599,10 +599,11 @@ public final class TableRegistry {
      * seeded during {@code bootstrap} (see {@link PermissionCatalog}); transform here
      * just builds {@code permission_name_map} by inner-joining v4 NAME against the
      * already-seeded v5 PERMISSION table. v4 permission names that no longer exist in
-     * v5 (e.g. {@code VIEW_BADGES}) drop out of the map. Implication fan-out (v4
-     * {@code ACCESS_MANAGEMENT} -> v5 {@code PORTFOLIO_ACCESS_CONTROL_BYPASS}) is
-     * applied on the join-table {@code tgt_*} tables. See {@code TEAMS_PERMISSIONS} and
-     * the consolidated {@code USERS_PERMISSIONS} transforms.
+     * v5 (e.g. {@code VIEW_BADGES}) drop out of the map. Implication fan-outs (v4
+     * {@code ACCESS_MANAGEMENT} -> v5 {@code PORTFOLIO_ACCESS_CONTROL_BYPASS}, and v4
+     * {@code SYSTEM_CONFIGURATION} -> v5 {@code SECRET_MANAGEMENT}) are applied on the
+     * join-table {@code tgt_*} tables. See {@code TEAMS_PERMISSIONS} and the consolidated
+     * {@code USERS_PERMISSIONS} transforms.
      */
     private static final TableMigration PERMISSION = new TableMigration(
         "PERMISSION",
@@ -726,16 +727,32 @@ public final class TableRegistry {
           JOIN "%1$s".permission_name_map m ON m.orig_id = j."PERMISSION_ID"
         ON CONFLICT DO NOTHING;
 
-        -- Implication fan-out: v4 ACCESS_MANAGEMENT carried implicit portfolio-access-control
-        -- bypass. v5 split that into the explicit PORTFOLIO_ACCESS_CONTROL_BYPASS permission
-        -- (v5.6.0-31). Grant it to every user that holds ACCESS_MANAGEMENT in v4. The v5.6.0-31
-        -- changeset also matched ACCESS_MANAGEMENT_CREATE, but that permission did not exist
-        -- in v4, so the v4-to-v5 path filters on the umbrella only.
+        -- Implication fan-outs: v4 carried two v5-only permissions implicitly via their
+        -- v4-era equivalents. v5 split each into a dedicated permission, and the migrator
+        -- preserves v4 authorization semantics by granting the new permission to every v4
+        -- holder of the equivalent. The target permissions are seeded by PermissionCatalog
+        -- during bootstrap; the inner join against "PERMISSION" produces zero rows (rather
+        -- than a NULL PERMISSION_ID constraint violation) if a catalog row is missing.
+        --
+        --   ACCESS_MANAGEMENT    -> PORTFOLIO_ACCESS_CONTROL_BYPASS (v5.6.0-31). The v5.6.0-31
+        --                          changeset also matched ACCESS_MANAGEMENT_CREATE, but that
+        --                          permission did not exist in v4, so the v4-to-v5 path
+        --                          filters on the umbrella only.
+        --   SYSTEM_CONFIGURATION -> SECRET_MANAGEMENT. v4 had no separate secret-management
+        --                          permission; repository basic-auth passwords and analyzer /
+        --                          vulnerability-source API credentials were configurable by
+        --                          anyone with SYSTEM_CONFIGURATION. Only the umbrella is
+        --                          fanned out; the _CREATE / _UPDATE / _DELETE variants did
+        --                          not exist in v4.
         INSERT INTO "%1$s".tgt_users_permissions ("USER_ID", "PERMISSION_ID")
-        SELECT DISTINCT up."USER_ID", (SELECT "ID" FROM "PERMISSION" WHERE "NAME" = 'PORTFOLIO_ACCESS_CONTROL_BYPASS')
+        SELECT DISTINCT up."USER_ID", tgt."ID"
           FROM "%1$s".tgt_users_permissions up
-          JOIN "PERMISSION" p ON p."ID" = up."PERMISSION_ID"
-         WHERE p."NAME" = 'ACCESS_MANAGEMENT'
+          JOIN "PERMISSION" src ON src."ID" = up."PERMISSION_ID"
+          JOIN "PERMISSION" tgt ON tgt."NAME" = CASE src."NAME"
+              WHEN 'ACCESS_MANAGEMENT'    THEN 'PORTFOLIO_ACCESS_CONTROL_BYPASS'
+              WHEN 'SYSTEM_CONFIGURATION' THEN 'SECRET_MANAGEMENT'
+          END
+         WHERE src."NAME" IN ('ACCESS_MANAGEMENT', 'SYSTEM_CONFIGURATION')
         ON CONFLICT DO NOTHING
         """,
         """
@@ -2980,15 +2997,18 @@ public final class TableRegistry {
           JOIN "%1$s".permission_name_map  pm ON pm.orig_id = j."PERMISSION_ID"
         ON CONFLICT DO NOTHING;
 
-        -- Implication fan-out: see the matching USERS_PERMISSIONS step. v4 ACCESS_MANAGEMENT
-        -- carried implicit portfolio-access-control bypass; v5 split that into
-        -- PORTFOLIO_ACCESS_CONTROL_BYPASS (v5.6.0-31). Grant it to every team that holds
-        -- ACCESS_MANAGEMENT in v4.
+        -- Implication fan-outs: see the matching USERS_PERMISSIONS step for the rationale.
+        --   ACCESS_MANAGEMENT    -> PORTFOLIO_ACCESS_CONTROL_BYPASS
+        --   SYSTEM_CONFIGURATION -> SECRET_MANAGEMENT
         INSERT INTO "%1$s".tgt_teams_permissions ("TEAM_ID", "PERMISSION_ID")
-        SELECT DISTINCT tp."TEAM_ID", (SELECT "ID" FROM "PERMISSION" WHERE "NAME" = 'PORTFOLIO_ACCESS_CONTROL_BYPASS')
+        SELECT DISTINCT tp."TEAM_ID", tgt."ID"
           FROM "%1$s".tgt_teams_permissions tp
-          JOIN "PERMISSION" p ON p."ID" = tp."PERMISSION_ID"
-         WHERE p."NAME" = 'ACCESS_MANAGEMENT'
+          JOIN "PERMISSION" src ON src."ID" = tp."PERMISSION_ID"
+          JOIN "PERMISSION" tgt ON tgt."NAME" = CASE src."NAME"
+              WHEN 'ACCESS_MANAGEMENT'    THEN 'PORTFOLIO_ACCESS_CONTROL_BYPASS'
+              WHEN 'SYSTEM_CONFIGURATION' THEN 'SECRET_MANAGEMENT'
+          END
+         WHERE src."NAME" IN ('ACCESS_MANAGEMENT', 'SYSTEM_CONFIGURATION')
         ON CONFLICT DO NOTHING
         """,
         """

--- a/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/verify/RowCountNotes.java
+++ b/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/verify/RowCountNotes.java
@@ -46,10 +46,11 @@ final class RowCountNotes {
         Map.entry("VULNERABLESOFTWARE", "dropped rows without vulnerability refs or with invalid UUID"),
         Map.entry("USER", "consolidated from MANAGED/LDAP/OIDC users; invalid rows skipped"),
         // Permission join tables: v4-only permissions are dropped during the rename remap, while
-        // PORTFOLIO_ACCESS_CONTROL_BYPASS is fanned out for ACCESS_MANAGEMENT holders. The net delta
-        // is a deterministic function of the remap, not a loss indicator either way.
-        Map.entry("TEAMS_PERMISSIONS", "permissions remapped (v4-only dropped); BYPASS fan-out added; net delta expected"),
-        Map.entry("USERS_PERMISSIONS", "permissions remapped (v4-only dropped); BYPASS fan-out added; net delta expected"),
+        // v5-only permissions (PORTFOLIO_ACCESS_CONTROL_BYPASS, SECRET_MANAGEMENT) are fanned out
+        // for the v4 holders of their v4-era equivalents. The net delta is a deterministic
+        // function of the remap, not a loss indicator either way.
+        Map.entry("TEAMS_PERMISSIONS", "permissions remapped (v4-only dropped); v5-only permission fan-outs added; net delta expected"),
+        Map.entry("USERS_PERMISSIONS", "permissions remapped (v4-only dropped); v5-only permission fan-outs added; net delta expected"),
         Map.entry("PROJECT_ACCESS_TEAMS", "dropped rows with NULL TEAM_ID; dedup on (PROJECT_ID, TEAM_ID)"),
         Map.entry("PROJECT_ACCESS_USERS", "derived from PROJECT_ACCESS_TEAMS join USERS_TEAMS; dedup on (PROJECT_ID, USER_ID)")
     );

--- a/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/UsersPermissionsIT.java
+++ b/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/UsersPermissionsIT.java
@@ -44,7 +44,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * inner-joining v4 NAME against v5 PERMISSION; v4 names absent from v5 (e.g.
  * {@code VIEW_BADGES}) drop out and their join rows are silently removed. The migrator
  * also fans v4 {@code ACCESS_MANAGEMENT} out to v5 {@code PORTFOLIO_ACCESS_CONTROL_BYPASS}
- * to preserve v4's implicit portfolio-access-control bypass.
+ * (preserving v4's implicit portfolio-access-control bypass) and v4
+ * {@code SYSTEM_CONFIGURATION} out to v5 {@code SECRET_MANAGEMENT} (preserving v4's implicit
+ * secret-management ability).
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -72,15 +74,19 @@ class UsersPermissionsIT {
     @Test
     @Order(1)
     void mapsPermissionsByNameAndRewritesJoins() throws Exception {
-        // Seed v4: a TEAM, two permissions (one carried over to v5, one v4-only), a MANAGED
-        // user "alice" with both, an LDAP user "bob" with only the v4-only one, and an OIDC
-        // user "carol" with ACCESS_MANAGEMENT to exercise the implication fan-out.
+        // Seed v4: a TEAM, four permissions (two carried over to v5, one v4-only, one that
+        // implies a v5-only permission), a MANAGED user "alice" with VIEW_PORTFOLIO and the
+        // v4-only one, an LDAP user "bob" with only the v4-only one, an OIDC user "carol" with
+        // ACCESS_MANAGEMENT to exercise the bypass fan-out, and a MANAGED user "dave" with
+        // SYSTEM_CONFIGURATION to exercise the secret-management fan-out. Engineering holds
+        // both ACCESS_MANAGEMENT and SYSTEM_CONFIGURATION to exercise both fan-outs at the team level.
         source.jdbi().useHandle(h -> {
             h.execute("INSERT INTO \"TEAM\" (\"ID\", \"NAME\", \"UUID\") VALUES (1, 'Engineering', '11111111-1111-1111-1111-111111111111')");
             h.execute("INSERT INTO \"PERMISSION\" (\"ID\", \"NAME\") VALUES (1, 'VIEW_PORTFOLIO')");
             // VIEW_BADGES was a v4 permission that v5 removed; verifies v4-only names drop out.
             h.execute("INSERT INTO \"PERMISSION\" (\"ID\", \"NAME\") VALUES (2, 'VIEW_BADGES')");
             h.execute("INSERT INTO \"PERMISSION\" (\"ID\", \"NAME\") VALUES (3, 'ACCESS_MANAGEMENT')");
+            h.execute("INSERT INTO \"PERMISSION\" (\"ID\", \"NAME\") VALUES (4, 'SYSTEM_CONFIGURATION')");
             h.execute("""
                 INSERT INTO "MANAGEDUSER" (
                     "ID", "USERNAME", "PASSWORD", "FULLNAME", "EMAIL",
@@ -98,11 +104,22 @@ class UsersPermissionsIT {
                 INSERT INTO "OIDCUSER" ("ID", "USERNAME", "EMAIL", "SUBJECT_IDENTIFIER")
                 VALUES (30, 'carol', 'carol@oidc.example.com', 'sub-carol')
                 """);
+            h.execute("""
+                INSERT INTO "MANAGEDUSER" (
+                    "ID", "USERNAME", "PASSWORD", "FULLNAME", "EMAIL",
+                    "FORCE_PASSWORD_CHANGE", "LAST_PASSWORD_CHANGE",
+                    "NON_EXPIRY_PASSWORD", "SUSPENDED"
+                )
+                VALUES (40, 'dave', 'hash', 'Dave Managed', 'dave@example.com',
+                        FALSE, '2025-01-01T00:00:00Z', FALSE, FALSE)
+                """);
             h.execute("INSERT INTO \"MANAGEDUSERS_PERMISSIONS\" (\"MANAGEDUSER_ID\", \"PERMISSION_ID\") VALUES (10, 1)");
             h.execute("INSERT INTO \"MANAGEDUSERS_PERMISSIONS\" (\"MANAGEDUSER_ID\", \"PERMISSION_ID\") VALUES (10, 2)");
             h.execute("INSERT INTO \"LDAPUSERS_PERMISSIONS\" (\"LDAPUSER_ID\", \"PERMISSION_ID\") VALUES (20, 2)");
             h.execute("INSERT INTO \"OIDCUSERS_PERMISSIONS\" (\"OIDCUSER_ID\", \"PERMISSION_ID\") VALUES (30, 3)");
+            h.execute("INSERT INTO \"MANAGEDUSERS_PERMISSIONS\" (\"MANAGEDUSER_ID\", \"PERMISSION_ID\") VALUES (40, 4)");
             h.execute("INSERT INTO \"TEAMS_PERMISSIONS\" (\"TEAM_ID\", \"PERMISSION_ID\") VALUES (1, 3)");
+            h.execute("INSERT INTO \"TEAMS_PERMISSIONS\" (\"TEAM_ID\", \"PERMISSION_ID\") VALUES (1, 4)");
         });
 
         runPipeline();
@@ -119,7 +136,7 @@ class UsersPermissionsIT {
                 .list());
 
         assertThat(mapRows).extracting(m -> m.get("name"))
-            .containsExactlyInAnyOrder("VIEW_PORTFOLIO", "ACCESS_MANAGEMENT");
+            .containsExactlyInAnyOrder("VIEW_PORTFOLIO", "ACCESS_MANAGEMENT", "SYSTEM_CONFIGURATION");
 
         // Full v5 catalog is seeded regardless of which subset v4 had. PORTFOLIO_ACCESS_CONTROL_BYPASS
         // (a v5.6.0 addition not present in v4) must be available for the implication fan-out below.
@@ -130,13 +147,15 @@ class UsersPermissionsIT {
         assertThat(perms).contains(
             "ACCESS_MANAGEMENT", "ACCESS_MANAGEMENT_CREATE", "ACCESS_MANAGEMENT_READ",
             "ACCESS_MANAGEMENT_UPDATE", "ACCESS_MANAGEMENT_DELETE",
-            "PORTFOLIO_ACCESS_CONTROL_BYPASS", "VIEW_PORTFOLIO");
-        assertThat(perms).doesNotContain("VIEW_BADGES", "SECRET_MANAGEMENT_READ");
+            "PORTFOLIO_ACCESS_CONTROL_BYPASS", "VIEW_PORTFOLIO",
+            "SECRET_MANAGEMENT", "SYSTEM_CONFIGURATION");
+        assertThat(perms).doesNotContain("VIEW_BADGES");
 
         // USERS_PERMISSIONS final state:
         //   - alice keeps VIEW_PORTFOLIO; her VIEW_BADGES assignment drops with the name.
         //   - bob's only assignment was VIEW_BADGES, so he ends with no permissions.
         //   - carol keeps ACCESS_MANAGEMENT AND gains PORTFOLIO_ACCESS_CONTROL_BYPASS via fan-out.
+        //   - dave keeps SYSTEM_CONFIGURATION AND gains SECRET_MANAGEMENT via fan-out.
         final List<Map<String, Object>> userPerms = target.jdbi().withHandle(h ->
             h.createQuery("""
                     SELECT u."USERNAME" AS username, p."NAME" AS permission_name
@@ -152,10 +171,12 @@ class UsersPermissionsIT {
             .containsExactlyInAnyOrder(
                 "alice:VIEW_PORTFOLIO",
                 "carol:ACCESS_MANAGEMENT",
-                "carol:PORTFOLIO_ACCESS_CONTROL_BYPASS");
+                "carol:PORTFOLIO_ACCESS_CONTROL_BYPASS",
+                "dave:SYSTEM_CONFIGURATION",
+                "dave:SECRET_MANAGEMENT");
 
-        // TEAMS_PERMISSIONS: Engineering had ACCESS_MANAGEMENT, must also gain
-        // PORTFOLIO_ACCESS_CONTROL_BYPASS via fan-out.
+        // TEAMS_PERMISSIONS: Engineering held ACCESS_MANAGEMENT and SYSTEM_CONFIGURATION,
+        // so must also gain PORTFOLIO_ACCESS_CONTROL_BYPASS and SECRET_MANAGEMENT via fan-out.
         final List<Map<String, Object>> teamPerms = target.jdbi().withHandle(h ->
             h.createQuery("""
                     SELECT t."NAME" AS team_name, p."NAME" AS permission_name
@@ -170,7 +191,9 @@ class UsersPermissionsIT {
         assertThat(teamPerms).extracting(m -> m.get("team_name") + ":" + m.get("permission_name"))
             .containsExactlyInAnyOrder(
                 "Engineering:ACCESS_MANAGEMENT",
-                "Engineering:PORTFOLIO_ACCESS_CONTROL_BYPASS");
+                "Engineering:PORTFOLIO_ACCESS_CONTROL_BYPASS",
+                "Engineering:SYSTEM_CONFIGURATION",
+                "Engineering:SECRET_MANAGEMENT");
     }
 
     /**
@@ -221,7 +244,27 @@ class UsersPermissionsIT {
             .containsExactlyInAnyOrder(
                 "alice:VIEW_PORTFOLIO",
                 "carol:ACCESS_MANAGEMENT",
-                "carol:PORTFOLIO_ACCESS_CONTROL_BYPASS");
+                "carol:PORTFOLIO_ACCESS_CONTROL_BYPASS",
+                "dave:SYSTEM_CONFIGURATION",
+                "dave:SECRET_MANAGEMENT");
+
+        final List<Map<String, Object>> teamPerms = target.jdbi().withHandle(h ->
+            h.createQuery("""
+                    SELECT t."NAME" AS team_name, p."NAME" AS permission_name
+                      FROM "TEAMS_PERMISSIONS" tp
+                      JOIN "TEAM" t       ON t."ID" = tp."TEAM_ID"
+                      JOIN "PERMISSION" p ON p."ID" = tp."PERMISSION_ID"
+                     ORDER BY t."NAME", p."NAME"
+                    """)
+                .mapToMap()
+                .list());
+
+        assertThat(teamPerms).extracting(m -> m.get("team_name") + ":" + m.get("permission_name"))
+            .containsExactlyInAnyOrder(
+                "Engineering:ACCESS_MANAGEMENT",
+                "Engineering:PORTFOLIO_ACCESS_CONTROL_BYPASS",
+                "Engineering:SYSTEM_CONFIGURATION",
+                "Engineering:SECRET_MANAGEMENT");
     }
 
     private void runPipeline() throws Exception {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Grants SECRET_MANAGEMENT to principals with SYSTEM_CONFIGURATION permission.

Closes a gap where users successfully migrate from v4 to v5, are told to configure secrets for their analyzers etc., but none of their users have the required SECRET_MANAGEMENT permission.

in v4, secrets were configured by users with the SYSTEM_CONFIGURATION permission. To retain these semantics, we grant the SECRET_MANAGEMENT permission accordingly.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
