### PR TITLE
Change tie-breaker sort columns for finding queries to allow more efficient sorting

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -278,11 +278,11 @@ public interface FindingDao {
             <#if apiOrderByClause??>
               ${apiOrderByClause}
             <#else>
-             ORDER BY fa."ID"
+             ORDER BY c."ID", v."ID"
             </#if>
              ${apiOffsetLimitClause!}
             """)
-    @AllowApiOrdering(alwaysBy = @AllowApiOrdering.AlwaysBy(queryName = "fa.\"ID\""), by = {
+    @AllowApiOrdering(alwaysBy = @AllowApiOrdering.AlwaysBy(queryName = "c.\"ID\", v.\"ID\""), by = {
             @AllowApiOrdering.Column(name = "vulnerability.vulnId", queryName = "v.\"VULNID\""),
             @AllowApiOrdering.Column(name = "vulnerability.severity", queryName = "\"vulnSeverity\""),
             @AllowApiOrdering.Column(name = "vulnerability.cvssV2BaseScore", queryName = "\"cvssV2BaseScore\""),
@@ -481,10 +481,12 @@ public interface FindingDao {
              </#if>
              <#if apiOrderByClause??>
               ${apiOrderByClause}
+             <#else>
+              ORDER BY c."ID", v."ID"
              </#if>
              ${apiOffsetLimitClause!}
             """)
-    @AllowApiOrdering(alwaysBy = @AllowApiOrdering.AlwaysBy(queryName = "fa.\"ID\""), by = {
+    @AllowApiOrdering(alwaysBy = @AllowApiOrdering.AlwaysBy(queryName = "c.\"ID\", v.\"ID\""), by = {
             @AllowApiOrdering.Column(name = "vulnerability.title", queryName = "v.\"TITLE\""),
             @AllowApiOrdering.Column(name = "vulnerability.vulnId", queryName = "v.\"VULNID\""),
             @AllowApiOrdering.Column(name = "vulnerability.severity", queryName = "\"vulnSeverity\""),

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -385,6 +385,58 @@ public class FindingResourceTest extends ResourceTest {
     }
 
     @Test
+    void shouldOrderFindingsByComponentIdAndVulnerabilityIdAscending() {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        final Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
+        final Project p2 = qm.createProject("Acme Example", null, "2.0", null, null, null, null, false);
+        final Project p3 = qm.createProject("Acme Example", null, "3.0", null, null, null, null, false);
+        final Component c1 = createComponent(p1, "Component A", "1.0");
+        final Component c2 = createComponent(p2, "Component B", "1.0");
+        final Component c3 = createComponent(p3, "Component C", "1.0");
+        final Vulnerability v1 = createVulnerability("Vuln-1", Severity.LOW);
+        final Vulnerability v2 = createVulnerability("Vuln-2", Severity.MEDIUM);
+        final Vulnerability v3 = createVulnerability("Vuln-3", Severity.HIGH);
+
+        qm.addVulnerability(v3, c3, "none");
+        qm.addVulnerability(v2, c2, "none");
+        qm.addVulnerability(v1, c1, "none");
+
+        Response response = jersey
+                .target(V1_FINDING)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].vulnerability.vulnId")
+                .isArray()
+                .containsExactly("Vuln-1", "Vuln-2", "Vuln-3");
+
+        final Project p4 = qm.createProject("Acme Example", null, "4.0", null, null, null, null, false);
+        final Component c4 = createComponent(p4, "Component D", "1.0");
+        final Component c5 = createComponent(p4, "Component E", "1.0");
+        final Component c6 = createComponent(p4, "Component F", "1.0");
+        final Vulnerability v4 = createVulnerability("Vuln-4", Severity.LOW);
+        final Vulnerability v5 = createVulnerability("Vuln-5", Severity.MEDIUM);
+        final Vulnerability v6 = createVulnerability("Vuln-6", Severity.HIGH);
+        qm.addVulnerability(v6, c6, "none");
+        qm.addVulnerability(v5, c5, "none");
+        qm.addVulnerability(v4, c4, "none");
+
+        response = jersey
+                .target(V1_FINDING + "/project/" + p4.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].vulnerability.vulnId")
+                .isArray()
+                .containsExactly("Vuln-4", "Vuln-5", "Vuln-6");
+    }
+
+    @Test
     public void exportFindingsByProjectTest() {
         initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Changes the sorting tie-breaker from `FINDINGATTRIBUTION.ID` to `COMPONENT.ID, VULNERABILITY.ID`. Because `FINDINGATTRIBUTION` is introduced via `LATERAL JOIN`, sorting by it forces Postgres to execute the join for the entire table before being able to sort.

This is mostly relevant to the global findings query, where the potential result set is MUCH larger than that for individual projects.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
