### PR TITLE
Backport: Bypass outbox for notification rule tests

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/NotificationPublisherResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/NotificationPublisherResource.java
@@ -44,32 +44,40 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.common.MdcKeys;
+import org.dependencytrack.dex.engine.api.DexEngine;
+import org.dependencytrack.dex.engine.api.request.CreateWorkflowRunRequest;
 import org.dependencytrack.model.NotificationPublisher;
 import org.dependencytrack.model.NotificationRule;
 import org.dependencytrack.model.validation.ValidUuid;
-import org.dependencytrack.notification.JdoNotificationEmitter;
+import org.dependencytrack.notification.PublishNotificationWorkflow;
 import org.dependencytrack.notification.api.publishing.NotificationPublisherFactory;
+import org.dependencytrack.notification.proto.v1.Group;
+import org.dependencytrack.notification.proto.v1.Level;
+import org.dependencytrack.notification.proto.v1.Notification;
+import org.dependencytrack.notification.proto.v1.Scope;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.plugin.api.config.RuntimeConfigSpec;
 import org.dependencytrack.plugin.runtime.NoSuchExtensionException;
 import org.dependencytrack.plugin.runtime.PluginManager;
+import org.dependencytrack.proto.internal.workflow.v1.PublishNotificationWorkflowArg;
 import org.dependencytrack.resources.AbstractApiResource;
 import org.dependencytrack.resources.v1.vo.CreateNotificationPublisherRequest;
 import org.dependencytrack.resources.v1.vo.UpdateNotificationPublisherRequest;
+import org.jspecify.annotations.Nullable;
 import org.owasp.security.logging.SecurityMarkers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Stream;
 
+import static org.dependencytrack.dex.DexWorkflowLabels.WF_LABEL_TRIGGERED_BY;
 import static org.dependencytrack.notification.NotificationModelConverter.convert;
 import static org.dependencytrack.notification.api.TestNotificationFactory.createTestNotification;
