### PR TITLE
Fix AuthZ being enforced on CORS preflight requests

### DIFF
--- a/alpine/alpine-server/src/main/java/alpine/server/filters/AuthorizationFilter.java
+++ b/alpine/alpine-server/src/main/java/alpine/server/filters/AuthorizationFilter.java
@@ -24,6 +24,7 @@ import alpine.persistence.AlpineQueryManager;
 import alpine.server.auth.PermissionRequired;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
@@ -58,6 +59,12 @@ public class AuthorizationFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
+        // Bypass authorization for CORS preflight.
+        // AuthenticationFilter does the same, so no principal is available to authorize against.
+        if (HttpMethod.OPTIONS.equals(requestContext.getMethod())) {
+            return;
+        }
+
         final Principal principal = (Principal) requestContext.getProperty("Principal");
         if (principal == null) {
             LOGGER.info(SecurityMarkers.SECURITY_FAILURE, "A request was made without the assertion of a valid user principal");

--- a/alpine/alpine-server/src/test/java/alpine/server/filters/AuthorizationFilterTest.java
+++ b/alpine/alpine-server/src/test/java/alpine/server/filters/AuthorizationFilterTest.java
@@ -86,6 +86,14 @@ public class AuthorizationFilterTest extends JerseyTest {
     }
 
     @Test
+    void shouldAllowCorsPreflightWithoutAuthentication() {
+        final Response response = target("/unprotected")
+                .request()
+                .options();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
     void shouldPopulateEffectivePermissionsOnRequestsWithoutPermissionRequired() {
         final String apiKey;
         try (final var qm = new AlpineQueryManager()) {


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes AuthZ being enforced on CORS preflight requests.

Fixes a regression introduced in c8d55d20a913002d5aa50e152d4807df49cc5fa5.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
