### PR TITLE
Fix URL-encoding of OSV ecosystem names when retrieving incremental advisories

### DIFF
--- a/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvAdvisorySource.java
+++ b/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvAdvisorySource.java
@@ -40,6 +40,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import static java.util.function.Predicate.not;
+import static org.dependencytrack.vulndatasource.osv.OsvEcosystems.encodeEcosystem;
 
 /**
  * @since 5.0.0
@@ -123,7 +124,7 @@ sealed interface OsvAdvisorySource extends Iterator<Osv>, Closeable {
             LOGGER.debug("Downloading advisory {}", advisoryId);
 
             final var request = HttpRequest.newBuilder()
-                    .uri(URI.create("%s/%s/%s.json".formatted(dataUrl, ecosystem, advisoryId)))
+                    .uri(URI.create("%s/%s/%s.json".formatted(dataUrl, encodeEcosystem(ecosystem), advisoryId)))
                     .GET()
                     .build();
 

--- a/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvEcosystems.java
+++ b/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvEcosystems.java
@@ -24,6 +24,9 @@ import org.dependencytrack.support.distrometadata.OsDistribution;
 import org.dependencytrack.support.distrometadata.UbuntuDistribution;
 import org.jspecify.annotations.Nullable;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 final class OsvEcosystems {
 
     private OsvEcosystems() {
@@ -53,6 +56,15 @@ final class OsvEcosystems {
             }
             default -> null;
         };
+    }
+
+    static String encodeEcosystem(String ecosystem) {
+        // Some ecosystems contain spaces, e.g. "Red Hat".
+        // NB: URLEncoder encodes spaces as "+", but GCS (where OSV hosts its data dumps)
+        // requires spaces to be percent-encoded.
+        return URLEncoder
+                .encode(ecosystem, StandardCharsets.UTF_8)
+                .replace("+", "%20");
     }
 
 }

--- a/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSource.java
+++ b/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSource.java
@@ -37,12 +37,10 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.net.URI;
-import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -54,6 +52,7 @@ import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 import static org.dependencytrack.vulndatasource.osv.CycloneDxPropertyNames.OSV_ECOSYSTEM;
+import static org.dependencytrack.vulndatasource.osv.OsvEcosystems.encodeEcosystem;
 
 /**
  * @since 5.0.0
@@ -267,15 +266,8 @@ final class OsvVulnDataSource implements VulnDataSource {
             throw new UncheckedIOException("Failed to create temp file", e);
         }
 
-        // Some ecosystems contain spaces, e.g. "Red Hat".
-        // NB: URLEncoder encodes spaces as "+", but GCS (where OSV hosts its data dumps)
-        // requires spaces to be percent-encoded.
-        final String encodedEcosystem = URLEncoder
-                .encode(ecosystem, StandardCharsets.UTF_8)
-                .replace("+", "%20");
-
         final var request = HttpRequest.newBuilder()
-                .uri(URI.create("%s/%s/all.zip".formatted(dataUrl, encodedEcosystem)))
+                .uri(URI.create("%s/%s/all.zip".formatted(dataUrl, encodeEcosystem(ecosystem))))
                 .GET()
                 .build();
 
@@ -323,7 +315,7 @@ final class OsvVulnDataSource implements VulnDataSource {
 
     private Set<String> getModifiedIds(String ecosystem, Instant watermark) {
         final var request = HttpRequest.newBuilder()
-                .uri(URI.create("%s/%s/modified_id.csv".formatted(dataUrl, ecosystem)))
+                .uri(URI.create("%s/%s/modified_id.csv".formatted(dataUrl, encodeEcosystem(ecosystem))))
                 .GET()
                 .build();
 

--- a/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSourceTest.java
+++ b/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSourceTest.java
@@ -529,4 +529,42 @@ class OsvVulnDataSourceTest {
         verify(0, getRequestedFor(urlPathMatching("/maven/OSV-.*\\.json")));
     }
 
+    @Test
+    void shouldPercentEncodeSpacesInEcosystemNameForIncrementalAdvisories(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        when(watermarkManagerMock.getWatermark("Red Hat")).thenReturn(Instant.parse("2024-01-01T00:00:00Z"));
+        String csvBody = """
+                2025-01-01T00:00:00Z,OSV-1
+                """;
+        stubFor(get(urlEqualTo("/Red%20Hat/modified_id.csv"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/csv")
+                        .withBody(csvBody)));
+        for (final String id : List.of("OSV-1")) {
+            stubFor(get(urlEqualTo("/Red%20Hat/" + id + ".json"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(/* language=JSON */ """
+                                    {"id":"%s","summary":"s","affected":[],"modified":"2025-01-01T00:00:00Z"}
+                                    """.formatted(id))));
+        }
+
+        try (var dataSource = new OsvVulnDataSource(
+                watermarkManagerMock,
+                objectMapper,
+                wmRuntimeInfo.getHttpBaseUrl(),
+                List.of("Red Hat"),
+                HttpClient.newHttpClient(),
+                false)) {
+            assertThat(dataSource.hasNext()).isTrue();
+            dataSource.next();
+            assertThat(dataSource.hasNext()).isFalse();
+        }
+
+        verify(1,getRequestedFor(urlEqualTo("/Red%20Hat/modified_id.csv")));
+        verify(0, getRequestedFor(urlPathMatching(".*/Red\\+Hat/.*")));
+
+        verify(1, getRequestedFor(urlPathMatching("/Red%20Hat/OSV-1\\.json")));
+    }
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->
Fixes URL-encoding of OSV ecosystem names when retrieving incremental advisories.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

See code comments.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations