### PR TITLE
Backport: Apply stricter PURL normalization for NPM package metadata resolution

### DIFF
--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/npm/NpmPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/npm/NpmPackageMetadataResolverFactory.java
@@ -57,6 +57,15 @@ public final class NpmPackageMetadataResolverFactory implements PackageMetadataR
             return null;
         }
 
+        // NPM package names are either `name` or `@scope/name` with a single scope segment,
+        // as per https://github.com/npm/validate-npm-package-name.
+        // Malformed package names like `scope/name` or `scope1/scope2/name` cause NPM
+        // to respond with 405 instead of 404.
+        final String namespace = purl.getNamespace();
+        if (namespace != null && (!namespace.startsWith("@") || namespace.contains("/"))) {
+            return null;
+        }
+
         try {
             return aPackageURL()
                     .withType(purl.getType())

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/npm/NpmPackageMetadataResolverFactoryTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/npm/NpmPackageMetadataResolverFactoryTest.java
@@ -36,10 +36,12 @@ class NpmPackageMetadataResolverFactoryTest extends AbstractExtensionFactoryTest
     @ParameterizedTest
     @CsvSource(nullValues = "", value = {
             "pkg:npm/foo@1.0, pkg:npm/foo@1.0",
-            "pkg:npm/ns/foo@1.0, pkg:npm/ns/foo@1.0",
+            "pkg:npm/%40scope/foo@1.0, pkg:npm/%40scope/foo@1.0",
             "pkg:pypi/foo@1.0, ",
             "pkg:npm/foo, ",
-            "pkg:npm/ns/foo@1.0?key=value#sub/path, pkg:npm/ns/foo@1.0",
+            "pkg:npm/%40scope/foo@1.0?key=value#sub/path, pkg:npm/%40scope/foo@1.0",
+            "pkg:npm/ns/foo@1.0, ",
+            "pkg:npm/angular/cli/node_modules/open@8.4.0, ",
     })
     void shouldNormalize(String input, String expected) throws Exception {
         assertThat(factory.normalize(new PackageURL(input)))


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Apply stricter PURL normalization for NPM package metadata resolution

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #6304

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
