### PR TITLE
Backport: v4-migrator: Fail fast when detecting bootstrap being pointed at v4 database

### DIFF
--- a/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/preflight/Preflight.java
+++ b/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/preflight/Preflight.java
@@ -84,7 +84,9 @@ public final class Preflight {
         final List<String> warnings = new ArrayList<>();
 
         checkTargetVersion(failures);
-        if (mode != Mode.PRE_BOOTSTRAP) {
+        if (mode == Mode.PRE_BOOTSTRAP) {
+            checkTargetNotV4(failures);
+        } else {
             checkTargetExtensions(failures);
             if (isV5SchemaApplied(failures)) {
                 checkFlywayHead(failures);
@@ -124,6 +126,38 @@ public final class Preflight {
             }
         } catch (final RuntimeException e) {
             failures.add("Could not query target PostgreSQL version: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Refuse to bootstrap on top of a v4 schema. {@code SCHEMAVERSION} (DataNucleus version
+     * table) and {@code EVENTSERVICELOG} are unique to v4 and never appear in v5 migrations;
+     * either being present is a strong signal that {@code --target} was pointed at the source
+     * database by mistake. Without this gate, Flyway would still fail later with a generic
+     * "non-empty schema without history table" error that obscures the user error.
+     */
+    private void checkTargetNotV4(final List<String> failures) {
+        final String[] v4Markers = {"\"SCHEMAVERSION\"", "\"EVENTSERVICELOG\""};
+        final List<String> found = new ArrayList<>();
+        for (final String table : v4Markers) {
+            try {
+                final boolean present = targetJdbi.withHandle(h ->
+                    h.createQuery("SELECT to_regclass(:t) IS NOT NULL")
+                        .bind("t", table)
+                        .mapTo(Boolean.class)
+                        .one());
+                if (present) {
+                    found.add(table);
+                }
+            } catch (final RuntimeException e) {
+                failures.add("Could not probe target for v4 schema markers: " + e.getMessage());
+                return;
+            }
+        }
+        if (!found.isEmpty()) {
+            failures.add("Target appears to be a v4 Dependency-Track database (found: "
+                + String.join(", ", found) + "). Bootstrap requires a fresh database; "
+                + "did you accidentally point --target at your v4 source?");
         }
     }
 

--- a/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/BootstrapIT.java
+++ b/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/BootstrapIT.java
@@ -81,6 +81,29 @@ class BootstrapIT {
 
     @Test
     @Order(2)
+    void shouldRejectPreBootstrapWhenV4SchemaMarkersPresent() {
+        jdbi().useHandle(h -> {
+            h.execute("CREATE TABLE \"SCHEMAVERSION\" (id int)");
+            h.execute("CREATE TABLE \"EVENTSERVICELOG\" (id int)");
+        });
+        try {
+            final GlobalOptions opts = optsForContainer();
+            final PreflightResult result = new Preflight(jdbi(), null, opts, Mode.PRE_BOOTSTRAP).run();
+            assertThat(result.ok()).isFalse();
+            assertThat(result.failures())
+                .anyMatch(f -> f.contains("v4 Dependency-Track database")
+                    && f.contains("SCHEMAVERSION")
+                    && f.contains("EVENTSERVICELOG"));
+        } finally {
+            jdbi().useHandle(h -> {
+                h.execute("DROP TABLE \"SCHEMAVERSION\"");
+                h.execute("DROP TABLE \"EVENTSERVICELOG\"");
+            });
+        }
+    }
+
+    @Test
+    @Order(3)
     void defaultPreflightRejectsFreshDbWithActionableMessage() {
         final GlobalOptions opts = optsForContainer();
         opts.stagingSchema = "dt_v4_migration_default_check";
@@ -90,7 +113,7 @@ class BootstrapIT {
     }
 
     @Test
-    @Order(3)
+    @Order(4)
     void bootstrapAppliesFlywayUpToExpectedHead() {
         final GlobalOptions opts = optsForContainer();
         opts.stagingSchema = "dt_v4_migration_bootstrap";
@@ -147,7 +170,7 @@ class BootstrapIT {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     void shouldRemainIdempotentWhenBootstrapInvokedTwice() {
         final GlobalOptions opts = optsForContainer();
         opts.stagingSchema = "dt_v4_migration_bootstrap";


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

v4-migrator: Fail fast when detecting bootstrap being pointed at v4 database

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #6332
Relates to https://github.com/DependencyTrack/dependency-track/issues/6330

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
