### PR TITLE
Do not suggest internal sort tie-breaker columns as sortable via API

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/AllowApiOrdering.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/AllowApiOrdering.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.persistence.jdbi;
 
+import alpine.persistence.OrderDirection;
 import org.jdbi.v3.core.config.ConfigRegistry;
 import org.jdbi.v3.core.extension.SimpleExtensionConfigurer;
 import org.jdbi.v3.core.extension.annotation.UseExtensionConfigurer;
@@ -48,12 +49,13 @@ public @interface AllowApiOrdering {
     Column[] by();
 
     /**
-     * Name of the column that should always be included in the {@code ORDER BY}
-     * clause. A corresponding {@link Column} must be provided to {@link #by()}.
+     * Tiebreaker column appended after the user-supplied {@code ORDER BY} on every query.
      * <p>
-     * Can optionally include the ordering direction as {@code asc} or {@code desc}.
+     * Unlike {@link #by()}, the tiebreaker is never exposed to API consumers, so internal
+     * columns (e.g. row IDs) can be used without leaking into
+     * {@link org.dependencytrack.exception.InvalidSortFieldException#getAllowedFieldNames()}.
      */
-    String alwaysBy() default "";
+    AlwaysBy alwaysBy() default @AlwaysBy;
 
     @Documented
     @Retention(RetentionPolicy.RUNTIME)
@@ -79,6 +81,23 @@ public @interface AllowApiOrdering {
 
     }
 
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @interface AlwaysBy {
+
+        /**
+         * Raw SQL column expression appended to the {@code ORDER BY} clause as a tiebreaker.
+         */
+        String queryName() default "";
+
+        /**
+         * Optional sort direction for the tiebreaker.
+         */
+        OrderDirection direction() default OrderDirection.UNSPECIFIED;
+
+    }
+
     final class ExtensionConfigurer extends SimpleExtensionConfigurer {
 
         @Override
@@ -86,7 +105,11 @@ public @interface AllowApiOrdering {
             final var allowOrderingAnnotation = (AllowApiOrdering) annotation;
 
             final var config = configRegistry.get(ApiRequestConfig.class);
-            config.setOrderingAlwaysBy(allowOrderingAnnotation.alwaysBy());
+            final String alwaysByQueryName = trimToNull(allowOrderingAnnotation.alwaysBy().queryName());
+            config.setOrderingAlwaysBy(
+                    alwaysByQueryName != null
+                            ? new ApiRequestConfig.AlwaysByOrdering(alwaysByQueryName, allowOrderingAnnotation.alwaysBy().direction())
+                            : null);
             config.setOrderingAllowedColumns(Arrays.stream(allowOrderingAnnotation.by())
                     .map(column -> new ApiRequestConfig.OrderingColumn(
                             column.name(),

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestConfig.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestConfig.java
@@ -18,7 +18,9 @@
  */
 package org.dependencytrack.persistence.jdbi;
 
+import alpine.persistence.OrderDirection;
 import org.jdbi.v3.core.config.JdbiConfig;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Optional;
 import java.util.Set;
@@ -29,7 +31,7 @@ import java.util.Set;
 public class ApiRequestConfig implements JdbiConfig<ApiRequestConfig> {
 
     private Set<OrderingColumn> orderingAllowedColumns;
-    private String orderingAlwaysBy = "";
+    private @Nullable AlwaysByOrdering orderingAlwaysBy;
     private String projectIdColumn = "\"PROJECT\".\"ID\"";
 
     @SuppressWarnings("unused")
@@ -64,11 +66,12 @@ public class ApiRequestConfig implements JdbiConfig<ApiRequestConfig> {
         this.orderingAllowedColumns = orderingAllowedColumns;
     }
 
-    String orderingAlwaysBy() {
+    @Nullable
+    AlwaysByOrdering orderingAlwaysBy() {
         return orderingAlwaysBy;
     }
 
-    public void setOrderingAlwaysBy(final String orderingAlwaysBy) {
+    public void setOrderingAlwaysBy(final @Nullable AlwaysByOrdering orderingAlwaysBy) {
         this.orderingAlwaysBy = orderingAlwaysBy;
     }
 
@@ -80,6 +83,14 @@ public class ApiRequestConfig implements JdbiConfig<ApiRequestConfig> {
 
         public OrderingColumn(final String name) {
             this(name, null);
+        }
+
+    }
+
+    public record AlwaysByOrdering(String queryName, OrderDirection direction) {
+
+        public AlwaysByOrdering(String queryName) {
+            this(queryName, OrderDirection.UNSPECIFIED);
         }
 
     }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizer.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizer.java
@@ -26,6 +26,7 @@ import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.auth.ProjectAccess;
 import org.dependencytrack.exception.InvalidSortFieldException;
 import org.dependencytrack.persistence.Ordering;
+import org.dependencytrack.persistence.jdbi.ApiRequestConfig.AlwaysByOrdering;
 import org.dependencytrack.persistence.jdbi.ApiRequestConfig.OrderingColumn;
 import org.jdbi.v3.core.qualifier.QualifiedType;
 import org.jdbi.v3.core.statement.StatementContext;
@@ -136,15 +137,12 @@ class ApiRequestStatementCustomizer implements StatementCustomizer {
                                     .map(OrderingColumn::name)
                                     .toList()));
 
-            orderingBuilder.append("ORDER BY ");
-            if (orderingColumn.queryName() == null) {
-                orderingBuilder
-                        .append("\"")
-                        .append(ordering.by())
-                        .append("\"");
-            } else {
-                orderingBuilder.append(orderingColumn.queryName());
-            }
+            final String orderByColumnSql =
+                    orderingColumn.queryName() != null
+                            ? orderingColumn.queryName()
+                            : "\"" + ordering.by() + "\"";
+
+            orderingBuilder.append("ORDER BY ").append(orderByColumnSql);
 
             if (ordering.direction() != null && ordering.direction() != OrderDirection.UNSPECIFIED) {
                 orderingBuilder
@@ -152,36 +150,13 @@ class ApiRequestStatementCustomizer implements StatementCustomizer {
                         .append(ordering.direction() == OrderDirection.ASCENDING ? "ASC" : "DESC");
             }
 
-            if (!config.orderingAlwaysBy().isBlank() && (ordering.by() == null || !ordering.by().equals(config.orderingAlwaysBy()))) {
-                final String[] alwaysByParts = config.orderingAlwaysBy().split("\\s");
-                if (alwaysByParts.length > 2) {
-                    throw new IllegalArgumentException("alwaysBy must consist of no more than two parts");
-                }
-
-                final OrderingColumn orderingColumnAlwaysBy = config
-                        .orderingAllowedColumn(alwaysByParts[0])
-                        .orElseThrow(() -> new InvalidSortFieldException(
-                                alwaysByParts[0],
-                                config.orderingAllowedColumns().stream()
-                                        .map(OrderingColumn::name)
-                                        .toList()));
-
-                if (orderingColumnAlwaysBy.queryName() == null) {
-                    orderingBuilder
-                            .append(orderingBuilder.isEmpty() ? "ORDER BY \"" : ", \"")
-                            .append(orderingColumnAlwaysBy.name())
-                            .append("\"");
-                } else {
-                    orderingBuilder
-                            .append(orderingBuilder.isEmpty() ? "ORDER BY " : ", ")
-                            .append(orderingColumnAlwaysBy.queryName());
-                }
-
-                if (alwaysByParts.length == 2
-                        && ("asc".equalsIgnoreCase(alwaysByParts[1]) || "desc".equalsIgnoreCase(alwaysByParts[1]))) {
+            final AlwaysByOrdering alwaysBy = config.orderingAlwaysBy();
+            if (alwaysBy != null && !alwaysBy.queryName().equals(orderByColumnSql)) {
+                orderingBuilder.append(", ").append(alwaysBy.queryName());
+                if (alwaysBy.direction() != null && alwaysBy.direction() != OrderDirection.UNSPECIFIED) {
                     orderingBuilder
                             .append(" ")
-                            .append(alwaysByParts[1]);
+                            .append(alwaysBy.direction() == OrderDirection.ASCENDING ? "ASC" : "DESC");
                 }
             }
         }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -282,7 +282,7 @@ public interface FindingDao {
             </#if>
              ${apiOffsetLimitClause!}
             """)
-    @AllowApiOrdering(alwaysBy = "attribution.id", by = {
+    @AllowApiOrdering(alwaysBy = @AllowApiOrdering.AlwaysBy(queryName = "fa.\"ID\""), by = {
             @AllowApiOrdering.Column(name = "vulnerability.vulnId", queryName = "v.\"VULNID\""),
             @AllowApiOrdering.Column(name = "vulnerability.severity", queryName = "\"vulnSeverity\""),
             @AllowApiOrdering.Column(name = "vulnerability.cvssV2BaseScore", queryName = "\"cvssV2BaseScore\""),
@@ -296,7 +296,6 @@ public interface FindingDao {
             @AllowApiOrdering.Column(name = "component.version", queryName = "c.\"VERSION\""),
             @AllowApiOrdering.Column(name = "analysis.state", queryName = "a.\"STATE\""),
             @AllowApiOrdering.Column(name = "analysis.isSuppressed", queryName = "a.\"SUPPRESSED\""),
-            @AllowApiOrdering.Column(name = "attribution.id", queryName = "fa.\"ID\""),
             @AllowApiOrdering.Column(name = "attribution.attributedOn", queryName = "fa.\"ATTRIBUTED_ON\"")
     })
     @DefineNamedBindings
@@ -485,7 +484,7 @@ public interface FindingDao {
              </#if>
              ${apiOffsetLimitClause!}
             """)
-    @AllowApiOrdering(alwaysBy = "attribution.id", by = {
+    @AllowApiOrdering(alwaysBy = @AllowApiOrdering.AlwaysBy(queryName = "fa.\"ID\""), by = {
             @AllowApiOrdering.Column(name = "vulnerability.title", queryName = "v.\"TITLE\""),
             @AllowApiOrdering.Column(name = "vulnerability.vulnId", queryName = "v.\"VULNID\""),
             @AllowApiOrdering.Column(name = "vulnerability.severity", queryName = "\"vulnSeverity\""),
@@ -499,7 +498,6 @@ public interface FindingDao {
             @AllowApiOrdering.Column(name = "component.version", queryName = "c.\"VERSION\""),
             @AllowApiOrdering.Column(name = "analysis.state", queryName = "a.\"STATE\""),
             @AllowApiOrdering.Column(name = "analysis.isSuppressed", queryName = "a.\"SUPPRESSED\""),
-            @AllowApiOrdering.Column(name = "attribution.id", queryName = "fa.\"ID\""),
             @AllowApiOrdering.Column(name = "attribution.attributedOn", queryName = "fa.\"ATTRIBUTED_ON\"")
     })
     @DefineNamedBindings
@@ -639,8 +637,7 @@ public interface FindingDao {
             </#if>
             ${apiOffsetLimitClause!}
             """)
-    @AllowApiOrdering(alwaysBy = "vulnerability.id", by = {
-            @AllowApiOrdering.Column(name = "vulnerability.id", queryName = "v.\"ID\""),
+    @AllowApiOrdering(alwaysBy = @AllowApiOrdering.AlwaysBy(queryName = "v.\"ID\""), by = {
             @AllowApiOrdering.Column(name = "vulnerability.vulnId", queryName = "v.\"VULNID\""),
             @AllowApiOrdering.Column(name = "vulnerability.title", queryName = "v.\"TITLE\""),
             @AllowApiOrdering.Column(name = "vulnerability.severity", queryName = "\"vulnSeverity\""),

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
@@ -227,7 +227,7 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
             <#-- @ftlvariable name="apiOrderByClause" type="String" -->
             <#-- @ftlvariable name="apiOffsetLimitClause" type="String" -->
             <#-- @ftlvariable name="apiProjectAclCondition" type="String" -->
-            SELECT "PROJECT"."ID" AS "id"
+            SELECT "PROJECT"."ID"
                  , "PROJECT"."UUID" AS "uuid"
                  , "GROUP" AS "group"
                  , "NAME" AS "name"
@@ -285,12 +285,11 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
             <#if apiOrderByClause??>
               ${apiOrderByClause}
             <#else>
-             ORDER BY "name", "id"
+             ORDER BY "name", "PROJECT"."ID"
             </#if>
             ${apiOffsetLimitClause!}
             """)
-    @AllowApiOrdering(alwaysBy = "id", by = {
-            @AllowApiOrdering.Column(name = "id"),
+    @AllowApiOrdering(alwaysBy = @AllowApiOrdering.AlwaysBy(queryName = "\"PROJECT\".\"ID\""), by = {
             @AllowApiOrdering.Column(name = "group"),
             @AllowApiOrdering.Column(name = "name"),
             @AllowApiOrdering.Column(name = "version"),
@@ -492,7 +491,7 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
             <#-- @ftlvariable name="apiOrderByClause" type="String" -->
             <#-- @ftlvariable name="apiOffsetLimitClause" type="String" -->
             <#-- @ftlvariable name="apiProjectAclCondition" type="String" -->
-            SELECT "PROJECT"."ID" AS "id"
+            SELECT "PROJECT"."ID"
                  , "PROJECT"."CLASSIFIER" AS "classifier"
                  , "PROJECT"."CPE"
                  , "PROJECT"."DESCRIPTION"
@@ -571,12 +570,11 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
             <#if apiOrderByClause??>
                 ${apiOrderByClause}
             <#else>
-                ORDER BY "name", "id"
+                ORDER BY "name", "PROJECT"."ID"
             </#if>
             ${apiOffsetLimitClause!}
             """)
-    @AllowApiOrdering(alwaysBy = "id", by = {
-            @AllowApiOrdering.Column(name = "id"),
+    @AllowApiOrdering(alwaysBy = @AllowApiOrdering.AlwaysBy(queryName = "\"PROJECT\".\"ID\""), by = {
             @AllowApiOrdering.Column(name = "group"),
             @AllowApiOrdering.Column(name = "name"),
             @AllowApiOrdering.Column(name = "version"),

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizerTest.java
@@ -30,6 +30,7 @@ import alpine.resources.AlpineRequest;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.exception.InvalidSortFieldException;
+import org.dependencytrack.persistence.jdbi.ApiRequestConfig.AlwaysByOrdering;
 import org.dependencytrack.persistence.jdbi.ApiRequestConfig.OrderingColumn;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.StatementCustomizer;
@@ -223,12 +224,12 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testWithAlpineRequestOrderingWithAlwaysByNotAllowed() {
+    public void shouldNotLeakAlwaysByInInvalidSortFieldException() {
         final var request = new AlpineRequest(
                 /* principal */ null,
                 /* pagination */ null,
                 /* filter */ null,
-                /* orderBy */ "valueA",
+                /* orderBy */ "foobar",
                 /* orderDirection */ OrderDirection.DESCENDING
         );
 
@@ -236,7 +237,7 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
                 .isThrownBy(() -> useJdbiHandle(request, handle -> handle
                         .configure(ApiRequestConfig.class, config -> {
                             config.setOrderingAllowedColumns(Set.of(new OrderingColumn("valueA")));
-                            config.setOrderingAlwaysBy("foobar");
+                            config.setOrderingAlwaysBy(new AlwaysByOrdering("fa.\"ID\""));
                         })
                         .createQuery(TEST_QUERY_TEMPLATE)
                         .mapTo(Integer.class)
@@ -244,34 +245,14 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
                 .withMessage("Sorting by field 'foobar' is not supported")
                 .satisfies(e -> {
                     assertThat(e.getFieldName()).isEqualTo("foobar");
-                    assertThat(e.getAllowedFieldNames()).containsOnly("valueA");
+                    assertThat(e.getAllowedFieldNames())
+                            .containsOnly("valueA")
+                            .doesNotContain("fa.\"ID\"");
                 });
     }
 
     @Test
-    public void testWithAlpineRequestOrderingWithAlwaysByInvalidFormat() {
-        final var request = new AlpineRequest(
-                /* principal */ null,
-                /* pagination */ null,
-                /* filter */ null,
-                /* orderBy */ "valueA",
-                /* orderDirection */ OrderDirection.DESCENDING
-        );
-
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> useJdbiHandle(request, handle -> handle
-                        .configure(ApiRequestConfig.class, config -> {
-                            config.setOrderingAllowedColumns(Set.of(new OrderingColumn("valueA")));
-                            config.setOrderingAlwaysBy("foo bar baz");
-                        })
-                        .createQuery(TEST_QUERY_TEMPLATE)
-                        .mapTo(Integer.class)
-                        .findOne()))
-                .withMessage("alwaysBy must consist of no more than two parts");
-    }
-
-    @Test
-    public void testWithAlpineRequestOrderingWithAlwaysByMatchingOrderBy() {
+    public void shouldNotAppendAlwaysByWhenItMatchesOrderBy() {
         final var request = new AlpineRequest(
                 /* principal */ null,
                 /* pagination */ null,
@@ -283,7 +264,7 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
         useJdbiHandle(request, handle -> handle
                 .configure(ApiRequestConfig.class, config -> {
                     config.setOrderingAllowedColumns(Set.of(new OrderingColumn("valueA")));
-                    config.setOrderingAlwaysBy("valueA");
+                    config.setOrderingAlwaysBy(new AlwaysByOrdering("\"valueA\""));
                 })
                 .addCustomizer(inspectStatement(ctx -> {
                     assertThat(ctx.getRenderedSql()).isEqualToIgnoringWhitespace("""
@@ -309,8 +290,8 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
 
         useJdbiHandle(request, handle -> handle
                 .configure(ApiRequestConfig.class, config -> {
-                    config.setOrderingAllowedColumns(Set.of(new OrderingColumn("valueA"), new OrderingColumn("valueB")));
-                    config.setOrderingAlwaysBy("valueB");
+                    config.setOrderingAllowedColumns(Set.of(new OrderingColumn("valueA")));
+                    config.setOrderingAlwaysBy(new AlwaysByOrdering("\"valueB\""));
                 })
                 .addCustomizer(inspectStatement(ctx -> {
                     assertThat(ctx.getRenderedSql()).isEqualToIgnoringWhitespace("""
@@ -336,39 +317,12 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
 
         useJdbiHandle(request, handle -> handle
                 .configure(ApiRequestConfig.class, config -> {
-                    config.setOrderingAllowedColumns(Set.of(new OrderingColumn("valueA"), new OrderingColumn("valueB")));
-                    config.setOrderingAlwaysBy("valueB asc");
+                    config.setOrderingAllowedColumns(Set.of(new OrderingColumn("valueA")));
+                    config.setOrderingAlwaysBy(new AlwaysByOrdering("\"valueB\"", OrderDirection.ASCENDING));
                 })
                 .addCustomizer(inspectStatement(ctx -> {
                     assertThat(ctx.getRenderedSql()).isEqualToIgnoringWhitespace("""
-                            SELECT 1 AS "valueA", 2 AS "valueB" FROM "PROJECT" WHERE TRUE ORDER BY "valueA" DESC, "valueB" asc
-                            """);
-
-                    assertThat(ctx.getBinding()).hasToString("{}");
-                }))
-                .createQuery(TEST_QUERY_TEMPLATE)
-                .mapTo(Integer.class)
-                .findOne());
-    }
-
-    @Test
-    public void testWithAlpineRequestOrderingWithOnlyAlwaysBy() {
-        final var request = new AlpineRequest(
-                /* principal */ null,
-                /* pagination */ null,
-                /* filter */ null,
-                /* orderBy */ "valueB",
-                /* orderDirection */ null
-        );
-
-        useJdbiHandle(request, handle -> handle
-                .configure(ApiRequestConfig.class, config -> {
-                    config.setOrderingAllowedColumns(Set.of(new OrderingColumn("valueB")));
-                    config.setOrderingAlwaysBy("valueB");
-                })
-                .addCustomizer(inspectStatement(ctx -> {
-                    assertThat(ctx.getRenderedSql()).isEqualToIgnoringWhitespace("""
-                            SELECT 1 AS "valueA", 2 AS "valueB" FROM "PROJECT" WHERE TRUE ORDER BY "valueB"
+                            SELECT 1 AS "valueA", 2 AS "valueB" FROM "PROJECT" WHERE TRUE ORDER BY "valueA" DESC, "valueB" ASC
                             """);
 
                     assertThat(ctx.getBinding()).hasToString("{}");

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -158,7 +158,6 @@ class ProjectResourceTest extends ResourceTest {
                           "detail": "Sorting by field 'invalidField' is not supported",
                           "invalidField": "invalidField",
                           "supportedFields": [
-                            "id",
                             "group",
                             "name",
                             "version",
@@ -195,7 +194,6 @@ class ProjectResourceTest extends ResourceTest {
                           "detail": "Sorting by field 'invalidField' is not supported",
                           "invalidField": "invalidField",
                           "supportedFields": [
-                            "id",
                             "group",
                             "name",
                             "version",


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Do not suggest internal sort tie-breaker columns as sortable via API.

Avoids confusion, for example when using ID columns as tie-breakers, when the corresponding API response does not expose an ID field. Previously, the `/problems/invalid-sort-field` error response would list such fields under `supportedFields`.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
