### PR TITLE
Reject parent objects with null UUID when creating/updating/patching projects

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -480,7 +480,12 @@ public class ProjectResource extends AbstractApiResource {
     @Operation(
             summary = "Creates a new project",
             description = """
-                    <p>If a parent project exists, <code>parent.uuid</code> is required</p>
+                    <p>
+                      To create the project under a parent, set <code>parent</code> to an object
+                      containing the parent's <code>uuid</code>. To create a top-level project,
+                      omit <code>parent</code> or set it to <code>null</code>. Providing
+                      <code>parent</code> without a non-null <code>uuid</code> is rejected with 400.
+                    </p>
                     <p>
                       When portfolio access control is enabled, one or more teams to grant access
                       to can be provided via <code>accessTeams</code>. Either <code>uuid</code> or
@@ -538,8 +543,15 @@ public class ProjectResource extends AbstractApiResource {
                 }
             }
             final Project createdProject = qm.callInTransaction(() -> {
-                if (jsonProject.getParent() != null && jsonProject.getParent().getUuid() != null) {
-                    Project parent = qm.getObjectByUuid(Project.class, jsonProject.getParent().getUuid());
+                if (jsonProject.getParent() != null) {
+                    final UUID parentUuid = jsonProject.getParent().getUuid();
+                    if (parentUuid == null) {
+                        throw new ClientErrorException(Response
+                                .status(Response.Status.BAD_REQUEST)
+                                .entity("parent.uuid must be provided when parent is set")
+                                .build());
+                    }
+                    final Project parent = qm.getObjectByUuid(Project.class, parentUuid);
                     if (parent == null) {
                         throw new NoSuchElementException("Parent project could not be found");
                     }
@@ -653,7 +665,14 @@ public class ProjectResource extends AbstractApiResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Updates a project",
-            description = "<p>Requires permission <strong>PORTFOLIO_MANAGEMENT</strong> or <strong>PORTFOLIO_MANAGEMENT_UPDATE</strong></p>"
+            description = """
+                    <p>
+                      To re-parent the project, set <code>parent</code> to an object containing
+                      the new parent's <code>uuid</code>. Omit <code>parent</code> (or set it to
+                      <code>null</code>) to leave the parent unchanged. Providing <code>parent</code>
+                      without a non-null <code>uuid</code> is rejected with 400.
+                    </p>
+                    <p>Requires permission <strong>PORTFOLIO_MANAGEMENT</strong> or <strong>PORTFOLIO_MANAGEMENT_UPDATE</strong></p>"""
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -661,6 +680,7 @@ public class ProjectResource extends AbstractApiResource {
                     description = "The updated project",
                     content = @Content(schema = @Schema(implementation = Project.class))
             ),
+            @ApiResponse(responseCode = "400", description = "Bad Request"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(
                     responseCode = "403",
@@ -707,8 +727,15 @@ public class ProjectResource extends AbstractApiResource {
                 }
                 requireAccess(qm, project);
 
-                if (jsonProject.getParent() != null && jsonProject.getParent().getUuid() != null) {
-                    Project parent = qm.getObjectByUuid(Project.class, jsonProject.getParent().getUuid());
+                if (jsonProject.getParent() != null) {
+                    final UUID parentUuid = jsonProject.getParent().getUuid();
+                    if (parentUuid == null) {
+                        throw new ClientErrorException(Response
+                                .status(Response.Status.BAD_REQUEST)
+                                .entity("parent.uuid must be provided when parent is set")
+                                .build());
+                    }
+                    final Project parent = qm.getObjectByUuid(Project.class, parentUuid);
                     if (parent == null) {
                         throw new NoSuchElementException("Parent project could not be found");
                     }
@@ -775,7 +802,14 @@ public class ProjectResource extends AbstractApiResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Partially updates a project",
-            description = "<p>Requires permission <strong>PORTFOLIO_MANAGEMENT</strong> or <strong>PORTFOLIO_MANAGEMENT_UPDATE</strong></p>"
+            description = """
+                    <p>
+                      To re-parent the project, set <code>parent</code> to an object containing
+                      the new parent's <code>uuid</code>. Omit <code>parent</code> (or set it to
+                      <code>null</code>) to leave the parent unchanged. Providing <code>parent</code>
+                      without a non-null <code>uuid</code> is rejected with 400.
+                    </p>
+                    <p>Requires permission <strong>PORTFOLIO_MANAGEMENT</strong> or <strong>PORTFOLIO_MANAGEMENT_UPDATE</strong></p>"""
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -783,6 +817,7 @@ public class ProjectResource extends AbstractApiResource {
                     description = "The updated project",
                     content = @Content(schema = @Schema(implementation = Project.class))
             ),
+            @ApiResponse(responseCode = "400", description = "Bad Request"),
             @ApiResponse(
                     responseCode = "403",
                     description = "Access to the requested project, the provided parent, or the previous latest project version, is forbidden",
@@ -858,8 +893,15 @@ public class ProjectResource extends AbstractApiResource {
                     project.setClassifier(null);
                     modified = true;
                 }
-                if (jsonProject.getParent() != null && jsonProject.getParent().getUuid() != null) {
-                    final Project parent = qm.getObjectByUuid(Project.class, jsonProject.getParent().getUuid());
+                if (jsonProject.getParent() != null) {
+                    final UUID parentUuid = jsonProject.getParent().getUuid();
+                    if (parentUuid == null) {
+                        throw new ClientErrorException(Response
+                                .status(Response.Status.BAD_REQUEST)
+                                .entity("parent.uuid must be provided when parent is set")
+                                .build());
+                    }
+                    final Project parent = qm.getObjectByUuid(Project.class, parentUuid);
                     if (parent == null) {
                         throw new ClientErrorException(Response
                                 .status(Response.Status.NOT_FOUND)

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -2320,6 +2320,26 @@ class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
+    void shouldReturnBadRequestWhenCreatingProjectWithNullParentUuid() {
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_CREATE);
+
+        final Response response = jersey
+                .target(V1_PROJECT)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "parent": {
+                            "uuid": null
+                          },
+                          "name": "acme-app"
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(getPlainTextBody(response)).isEqualTo("parent.uuid must be provided when parent is set");
+    }
+
+    @Test
     void createProjectInaccessibleParentTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_CREATE);
         enablePortfolioAccessControl();
@@ -2576,6 +2596,31 @@ class ProjectResourceTest extends ResourceTest {
                   "detail": "Parent project could not be found"
                 }
                 """);
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenUpdatingProjectWithNullParentUuid() {
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_UPDATE);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final Response response = jersey
+                .target(V1_PROJECT)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "parent": {
+                            "uuid": null
+                          },
+                          "uuid": "%s",
+                          "name": "acme-app"
+                        }
+                        """.formatted(project.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(getPlainTextBody(response)).isEqualTo("parent.uuid must be provided when parent is set");
     }
 
     @Test
@@ -2838,6 +2883,29 @@ class ProjectResourceTest extends ResourceTest {
         qm.getPersistenceManager().refresh(project);
         assertThat(project.getParent()).isNotNull();
         assertThat(project.getParent().getUuid()).isEqualTo(parent.getUuid());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenPatchingProjectWithNullParentUuid() {
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_UPDATE);
+
+        final Project project = qm.createProject("DEF", null, "2.0", null, null, null, null, false);
+
+        final Response response = jersey
+                .target(V1_PROJECT + "/" + project.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
+                .method(HttpMethod.PATCH, Entity.json(/* language=JSON */ """
+                        {
+                          "parent": {
+                            "uuid": null
+                          }
+                        }
+                        """));
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(getPlainTextBody(response)).isEqualTo("parent.uuid must be provided when parent is set");
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Reject parent objects with null UUID when creating/updating/patching projects.

Also adds the expected format to the respective operation's description.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Reported via Slack: https://owasp.slack.com/archives/C6R3R32H4/p1780930173630299

Note that this is **not** a regression in v5. v4 had the same issue.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
