### PR TITLE
Fix NO_PROXY being rejected as legacy Alpine property

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/common/LegacyConfigPropertyValidator.java
+++ b/apiserver/src/main/java/org/dependencytrack/common/LegacyConfigPropertyValidator.java
@@ -112,6 +112,7 @@ public final class LegacyConfigPropertyValidator {
             "alpine.worker.threads");
 
     static final Map<String, String> LEGACY_V5_RC1_PROPERTY_RENAMES = buildLegacyV5Rc1Renames();
+    private static final Set<String> STANDARD_SYSTEM_ENV_VARS = Set.of("NO_PROXY");
 
     private LegacyConfigPropertyValidator() {
     }
@@ -175,7 +176,10 @@ public final class LegacyConfigPropertyValidator {
 
             // We previously aliased `dt.X` to `X`. Make sure the latter is also recognized.
             final String bareName = oldName.substring("dt.".length());
-            if (config.getConfigValue(bareName).getValue() != null) {
+            final ConfigValue bareValue = config.getConfigValue(bareName);
+            if (bareValue.getValue() != null
+                    && (!bareValue.getSourceName().startsWith(EnvConfigSource.NAME)
+                            || !STANDARD_SYSTEM_ENV_VARS.contains(envForm(bareName)))) {
                 present.put(bareName, newName);
             }
         });

--- a/apiserver/src/test/java/org/dependencytrack/common/LegacyConfigPropertyValidatorTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/common/LegacyConfigPropertyValidatorTest.java
@@ -189,6 +189,27 @@ class LegacyConfigPropertyValidatorTest {
     }
 
     @Test
+    void shouldNotFailWhenStandardNoProxyEnvVarIsSet() {
+        final Config config = new SmallRyeConfigBuilder()
+                .withSources(new EnvConfigSource(Map.of("NO_PROXY", "localhost,127.0.0.1"), 300))
+                .build();
+
+        assertThatCode(() -> LegacyConfigPropertyValidator.validate(config))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldStillFailOnUnprefixedNoProxyFromPropertiesFile() {
+        final Config config = new SmallRyeConfigBuilder()
+                .withDefaultValue("no.proxy", "localhost,127.0.0.1")
+                .build();
+
+        assertThatThrownBy(() -> LegacyConfigPropertyValidator.validate(config))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("no.proxy -> dt.http.proxy.exclusions");
+    }
+
+    @Test
     void shouldKeepEveryRenameEntryPointingAtDtPrefixedOldName() {
         assertThat(LegacyConfigPropertyValidator.LEGACY_V5_RC1_PROPERTY_RENAMES)
                 .allSatisfy((oldName, newName) -> {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes `NO_PROXY` being rejected as legacy Alpine property.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6306 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
