### PR TITLE
Allow out-of-order execution of Flyway migrations

### DIFF
--- a/dex/engine-migration/pom.xml
+++ b/dex/engine-migration/pom.xml
@@ -36,9 +36,11 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-core</artifactId>
+            <groupId>org.dependencytrack</groupId>
+            <artifactId>flyway-support</artifactId>
+            <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-database-postgresql</artifactId>

--- a/dex/engine-migration/src/main/java/org/dependencytrack/dex/engine/migration/MigrationExecutor.java
+++ b/dex/engine-migration/src/main/java/org/dependencytrack/dex/engine/migration/MigrationExecutor.java
@@ -18,29 +18,12 @@
  */
 package org.dependencytrack.dex.engine.migration;
 
-import org.flywaydb.core.Flyway;
-
 import javax.sql.DataSource;
 
-public final class MigrationExecutor {
+public final class MigrationExecutor extends org.dependencytrack.support.flyway.MigrationExecutor {
 
-    private final Flyway flyway;
-
-    public MigrationExecutor(final DataSource dataSource) {
-        this.flyway = Flyway.configure()
-                .dataSource(dataSource)
-                .baselineVersion("0.0.0")
-                .baselineOnMigrate(true)
-                .cleanDisabled(true)
-                .placeholderReplacement(false)
-                .table("dex_schema_history")
-                .locations("classpath:org/dependencytrack/dex/engine/migration")
-                .loggers("slf4j")
-                .load();
-    }
-
-    public void execute() {
-        flyway.migrate();
+    public MigrationExecutor(DataSource dataSource) {
+        super(dataSource, "0.0.0", "classpath:org/dependencytrack/dex/engine/migration", "dex_schema_history", null, false);
     }
 
 }

--- a/migration/pom.xml
+++ b/migration/pom.xml
@@ -18,15 +18,17 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.dependencytrack</groupId>
+            <artifactId>flyway-support</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-core</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-database-postgresql</artifactId>

--- a/migration/src/main/java/org/dependencytrack/migration/MigrationExecutor.java
+++ b/migration/src/main/java/org/dependencytrack/migration/MigrationExecutor.java
@@ -18,39 +18,18 @@
  */
 package org.dependencytrack.migration;
 
-import org.flywaydb.core.Flyway;
-import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.jspecify.annotations.Nullable;
 
 import javax.sql.DataSource;
 
-public final class MigrationExecutor {
-
-    private static final String LOCATION = "org/dependencytrack/migration";
-
-    private final Flyway flyway;
+public final class MigrationExecutor extends org.dependencytrack.support.flyway.MigrationExecutor {
 
     public MigrationExecutor(DataSource dataSource) {
         this(dataSource, null);
     }
 
     public MigrationExecutor(DataSource dataSource, @Nullable String targetVersion) {
-        final FluentConfiguration cfg = Flyway.configure()
-                .dataSource(dataSource)
-                .baselineVersion("202605022031")
-                .baselineOnMigrate(true)
-                .cleanDisabled(true)
-                .placeholderReplacement(false)
-                .locations("classpath:" + LOCATION)
-                .loggers("slf4j");
-        if (targetVersion != null) {
-            cfg.target(targetVersion);
-        }
-        this.flyway = cfg.load();
-    }
-
-    public void execute() {
-        flyway.migrate();
+        super(dataSource, "202605022031", "classpath:org/dependencytrack/migration", null, targetVersion, true);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <module>common</module>
         <module>support/cyclonedx-proto</module>
         <module>support/datanucleus-plugin</module>
+        <module>support/flyway</module>
         <module>support/jdbi</module>
         <module>support/os-distro-metadata</module>
         <module>support/smallrye-config-secret-handler-file</module>

--- a/support/flyway/pom.xml
+++ b/support/flyway/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This file is part of Dependency-Track.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright (c) OWASP Foundation. All Rights Reserved.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.dependencytrack</groupId>
+        <artifactId>dependency-track-parent</artifactId>
+        <version>5.1.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>flyway-support</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Support :: Flyway</name>
+
+    <properties>
+        <project.parentBaseDir>${project.basedir}/../..</project.parentBaseDir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <!--
+                      Module path cannot be used due to testcontainers incompatibility:
+                      https://github.com/testcontainers/testcontainers-java/issues/7337
+                    -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <useModulePath>false</useModulePath>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!--
+                      Module path cannot be used due to testcontainers incompatibility:
+                      https://github.com/testcontainers/testcontainers-java/issues/7337
+                    -->
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/support/flyway/src/main/java/module-info.java
+++ b/support/flyway/src/main/java/module-info.java
@@ -20,10 +20,10 @@
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-module org.dependencytrack.dex.engine.migration {
-    exports org.dependencytrack.dex.engine.migration;
+module org.dependencytrack.support.flyway {
+    exports org.dependencytrack.support.flyway;
 
+    requires flyway.core;
     requires java.sql;
-    requires org.dependencytrack.support.flyway;
     requires org.jspecify;
 }

--- a/support/flyway/src/main/java/org/dependencytrack/support/flyway/MigrationExecutor.java
+++ b/support/flyway/src/main/java/org/dependencytrack/support/flyway/MigrationExecutor.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.flyway;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.jspecify.annotations.Nullable;
+
+import javax.sql.DataSource;
+
+import static java.util.Objects.requireNonNull;
+
+/// @since 5.0.1
+public class MigrationExecutor {
+
+    private final Flyway flyway;
+
+    /// @param dataSource         The data source to use.
+    /// @param baselineVersion    The baseline schema version.
+    /// @param location           Location of the migration files.
+    /// @param schemaHistoryTable Name of the schema history table.
+    /// @param targetVersion      The schema version to migrate to.
+    /// @param outOfOrder         Whether to allow out-of-order execution of migrations.
+    /// When `true`, allows patch branches to backport a subset of migrations
+    /// from the mainline without blocking the subsequent minor upgrade on validation.
+    /// Enable only where backports are anticipated. When disabled, Flyway aborts if it discovers an
+    /// unapplied migration with a version lower than the latest in history.
+    /// @see [How to fix or avoid ignored migrations in Flyway](https://www.red-gate.com/hub/product-learning/flyway/how-to-fix-or-avoid-ignored-migrations-in-flyway/).
+    public MigrationExecutor(
+            DataSource dataSource,
+            String baselineVersion,
+            String location,
+            @Nullable String schemaHistoryTable,
+            @Nullable String targetVersion,
+            boolean outOfOrder) {
+        final FluentConfiguration config = Flyway.configure()
+                .dataSource(requireNonNull(dataSource, "dataSource must not be null"))
+                .baselineVersion(requireNonNull(baselineVersion, "baselineVersion must not be null"))
+                .locations(requireNonNull(location, "location must not be null"))
+                .baselineOnMigrate(true)
+                .cleanDisabled(true)
+                .placeholderReplacement(false)
+                .outOfOrder(outOfOrder)
+                .loggers("slf4j");
+        if (schemaHistoryTable != null) {
+            config.table(schemaHistoryTable);
+        }
+        if (targetVersion != null) {
+            config.target(targetVersion);
+        }
+        this.flyway = config.load();
+    }
+
+    public void execute() {
+        flyway.migrate();
+    }
+
+}

--- a/support/flyway/src/test/java/org/dependencytrack/support/flyway/MigrationExecutorTest.java
+++ b/support/flyway/src/test/java/org/dependencytrack/support/flyway/MigrationExecutorTest.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.flyway;
+
+import org.flywaydb.core.api.exception.FlywayValidateException;
+import org.junit.jupiter.api.Test;
+import org.postgresql.ds.PGSimpleDataSource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+class MigrationExecutorTest {
+
+    private static final String STAGE1_MIGRATIONS_LOCATION = "classpath:org/dependencytrack/support/flyway/outoforder/stage1";
+    private static final String STAGE2_MIGRATIONS_LOCATION = "classpath:org/dependencytrack/support/flyway/outoforder/stage2";
+    private static final String BASELINE_SCHEMA_VERSION = "0";
+
+    @Container
+    private final PostgreSQLContainer postgresContainer =
+            new PostgreSQLContainer(DockerImageName.parse("postgres:14-alpine"))
+                    .withCommand("postgres", "-c", "fsync=off", "-c", "full_page_writes=off")
+                    .withTmpFs(Map.of("/var/lib/postgresql/data", "rw"));
+
+    @Test
+    void shouldApplyMigrationsOutOfOrder() throws Exception {
+        final DataSource dataSource = createDataSource();
+
+        new MigrationExecutor(dataSource, BASELINE_SCHEMA_VERSION, STAGE1_MIGRATIONS_LOCATION, null, null, true).execute();
+
+        new MigrationExecutor(dataSource, BASELINE_SCHEMA_VERSION, STAGE2_MIGRATIONS_LOCATION, null, null, true).execute();
+
+        final Map<String, Integer> ranksByVersion = readSchemaHistoryRanks();
+        assertThat(ranksByVersion).containsKeys("001", "002", "003");
+        assertThat(ranksByVersion.get("002")).isGreaterThan(ranksByVersion.get("003"));
+    }
+
+    @Test
+    void shouldRejectOutOfOrderMigrationWhenOutOfOrderIsDisabled() {
+        final DataSource dataSource = createDataSource();
+
+        new MigrationExecutor(dataSource, BASELINE_SCHEMA_VERSION, STAGE1_MIGRATIONS_LOCATION, null, null, false).execute();
+
+        assertThatThrownBy(() ->
+                new MigrationExecutor(dataSource, BASELINE_SCHEMA_VERSION, STAGE2_MIGRATIONS_LOCATION, null, null, false).execute())
+                .isInstanceOf(FlywayValidateException.class)
+                .hasMessageContaining("Detected resolved migration not applied to database: 002");
+    }
+
+    @Test
+    void shouldExecuteMigrationIdempotently() {
+        final DataSource dataSource = createDataSource();
+        new MigrationExecutor(dataSource, BASELINE_SCHEMA_VERSION, STAGE1_MIGRATIONS_LOCATION, null, null, true).execute();
+        new MigrationExecutor(dataSource, BASELINE_SCHEMA_VERSION, STAGE1_MIGRATIONS_LOCATION, null, null, true).execute();
+    }
+
+    private DataSource createDataSource() {
+        final var dataSource = new PGSimpleDataSource();
+        dataSource.setUrl(postgresContainer.getJdbcUrl());
+        dataSource.setUser(postgresContainer.getUsername());
+        dataSource.setPassword(postgresContainer.getPassword());
+        return dataSource;
+    }
+
+    private Map<String, Integer> readSchemaHistoryRanks() throws SQLException {
+        final var result = new LinkedHashMap<String, Integer>();
+        try (final Connection connection = postgresContainer.createConnection("");
+             final Statement statement = connection.createStatement();
+             final ResultSet rs = statement.executeQuery("""
+                     SELECT version
+                          , installed_rank
+                       FROM flyway_schema_history
+                      WHERE version IS NOT NULL
+                     """)) {
+            while (rs.next()) {
+                result.put(
+                        rs.getString("version"),
+                        rs.getInt("installed_rank"));
+            }
+        }
+
+        return result;
+    }
+
+}

--- a/support/flyway/src/test/resources/org/dependencytrack/support/flyway/outoforder/stage1/V001__create_a.sql
+++ b/support/flyway/src/test/resources/org/dependencytrack/support/flyway/outoforder/stage1/V001__create_a.sql
@@ -1,0 +1,1 @@
+CREATE TABLE a (id INT);

--- a/support/flyway/src/test/resources/org/dependencytrack/support/flyway/outoforder/stage1/V003__create_c.sql
+++ b/support/flyway/src/test/resources/org/dependencytrack/support/flyway/outoforder/stage1/V003__create_c.sql
@@ -1,0 +1,1 @@
+CREATE TABLE c (id INT);

--- a/support/flyway/src/test/resources/org/dependencytrack/support/flyway/outoforder/stage2/V001__create_a.sql
+++ b/support/flyway/src/test/resources/org/dependencytrack/support/flyway/outoforder/stage2/V001__create_a.sql
@@ -1,0 +1,1 @@
+CREATE TABLE a (id INT);

--- a/support/flyway/src/test/resources/org/dependencytrack/support/flyway/outoforder/stage2/V002__create_b.sql
+++ b/support/flyway/src/test/resources/org/dependencytrack/support/flyway/outoforder/stage2/V002__create_b.sql
@@ -1,0 +1,1 @@
+CREATE TABLE b (id INT);

--- a/support/flyway/src/test/resources/org/dependencytrack/support/flyway/outoforder/stage2/V003__create_c.sql
+++ b/support/flyway/src/test/resources/org/dependencytrack/support/flyway/outoforder/stage2/V003__create_c.sql
@@ -1,0 +1,1 @@
+CREATE TABLE c (id INT);


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Allows out-of-order execution of Flyway migrations.

This is necessary to allow migrations to be backported to patch releases. When users who deployed the patch release later upgrade to the next minor version, Flyway must execute all missing migrations, even if they're technically older than what the patch release already applied.

Also introduces a new flyway-support module to centralize this configuration in a way that both apiserver and dex can inherit.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Note that allowing out-of-order practically matches the behavior of Liquibase, which we used before switching to Flyway due to license concerns.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
