### PR TITLE
Fix email notification publisher not populating the "From" header

### DIFF
--- a/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/email/EmailNotificationPublisher.java
+++ b/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/email/EmailNotificationPublisher.java
@@ -85,7 +85,7 @@ final class EmailNotificationPublisher implements NotificationPublisher {
 
         try {
             final var message = new MimeMessage(session);
-            message.setSender(new InternetAddress(senderAddress));
+            message.setFrom(new InternetAddress(senderAddress));
             message.setRecipients(Message.RecipientType.TO, recipients);
             message.setSubject(messageSubject);
 

--- a/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/email/EmailNotificationPublisherTest.java
+++ b/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/email/EmailNotificationPublisherTest.java
@@ -20,6 +20,7 @@ package org.dependencytrack.notification.publishing.email;
 
 import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.util.ServerSetup;
+import jakarta.mail.Address;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
@@ -32,6 +33,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -87,6 +90,7 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
 
     private void validateBomConsumedNotificationPublish() {
         final ReceivedMessage message = getReceivedMessage();
+        assertThat(message.from()).containsExactly("dependencytrack@example.com");
         assertThat(message.subject()).isEqualTo("[Dependency-Track] Bill of Materials Consumed");
         assertThat(message.content()).isEqualToNormalizingNewlines("""
                 Bill of Materials Consumed
@@ -110,6 +114,7 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
 
     private void validateBomProcessingFailedNotificationPublish() {
         final ReceivedMessage message = getReceivedMessage();
+        assertThat(message.from()).containsExactly("dependencytrack@example.com");
         assertThat(message.subject()).isEqualTo("[Dependency-Track] Bill of Materials Processing Failed");
         assertThat(message.content()).isEqualToNormalizingNewlines("""
                 Bill of Materials Processing Failed
@@ -138,6 +143,7 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
 
     private void validateBomValidationFailedNotificationPublish() {
         final ReceivedMessage message = getReceivedMessage();
+        assertThat(message.from()).containsExactly("dependencytrack@example.com");
         assertThat(message.subject()).isEqualTo("[Dependency-Track] Bill of Materials Validation Failed");
         assertThat(message.content()).isEqualToNormalizingNewlines("""
                 Bill of Materials Validation Failed
@@ -170,6 +176,7 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
 
     private void validateNewVulnerabilityNotificationPublish() {
         final ReceivedMessage message = getReceivedMessage();
+        assertThat(message.from()).containsExactly("dependencytrack@example.com");
         assertThat(message.subject()).isEqualTo("[Dependency-Track] New Vulnerability Identified on Project: [projectName : projectVersion]");
         assertThat(message.content()).isEqualToNormalizingNewlines("""
                 New Vulnerability Identified on Project: [projectName : projectVersion]
@@ -202,6 +209,7 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
 
     private void validateNewVulnerableDependencyNotificationPublish() {
         final ReceivedMessage message = getReceivedMessage();
+        assertThat(message.from()).containsExactly("dependencytrack@example.com");
         assertThat(message.subject()).isEqualTo("[Dependency-Track] Vulnerable Dependency Introduced on Project: [projectName : projectVersion]");
         assertThat(message.content()).isEqualToNormalizingNewlines("""
                 Vulnerable Dependency Introduced on Project: [projectName : projectVersion]
@@ -236,6 +244,7 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
 
     private void validateNewVulnerabilitiesSummaryNotificationPublish() {
         final ReceivedMessage message = getReceivedMessage();
+        assertThat(message.from()).containsExactly("dependencytrack@example.com");
         assertThat(message.subject()).isEqualTo("[Dependency-Track] New Vulnerabilities Summary");
         assertThat(message.content()).isEqualToIgnoringWhitespace("""
                 New Vulnerabilities Summary
@@ -286,6 +295,7 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
 
     private void validateNewPolicyViolationsSummaryNotificationPublish() {
         final ReceivedMessage message = getReceivedMessage();
+        assertThat(message.from()).containsExactly("dependencytrack@example.com");
         assertThat(message.subject()).isEqualTo("[Dependency-Track] New Policy Violations Summary");
         assertThat(message.content()).isEqualToIgnoringWhitespace("""
                 New Policy Violations Summary
@@ -334,7 +344,7 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
                 """);
     }
 
-    private record ReceivedMessage(String subject, String content) {
+    private record ReceivedMessage(List<String> from, String subject, String content) {
     }
 
     private ReceivedMessage getReceivedMessage() {
@@ -349,7 +359,11 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
             assertThat(content.getCount()).isEqualTo(1);
             assertThat(content.getBodyPart(0)).isInstanceOf(MimeBodyPart.class);
 
+            final Address[] from = message.getFrom();
             return new ReceivedMessage(
+                    from != null
+                            ? Arrays.stream(from).map(Address::toString).toList()
+                            : List.of(),
                     message.getSubject(),
                     (String) content.getBodyPart(0).getContent());
         } catch (IOException e) {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes email notification publisher not populating the "From" header.

It was erroneously setting the sender, but it should set `From:`.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6333 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
