### PR TITLE
Fix NPE during LDAP auth when bind credentials are not configured

### DIFF
--- a/alpine/alpine-server/src/main/java/alpine/server/auth/LdapConnectionWrapper.java
+++ b/alpine/alpine-server/src/main/java/alpine/server/auth/LdapConnectionWrapper.java
@@ -151,8 +151,12 @@ public class LdapConnectionWrapper {
     public DirContext createDirContext() throws NamingException {
         LOGGER.debug("Creating directory service context (DirContext)");
         final Hashtable<String, String> env = new Hashtable<>();
-        env.put(Context.SECURITY_PRINCIPAL, bindUsername);
-        env.put(Context.SECURITY_CREDENTIALS, bindPassword);
+        if (bindUsername != null && !bindUsername.isBlank()) {
+            env.put(Context.SECURITY_PRINCIPAL, bindUsername);
+            if (bindPassword != null && !bindPassword.isBlank()) {
+                env.put(Context.SECURITY_CREDENTIALS, bindPassword);
+            }
+        }
         env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
         env.put(Context.PROVIDER_URL, ldapUrl);
         if (ldapSslTls) {

--- a/alpine/alpine-server/src/test/java/alpine/server/auth/LdapConnectionWrapperTest.java
+++ b/alpine/alpine-server/src/test/java/alpine/server/auth/LdapConnectionWrapperTest.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package alpine.server.auth;
+
+import alpine.config.AlpineConfigKeys;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.ldap.LLdapContainer;
+
+import javax.naming.AuthenticationNotSupportedException;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@Testcontainers
+class LdapConnectionWrapperTest {
+
+    @Container
+    private static final LLdapContainer LDAP = new LLdapContainer("lldap/lldap:2026-03-04-alpine")
+            .withUserPass("password")
+            .withEnv("LLDAP_JWT_SECRET", "0123456789abcdef0123456789abcdef");
+
+    @Test
+    void shouldNotThrowNpeWhenBindCredentialsAreEmpty() {
+        final var config = new SmallRyeConfigBuilder()
+                .withDefaultValues(Map.ofEntries(
+                        Map.entry(AlpineConfigKeys.LDAP_ENABLED, "true"),
+                        Map.entry(AlpineConfigKeys.LDAP_SERVER_URL, LDAP.getLdapUrl()),
+                        Map.entry(AlpineConfigKeys.LDAP_BASEDN, LDAP.getBaseDn()),
+                        Map.entry(AlpineConfigKeys.LDAP_BIND_USERNAME, ""),
+                        Map.entry(AlpineConfigKeys.LDAP_BIND_PASSWORD, ""),
+                        Map.entry(AlpineConfigKeys.LDAP_NAME_ATTRIBUTE, "uid"),
+                        Map.entry(AlpineConfigKeys.LDAP_MAIL_ATTRIBUTE, "mail"),
+                        Map.entry(AlpineConfigKeys.LDAP_USER_PROVISIONING, "true"),
+                        Map.entry(AlpineConfigKeys.LDAP_TEAM_SYNCHRONIZATION, "false")))
+                .build();
+        final var wrapper = new LdapConnectionWrapper(config);
+
+        // LLDAP testcontainer doesn't support unauthenticated usage,
+        // we assert whether authentication was *attempted* without credentials instead.
+        assertThatExceptionOfType(AuthenticationNotSupportedException.class)
+                .isThrownBy(wrapper::createDirContext)
+                .withMessageContaining("error code 48");
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes NPE during LDAP auth when bind credentials are not configured.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6316

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
