### PR TITLE
Backport: Support non-UTC timezones for metrics operations

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/metrics/FetchProjectMetricsUpdateCandidatesActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/metrics/FetchProjectMetricsUpdateCandidatesActivity.java
@@ -50,8 +50,8 @@ public final class FetchProjectMetricsUpdateCandidatesActivity implements Activi
                                      SELECT 1
                                        FROM "PROJECTMETRICS"
                                       WHERE "PROJECT_ID" = "PROJECT"."ID"
-                                        AND "LAST_OCCURRENCE" >= CURRENT_DATE
-                                        AND "LAST_OCCURRENCE" < CURRENT_DATE + INTERVAL '1 day'
+                                        AND "LAST_OCCURRENCE" >= date_trunc('day', CURRENT_TIMESTAMP AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+                                        AND "LAST_OCCURRENCE" < (date_trunc('day', CURRENT_TIMESTAMP AT TIME ZONE 'UTC') + INTERVAL '1 day') AT TIME ZONE 'UTC'
                                    )
                                  ORDER BY "ID"
                                  LIMIT :batchSize

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/MetricsDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/MetricsDao.java
@@ -65,12 +65,12 @@ public interface MetricsDao extends SqlObject {
             <#if apiProjectAclCondition?c_lower_case == 'true'>
             SELECT *
               FROM "PORTFOLIOMETRICS_GLOBAL"
-             WHERE "LAST_OCCURRENCE" >= CURRENT_DATE - (INTERVAL '1 day' * (:days - 1))
+             WHERE "LAST_OCCURRENCE" >= CAST(CURRENT_TIMESTAMP AT TIME ZONE 'UTC' AS date) - (INTERVAL '1 day' * (:days - 1))
              ORDER BY "LAST_OCCURRENCE";
             <#else>
             WITH
             date_range AS(
-              SELECT DATE_TRUNC('day', CURRENT_DATE - (INTERVAL '1 day' * day)) AS metrics_date
+              SELECT DATE_TRUNC('day', CAST(CURRENT_TIMESTAMP AT TIME ZONE 'UTC' AS date) - (INTERVAL '1 day' * day)) AS metrics_date
                 FROM GENERATE_SERIES(0, GREATEST(:days - 1, 0)) day
             ),
             projects_in_scope AS(
@@ -90,9 +90,9 @@ public interface MetricsDao extends SqlObject {
                    FROM projects_in_scope
                   INNER JOIN "PROJECTMETRICS" pm
                      ON pm."PROJECT_ID" = projects_in_scope."ID"
-                  WHERE pm."LAST_OCCURRENCE" < date_range.metrics_date + INTERVAL '1 day'
+                  WHERE pm."LAST_OCCURRENCE" < (date_range.metrics_date + INTERVAL '1 day') AT TIME ZONE 'UTC'
                     -- Consider data from previous day in case we don't have any for today.
-                    AND pm."LAST_OCCURRENCE" >= date_range.metrics_date - INTERVAL '1 day'
+                    AND pm."LAST_OCCURRENCE" >= (date_range.metrics_date - INTERVAL '1 day') AT TIME ZONE 'UTC'
                   ORDER BY pm."PROJECT_ID", pm."LAST_OCCURRENCE" DESC
                ) AS latest_metrics ON TRUE
             ),
@@ -172,15 +172,37 @@ public interface MetricsDao extends SqlObject {
     @RegisterBeanMapper(PortfolioMetrics.class)
     List<PortfolioMetrics> getPortfolioMetricsForDays(@Bind int days);
 
-    @SqlUpdate("""
-            REFRESH MATERIALIZED VIEW CONCURRENTLY "PORTFOLIOMETRICS_GLOBAL"
-            """)
-    void refreshGlobalPortfolioMetrics();
+    default void refreshGlobalPortfolioMetrics() {
+        if (!getHandle().isInTransaction()) {
+            // Required so SET LOCAL doesn't silently no-op.
+            throw new IllegalStateException(
+                    "refreshGlobalPortfolioMetrics must run inside a transaction");
+        }
 
-    @SqlUpdate("""
-            REFRESH MATERIALIZED VIEW CONCURRENTLY "VULNERABILITYMETRICS"
-            """)
-    void refreshVulnerabilityMetrics();
+        // NB: All other metrics operations explicitly cast timestamps to UTC
+        // and do not require this workaround. Setting the local timezone here
+        // was done to avoid having to drop and re-create the materialized view
+        // via schema migration. If the view ever needs updating for unrelated
+        // reasons, this workaround could be removed.
+        getHandle().execute("SET LOCAL TIME ZONE 'UTC'");
+        getHandle().execute("REFRESH MATERIALIZED VIEW CONCURRENTLY \"PORTFOLIOMETRICS_GLOBAL\"");
+    }
+
+    default void refreshVulnerabilityMetrics() {
+        if (!getHandle().isInTransaction()) {
+            // Required so SET LOCAL doesn't silently no-op.
+            throw new IllegalStateException(
+                    "refreshVulnerabilityMetrics must run inside a transaction");
+        }
+
+        // NB: All other metrics operations explicitly cast timestamps to UTC
+        // and do not require this workaround. Setting the local timezone here
+        // was done to avoid having to drop and re-create the materialized view
+        // via schema migration. If the view ever needs updating for unrelated
+        // reasons, this workaround could be removed.
+        getHandle().execute("SET LOCAL TIME ZONE 'UTC'");
+        getHandle().execute("REFRESH MATERIALIZED VIEW CONCURRENTLY \"VULNERABILITYMETRICS\"");
+    }
 
     @SqlQuery("""
             SELECT "YEAR" AS "year"
@@ -242,7 +264,7 @@ public interface MetricsDao extends SqlObject {
     @RegisterBeanMapper(ProjectMetrics.class)
     List<ProjectMetrics> getMostRecentProjectMetrics(@Bind Collection<Long> projectIds);
 
-@SqlQuery("""
+    @SqlQuery("""
             WITH RECURSIVE
             collection_descendants AS(
               SELECT child."ID" AS project_id
@@ -302,8 +324,8 @@ public interface MetricsDao extends SqlObject {
                WHERE "COLLECTION_LOGIC" IS NULL
             ),
             date_range AS(
-              SELECT d::DATE AS metrics_date
-                FROM GENERATE_SERIES(:since::DATE, CURRENT_DATE, '1 day') d
+              SELECT CAST(d AS date) AS metrics_date
+                FROM GENERATE_SERIES(CAST(:since AS date), CAST(CURRENT_TIMESTAMP AT TIME ZONE 'UTC' AS date), '1 day') d
             ),
             latest_daily_child_metrics AS(
               SELECT date_range.metrics_date
@@ -315,8 +337,8 @@ public interface MetricsDao extends SqlObject {
                     FROM leaf_descendants
                    INNER JOIN "PROJECTMETRICS" pm
                       ON pm."PROJECT_ID" = leaf_descendants."ID"
-                   WHERE pm."LAST_OCCURRENCE" < date_range.metrics_date + INTERVAL '1 day'
-                     AND pm."LAST_OCCURRENCE" >= date_range.metrics_date - INTERVAL '1 day'
+                   WHERE pm."LAST_OCCURRENCE" < (date_range.metrics_date + INTERVAL '1 day') AT TIME ZONE 'UTC'
+                     AND pm."LAST_OCCURRENCE" >= (date_range.metrics_date - INTERVAL '1 day') AT TIME ZONE 'UTC'
                    ORDER BY pm."PROJECT_ID", pm."LAST_OCCURRENCE" DESC
                 ) AS latest_metrics ON TRUE
             ),
@@ -554,6 +576,7 @@ public interface MetricsDao extends SqlObject {
     @SqlUpdate("""
             DO $$
             DECLARE
+                today_utc DATE := CAST(CURRENT_TIMESTAMP AT TIME ZONE 'UTC' AS date);
                 target_date DATE;
                 next_date DATE;
                 partition_suffix TEXT;
@@ -564,8 +587,8 @@ public interface MetricsDao extends SqlObject {
                 metric_tables TEXT[] := ARRAY['PROJECTMETRICS', 'DEPENDENCYMETRICS'];
             BEGIN
                 FOR day_offset IN 0..1 LOOP
-                    target_date := CURRENT_DATE + day_offset;
-                    next_date := CURRENT_DATE + day_offset + 1;
+                    target_date := today_utc + day_offset;
+                    next_date := target_date + 1;
                     partition_suffix := to_char(target_date, 'YYYYMMDD');
             
                     FOREACH table_name IN ARRAY metric_tables
@@ -585,8 +608,8 @@ public interface MetricsDao extends SqlObject {
                                 'ALTER TABLE %I ATTACH PARTITION %I FOR VALUES FROM (%L) TO (%L);',
                                 table_name,
                                 partition_name,
-                                target_date,
-                                next_date
+                                CAST(target_date AS timestamp) AT TIME ZONE 'UTC',
+                                CAST(next_date AS timestamp) AT TIME ZONE 'UTC'
                             );
                         END IF;
                     END LOOP;
@@ -600,7 +623,7 @@ public interface MetricsDao extends SqlObject {
             SELECT inhrelid::regclass::text AS partition_name
             FROM pg_inherits
             WHERE inhparent = CAST(:parentTable AS regclass)
-              AND to_date(split_part(replace(inhrelid::regclass::text, '"', ''), '_', 2), 'YYYYMMDD') <= CURRENT_DATE - :retentionDays
+              AND to_date(split_part(replace(inhrelid::regclass::text, '"', ''), '_', 2), 'YYYYMMDD') <= CAST(CURRENT_TIMESTAMP AT TIME ZONE 'UTC' AS date) - :retentionDays
             ORDER BY partition_name
             """)
     List<String> getExpiredPartitions(@Bind String parentTable, @Bind int retentionDays);
@@ -639,11 +662,11 @@ public interface MetricsDao extends SqlObject {
 
     default boolean isPartitionDetachPending(String parentTable, String partition) {
         return getHandle().createQuery("""
-                SELECT inhdetachpending
-                  FROM pg_inherits
-                  WHERE inhparent = CAST(:parentTable AS regclass)
-                    AND inhrelid = CAST(:partition AS regclass)
-                """)
+                        SELECT inhdetachpending
+                          FROM pg_inherits
+                          WHERE inhparent = CAST(:parentTable AS regclass)
+                            AND inhrelid = CAST(:partition AS regclass)
+                        """)
                 .bind("parentTable", parentTable)
                 .bind("partition", partition)
                 .mapTo(Boolean.class)

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyFunctions.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyFunctions.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -538,16 +538,16 @@ final class CelPolicyFunctions {
             return false;
         }
         Instant instant = Instant.ofEpochSecond(componentPublishedDate.getSeconds(), componentPublishedDate.getNanos());
-        final LocalDate publishedDate = LocalDate.ofInstant(instant, ZoneId.systemDefault());
+        final LocalDate publishedDate = LocalDate.ofInstant(instant, ZoneOffset.UTC);
         final LocalDate ageDate = publishedDate.plus(agePeriod);
-        final LocalDate today = LocalDate.now(ZoneId.systemDefault());
+        final LocalDate today = LocalDate.now(ZoneOffset.UTC);
         return switch (comparator) {
             case "NUMERIC_GREATER_THAN", ">" -> ageDate.isBefore(today);
             case "NUMERIC_GREATER_THAN_OR_EQUAL", ">=" -> ageDate.isEqual(today) || ageDate.isBefore(today);
             case "NUMERIC_EQUAL", "==" -> ageDate.isEqual(today);
             case "NUMERIC_NOT_EQUAL", "!=" -> !ageDate.isEqual(today);
             case "NUMERIC_LESSER_THAN_OR_EQUAL", "<=" -> ageDate.isEqual(today) || ageDate.isAfter(today);
-            case "NUMERIC_LESS_THAN", "<" -> ageDate.isAfter(LocalDate.now(ZoneId.systemDefault()));
+            case "NUMERIC_LESS_THAN", "<" -> ageDate.isAfter(today);
             default -> {
                 LOGGER.warn("%s: Operator %s is not supported for component age conditions".formatted(COMPARE_AGE.functionName(), comparator));
                 yield false;

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/MetricsResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/MetricsResource.java
@@ -56,6 +56,7 @@ import org.dependencytrack.resources.v1.problems.ProblemDetails;
 import org.dependencytrack.util.DateUtil;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
@@ -140,7 +141,8 @@ public class MetricsResource extends AbstractApiResource {
     @Operation(
             summary = "Returns historical metrics for the entire portfolio from a specific date",
             description = """
-                    <p>Date format must be <code>YYYYMMDD</code></p>
+                    <p>Date format must be <code>YYYYMMDD</code>. The number of days returned is computed against the current UTC date.
+                    </p>
                     <p>Requires permission <strong>VIEW_PORTFOLIO</strong></p>""")
     @ApiResponses(value = {
             @ApiResponse(
@@ -168,7 +170,7 @@ public class MetricsResource extends AbstractApiResource {
             // NB: Calculate days between the given date and *tomorrow*,
             // because LocalDate#until's end date is exclusive,
             // and we want to include data for *today*.
-            final var sincePeriod = since.until(LocalDate.now().plusDays(1));
+            final var sincePeriod = since.until(LocalDate.now(ZoneOffset.UTC).plusDays(1));
             final int sinceDays = sincePeriod.getDays();
 
             return handle.attach(MetricsDao.class).getPortfolioMetricsForDays(Math.min(retentionDays, sinceDays));
@@ -284,7 +286,7 @@ public class MetricsResource extends AbstractApiResource {
     @Operation(
             summary = "Returns historical metrics for a specific project from a specific date",
             description = """
-                    <p>Date format must be <code>YYYYMMDD</code></p>
+                    <p>Date format must be <code>YYYYMMDD</code>. The date is interpreted as UTC midnight.</p>
                     <p>Requires permission <strong>VIEW_PORTFOLIO</strong></p>"""
     )
     @ApiResponses(value = {
@@ -304,7 +306,7 @@ public class MetricsResource extends AbstractApiResource {
     public Response getProjectMetricsSince(
             @Parameter(description = "The UUID of the project to retrieve metrics for", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid,
-            @Parameter(description = "The start date to retrieve metrics for", required = true)
+            @Parameter(description = "The start date (UTC) to retrieve metrics for", required = true)
             @PathParam("date") String date) {
         final Date since = DateUtil.parseShortDate(date);
         return getProjectMetrics(UUID.fromString(uuid), since);
@@ -412,7 +414,7 @@ public class MetricsResource extends AbstractApiResource {
     @Operation(
             summary = "Returns historical metrics for a specific component from a specific date",
             description = """
-                    <p>Date format must be <code>YYYYMMDD</code></p>
+                    <p>Date format must be <code>YYYYMMDD</code>. The date is interpreted as UTC midnight.</p>
                     <p>Requires permission <strong>VIEW_PORTFOLIO</strong></p>"""
     )
     @ApiResponses(value = {
@@ -432,7 +434,7 @@ public class MetricsResource extends AbstractApiResource {
     public Response getComponentMetricsSince(
             @Parameter(description = "The UUID of the component to retrieve metrics for", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid,
-            @Parameter(description = "The start date to retrieve metrics for", required = true)
+            @Parameter(description = "The start date (UTC) to retrieve metrics for", required = true)
             @PathParam("date") String date) {
         final Date since = DateUtil.parseShortDate(date);
         if (since == null) {

--- a/apiserver/src/main/java/org/dependencytrack/util/DateUtil.java
+++ b/apiserver/src/main/java/org/dependencytrack/util/DateUtil.java
@@ -30,14 +30,15 @@ public final class DateUtil {
     }
 
     /**
-     * Convenience method that parses a date in yyyyMMdd format and
-     * returns a Date object. If the parsing fails, null is returned.
+     * Convenience method that parses a date in yyyyMMdd format as UTC midnight
+     * and returns a Date object. If the parsing fails, null is returned.
      * @param yyyyMMdd the date string to parse
      * @return a Date object
      * @since 3.0.0
      */
     public static Date parseShortDate(final String yyyyMMdd) {
         final SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd");
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
         try {
             return format.parse(yyyyMMdd);
         } catch (ParseException e) {

--- a/apiserver/src/test/java/org/dependencytrack/persistence/DatabasePartitionMaintenanceInitTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/DatabasePartitionMaintenanceInitTaskTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 
@@ -43,9 +44,7 @@ public class DatabasePartitionMaintenanceInitTaskTest extends PersistenceCapable
                 new InitTaskContext(new SmallRyeConfigBuilder().build(), dataSource));
 
         useJdbiHandle(handle -> {
-            final LocalDate todayDate = handle.createQuery("SELECT CURRENT_DATE")
-                    .mapTo(LocalDate.class)
-                    .one();
+            final LocalDate todayDate = LocalDate.now(ZoneOffset.UTC);
             var today = todayDate.format(DateTimeFormatter.BASIC_ISO_DATE);
             var tomorrow = todayDate.plusDays(1).format(DateTimeFormatter.BASIC_ISO_DATE);
 

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/MetricsDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/MetricsDaoTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Date;
@@ -38,8 +39,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.openJdbiHandle;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiHandle;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 
 public class MetricsDaoTest extends PersistenceCapableTest {
@@ -146,9 +149,7 @@ public class MetricsDaoTest extends PersistenceCapableTest {
     public void testCreateMetricsPartitions() {
         metricsDao.createMetricsPartitions();
 
-        final LocalDate todayDate = jdbiHandle.createQuery("SELECT CURRENT_DATE")
-                .mapTo(LocalDate.class)
-                .one();
+        final LocalDate todayDate = LocalDate.now(ZoneOffset.UTC);
         var today = todayDate.format(DateTimeFormatter.BASIC_ISO_DATE);
         var tomorrow = todayDate.plusDays(1).format(DateTimeFormatter.BASIC_ISO_DATE);
 
@@ -170,7 +171,7 @@ public class MetricsDaoTest extends PersistenceCapableTest {
     @Test
     public void testDropPartitionsWithPendingDetach() throws Exception {
         metricsTestDao.createPartitionForDaysAgo("PROJECTMETRICS", 91);
-        final String partitionSuffix = LocalDate.now().minusDays(91).format(DateTimeFormatter.BASIC_ISO_DATE);
+        final String partitionSuffix = LocalDate.now(ZoneOffset.UTC).minusDays(91).format(DateTimeFormatter.BASIC_ISO_DATE);
         final String partitionName = "\"PROJECTMETRICS_%s\"".formatted(partitionSuffix);
 
         // Simulate the partition into 'pending_detach' state
@@ -206,4 +207,45 @@ public class MetricsDaoTest extends PersistenceCapableTest {
         }
         assertThat(metricsDao.dropPartitions("\"PROJECTMETRICS\"", List.of(partitionName))).isEqualTo(1);
     }
+
+    @Test
+    public void shouldCreatePartitionsWithUtcBoundsRegardlessOfSessionTimeZone() {
+        // Regression for https://github.com/DependencyTrack/dependency-track/issues/6341.
+        // Partition bounds for the timestamptz-partitioned metrics tables must be anchored
+        // to UTC midnight independent of the session timezone. Otherwise, consecutive
+        // maintenance runs under different timezones produce overlapping or gapped ranges.
+        try {
+            jdbiHandle.execute("SET TIME ZONE 'Europe/Paris'");
+            metricsDao.createMetricsPartitions();
+
+            jdbiHandle.execute("SET TIME ZONE 'America/Los_Angeles'");
+            metricsDao.createMetricsPartitions();
+
+            jdbiHandle.execute("SET TIME ZONE 'UTC'");
+            final List<String> projectBounds = jdbiHandle.createQuery("""
+                            SELECT pg_get_expr(c.relpartbound, c.oid)
+                              FROM pg_class c
+                              JOIN pg_inherits i
+                                ON i.inhrelid = c.oid
+                             WHERE i.inhparent = CAST(:parent AS regclass)
+                             ORDER BY c.relname
+                            """)
+                    .bind("parent", "\"PROJECTMETRICS\"")
+                    .mapTo(String.class)
+                    .list();
+            assertThat(projectBounds)
+                    .hasSize(2)
+                    .allSatisfy(bound -> assertThat(bound).contains(" 00:00:00+00"));
+        } finally {
+            jdbiHandle.execute("SET TIME ZONE DEFAULT");
+        }
+    }
+
+    @Test
+    public void shouldRejectRefreshGlobalPortfolioMetricsOutsideTransaction() {
+        assertThatThrownBy(() ->
+                useJdbiHandle(handle -> handle.attach(MetricsDao.class).refreshGlobalPortfolioMetrics()))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
 }

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/MetricsTestDao.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/MetricsTestDao.java
@@ -26,6 +26,7 @@ import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 public interface MetricsTestDao extends SqlObject {
@@ -118,7 +119,7 @@ public interface MetricsTestDao extends SqlObject {
         String partitionName = tableName + "_" + partitionSuffix;
         String sql = String.format("""
             CREATE TABLE IF NOT EXISTS %s PARTITION OF %s
-            FOR VALUES FROM ('%s') TO ('%s');
+            FOR VALUES FROM (CAST('%s' AS timestamp) AT TIME ZONE 'UTC') TO (CAST('%s' AS timestamp) AT TIME ZONE 'UTC');
         """,
                 "\"" + partitionName + "\"",
                 "\"" + tableName + "\"",
@@ -129,7 +130,7 @@ public interface MetricsTestDao extends SqlObject {
     }
 
     default void createPartitionForDaysAgo(String tableName, int daysAgo) {
-        LocalDate targetDate = LocalDate.now().minusDays(daysAgo);
+        LocalDate targetDate = LocalDate.now(ZoneOffset.UTC).minusDays(daysAgo);
         createMetricsPartitionsForDate(tableName, targetDate);
     }
 }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/MetricsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/MetricsResourceTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -51,7 +52,6 @@ import java.util.function.Supplier;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiHandle;
-import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 import static org.hamcrest.Matchers.closeTo;
 import static org.mockito.Mockito.mock;
 
@@ -415,17 +415,15 @@ public class MetricsResourceTest extends ResourceTest {
         inaccessibleProject.setName("acme-app-inaccessible");
         qm.persist(inaccessibleProject);
 
-        final LocalDate dbToday = withJdbiHandle(handle ->
-                handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one());
-        final Instant dbNow = withJdbiHandle(handle ->
-                handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one());
+        final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        final Instant now = Instant.now();
 
         useJdbiHandle(handle -> {
             var dao = handle.attach(MetricsTestDao.class);
 
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday.minusDays(1));
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday.minusDays(2));
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today.minusDays(1));
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today.minusDays(2));
 
             {
                 // Create metrics for "yesterday".
@@ -433,7 +431,7 @@ public class MetricsResourceTest extends ResourceTest {
                 var accessibleProjectAMetrics = new ProjectMetrics();
                 accessibleProjectAMetrics.setProjectId(accessibleProjectA.getId());
                 accessibleProjectAMetrics.setComponents(2);
-                accessibleProjectAMetrics.setFirstOccurrence(Date.from(dbNow.minus(1, ChronoUnit.DAYS)));
+                accessibleProjectAMetrics.setFirstOccurrence(Date.from(now.minus(1, ChronoUnit.DAYS)));
                 accessibleProjectAMetrics.setLastOccurrence(accessibleProjectAMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(accessibleProjectAMetrics);
             }
@@ -447,7 +445,7 @@ public class MetricsResourceTest extends ResourceTest {
                 var accessibleProjectBMetrics = new ProjectMetrics();
                 accessibleProjectBMetrics.setProjectId(accessibleProjectB.getId());
                 accessibleProjectBMetrics.setComponents(1);
-                accessibleProjectBMetrics.setFirstOccurrence(Date.from(dbNow));
+                accessibleProjectBMetrics.setFirstOccurrence(Date.from(now));
                 accessibleProjectBMetrics.setLastOccurrence(accessibleProjectBMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(accessibleProjectBMetrics);
 
@@ -455,7 +453,7 @@ public class MetricsResourceTest extends ResourceTest {
                 var inactiveAccessibleProjectMetrics = new ProjectMetrics();
                 inactiveAccessibleProjectMetrics.setProjectId(inactiveAccessibleProject.getId());
                 inactiveAccessibleProjectMetrics.setComponents(111);
-                inactiveAccessibleProjectMetrics.setFirstOccurrence(Date.from(dbNow));
+                inactiveAccessibleProjectMetrics.setFirstOccurrence(Date.from(now));
                 inactiveAccessibleProjectMetrics.setLastOccurrence(inactiveAccessibleProjectMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(inactiveAccessibleProjectMetrics);
 
@@ -463,7 +461,7 @@ public class MetricsResourceTest extends ResourceTest {
                 var inaccessibleProjectMetrics = new ProjectMetrics();
                 inaccessibleProjectMetrics.setProjectId(inaccessibleProject.getId());
                 inaccessibleProjectMetrics.setComponents(666);
-                inaccessibleProjectMetrics.setFirstOccurrence(Date.from(dbNow));
+                inaccessibleProjectMetrics.setFirstOccurrence(Date.from(now));
                 inaccessibleProjectMetrics.setLastOccurrence(inaccessibleProjectMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(inaccessibleProjectMetrics);
             }
@@ -510,17 +508,15 @@ public class MetricsResourceTest extends ResourceTest {
         inaccessibleProject.setName("acme-app-inaccessible");
         qm.persist(inaccessibleProject);
 
-        final LocalDate dbToday = withJdbiHandle(handle ->
-                handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one());
-        final Instant dbNow = withJdbiHandle(handle ->
-                handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one());
+        final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        final Instant now = Instant.now();
 
         useJdbiHandle(handle -> {
             var dao = handle.attach(MetricsTestDao.class);
 
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday.minusDays(1));
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday.minusDays(2));
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today.minusDays(1));
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today.minusDays(2));
 
             {
                 // Create metrics for "yesterday".
@@ -528,7 +524,7 @@ public class MetricsResourceTest extends ResourceTest {
                 var accessibleProjectAMetrics = new ProjectMetrics();
                 accessibleProjectAMetrics.setProjectId(accessibleProjectA.getId());
                 accessibleProjectAMetrics.setComponents(2);
-                accessibleProjectAMetrics.setFirstOccurrence(Date.from(dbNow.minus(1, ChronoUnit.DAYS)));
+                accessibleProjectAMetrics.setFirstOccurrence(Date.from(now.minus(1, ChronoUnit.DAYS)));
                 accessibleProjectAMetrics.setLastOccurrence(accessibleProjectAMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(accessibleProjectAMetrics);
             }
@@ -542,7 +538,7 @@ public class MetricsResourceTest extends ResourceTest {
                 var accessibleProjectBMetrics = new ProjectMetrics();
                 accessibleProjectBMetrics.setProjectId(accessibleProjectB.getId());
                 accessibleProjectBMetrics.setComponents(1);
-                accessibleProjectBMetrics.setFirstOccurrence(Date.from(dbNow));
+                accessibleProjectBMetrics.setFirstOccurrence(Date.from(now));
                 accessibleProjectBMetrics.setLastOccurrence(accessibleProjectBMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(accessibleProjectBMetrics);
 
@@ -550,7 +546,7 @@ public class MetricsResourceTest extends ResourceTest {
                 var inactiveAccessibleProjectMetrics = new ProjectMetrics();
                 inactiveAccessibleProjectMetrics.setProjectId(inactiveAccessibleProject.getId());
                 inactiveAccessibleProjectMetrics.setComponents(111);
-                inactiveAccessibleProjectMetrics.setFirstOccurrence(Date.from(dbNow));
+                inactiveAccessibleProjectMetrics.setFirstOccurrence(Date.from(now));
                 inactiveAccessibleProjectMetrics.setLastOccurrence(inactiveAccessibleProjectMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(inactiveAccessibleProjectMetrics);
 
@@ -558,12 +554,12 @@ public class MetricsResourceTest extends ResourceTest {
                 var inaccessibleProjectMetrics = new ProjectMetrics();
                 inaccessibleProjectMetrics.setProjectId(inaccessibleProject.getId());
                 inaccessibleProjectMetrics.setComponents(666);
-                inaccessibleProjectMetrics.setFirstOccurrence(Date.from(dbNow));
+                inaccessibleProjectMetrics.setFirstOccurrence(Date.from(now));
                 inaccessibleProjectMetrics.setLastOccurrence(inaccessibleProjectMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(inaccessibleProjectMetrics);
             }
 
-            handle.attach(MetricsDao.class).refreshGlobalPortfolioMetrics();
+            handle.useTransaction(tx -> tx.attach(MetricsDao.class).refreshGlobalPortfolioMetrics());
         });
 
         final Response response = jersey
@@ -607,17 +603,15 @@ public class MetricsResourceTest extends ResourceTest {
         inaccessibleProject.setName("acme-app-inaccessible");
         qm.persist(inaccessibleProject);
 
-        final LocalDate dbToday = withJdbiHandle(handle ->
-                handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one());
-        final Instant dbNow = withJdbiHandle(handle ->
-                handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one());
+        final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        final Instant now = Instant.now();
 
         useJdbiHandle(handle -> {
             var dao = handle.attach(MetricsTestDao.class);
 
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday.minusDays(1));
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday.minusDays(2));
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today.minusDays(1));
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today.minusDays(2));
 
             {
                 // Create metrics for "yesterday".
@@ -652,7 +646,7 @@ public class MetricsResourceTest extends ResourceTest {
                 accessibleProjectAMetrics.setUnassigned(1);
                 accessibleProjectAMetrics.setVulnerabilities(1);
                 accessibleProjectAMetrics.setVulnerableComponents(1);
-                accessibleProjectAMetrics.setFirstOccurrence(Date.from(dbNow.minus(1, ChronoUnit.DAYS)));
+                accessibleProjectAMetrics.setFirstOccurrence(Date.from(now.minus(1, ChronoUnit.DAYS)));
                 accessibleProjectAMetrics.setLastOccurrence(accessibleProjectAMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(accessibleProjectAMetrics);
             }
@@ -693,7 +687,7 @@ public class MetricsResourceTest extends ResourceTest {
                 accessibleProjectBMetrics.setUnassigned(2);
                 accessibleProjectBMetrics.setVulnerabilities(2);
                 accessibleProjectBMetrics.setVulnerableComponents(2);
-                accessibleProjectBMetrics.setFirstOccurrence(Date.from(dbNow));
+                accessibleProjectBMetrics.setFirstOccurrence(Date.from(now));
                 accessibleProjectBMetrics.setLastOccurrence(accessibleProjectBMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(accessibleProjectBMetrics);
 
@@ -701,7 +695,7 @@ public class MetricsResourceTest extends ResourceTest {
                 var inactiveAccessibleProjectMetrics = new ProjectMetrics();
                 inactiveAccessibleProjectMetrics.setProjectId(inactiveAccessibleProject.getId());
                 inactiveAccessibleProjectMetrics.setComponents(111);
-                inactiveAccessibleProjectMetrics.setFirstOccurrence(Date.from(dbNow));
+                inactiveAccessibleProjectMetrics.setFirstOccurrence(Date.from(now));
                 inactiveAccessibleProjectMetrics.setLastOccurrence(inactiveAccessibleProjectMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(inactiveAccessibleProjectMetrics);
 
@@ -709,7 +703,7 @@ public class MetricsResourceTest extends ResourceTest {
                 var inaccessibleProjectMetrics = new ProjectMetrics();
                 inaccessibleProjectMetrics.setProjectId(inaccessibleProject.getId());
                 inaccessibleProjectMetrics.setVulnerabilities(666);
-                inaccessibleProjectMetrics.setFirstOccurrence(Date.from(dbNow));
+                inaccessibleProjectMetrics.setFirstOccurrence(Date.from(now));
                 inaccessibleProjectMetrics.setLastOccurrence(inaccessibleProjectMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(inaccessibleProjectMetrics);
             }
@@ -857,17 +851,15 @@ public class MetricsResourceTest extends ResourceTest {
         inaccessibleProject.setName("acme-app-inaccessible");
         qm.persist(inaccessibleProject);
 
-        final LocalDate dbToday = withJdbiHandle(handle ->
-                handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one());
-        final Instant dbNow = withJdbiHandle(handle ->
-                handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one());
+        final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        final Instant now = Instant.now();
 
         useJdbiHandle(handle -> {
             var dao = handle.attach(MetricsTestDao.class);
 
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday.minusDays(1));
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday.minusDays(2));
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today.minusDays(1));
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today.minusDays(2));
 
             {
                 // Create metrics for "yesterday".
@@ -902,7 +894,7 @@ public class MetricsResourceTest extends ResourceTest {
                 accessibleProjectAMetrics.setUnassigned(1);
                 accessibleProjectAMetrics.setVulnerabilities(1);
                 accessibleProjectAMetrics.setVulnerableComponents(1);
-                accessibleProjectAMetrics.setFirstOccurrence(Date.from(dbNow.minus(1, ChronoUnit.DAYS)));
+                accessibleProjectAMetrics.setFirstOccurrence(Date.from(now.minus(1, ChronoUnit.DAYS)));
                 accessibleProjectAMetrics.setLastOccurrence(accessibleProjectAMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(accessibleProjectAMetrics);
             }
@@ -943,7 +935,7 @@ public class MetricsResourceTest extends ResourceTest {
                 accessibleProjectBMetrics.setUnassigned(2);
                 accessibleProjectBMetrics.setVulnerabilities(2);
                 accessibleProjectBMetrics.setVulnerableComponents(2);
-                accessibleProjectBMetrics.setFirstOccurrence(Date.from(dbNow));
+                accessibleProjectBMetrics.setFirstOccurrence(Date.from(now));
                 accessibleProjectBMetrics.setLastOccurrence(accessibleProjectBMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(accessibleProjectBMetrics);
 
@@ -951,7 +943,7 @@ public class MetricsResourceTest extends ResourceTest {
                 var inactiveAccessibleProjectMetrics = new ProjectMetrics();
                 inactiveAccessibleProjectMetrics.setProjectId(inactiveAccessibleProject.getId());
                 inactiveAccessibleProjectMetrics.setComponents(111);
-                inactiveAccessibleProjectMetrics.setFirstOccurrence(Date.from(dbNow));
+                inactiveAccessibleProjectMetrics.setFirstOccurrence(Date.from(now));
                 inactiveAccessibleProjectMetrics.setLastOccurrence(inactiveAccessibleProjectMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(inactiveAccessibleProjectMetrics);
 
@@ -959,12 +951,12 @@ public class MetricsResourceTest extends ResourceTest {
                 var inaccessibleProjectMetrics = new ProjectMetrics();
                 inaccessibleProjectMetrics.setProjectId(inaccessibleProject.getId());
                 inaccessibleProjectMetrics.setVulnerabilities(666);
-                inaccessibleProjectMetrics.setFirstOccurrence(Date.from(dbNow));
+                inaccessibleProjectMetrics.setFirstOccurrence(Date.from(now));
                 inaccessibleProjectMetrics.setLastOccurrence(inaccessibleProjectMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(inaccessibleProjectMetrics);
             }
 
-            handle.attach(MetricsDao.class).refreshGlobalPortfolioMetrics();
+            handle.useTransaction(tx -> tx.attach(MetricsDao.class).refreshGlobalPortfolioMetrics());
         });
 
         final Response response = jersey
@@ -1109,17 +1101,15 @@ public class MetricsResourceTest extends ResourceTest {
         inaccessibleProject.setName("acme-app-inaccessible");
         qm.persist(inaccessibleProject);
 
-        final LocalDate dbToday = withJdbiHandle(handle ->
-                handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one());
-        final Instant dbNow = withJdbiHandle(handle ->
-                handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one());
+        final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        final Instant now = Instant.now();
 
         useJdbiHandle(handle -> {
             var dao = handle.attach(MetricsTestDao.class);
 
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday.minusDays(1));
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday.minusDays(2));
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today.minusDays(1));
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today.minusDays(2));
 
             {
                 // Create metrics for "yesterday".
@@ -1154,7 +1144,7 @@ public class MetricsResourceTest extends ResourceTest {
                 accessibleProjectAMetrics.setUnassigned(1);
                 accessibleProjectAMetrics.setVulnerabilities(1);
                 accessibleProjectAMetrics.setVulnerableComponents(1);
-                accessibleProjectAMetrics.setFirstOccurrence(Date.from(dbNow.minus(1, ChronoUnit.DAYS)));
+                accessibleProjectAMetrics.setFirstOccurrence(Date.from(now.minus(1, ChronoUnit.DAYS)));
                 accessibleProjectAMetrics.setLastOccurrence(accessibleProjectAMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(accessibleProjectAMetrics);
             }
@@ -1195,7 +1185,7 @@ public class MetricsResourceTest extends ResourceTest {
                 accessibleProjectBMetrics.setUnassigned(2);
                 accessibleProjectBMetrics.setVulnerabilities(2);
                 accessibleProjectBMetrics.setVulnerableComponents(2);
-                accessibleProjectBMetrics.setFirstOccurrence(Date.from(dbNow));
+                accessibleProjectBMetrics.setFirstOccurrence(Date.from(now));
                 accessibleProjectBMetrics.setLastOccurrence(accessibleProjectBMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(accessibleProjectBMetrics);
 
@@ -1203,7 +1193,7 @@ public class MetricsResourceTest extends ResourceTest {
                 var inactiveAccessibleProjectMetrics = new ProjectMetrics();
                 inactiveAccessibleProjectMetrics.setProjectId(inactiveAccessibleProject.getId());
                 inactiveAccessibleProjectMetrics.setComponents(111);
-                inactiveAccessibleProjectMetrics.setFirstOccurrence(Date.from(dbNow));
+                inactiveAccessibleProjectMetrics.setFirstOccurrence(Date.from(now));
                 inactiveAccessibleProjectMetrics.setLastOccurrence(inactiveAccessibleProjectMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(inactiveAccessibleProjectMetrics);
 
@@ -1211,14 +1201,14 @@ public class MetricsResourceTest extends ResourceTest {
                 var inaccessibleProjectMetrics = new ProjectMetrics();
                 inaccessibleProjectMetrics.setProjectId(inaccessibleProject.getId());
                 inaccessibleProjectMetrics.setVulnerabilities(666);
-                inaccessibleProjectMetrics.setFirstOccurrence(Date.from(dbNow));
+                inaccessibleProjectMetrics.setFirstOccurrence(Date.from(now));
                 inaccessibleProjectMetrics.setLastOccurrence(inaccessibleProjectMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(inaccessibleProjectMetrics);
             }
         });
 
         final Response response = jersey
-                .target(V1_METRICS + "/portfolio/since/" + dbToday.minusDays(2).format(DateTimeFormatter.ofPattern("yyyyMMdd")))
+                .target(V1_METRICS + "/portfolio/since/" + today.minusDays(2).format(DateTimeFormatter.ofPattern("yyyyMMdd")))
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -1359,17 +1349,15 @@ public class MetricsResourceTest extends ResourceTest {
         inaccessibleProject.setName("acme-app-inaccessible");
         qm.persist(inaccessibleProject);
 
-        final LocalDate dbToday = withJdbiHandle(handle ->
-                handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one());
-        final Instant dbNow = withJdbiHandle(handle ->
-                handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one());
+        final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        final Instant now = Instant.now();
 
         useJdbiHandle(handle -> {
             var dao = handle.attach(MetricsTestDao.class);
 
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday.minusDays(1));
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday.minusDays(2));
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today.minusDays(1));
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today.minusDays(2));
 
             {
                 // Create metrics for "yesterday".
@@ -1404,7 +1392,7 @@ public class MetricsResourceTest extends ResourceTest {
                 accessibleProjectAMetrics.setUnassigned(1);
                 accessibleProjectAMetrics.setVulnerabilities(1);
                 accessibleProjectAMetrics.setVulnerableComponents(1);
-                accessibleProjectAMetrics.setFirstOccurrence(Date.from(dbNow.minus(1, ChronoUnit.DAYS)));
+                accessibleProjectAMetrics.setFirstOccurrence(Date.from(now.minus(1, ChronoUnit.DAYS)));
                 accessibleProjectAMetrics.setLastOccurrence(accessibleProjectAMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(accessibleProjectAMetrics);
             }
@@ -1445,7 +1433,7 @@ public class MetricsResourceTest extends ResourceTest {
                 accessibleProjectBMetrics.setUnassigned(2);
                 accessibleProjectBMetrics.setVulnerabilities(2);
                 accessibleProjectBMetrics.setVulnerableComponents(2);
-                accessibleProjectBMetrics.setFirstOccurrence(Date.from(dbNow));
+                accessibleProjectBMetrics.setFirstOccurrence(Date.from(now));
                 accessibleProjectBMetrics.setLastOccurrence(accessibleProjectBMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(accessibleProjectBMetrics);
 
@@ -1453,7 +1441,7 @@ public class MetricsResourceTest extends ResourceTest {
                 var inactiveAccessibleProjectMetrics = new ProjectMetrics();
                 inactiveAccessibleProjectMetrics.setProjectId(inactiveAccessibleProject.getId());
                 inactiveAccessibleProjectMetrics.setComponents(111);
-                inactiveAccessibleProjectMetrics.setFirstOccurrence(Date.from(dbNow));
+                inactiveAccessibleProjectMetrics.setFirstOccurrence(Date.from(now));
                 inactiveAccessibleProjectMetrics.setLastOccurrence(inactiveAccessibleProjectMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(inactiveAccessibleProjectMetrics);
 
@@ -1461,16 +1449,16 @@ public class MetricsResourceTest extends ResourceTest {
                 var inaccessibleProjectMetrics = new ProjectMetrics();
                 inaccessibleProjectMetrics.setProjectId(inaccessibleProject.getId());
                 inaccessibleProjectMetrics.setVulnerabilities(666);
-                inaccessibleProjectMetrics.setFirstOccurrence(Date.from(dbNow));
+                inaccessibleProjectMetrics.setFirstOccurrence(Date.from(now));
                 inaccessibleProjectMetrics.setLastOccurrence(inaccessibleProjectMetrics.getFirstOccurrence());
                 dao.createProjectMetrics(inaccessibleProjectMetrics);
             }
 
-            handle.attach(MetricsDao.class).refreshGlobalPortfolioMetrics();
+            handle.useTransaction(tx -> tx.attach(MetricsDao.class).refreshGlobalPortfolioMetrics());
         });
 
         final Response response = jersey
-                .target(V1_METRICS + "/portfolio/since/" + dbToday.minusDays(2).format(DateTimeFormatter.ofPattern("yyyyMMdd")))
+                .target(V1_METRICS + "/portfolio/since/" + today.minusDays(2).format(DateTimeFormatter.ofPattern("yyyyMMdd")))
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -1632,9 +1620,9 @@ public class MetricsResourceTest extends ResourceTest {
 
         useJdbiHandle(handle -> {
             final var testDao = handle.attach(MetricsTestDao.class);
-            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
-            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
+            final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            final Instant now = Instant.now();
 
             final var metricsA = new ProjectMetrics();
             metricsA.setProjectId(childA.getId());
@@ -1644,8 +1632,8 @@ public class MetricsResourceTest extends ResourceTest {
             metricsA.setComponents(10);
             metricsA.setVulnerabilities(6);
             metricsA.setVulnerableComponents(4);
-            metricsA.setFirstOccurrence(Date.from(dbNow));
-            metricsA.setLastOccurrence(Date.from(dbNow));
+            metricsA.setFirstOccurrence(Date.from(now));
+            metricsA.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(metricsA);
 
             final var metricsB = new ProjectMetrics();
@@ -1656,8 +1644,8 @@ public class MetricsResourceTest extends ResourceTest {
             metricsB.setComponents(5);
             metricsB.setVulnerabilities(6);
             metricsB.setVulnerableComponents(3);
-            metricsB.setFirstOccurrence(Date.from(dbNow));
-            metricsB.setLastOccurrence(Date.from(dbNow));
+            metricsB.setFirstOccurrence(Date.from(now));
+            metricsB.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(metricsB);
         });
 
@@ -1707,24 +1695,24 @@ public class MetricsResourceTest extends ResourceTest {
 
         useJdbiHandle(handle -> {
             final var testDao = handle.attach(MetricsTestDao.class);
-            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
-            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
+            final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            final Instant now = Instant.now();
 
             final var metricsTagged = new ProjectMetrics();
             metricsTagged.setProjectId(childTagged.getId());
             metricsTagged.setCritical(5);
             metricsTagged.setComponents(10);
-            metricsTagged.setFirstOccurrence(Date.from(dbNow));
-            metricsTagged.setLastOccurrence(Date.from(dbNow));
+            metricsTagged.setFirstOccurrence(Date.from(now));
+            metricsTagged.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(metricsTagged);
 
             final var metricsUntagged = new ProjectMetrics();
             metricsUntagged.setProjectId(childUntagged.getId());
             metricsUntagged.setCritical(99);
             metricsUntagged.setComponents(99);
-            metricsUntagged.setFirstOccurrence(Date.from(dbNow));
-            metricsUntagged.setLastOccurrence(Date.from(dbNow));
+            metricsUntagged.setFirstOccurrence(Date.from(now));
+            metricsUntagged.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(metricsUntagged);
         });
 
@@ -1760,22 +1748,20 @@ public class MetricsResourceTest extends ResourceTest {
         child.setParent(parentProject);
         qm.persist(child);
 
-        final LocalDate dbToday = withJdbiHandle(handle ->
-                handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one());
-        final LocalDate dbYesterday = dbToday.minusDays(1);
-        final Instant dbNow = withJdbiHandle(handle ->
-                handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one());
+        final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        final LocalDate yesterday = today.minusDays(1);
+        final Instant now = Instant.now();
 
         useJdbiHandle(handle -> {
             final var testDao = handle.attach(MetricsTestDao.class);
-            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbYesterday);
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", yesterday);
 
             final var metricsToday = new ProjectMetrics();
             metricsToday.setProjectId(child.getId());
             metricsToday.setCritical(5);
             metricsToday.setComponents(10);
-            metricsToday.setFirstOccurrence(Date.from(dbNow));
+            metricsToday.setFirstOccurrence(Date.from(now));
             metricsToday.setLastOccurrence(metricsToday.getFirstOccurrence());
             testDao.createProjectMetrics(metricsToday);
 
@@ -1783,7 +1769,7 @@ public class MetricsResourceTest extends ResourceTest {
             metricsYesterday.setProjectId(child.getId());
             metricsYesterday.setCritical(3);
             metricsYesterday.setComponents(8);
-            metricsYesterday.setFirstOccurrence(Date.from(dbNow.minus(1, ChronoUnit.DAYS)));
+            metricsYesterday.setFirstOccurrence(Date.from(now.minus(1, ChronoUnit.DAYS)));
             metricsYesterday.setLastOccurrence(metricsYesterday.getFirstOccurrence());
             testDao.createProjectMetrics(metricsYesterday);
         });
@@ -1829,22 +1815,20 @@ public class MetricsResourceTest extends ResourceTest {
         child.setParent(parentProject);
         qm.persist(child);
 
-        final LocalDate dbToday = withJdbiHandle(handle ->
-                handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one());
-        final LocalDate dbYesterday = dbToday.minusDays(1);
-        final Instant dbNow = withJdbiHandle(handle ->
-                handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one());
+        final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        final LocalDate yesterday = today.minusDays(1);
+        final Instant now = Instant.now();
 
         useJdbiHandle(handle -> {
             final var testDao = handle.attach(MetricsTestDao.class);
-            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbYesterday);
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", yesterday);
 
             final var metricsToday = new ProjectMetrics();
             metricsToday.setProjectId(child.getId());
             metricsToday.setCritical(4);
             metricsToday.setComponents(12);
-            metricsToday.setFirstOccurrence(Date.from(dbNow));
+            metricsToday.setFirstOccurrence(Date.from(now));
             metricsToday.setLastOccurrence(metricsToday.getFirstOccurrence());
             testDao.createProjectMetrics(metricsToday);
 
@@ -1852,13 +1836,13 @@ public class MetricsResourceTest extends ResourceTest {
             metricsYesterday.setProjectId(child.getId());
             metricsYesterday.setCritical(2);
             metricsYesterday.setComponents(6);
-            metricsYesterday.setFirstOccurrence(Date.from(dbNow.minus(1, ChronoUnit.DAYS)));
+            metricsYesterday.setFirstOccurrence(Date.from(now.minus(1, ChronoUnit.DAYS)));
             metricsYesterday.setLastOccurrence(metricsYesterday.getFirstOccurrence());
             testDao.createProjectMetrics(metricsYesterday);
         });
 
         // /since/{today} covers only today.
-        final String todayStr = dbToday.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        final String todayStr = today.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
         final Response response = jersey
                 .target(V1_METRICS + "/project/" + parentProject.getUuid() + "/since/" + todayStr)
                 .request()
@@ -1879,7 +1863,7 @@ public class MetricsResourceTest extends ResourceTest {
                         """);
 
         // /since/{yesterday} covers yesterday + today.
-        final String yesterdayStr = dbYesterday.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        final String yesterdayStr = yesterday.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
         final Response response2 = jersey
                 .target(V1_METRICS + "/project/" + parentProject.getUuid() + "/since/" + yesterdayStr)
                 .request()
@@ -1916,24 +1900,24 @@ public class MetricsResourceTest extends ResourceTest {
 
         useJdbiHandle(handle -> {
             final var testDao = handle.attach(MetricsTestDao.class);
-            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
-            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
+            final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            final Instant now = Instant.now();
 
             final var metricsLatest = new ProjectMetrics();
             metricsLatest.setProjectId(childLatest.getId());
             metricsLatest.setCritical(7);
             metricsLatest.setComponents(20);
-            metricsLatest.setFirstOccurrence(Date.from(dbNow));
-            metricsLatest.setLastOccurrence(Date.from(dbNow));
+            metricsLatest.setFirstOccurrence(Date.from(now));
+            metricsLatest.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(metricsLatest);
 
             final var metricsOld = new ProjectMetrics();
             metricsOld.setProjectId(childNotLatest.getId());
             metricsOld.setCritical(99);
             metricsOld.setComponents(99);
-            metricsOld.setFirstOccurrence(Date.from(dbNow));
-            metricsOld.setLastOccurrence(Date.from(dbNow));
+            metricsOld.setFirstOccurrence(Date.from(now));
+            metricsOld.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(metricsOld);
         });
 
@@ -1990,29 +1974,29 @@ public class MetricsResourceTest extends ResourceTest {
 
         useJdbiHandle(handle -> {
             final var testDao = handle.attach(MetricsTestDao.class);
-            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
-            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
+            final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            final Instant now = Instant.now();
 
             final var metricsChildRegular = new ProjectMetrics();
             metricsChildRegular.setProjectId(childRegular.getId());
             metricsChildRegular.setCritical(3);
-            metricsChildRegular.setFirstOccurrence(Date.from(dbNow));
-            metricsChildRegular.setLastOccurrence(Date.from(dbNow));
+            metricsChildRegular.setFirstOccurrence(Date.from(now));
+            metricsChildRegular.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(metricsChildRegular);
 
             final var metricsGrandchildTagged = new ProjectMetrics();
             metricsGrandchildTagged.setProjectId(grandchildTagged.getId());
             metricsGrandchildTagged.setCritical(5);
-            metricsGrandchildTagged.setFirstOccurrence(Date.from(dbNow));
-            metricsGrandchildTagged.setLastOccurrence(Date.from(dbNow));
+            metricsGrandchildTagged.setFirstOccurrence(Date.from(now));
+            metricsGrandchildTagged.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(metricsGrandchildTagged);
 
             final var metricsGrandchildUntagged = new ProjectMetrics();
             metricsGrandchildUntagged.setProjectId(grandchildUntagged.getId());
             metricsGrandchildUntagged.setCritical(99);
-            metricsGrandchildUntagged.setFirstOccurrence(Date.from(dbNow));
-            metricsGrandchildUntagged.setLastOccurrence(Date.from(dbNow));
+            metricsGrandchildUntagged.setFirstOccurrence(Date.from(now));
+            metricsGrandchildUntagged.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(metricsGrandchildUntagged);
         });
 
@@ -2056,23 +2040,23 @@ public class MetricsResourceTest extends ResourceTest {
 
         useJdbiHandle(handle -> {
             final var testDao = handle.attach(MetricsTestDao.class);
-            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
-            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
+            final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
 
-            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
+            final Instant now = Instant.now();
 
             final var metricsA = new ProjectMetrics();
             metricsA.setProjectId(childA.getId());
             metricsA.setCritical(5);
-            metricsA.setFirstOccurrence(Date.from(dbNow));
-            metricsA.setLastOccurrence(Date.from(dbNow));
+            metricsA.setFirstOccurrence(Date.from(now));
+            metricsA.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(metricsA);
 
             final var metricsB = new ProjectMetrics();
             metricsB.setProjectId(childB.getId());
             metricsB.setCritical(3);
-            metricsB.setFirstOccurrence(Date.from(dbNow));
-            metricsB.setLastOccurrence(Date.from(dbNow));
+            metricsB.setFirstOccurrence(Date.from(now));
+            metricsB.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(metricsB);
         });
 
@@ -2122,23 +2106,23 @@ public class MetricsResourceTest extends ResourceTest {
 
         useJdbiHandle(handle -> {
             final var testDao = handle.attach(MetricsTestDao.class);
-            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
-            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
+            final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
 
-            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
+            final Instant now = Instant.now();
 
             final var metricsA = new ProjectMetrics();
             metricsA.setProjectId(grandchildA.getId());
             metricsA.setCritical(7);
-            metricsA.setFirstOccurrence(Date.from(dbNow));
-            metricsA.setLastOccurrence(Date.from(dbNow));
+            metricsA.setFirstOccurrence(Date.from(now));
+            metricsA.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(metricsA);
 
             final var metricsB = new ProjectMetrics();
             metricsB.setProjectId(grandchildB.getId());
             metricsB.setCritical(3);
-            metricsB.setFirstOccurrence(Date.from(dbNow));
-            metricsB.setLastOccurrence(Date.from(dbNow));
+            metricsB.setFirstOccurrence(Date.from(now));
+            metricsB.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(metricsB);
         });
 

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -85,6 +85,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
@@ -532,11 +533,11 @@ class ProjectResourceTest extends ResourceTest {
         projectMetrics.setLow(10);
         useJdbiHandle(handle -> {
             var dao = handle.attach(MetricsTestDao.class);
-            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
-            projectMetrics.setFirstOccurrence(Date.from(dbNow));
-            projectMetrics.setLastOccurrence(Date.from(dbNow));
+            final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            final Instant now = Instant.now();
+            projectMetrics.setFirstOccurrence(Date.from(now));
+            projectMetrics.setLastOccurrence(Date.from(now));
             dao.createProjectMetrics(projectMetrics);
         });
         project.setMetrics(projectMetrics);
@@ -787,15 +788,15 @@ class ProjectResourceTest extends ResourceTest {
 
         useJdbiHandle(handle -> {
             final var testDao = handle.attach(MetricsTestDao.class);
-            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
-            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
+            final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            final Instant now = Instant.now();
 
             final var childMetrics = new ProjectMetrics();
             childMetrics.setProjectId(projectC.getId());
             childMetrics.setInheritedRiskScore(7.0);
-            childMetrics.setFirstOccurrence(Date.from(dbNow));
-            childMetrics.setLastOccurrence(Date.from(dbNow));
+            childMetrics.setFirstOccurrence(Date.from(now));
+            childMetrics.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(childMetrics);
         });
 
@@ -1313,12 +1314,12 @@ class ProjectResourceTest extends ResourceTest {
 
         useJdbiHandle(handle -> {
             var dao = handle.attach(MetricsTestDao.class);
-            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday.minusDays(1));
-            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
-            final Instant projectMetricsOldOccurrence = dbNow.minus(1, ChronoUnit.HOURS);
-            final Instant projectMetricsLatestOccurrence = dbNow.minus(5, ChronoUnit.MINUTES);
+            final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today.minusDays(1));
+            final Instant now = Instant.now();
+            final Instant projectMetricsOldOccurrence = now.minus(1, ChronoUnit.HOURS);
+            final Instant projectMetricsLatestOccurrence = now.minus(5, ChronoUnit.MINUTES);
 
             final var projectMetricsOld = new ProjectMetrics();
             projectMetricsOld.setProjectId(project.getId());
@@ -1861,12 +1862,12 @@ class ProjectResourceTest extends ResourceTest {
 
         useJdbiHandle(handle -> {
             var dao = handle.attach(MetricsTestDao.class);
-            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            dao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday.minusDays(1));
-            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
-            final Instant projectMetricsOldOccurrence = dbNow.minus(1, ChronoUnit.HOURS);
-            final Instant projectMetricsLatestOccurrence = dbNow.minus(5, ChronoUnit.MINUTES);
+            final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", today.minusDays(1));
+            final Instant now = Instant.now();
+            final Instant projectMetricsOldOccurrence = now.minus(1, ChronoUnit.HOURS);
+            final Instant projectMetricsLatestOccurrence = now.minus(5, ChronoUnit.MINUTES);
 
             final var projectMetricsOld = new ProjectMetrics();
             projectMetricsOld.setProjectId(childProject.getId());
@@ -4822,16 +4823,16 @@ class ProjectResourceTest extends ResourceTest {
 
         useJdbiHandle(handle -> {
             final var testDao = handle.attach(MetricsTestDao.class);
-            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
-            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
+            final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            final Instant now = Instant.now();
 
             final var regularMetrics = new ProjectMetrics();
             regularMetrics.setProjectId(regularProject.getId());
             regularMetrics.setCritical(1);
             regularMetrics.setComponents(2);
-            regularMetrics.setFirstOccurrence(Date.from(dbNow));
-            regularMetrics.setLastOccurrence(Date.from(dbNow));
+            regularMetrics.setFirstOccurrence(Date.from(now));
+            regularMetrics.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(regularMetrics);
 
             final var childMetrics = new ProjectMetrics();
@@ -4839,8 +4840,8 @@ class ProjectResourceTest extends ResourceTest {
             childMetrics.setCritical(5);
             childMetrics.setHigh(3);
             childMetrics.setComponents(10);
-            childMetrics.setFirstOccurrence(Date.from(dbNow));
-            childMetrics.setLastOccurrence(Date.from(dbNow));
+            childMetrics.setFirstOccurrence(Date.from(now));
+            childMetrics.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(childMetrics);
         });
 
@@ -4910,15 +4911,15 @@ class ProjectResourceTest extends ResourceTest {
 
         useJdbiHandle(handle -> {
             final var testDao = handle.attach(MetricsTestDao.class);
-            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
-            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
+            final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            final Instant now = Instant.now();
 
             final var childMetrics = new ProjectMetrics();
             childMetrics.setProjectId(projectC.getId());
             childMetrics.setInheritedRiskScore(7.0);
-            childMetrics.setFirstOccurrence(Date.from(dbNow));
-            childMetrics.setLastOccurrence(Date.from(dbNow));
+            childMetrics.setFirstOccurrence(Date.from(now));
+            childMetrics.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(childMetrics);
         });
 
@@ -4978,15 +4979,15 @@ class ProjectResourceTest extends ResourceTest {
 
         useJdbiHandle(handle -> {
             final var testDao = handle.attach(MetricsTestDao.class);
-            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
-            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
+            final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            final Instant now = Instant.now();
 
             final var childMetrics = new ProjectMetrics();
             childMetrics.setProjectId(projectC.getId());
             childMetrics.setInheritedRiskScore(8.0);
-            childMetrics.setFirstOccurrence(Date.from(dbNow));
-            childMetrics.setLastOccurrence(Date.from(dbNow));
+            childMetrics.setFirstOccurrence(Date.from(now));
+            childMetrics.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(childMetrics);
         });
 
@@ -5029,16 +5030,16 @@ class ProjectResourceTest extends ResourceTest {
 
         useJdbiHandle(handle -> {
             final var testDao = handle.attach(MetricsTestDao.class);
-            final LocalDate dbToday = handle.createQuery("SELECT CURRENT_DATE").mapTo(LocalDate.class).one();
-            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", dbToday);
-            final Instant dbNow = handle.createQuery("SELECT CURRENT_TIMESTAMP").mapTo(Instant.class).one();
+            final LocalDate today = LocalDate.now(ZoneOffset.UTC);
+            testDao.createMetricsPartitionsForDate("PROJECTMETRICS", today);
+            final Instant now = Instant.now();
 
             final var grandchildMetrics = new ProjectMetrics();
             grandchildMetrics.setProjectId(leafGrandchild.getId());
             grandchildMetrics.setInheritedRiskScore(4.0);
             grandchildMetrics.setCritical(2);
-            grandchildMetrics.setFirstOccurrence(Date.from(dbNow));
-            grandchildMetrics.setLastOccurrence(Date.from(dbNow));
+            grandchildMetrics.setFirstOccurrence(Date.from(now));
+            grandchildMetrics.setLastOccurrence(Date.from(now));
             testDao.createProjectMetrics(grandchildMetrics);
         });
 

--- a/apiserver/src/test/java/org/dependencytrack/tasks/maintenance/MetricsMaintenanceTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/maintenance/MetricsMaintenanceTaskTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -142,8 +143,9 @@ public class MetricsMaintenanceTaskTest extends PersistenceCapableTest {
                 MAINTENANCE_METRICS_RETENTION_DAYS.getDescription());
 
         new MetricsMaintenanceTask().run();
-        var today = LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
-        var tomorrow = LocalDate.now().plusDays(1).format(DateTimeFormatter.BASIC_ISO_DATE);
+        final LocalDate todayDate = LocalDate.now(ZoneOffset.UTC);
+        var today = todayDate.format(DateTimeFormatter.BASIC_ISO_DATE);
+        var tomorrow = todayDate.plusDays(1).format(DateTimeFormatter.BASIC_ISO_DATE);
 
         var metricsPartitions = metricsDao.getProjectMetricsPartitions();
         assertThat(metricsPartitions.getFirst()).isEqualTo("\"PROJECTMETRICS_%s\"".formatted(today));

--- a/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/load/LoadPhase.java
+++ b/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/load/LoadPhase.java
@@ -136,8 +136,15 @@ public final class LoadPhase {
             }
         });
         // Refresh PORTFOLIOMETRICS_GLOBAL after PROJECTMETRICS is in place.
+        // The view body uses CURRENT_DATE and implicit timestamptz coercion, so the
+        // refresh must run with session TZ pinned to UTC to match the v5 apiserver
+        // contract (MetricsDao#refreshGlobalPortfolioMetrics does the same via
+        // SET LOCAL inside its transaction).
         LOGGER.info("Refreshing PORTFOLIOMETRICS_GLOBAL materialized view");
-        target.useHandle(h -> h.execute("REFRESH MATERIALIZED VIEW \"PORTFOLIOMETRICS_GLOBAL\""));
+        target.useTransaction(th -> {
+            th.execute("SET LOCAL TIME ZONE 'UTC'");
+            th.execute("REFRESH MATERIALIZED VIEW \"PORTFOLIOMETRICS_GLOBAL\"");
+        });
         LOGGER.info("Applying v5.7.0 cleanup deletes");
         replayV570CleanupDeletes();
     }
@@ -178,9 +185,10 @@ public final class LoadPhase {
                 final List<LocalDate> slice = days.subList(i, Math.min(i + chunk, days.size()));
                 target.useTransaction(th -> {
                     // Pin session TZ to UTC so partition boundaries are deterministic.
-                    // The v5 apiserver creates partitions via session-TZ DATE literals
-                    // (MetricsDao.createMetricsPartitions); aligning here means partitions
-                    // attach without overlap when v5 also runs in UTC (the documented setup).
+                    // v5's MetricsDao.createMetricsPartitions anchors its bounds to UTC
+                    // explicitly (CAST(... AS timestamp) AT TIME ZONE 'UTC'), so aligning
+                    // here makes the migrator's pre-created partitions attach without
+                    // overlap regardless of the operator's TZ.
                     th.execute("SET LOCAL TIME ZONE 'UTC'");
                     for (final LocalDate d : slice) {
                         final String child = "%s_%s".formatted(parent,


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Support non-UTC timezones for metrics operations.

Historically we implicitly assumed UTC (and configured our container images explicitly that way). But it turns out users want to customize the timezone used by the application, which makes the implicit assumptions fall apart, in particular WRT metrics and their partition maintenance.

This change makes the UTC-ness of metrics operations explicit, which allows the application to be set to arbitrary timezones and still function as intended.

Also addresses other code locations that implicitly relied on UTC and made that expectation explicit.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #6344
Fixes https://github.com/DependencyTrack/dependency-track/issues/6341

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
