### PR TITLE
Fix incomplete field coverage of /v1/finding/project/{uuid}'s searchText filter

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -273,6 +273,9 @@ public interface FindingDao {
                  LOWER(c."NAME") LIKE ('%' || LOWER(:searchText) || '%') ESCAPE '!'
                  OR LOWER(c."GROUP") LIKE ('%' || LOWER(:searchText) || '%') ESCAPE '!'
                  OR LOWER(v."VULNID") LIKE ('%' || LOWER(:searchText) || '%') ESCAPE '!'
+                 OR CAST(v."UUID" AS TEXT) = LOWER(:searchText)
+                 OR CAST(c."UUID" AS TEXT) = LOWER(:searchText)
+                 OR LOWER(CAST(c."UUID" AS TEXT) || ':' || CAST(v."UUID" AS TEXT)) = LOWER(:searchText)
                )
             </#if>
             <#if apiOrderByClause??>

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
@@ -142,7 +142,9 @@ public class FindingResource extends AbstractApiResource {
             in = ParameterIn.QUERY,
             description = """
                     Case-insensitive substring filter matched against component name, \
-                    component group, and vulnerability ID."""
+                    component group, and vulnerability ID. Additionally matched as an \
+                    exact value against component UUID, vulnerability UUID, and the \
+                    `componentUuid:vulnerabilityUuid` pair."""
     )
     @PermissionRequired(Permissions.Constants.VIEW_VULNERABILITY)
     public Response getFindingsByProject(@Parameter(description = "The UUID of the project", schema = @Schema(type = "string", format = "uuid"), required = true)

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -223,6 +223,19 @@ public class FindingResourceTest extends ResourceTest {
         assertThat(searchFindings.apply("%char")).containsExactly("FOO-100");
         assertThat(searchFindings.apply("char_x")).containsExactly("FOO-100");
         assertThat(searchFindings.apply("alph_")).isEmpty();
+        assertThat(searchFindings.apply(vulnBar.getUuid().toString()))
+                .containsExactly("BAR-200");
+        assertThat(searchFindings.apply(vulnBar.getUuid().toString().toUpperCase()))
+                .containsExactly("BAR-200");
+        assertThat(searchFindings.apply(componentBeta.getUuid().toString()))
+                .containsExactly("BAR-200");
+        assertThat(searchFindings.apply(
+                componentBeta.getUuid() + ":" + vulnBar.getUuid()))
+                .containsExactly("BAR-200");
+        assertThat(searchFindings.apply(
+                componentAlpha.getUuid() + ":" + vulnBar.getUuid()))
+                .isEmpty();
+        assertThat(searchFindings.apply(UUID.randomUUID().toString())).isEmpty();
     }
 
     @Test


### PR DESCRIPTION




### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes incomplete field coverage of `/v1/finding/project/{uuid}`'s `searchText` filter

The frontend relies on searching by UUID, and occasionally even by `{componentUuid}:{vulnUuid}`.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6319

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