-import static org.dependencytrack.notification.proto.v1.Level.LEVEL_ERROR;
-import static org.dependencytrack.notification.proto.v1.Level.LEVEL_INFORMATIONAL;
-import static org.dependencytrack.notification.proto.v1.Level.LEVEL_WARNING;
 
 /**
  * JAX-RS resources for processing notification publishers.
@@ -88,10 +96,12 @@ public class NotificationPublisherResource extends AbstractApiResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(NotificationPublisherResource.class);
 
     private final PluginManager pluginManager;
+    private final DexEngine dexEngine;
 
     @Inject
-    NotificationPublisherResource(PluginManager pluginManager) {
+    NotificationPublisherResource(PluginManager pluginManager, DexEngine dexEngine) {
         this.pluginManager = pluginManager;
+        this.dexEngine = dexEngine;
     }
 
     @GET
@@ -334,39 +344,44 @@ public class NotificationPublisherResource extends AbstractApiResource {
             @Parameter(description = "The UUID of the rule to test", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String ruleUuid) {
         try (final var qm = new QueryManager(getAlpineRequest())) {
-            return qm.callInTransaction(() -> {
-                NotificationRule rule = qm.getObjectByUuid(NotificationRule.class, ruleUuid);
-                if (rule == null) {
-                    return Response.status(Response.Status.NOT_FOUND).build();
+            final NotificationRule rule = qm.getObjectByUuid(NotificationRule.class, ruleUuid);
+            if (rule == null) {
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+
+            final var createRunRequests = new ArrayList<CreateWorkflowRunRequest<?>>();
+            for (final var notificationGroup : rule.getNotifyOn()) {
+                final Group group = convert(notificationGroup);
+                final Notification notification = buildTestNotification(
+                        convert(rule.getScope()), group, convert(rule.getNotificationLevel()));
+                if (notification == null) {
+                    continue;
                 }
 
-                final List<org.dependencytrack.notification.proto.v1.Notification> notifications =
-                        rule.getNotifyOn().stream()
-                                // Notifications of the same group may have different contents,
-                                // depending on the level, or may only support a single level.
-                                // To increase utility of this test feature, ensure that we
-                                // generate notifications for all applicable levels.
-                                .flatMap(group -> switch (rule.getNotificationLevel()) {
-                                    case INFORMATIONAL -> Stream.of(
-                                            createTestNotification(convert(rule.getScope()), convert(group), LEVEL_INFORMATIONAL),
-                                            createTestNotification(convert(rule.getScope()), convert(group), LEVEL_WARNING),
-                                            createTestNotification(convert(rule.getScope()), convert(group), LEVEL_ERROR));
-                                    case WARNING -> Stream.of(
-                                            createTestNotification(convert(rule.getScope()), convert(group), LEVEL_WARNING),
-                                            createTestNotification(convert(rule.getScope()), convert(group), LEVEL_ERROR));
-                                    case ERROR -> Stream.of(
-                                            createTestNotification(convert(rule.getScope()), convert(group), LEVEL_ERROR));
-                                })
-                                .filter(Objects::nonNull)
-                                .peek(notification -> notification.toBuilder()
-                                        .setTitle("[TEST] " + notification.getTitle())
-                                        .build())
-                                .toList();
+                final var workflowArg = PublishNotificationWorkflowArg.newBuilder()
+                        .setNotificationId(notification.getId())
+                        .setNotification(notification)
+                        .addNotificationRuleNames(rule.getName())
+                        .build();
 
-                new JdoNotificationEmitter(qm).emitAll(notifications);
+                createRunRequests.add(
+                        new CreateWorkflowRunRequest<>(PublishNotificationWorkflow.class)
+                                .withWorkflowInstanceId(
+                                        "publish-test-notification:%s:%s".formatted(
+                                                rule.getUuid(), notificationGroup))
+                                .withLabels(Map.of(WF_LABEL_TRIGGERED_BY, getPrincipal().getName()))
+                                .withArgument(workflowArg));
+            }
 
-                return Response.ok().build();
-            });
+            if (!createRunRequests.isEmpty()) {
+                dexEngine.createRuns(createRunRequests);
+
+                try (var _ = MDC.putCloseable(MdcKeys.MDC_NOTIFICATION_RULE_NAME, rule.getName())) {
+                    LOGGER.info(SecurityMarkers.SECURITY_AUDIT, "Triggered test notification(s)");
+                }
+            }
+
+            return Response.ok().build();
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Exception occured while sending the notification.").build();
@@ -384,6 +399,26 @@ public class NotificationPublisherResource extends AbstractApiResource {
                     .entity("No extension with name '%s' exists".formatted(extensionName))
                     .build());
         }
+    }
+
+    private @Nullable Notification buildTestNotification(Scope scope, Group group, Level ruleLevel) {
+        final List<Level> levelsToTry = switch (ruleLevel) {
+            case LEVEL_INFORMATIONAL -> List.of(Level.LEVEL_INFORMATIONAL, Level.LEVEL_WARNING, Level.LEVEL_ERROR);
+            case LEVEL_WARNING -> List.of(Level.LEVEL_WARNING, Level.LEVEL_ERROR);
+            case LEVEL_ERROR -> List.of(Level.LEVEL_ERROR);
+            default -> List.of();
+        };
+
+        for (final Level level : levelsToTry) {
+            final Notification notification = createTestNotification(scope, group, level);
+            if (notification != null) {
+                return notification.toBuilder()
+                        .setTitle("[TEST] " + notification.getTitle())
+                        .build();
+            }
+        }
+
+        return null;
     }
 
 }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
@@ -30,6 +30,8 @@ import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.cache.api.NoopCacheManager;
+import org.dependencytrack.dex.engine.api.DexEngine;
+import org.dependencytrack.dex.engine.api.request.CreateWorkflowRunRequest;
 import org.dependencytrack.model.NotificationPublisher;
 import org.dependencytrack.model.NotificationRule;
 import org.dependencytrack.notification.DefaultNotificationPublisherInitializer;
@@ -39,26 +41,35 @@ import org.dependencytrack.notification.NotificationScope;
 import org.dependencytrack.notification.publishing.DefaultNotificationPublishersPlugin;
 import org.dependencytrack.persistence.jdbi.JdbiFactory;
 import org.dependencytrack.plugin.runtime.PluginManager;
+import org.dependencytrack.proto.internal.workflow.v1.PublishNotificationWorkflowArg;
 import org.dependencytrack.resources.v1.vo.UpdateNotificationPublisherRequest;
 import org.glassfish.jersey.inject.hk2.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
 
 import java.net.http.HttpClient;
-import java.util.HashSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 
 class NotificationPublisherResourceTest extends ResourceTest {
 
+    private static final DexEngine DEX_ENGINE_MOCK = mock(DexEngine.class);
     private static PluginManager pluginManager;
 
     @RegisterExtension
@@ -70,8 +81,14 @@ class NotificationPublisherResourceTest extends ResourceTest {
                         @Override
                         protected void configure() {
                             bindFactory(() -> pluginManager).to(PluginManager.class);
+                            bindFactory(() -> DEX_ENGINE_MOCK).to(DexEngine.class);
                         }
                     }));
+
+    @BeforeEach
+    void resetDexEngineMock() {
+        reset(DEX_ENGINE_MOCK);
+    }
 
     @BeforeAll
     static void beforeAll() {
@@ -453,7 +470,7 @@ class NotificationPublisherResourceTest extends ResourceTest {
     }
 
     @Test
-    void testNotificationRuleTest() {
+    void shouldDispatchTestWorkflowRunPerGroupTargetingOnlyTheRequestedRule() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION);
 
         new DefaultNotificationPublisherInitializer().seedDefaultPublishers(pluginManager);
@@ -463,30 +480,101 @@ class NotificationPublisherResourceTest extends ResourceTest {
         qm.persist(slackPublisher);
         qm.detach(NotificationPublisher.class, slackPublisher.getId());
 
-        NotificationRule rule = qm.createNotificationRule("Example Rule 1", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, slackPublisher);
+        NotificationRule rule = qm.createNotificationRule(
+                "Example Rule 1",
+                NotificationScope.PORTFOLIO,
+                NotificationLevel.INFORMATIONAL,
+                slackPublisher);
+        qm.createNotificationRule(
+                        "Other Rule",
+                        NotificationScope.PORTFOLIO,
+                        NotificationLevel.INFORMATIONAL,
+                        slackPublisher)
+                .setNotifyOn(Set.of(NotificationGroup.NEW_VULNERABILITY));
 
-        Set<NotificationGroup> groups = new HashSet<>(Set.of(NotificationGroup.BOM_CONSUMED, NotificationGroup.BOM_PROCESSED, NotificationGroup.BOM_PROCESSING_FAILED,
-                NotificationGroup.BOM_VALIDATION_FAILED, NotificationGroup.NEW_VULNERABILITY, NotificationGroup.NEW_VULNERABLE_DEPENDENCY,
-                NotificationGroup.POLICY_VIOLATION, NotificationGroup.PROJECT_CREATED, NotificationGroup.PROJECT_AUDIT_CHANGE,
-                NotificationGroup.VEX_CONSUMED, NotificationGroup.VEX_PROCESSED));
+        final Set<NotificationGroup> groups = Set.of(
+                NotificationGroup.BOM_CONSUMED,
+                NotificationGroup.BOM_PROCESSED,
+                NotificationGroup.BOM_PROCESSING_FAILED,
+                NotificationGroup.BOM_VALIDATION_FAILED,
+                NotificationGroup.NEW_VULNERABILITY,
+                NotificationGroup.NEW_VULNERABLE_DEPENDENCY,
+                NotificationGroup.POLICY_VIOLATION,
+                NotificationGroup.PROJECT_CREATED,
+                NotificationGroup.PROJECT_AUDIT_CHANGE,
+                NotificationGroup.VEX_CONSUMED,
+                NotificationGroup.VEX_PROCESSED);
         rule.setNotifyOn(groups);
         rule.setPublisherConfig("{\"destination\":\"https://example.com/webhook\"}");
 
-        Response response = jersey.target(V1_NOTIFICATION_PUBLISHER + "/test/" + rule.getUuid()).request()
+        final Response response = jersey
+                .target(V1_NOTIFICATION_PUBLISHER + "/test/" + rule.getUuid())
+                .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity("", MediaType.APPLICATION_FORM_URLENCODED_TYPE));
 
-        Assertions.assertEquals(200, response.getStatus());
-        assertThat(qm.getNotificationOutbox()).hasSize(11);
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        final Collection<? extends CreateWorkflowRunRequest<?>> requests = captureBatchedCreateRunRequests();
+        assertThat(requests).hasSize(groups.size());
+        assertThat(requests).allSatisfy(request -> {
+            assertThat(request.workflowInstanceId())
+                    .startsWith("publish-test-notification:" + rule.getUuid() + ":");
+            final var arg = (PublishNotificationWorkflowArg) request.argument();
+            assertThat(arg.getNotificationRuleNamesList()).containsExactly("Example Rule 1");
+            assertThat(arg.getNotification().getTitle()).startsWith("[TEST] ");
+        });
+        assertThat(qm.getNotificationOutbox()).isEmpty();
     }
 
     @Test
-    void testNotificationRuleNotFoundTest() {
+    void shouldDispatchTestNotificationForScheduledSummaryRule() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION);
 
-        final Response response = jersey.target(V1_NOTIFICATION_PUBLISHER + "/test/" + UUID.randomUUID()).request()
+        new DefaultNotificationPublisherInitializer().seedDefaultPublishers(pluginManager);
+
+        final NotificationPublisher slackPublisher = qm.getNotificationPublisher("Slack");
+        final NotificationRule rule = qm.createScheduledNotificationRule("Scheduled Rule",
+                NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, slackPublisher);
+        rule.setNotifyOn(Set.of(NotificationGroup.NEW_VULNERABILITIES_SUMMARY));
+        rule.setPublisherConfig("{\"destination\":\"https://example.com/webhook\"}");
+
+        final Response response = jersey
+                .target(V1_NOTIFICATION_PUBLISHER + "/test/" + rule.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.entity("", MediaType.APPLICATION_FORM_URLENCODED_TYPE));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        final Collection<? extends CreateWorkflowRunRequest<?>> requests = captureBatchedCreateRunRequests();
+        assertThat(requests).singleElement().satisfies(request -> {
+            assertThat(request.workflowInstanceId())
+                    .isEqualTo("publish-test-notification:%s:NEW_VULNERABILITIES_SUMMARY".formatted(rule.getUuid()));
+            final var arg = (PublishNotificationWorkflowArg) request.argument();
+            assertThat(arg.getNotificationRuleNamesList()).containsExactly("Scheduled Rule");
+            assertThat(arg.getNotification().getTitle()).startsWith("[TEST] ");
+        });
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenRuleDoesNotExist() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION);
+
+        final Response response = jersey
+                .target(V1_NOTIFICATION_PUBLISHER + "/test/" + UUID.randomUUID())
+                .request()
                 .header(X_API_KEY, apiKey)
                 .post(null);
         assertThat(response.getStatus()).isEqualTo(404);
+        verify(DEX_ENGINE_MOCK, never()).createRuns(any());
     }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Collection<? extends CreateWorkflowRunRequest<?>> captureBatchedCreateRunRequests() {
+        final ArgumentCaptor<Collection> captor = ArgumentCaptor.forClass(Collection.class);
+        verify(DEX_ENGINE_MOCK).createRuns(captor.capture());
+        return (Collection<? extends CreateWorkflowRunRequest<?>>) captor.getValue();
+    }
+
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes two separate issues:

* The test functionality not working for scheduled notifications. The issue is that those don't flow through the outbox and the notification router in the "production" flow, so emitting them to the outbox just causes the router to discard them.
* The outbox has no concept of targeting individual rules, that's the job of the router to figure out. This caused the test button to "accidentally" test all notification rules, not just the selected one.

It would've been nice to capture the full outbox -> routing -> publish lifecycle here, but upon second look it doesn't make sense. Especially since routing is unnecessary since we already know which rule to target.

Note that this has the nice side effect of dex de-duplicating requests when impatient users click the test button repeatedly.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #6305

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
