### PR TITLE
v4-migrator: Fix confusing debug log for missing tgt_permission table

### DIFF
--- a/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/verify/VerifyPhase.java
+++ b/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/verify/VerifyPhase.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
+import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -259,9 +260,24 @@ public final class VerifyPhase {
                     .mapTo(Long.class)
                     .one());
         } catch (final RuntimeException e) {
-            LOGGER.debug("count(*) failed for {}: {}", qualifiedTable, e.toString());
+            // Some registry entries declare a transform that does not materialize a tgt_*
+            // table of the same name (e.g. PERMISSION builds permission_name_map against
+            // the v5 catalog seeded at bootstrap). Treat a missing relation as a normal
+            // "no row count to report" outcome and only log unexpected failures.
+            if (!isUndefinedTable(e)) {
+                LOGGER.debug("count(*) failed for {}: {}", qualifiedTable, e.toString());
+            }
             return null;
         }
+    }
+
+    private static boolean isUndefinedTable(final Throwable t) {
+        for (Throwable c = t; c != null; c = c.getCause()) {
+            if (c instanceof SQLException sql && "42P01".equals(sql.getSQLState())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private String qualified(final String table) {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes confusing v4-migrator debug log for missing `tgt_permission` table.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6335

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
