### PR TITLE
Add protobuf publishing option for webhook notifications

### DIFF
--- a/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/webhook/WebhookNotificationPublisher.java
+++ b/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/webhook/WebhookNotificationPublisher.java
@@ -27,6 +27,7 @@ import org.dependencytrack.notification.proto.v1.Notification;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublisher;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.HttpTimeoutException;
@@ -49,15 +50,26 @@ final class WebhookNotificationPublisher implements NotificationPublisher {
     public void publish(NotificationPublishContext ctx, Notification notification) throws IOException {
         final var ruleConfig = ctx.ruleConfig(WebhookNotificationPublisherRuleConfigV1.class);
 
-        final RenderedNotificationTemplate renderedTemplate = ctx.templateRenderer().render(notification);
-        if (renderedTemplate == null) {
-            throw new IllegalStateException("No template configured");
+        final String mimeType;
+        final BodyPublisher body;
+        if (Boolean.TRUE.equals(ruleConfig.getPublishProtobuf())) {
+            // https://protobuf.dev/reference/protobuf/mime-types/
+            mimeType = "application/protobuf";
+            body = BodyPublishers.ofByteArray(notification.toByteArray());
+        } else {
+            final RenderedNotificationTemplate renderedTemplate = ctx.templateRenderer().render(notification);
+            if (renderedTemplate == null) {
+                throw new IllegalStateException("No template configured");
+            }
+
+            mimeType = renderedTemplate.mimeType();
+            body = BodyPublishers.ofString(renderedTemplate.content());
         }
 
         final var requestBuilder = HttpRequest
                 .newBuilder(ruleConfig.getDestinationUrl())
-                .header("Content-Type", renderedTemplate.mimeType())
-                .POST(BodyPublishers.ofString(renderedTemplate.content()))
+                .header("Content-Type", mimeType)
+                .POST(body)
                 .timeout(Duration.ofSeconds(10));
 
         final String authHeaderName = ruleConfig.getAuthHeaderName();

--- a/notification/publishing/src/main/resources/org/dependencytrack/notification/publishing/webhook/webhook-notification-publisher-rule-config-v1.schema.json
+++ b/notification/publishing/src/main/resources/org/dependencytrack/notification/publishing/webhook/webhook-notification-publisher-rule-config-v1.schema.json
@@ -25,6 +25,11 @@
       "description": "Value of the authentication header (e.g. a bearer token).",
       "minLength": 1,
       "x-secret-ref": true
+    },
+    "publishProtobuf": {
+      "type": "boolean",
+      "title": "Publish Protobuf",
+      "description": "Whether to publish notifications in Protobuf format instead of applying a template."
     }
   },
   "required": [

--- a/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/webhook/WebhookNotificationPublisherTest.java
+++ b/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/webhook/WebhookNotificationPublisherTest.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.binaryEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
@@ -440,4 +441,39 @@ class WebhookNotificationPublisherTest extends AbstractNotificationPublisherTest
         }
     }
 
