### PR TITLE
Backport: v4-migrator: only run post-load actions when load phase completes successfully

### DIFF
--- a/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/load/LoadPhase.java
+++ b/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/load/LoadPhase.java
@@ -75,14 +75,11 @@ public final class LoadPhase {
         long totalRows = 0;
         int tableCount = 0;
         preLoad();
-        try {
-            for (final TableMigration t : TableRegistry.loaded()) {
-                totalRows += loadOne(t);
-                tableCount++;
-            }
-        } finally {
-            postLoad();
+        for (final TableMigration t : TableRegistry.loaded()) {
+            totalRows += loadOne(t);
+            tableCount++;
         }
+        postLoad();
 
         if (dropStagingAfter) {
             LOGGER.info("Dropping staging schema (--drop-staging set).");


### PR DESCRIPTION



### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

v4-migrator: only run post-load actions when load phase completes successfully.

Running `postLoad` in a `finally` block meant that the actions would execute even in the error case.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #6310
Fixes https://github.com/DependencyTrack/dependency-track/issues/6309

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
