### PR TITLE
Backport: v4-migrator: Add TCP keepalive and optional socket timeout

### DIFF
--- a/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/config/Connections.java
+++ b/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/config/Connections.java
@@ -29,11 +29,18 @@ import java.util.Properties;
 
 public final class Connections {
 
+    /**
+     * Initial-connect timeout (seconds). Bounds the auth/startup exchange that
+     * {@code connectTimeout} (PG JDBC default 10s) does not cover. Without this,
+     * a stalled handshake can hang indefinitely.
+     */
+    private static final int LOGIN_TIMEOUT_SECONDS = 30;
+
     private Connections() {
     }
 
     public static Jdbi targetJdbi(final GlobalOptions opts) {
-        return Jdbi.create(opts.targetUrl, opts.targetUser, opts.targetPass);
+        return Jdbi.create(buildTargetDataSource(opts));
     }
 
     /**
@@ -42,15 +49,7 @@ public final class Connections {
      * the migrator's bootstrap is serial, so there is no need for a pool.
      */
     public static DataSource targetDataSource(final GlobalOptions opts) {
-        final PGSimpleDataSource ds = new PGSimpleDataSource();
-        ds.setUrl(opts.targetUrl);
-        if (opts.targetUser != null) {
-            ds.setUser(opts.targetUser);
-        }
-        if (opts.targetPass != null) {
-            ds.setPassword(opts.targetPass);
-        }
-        return ds;
+        return buildTargetDataSource(opts);
     }
 
     public static Connection openSource(final SourceOptions opts) throws SQLException {
@@ -61,6 +60,42 @@ public final class Connections {
         if (opts.sourcePass != null) {
             props.setProperty("password", opts.sourcePass);
         }
+        // tcpKeepAlive is a PostgreSQL JDBC-specific property; MSSQL would error on
+        // unknown keys, so only set it for PG sources. Other flavors get OS defaults.
+        if (opts.sourceUrl != null && opts.sourceUrl.startsWith("jdbc:postgresql:")) {
+            props.setProperty("tcpKeepAlive", "true");
+        }
         return DriverManager.getConnection(opts.sourceUrl, props);
+    }
+
+    private static PGSimpleDataSource buildTargetDataSource(final GlobalOptions opts) {
+        final PGSimpleDataSource ds = new PGSimpleDataSource();
+        ds.setUrl(opts.targetUrl);
+        if (opts.targetUser != null) {
+            ds.setUser(opts.targetUser);
+        }
+        if (opts.targetPass != null) {
+            ds.setPassword(opts.targetPass);
+        }
+        applyHardening(ds, opts);
+        return ds;
+    }
+
+    /**
+     * Applies network-reliability settings that PG JDBC ships with disabled or unbounded.
+     * Without these, a silently broken TCP connection (k8s/NAT/LB idle drop, peer crash,
+     * stateful firewall reaping the flow) leaves the driver blocked forever in a socket
+     * read — see #6292, where the load phase hung for 113h on COMPONENT with no
+     * observable backend session.
+     */
+    private static void applyHardening(final PGSimpleDataSource ds, final GlobalOptions opts) {
+        // OS-level dead-peer detection. Linux probes after ~2h by default (tunable via
+        // tcp_keepalive_time/_intvl/_probes); converts a dead-but-unclosed socket into a
+        // SocketException -> SQLException that propagates out of inTransaction(...).
+        ds.setTcpKeepAlive(true);
+        ds.setLoginTimeout(LOGIN_TIMEOUT_SECONDS);
+        if (opts.socketTimeoutSeconds > 0) {
+            ds.setSocketTimeout(opts.socketTimeoutSeconds);
+        }
     }
 }

--- a/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/config/GlobalOptions.java
+++ b/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/config/GlobalOptions.java
@@ -57,4 +57,12 @@ public final class GlobalOptions {
             description = "Run preflight and print a plan; do not mutate any database.")
     public boolean dryRun;
 
+    @Option(names = "--socket-timeout",
+            description = "Upper bound, in seconds, on any single PostgreSQL network read. "
+                + "When set, a stalled connection (dropped peer, broken firewall flow) surfaces "
+                + "as a SQLException instead of hanging indefinitely. Must exceed the longest "
+                + "expected single statement. 0 disables. Default: ${DEFAULT-VALUE}.",
+            defaultValue = "0")
+    public int socketTimeoutSeconds;
+
 }

--- a/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/config/ConnectionsTest.java
+++ b/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/config/ConnectionsTest.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.v4migrator.config;
+
+import org.postgresql.ds.PGSimpleDataSource;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConnectionsTest {
+
+    @Test
+    void shouldHardenTargetDataSourceWithKeepAliveAndLoginTimeout() {
+        final GlobalOptions opts = new GlobalOptions();
+        opts.targetUrl = "jdbc:postgresql://localhost:5432/dtrack";
+        opts.targetUser = "u";
+        opts.targetPass = "p";
+
+        final DataSource ds = Connections.targetDataSource(opts);
+
+        assertThat(ds).isInstanceOf(PGSimpleDataSource.class);
+        final PGSimpleDataSource pg = (PGSimpleDataSource) ds;
+        assertThat(pg.getTcpKeepAlive()).isTrue();
+        assertThat(pg.getLoginTimeout()).isEqualTo(30);
+        assertThat(pg.getSocketTimeout()).isZero();
+    }
+
+    @Test
+    void shouldPropagateSocketTimeoutWhenSet() {
+        final GlobalOptions opts = new GlobalOptions();
+        opts.targetUrl = "jdbc:postgresql://localhost:5432/dtrack";
+        opts.socketTimeoutSeconds = 120;
+
+        final DataSource ds = Connections.targetDataSource(opts);
+
+        assertThat(((PGSimpleDataSource) ds).getSocketTimeout()).isEqualTo(120);
+    }
+
+    @Test
+    void shouldLeaveSocketTimeoutDisabledWhenZero() {
+        final GlobalOptions opts = new GlobalOptions();
+        opts.targetUrl = "jdbc:postgresql://localhost:5432/dtrack";
+        opts.socketTimeoutSeconds = 0;
+
+        final DataSource ds = Connections.targetDataSource(opts);
+
+        assertThat(((PGSimpleDataSource) ds).getSocketTimeout()).isZero();
+    }
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

v4-migrator: Add TCP keepalive and optional socket timeout

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #6302
Closes #6292

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