+    @Test
+    void shouldSendProtobufWhenConfigured() {
+        try (final var factory = new WebhookNotificationPublisherFactory()) {
+            final var configRegistry = new MockConfigRegistry(
+                    Map.of(), null, RuntimeConfigMapper.getInstance(), null);
+            factory.init(
+                    new MutableServiceRegistry()
+                            .register(ConfigRegistry.class, configRegistry)
+                            .register(HttpClient.class, HttpClient.newHttpClient()));
+
+            try (final var publisher = factory.create()) {
+                final RuntimeConfigSpec ruleConfigSpec = factory.ruleConfigSpec();
+                final var ruleConfig = (WebhookNotificationPublisherRuleConfigV1) ruleConfigSpec.defaultConfig();
+                ruleConfig.setDestinationUrl(URI.create(WIREMOCK.baseUrl()));
+                ruleConfig.setPublishProtobuf(true);
+
+                final var templateRendererFactory =
+                        new PebbleNotificationTemplateRendererFactory(
+                                Map.of("baseUrl", () -> "https://example.com"));
+                final NotificationTemplateRenderer templateRenderer =
+                        templateRendererFactory.createRenderer(factory.defaultTemplate());
+
+                final var ctx = new NotificationPublishContext(ruleConfig, templateRenderer);
+
+                final var notification = createBomConsumedTestNotification();
+                final var expectedProtobuf = notification.toByteArray();
+                assertThatNoException()
+                        .isThrownBy(() -> publisher.publish(ctx, notification));
+
+                WIREMOCK.verify(postRequestedFor(anyUrl())
+                        .withHeader("Content-Type", equalTo("application/protobuf"))
+                        .withRequestBody(binaryEqualTo(expectedProtobuf)));
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Description

This adds a new option to webhook notifications to publish protobuf messages instead of rendering templates.
This is analogous to the existing option for Kafka notifications.


### Addressed Issue

Fixes: #6342
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<img width="821" height="482" alt="image" src="https://github.com/user-attachments/assets/8b63316f-12a2-490b-a83d-d1ca65b8ff73" />

Data recieved:
```
ProtoBuf: Notification { level: Informational, scope: Portfolio, group: PolicyViolation, title: "[TEST] Policy Violation on Project: [projectName : projectVersion]", content: "A operational policy violation occurred", timestamp: Some(Timestamp { seconds: 1781165497, nanos: 183000000 }), subject: Some(Any { type_url: "type.googleapis.com/org.dependencytrack.notification.v1.PolicyViolationSubject", value: [10, 71, 10, 36, 57, 52, 102, 56, 55, 51, 50, 49, 45, 97, 53, 100, 49, 45, 52, 99, 50, 102, 45, 98, 50, 102, 101, 45, 57, 53, 49, 54, 53, 100, 101, 98, 101, 98, 99, 54, 26, 13, 99, 111, 109, 112, 111, 110, 101, 110, 116, 78, 97, 109, 101, 34, 16, 99, 111, 109, 112, 111, 110, 101, 110, 116, 86, 101, 114, 115, 105, 111, 110, 18, 148, 1, 10, 36, 99, 57, 99, 57, 53, 51, 57, 97, 45, 101, 51, 56, 49, 45, 52, 98, 51, 54, 45, 97, 99, 53, 50, 45, 54, 97, 55, 97, 98, 56, 51, 98, 50, 99, 57, 53, 18, 11, 112, 114, 111, 106, 101, 99, 116, 78, 97, 109, 101, 26, 14, 112, 114, 111, 106, 101, 99, 116, 86, 101, 114, 115, 105, 111, 110, 34, 18, 112, 114, 111, 106, 101, 99, 116, 68, 101, 115, 99, 114, 105, 112, 116, 105, 111, 110, 42, 45, 112, 107, 103, 58, 109, 97, 118, 101, 110, 47, 111, 114, 103, 46, 97, 99, 109, 101, 47, 112, 114, 111, 106, 101, 99, 116, 78, 97, 109, 101, 64, 112, 114, 111, 106, 101, 99, 116, 86, 101, 114, 115, 105, 111, 110, 50, 4, 116, 97, 103, 49, 50, 4, 116, 97, 103, 50, 56, 1, 26, 205, 1, 10, 36, 50, 54, 99, 97, 52, 98, 100, 99, 45, 99, 97, 49, 53, 45, 52, 97, 101, 101, 45, 97, 52, 98, 101, 45, 55, 53, 100, 53, 53, 50, 52, 99, 51, 53, 55, 50, 18, 11, 79, 80, 69, 82, 65, 84, 73, 79, 78, 65, 76, 26, 11, 8, 185, 219, 169, 209, 6, 16, 167, 196, 159, 87, 34, 138, 1, 10, 36, 54, 49, 53, 52, 53, 98, 49, 51, 45, 56, 51, 51, 101, 45, 52, 52, 101, 100, 45, 97, 101, 100, 49, 45, 55, 49, 55, 100, 55, 101, 49, 53, 100, 53, 51, 48, 18, 11, 80, 65, 67, 75, 65, 71, 69, 95, 85, 82, 76, 26, 2, 73, 83, 34, 23, 112, 107, 103, 58, 109, 97, 118, 101, 110, 47, 102, 111, 111, 47, 98, 97, 114, 64, 49, 46, 50, 46, 51, 42, 56, 10, 36, 53, 48, 56, 99, 102, 50, 57, 99, 45, 48, 50, 49, 54, 45, 52, 55, 57, 100, 45, 56, 57, 55, 53, 45, 51, 53, 99, 57, 99, 54, 52, 57, 54, 57, 51, 50, 18, 10, 112, 111, 108, 105, 99, 121, 78, 97, 109, 101, 26, 4, 70, 65, 73, 76] }), id: "019eb5bc-9b5f-7e58-a68b-abe9394b4d8c" }
```

Also tested creating a webhook notification before deploying this version. The notifications continue to work and still send JSON body as expected.

Regarding the checklist entry for documentation I noticed that the Documentation currently has only minimal information on webhooks. It would still be accurate after merging this.
I can expand that if desired.
<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [x] This PR introduces new or alters existing behavior, <del>and I have updated the [documentation] accordingly</del>
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
