### PR TITLE
Exclude retrieval of components and aliases during OSVDownloadTask

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -806,19 +806,23 @@ public class QueryManager extends AlpineQueryManager {
     }
 
     public Vulnerability getVulnerabilityByVulnId(String source, String vulnId) {
-        return getVulnerabilityQueryManager().getVulnerabilityByVulnId(source, vulnId, false);
+        return getVulnerabilityQueryManager().getVulnerabilityByVulnId(source, vulnId, false, true);
     }
 
     public Vulnerability getVulnerabilityByVulnId(String source, String vulnId, boolean includeVulnerableSoftware) {
-        return getVulnerabilityQueryManager().getVulnerabilityByVulnId(source, vulnId, includeVulnerableSoftware);
+        return getVulnerabilityQueryManager().getVulnerabilityByVulnId(source, vulnId, includeVulnerableSoftware, true);
+    }
+
+    public Vulnerability getVulnerabilityByVulnId(String source, String vulnId, boolean includeVulnerableSoftware, boolean includeComponentsAndAliases) {
+        return getVulnerabilityQueryManager().getVulnerabilityByVulnId(source, vulnId, includeVulnerableSoftware, includeComponentsAndAliases);
     }
 
     public Vulnerability getVulnerabilityByVulnId(Vulnerability.Source source, String vulnId) {
-        return getVulnerabilityQueryManager().getVulnerabilityByVulnId(source, vulnId, false);
+        return getVulnerabilityQueryManager().getVulnerabilityByVulnId(source, vulnId, false, true);
     }
 
     public Vulnerability getVulnerabilityByVulnId(Vulnerability.Source source, String vulnId, boolean includeVulnerableSoftware) {
-        return getVulnerabilityQueryManager().getVulnerabilityByVulnId(source, vulnId, includeVulnerableSoftware);
+        return getVulnerabilityQueryManager().getVulnerabilityByVulnId(source, vulnId, includeVulnerableSoftware, true);
     }
 
     public void addVulnerability(Vulnerability vulnerability, Component component, AnalyzerIdentity analyzerIdentity) {

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -197,15 +197,15 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
      * @param vulnId the name of the vulnerability
      * @return the matching Vulnerability object, or null if not found
      */
-    public Vulnerability getVulnerabilityByVulnId(String source, String vulnId, boolean includeVulnerableSoftware) {
+    public Vulnerability getVulnerabilityByVulnId(String source, String vulnId, boolean includeVulnerableSoftware, boolean includeComponentsAndAliases) {
         final Query<Vulnerability> query = pm.newQuery(Vulnerability.class, "source == :source && vulnId == :vulnId");
-        query.getFetchPlan().addGroup(Vulnerability.FetchGroup.COMPONENTS.name());
+        if (includeComponentsAndAliases) {query.getFetchPlan().addGroup(Vulnerability.FetchGroup.COMPONENTS.name());}
         if (includeVulnerableSoftware) {
             query.getFetchPlan().addGroup(Vulnerability.FetchGroup.VULNERABLE_SOFTWARE.name());
         }
         query.setRange(0, 1);
         final Vulnerability vulnerability = singleResult(query.execute(source, vulnId));
-        if (vulnerability != null) {
+        if ((vulnerability != null) && includeComponentsAndAliases) {
             vulnerability.setAliases(getVulnerabilityAliases(vulnerability));
         }
         return vulnerability;
@@ -217,8 +217,8 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
      * @param vulnId the name of the vulnerability
      * @return the matching Vulnerability object, or null if not found
      */
-    public Vulnerability getVulnerabilityByVulnId(Vulnerability.Source source, String vulnId, boolean includeVulnerableSoftware) {
-        return getVulnerabilityByVulnId(source.name(), vulnId, includeVulnerableSoftware);
+    public Vulnerability getVulnerabilityByVulnId(Vulnerability.Source source, String vulnId, boolean includeVulnerableSoftware, boolean includeComponentsAndAliases) {
+        return getVulnerabilityByVulnId(source.name(), vulnId, includeVulnerableSoftware, includeComponentsAndAliases);
     }
 
     /**

--- a/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
+++ b/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
@@ -658,7 +658,7 @@ public class OsvDownloadTask implements LoggableSubscriber {
                     Vulnerability.class,
                     VulnerableSoftware.class);
             qm.runInTransaction(() -> {
-                final Vulnerability existingVulnerability = qm.getVulnerabilityByVulnId(vulnerability.getSource(), vulnerability.getVulnId());
+                final Vulnerability existingVulnerability = qm.getVulnerabilityByVulnId(vulnerability.getSource(), vulnerability.getVulnId(), false, false);
                 final Vulnerability.Source vulnerabilitySource = extractSource(advisory.getId());
                 final ConfigPropertyConstants vulnAuthoritativeSourceToggle = switch (vulnerabilitySource) {
                     case NVD -> VULNERABILITY_SOURCE_NVD_ENABLED;


### PR DESCRIPTION
### Description
**General workflow OSV Download Task**
The OSV download task includes a method called `updateDatasource(final OSVAdvisory advisory)`. Based on profiling results, this method appears to be the main hotspot.

The method has two possible paths: either the vulnerability referenced by the advisory is already persisted and both the source and metadata are unchanged, or the vulnerability has not been persisted yet, has been modified, or is being reported by OSV for the first time.

For a typical full download—where most advisories have already been fetched before—the first case should apply most of the time: the vulnerability already exists and hasn’t changed since the last run. This fix therefore focuses on optimizing that fast path. For an initial full download where no vulnerabilities have been persisted yet, other parts of the code dominate the runtime, and this change won’t affect that.

**Proposed change**
`getVulnerabilityByVulnId()` is called during the fast path and fetches the persisted vulnerability and all associated components. For the call originating from the OSVDownloadTask, components are no longer fetched, as it is unnecessary in this context and takes more time than needed. 

### Addressed Issue
Hopefully this will make the OSV download faster; addresses issue #5934 .

### Additional Details
I’m not sure this PR fully resolves the issue—it’s likely only one piece of a larger solution, but hopefully a good first step.

### Checklist
- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
