### PR TITLE
Fix URL-encoding of OSV ecosystem names

### DIFF
--- a/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSource.java
+++ b/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSource.java
@@ -37,10 +37,12 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -265,8 +267,15 @@ final class OsvVulnDataSource implements VulnDataSource {
             throw new UncheckedIOException("Failed to create temp file", e);
         }
 
+        // Some ecosystems contain spaces, e.g. "Red Hat".
+        // NB: URLEncoder encodes spaces as "+", but GCS (where OSV hosts its data dumps)
+        // requires spaces to be percent-encoded.
+        final String encodedEcosystem = URLEncoder
+                .encode(ecosystem, StandardCharsets.UTF_8)
+                .replace("+", "%20");
+
         final var request = HttpRequest.newBuilder()
-                .uri(URI.create("%s/%s/all.zip".formatted(dataUrl, ecosystem)))
+                .uri(URI.create("%s/%s/all.zip".formatted(dataUrl, encodedEcosystem)))
                 .GET()
                 .build();
 

--- a/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSourceTest.java
+++ b/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSourceTest.java
@@ -20,7 +20,6 @@ package org.dependencytrack.vulndatasource.osv;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.google.protobuf.util.JsonFormat;
@@ -47,6 +46,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -232,6 +232,42 @@ class OsvVulnDataSourceTest {
     }
 
     @Test
+    void shouldPercentEncodeSpacesInEcosystemNameForFullArchive(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        final var zipBytes = new ByteArrayOutputStream();
+        try (var zos = new ZipOutputStream(zipBytes)) {
+            zos.putNextEntry(new ZipEntry("osv-advisory.json"));
+            zos.write(/* language=JSON */ """
+                    {
+                      "id": "OSV-1",
+                      "summary": "test",
+                      "affected": [],
+                      "modified": "2024-01-01T00:00:00Z"
+                    }
+                    """.getBytes());
+            zos.closeEntry();
+        }
+        stubFor(get(urlEqualTo("/Red%20Hat/all.zip"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/zip")
+                        .withBody(zipBytes.toByteArray())));
+
+        try (var dataSource = new OsvVulnDataSource(
+                null,
+                objectMapper,
+                wmRuntimeInfo.getHttpBaseUrl(),
+                List.of("Red Hat"),
+                HttpClient.newHttpClient(),
+                false)) {
+            assertTrue(dataSource.hasNext());
+            assertThat(dataSource.next().getVulnerabilitiesList().getFirst().getId()).isEqualTo("OSV-1");
+        }
+
+        verify(getRequestedFor(urlEqualTo("/Red%20Hat/all.zip")));
+        verify(0, getRequestedFor(urlPathMatching(".*/Red\\+Hat/.*")));
+    }
+
+    @Test
     void shouldSkipDirectoryAndNonJsonEntriesInFullArchive(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         ByteArrayOutputStream zipBytes = new ByteArrayOutputStream();
         try (ZipOutputStream zos = new ZipOutputStream(zipBytes)) {
@@ -310,8 +346,8 @@ class OsvVulnDataSourceTest {
             assertThat(dataSource.hasNext()).isFalse();
         }
 
-        WireMock.verify(getRequestedFor(urlEqualTo("/maven/all.zip")));
-        WireMock.verify(0, getRequestedFor(urlPathMatching(".*/modified_id\\.csv")));
+        verify(getRequestedFor(urlEqualTo("/maven/all.zip")));
+        verify(0, getRequestedFor(urlPathMatching(".*/modified_id\\.csv")));
     }
 
     @Test
@@ -352,8 +388,8 @@ class OsvVulnDataSourceTest {
             assertThat(dataSource.hasNext()).isFalse();
         }
 
-        WireMock.verify(getRequestedFor(urlEqualTo("/maven/all.zip")));
-        WireMock.verify(0, getRequestedFor(urlPathMatching(".*/modified_id\\.csv")));
+        verify(getRequestedFor(urlEqualTo("/maven/all.zip")));
+        verify(0, getRequestedFor(urlPathMatching(".*/modified_id\\.csv")));
     }
 
     @Test
@@ -394,9 +430,9 @@ class OsvVulnDataSourceTest {
             assertThat(dataSource.hasNext()).isFalse();
         }
 
-        WireMock.verify(getRequestedFor(urlEqualTo("/maven/modified_id.csv")));
-        WireMock.verify(getRequestedFor(urlEqualTo("/maven/OSV-123.json")));
-        WireMock.verify(0, getRequestedFor(urlEqualTo("/maven/all.zip")));
+        verify(getRequestedFor(urlEqualTo("/maven/modified_id.csv")));
+        verify(getRequestedFor(urlEqualTo("/maven/OSV-123.json")));
+        verify(0, getRequestedFor(urlEqualTo("/maven/all.zip")));
     }
 
     @Test
@@ -429,13 +465,13 @@ class OsvVulnDataSourceTest {
                 HttpClient.newHttpClient(),
                 false)) {
             assertThat(dataSource.hasNext()).isTrue();
-            WireMock.verify(1, getRequestedFor(urlPathMatching("/maven/OSV-.*\\.json")));
+            verify(1, getRequestedFor(urlPathMatching("/maven/OSV-.*\\.json")));
 
             dataSource.next();
-            WireMock.verify(1, getRequestedFor(urlPathMatching("/maven/OSV-.*\\.json")));
+            verify(1, getRequestedFor(urlPathMatching("/maven/OSV-.*\\.json")));
 
             assertThat(dataSource.hasNext()).isTrue();
-            WireMock.verify(2, getRequestedFor(urlPathMatching("/maven/OSV-.*\\.json")));
+            verify(2, getRequestedFor(urlPathMatching("/maven/OSV-.*\\.json")));
 
             dataSource.next();
             assertThat(dataSource.hasNext()).isFalse();
@@ -488,9 +524,9 @@ class OsvVulnDataSourceTest {
             assertThat(dataSource.hasNext()).isFalse();
         }
 
-        WireMock.verify(getRequestedFor(urlEqualTo("/maven/modified_id.csv")));
-        WireMock.verify(getRequestedFor(urlEqualTo("/maven/all.zip")));
-        WireMock.verify(0, getRequestedFor(urlPathMatching("/maven/OSV-.*\\.json")));
+        verify(getRequestedFor(urlEqualTo("/maven/modified_id.csv")));
+        verify(getRequestedFor(urlEqualTo("/maven/all.zip")));
+        verify(0, getRequestedFor(urlPathMatching("/maven/OSV-.*\\.json")));
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes URL-encoding of OSV ecosystem names.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

See code comments.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
