### PR TITLE
Handle PAC-inaccessible target projects more gracefully for BOM uploads with autoCreate=true

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -120,6 +120,7 @@ import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_T
 import static org.dependencytrack.notification.api.NotificationFactory.createBomValidationFailedNotification;
 import static org.dependencytrack.notification.api.NotificationFactory.createProjectCreatedNotification;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiTransaction;
+import static org.dependencytrack.util.PersistenceUtil.isUniqueConstraintViolation;
 
 /**
  * JAX-RS resources for processing bill-of-material (bom) documents.
@@ -189,9 +190,9 @@ public class BomResource extends AbstractApiResource {
             @QueryParam("version") String version
     ) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
-            String versionParameter =  Objects.toString(StringUtils.trimToNull(version), DEFAULT_EXPORT_VERSION);
+            String versionParameter = Objects.toString(StringUtils.trimToNull(version), DEFAULT_EXPORT_VERSION);
             Version cdxOutputVersion = Version.fromVersionString(versionParameter);
-            if(cdxOutputVersion == null) {
+            if (cdxOutputVersion == null) {
                 return Response.status(Response.Status.BAD_REQUEST).entity("Invalid BOM version specified.").build();
             }
 
@@ -397,7 +398,16 @@ public class BomResource extends AbstractApiResource {
             );
             try (final var qm = new QueryManager(getAlpineRequest())) {
                 projectInfo = qm.callInTransaction(() -> {
-                    Project project = qm.getProject(request.getProjectName(), request.getProjectVersion());
+                    final String trimmedProjectName = StringUtils.trimToNull(request.getProjectName());
+                    final String trimmedProjectVersion = StringUtils.trimToNull(request.getProjectVersion());
+
+                    // NB: Bypass portfolio ACL for this lookup since it would otherwise filter out existing
+                    // projects that are inaccessible. `autoCreate=true` would then lead to us trying to create
+                    // a project that already exists, triggering a unique constraint violation.
+                    // Access to the project (and potentially its parent) is asserted explicitly via requireAccess().
+                    Project project = ProjectAccess.unrestricted(
+                            () -> qm.getProject(trimmedProjectName, trimmedProjectVersion));
+
                     if (project == null && request.isAutoCreate()) {
                         if (hasPermission(Permissions.Constants.PORTFOLIO_MANAGEMENT) || hasPermission(Permissions.Constants.PORTFOLIO_MANAGEMENT_CREATE) || hasPermission(Permissions.Constants.PROJECT_CREATION_UPLOAD)) {
                             Project parent = null;
@@ -412,7 +422,7 @@ public class BomResource extends AbstractApiResource {
                                     );
                                     final String trimmedParentName = StringUtils.trimToNull(request.getParentName());
                                     final String trimmedParentVersion = StringUtils.trimToNull(request.getParentVersion());
-                                    parent = qm.getProject(trimmedParentName, trimmedParentVersion);
+                                    parent = ProjectAccess.unrestricted(() -> qm.getProject(trimmedParentName, trimmedParentVersion));
                                 }
 
                                 if (parent == null) {
@@ -423,16 +433,25 @@ public class BomResource extends AbstractApiResource {
                                 }
                                 requireAccess(qm, parent, "Access to the specified parent project is forbidden");
                             }
-                            final String trimmedProjectName = StringUtils.trimToNull(request.getProjectName());
                             if (request.isLatest()) {
                                 final Project oldLatest = ProjectAccess.unrestricted(() -> qm.getLatestProjectVersion(trimmedProjectName));
                                 if (oldLatest != null) {
                                     requireAccess(qm, oldLatest, "Access to the previous latest project version is forbidden");
                                 }
                             }
-                            project = qm.createProject(trimmedProjectName, null,
-                                    StringUtils.trimToNull(request.getProjectVersion()), request.getProjectTags(), parent,
-                                    null, null, request.isLatest(), true);
+                            try {
+                                project = qm.createProject(trimmedProjectName, null,
+                                        trimmedProjectVersion, request.getProjectTags(), parent,
+                                        null, null, request.isLatest(), true);
+                            } catch (RuntimeException e) {
+                                if (isUniqueConstraintViolation(e)) {
+                                    throw new WebApplicationException(Response
+                                            .status(Response.Status.CONFLICT)
+                                            .entity("A project with the specified name and version already exists.")
+                                            .build());
+                                }
+                                throw e;
+                            }
                             Principal principal = getPrincipal();
                             qm.updateNewProjectACL(project, principal);
                             new JdoNotificationEmitter(qm).emit(
@@ -574,7 +593,14 @@ public class BomResource extends AbstractApiResource {
                 projectInfo = qm.callInTransaction(() -> {
                     final String trimmedProjectName = StringUtils.trimToNull(projectName);
                     final String trimmedProjectVersion = StringUtils.trimToNull(projectVersion);
-                    Project project = qm.getProject(trimmedProjectName, trimmedProjectVersion);
+
+                    // NB: Bypass portfolio ACL for this lookup since it would otherwise filter out existing
+                    // projects that are inaccessible. `autoCreate=true` would then lead to us trying to create
+                    // a project that already exists, triggering a unique constraint violation.
+                    // Access to the project (and potentially its parent) is asserted explicitly via requireAccess().
+                    Project project = ProjectAccess.unrestricted(
+                            () -> qm.getProject(trimmedProjectName, trimmedProjectVersion));
+
                     if (project == null && autoCreate) {
                         if (hasPermission(Permissions.Constants.PORTFOLIO_MANAGEMENT) || hasPermission(Permissions.Constants.PORTFOLIO_MANAGEMENT_CREATE) || hasPermission(Permissions.Constants.PROJECT_CREATION_UPLOAD)) {
                             Project parent = null;
@@ -584,7 +610,7 @@ public class BomResource extends AbstractApiResource {
                                 } else {
                                     final String trimmedParentName = StringUtils.trimToNull(parentName);
                                     final String trimmedParentVersion = StringUtils.trimToNull(parentVersion);
-                                    parent = qm.getProject(trimmedParentName, trimmedParentVersion);
+                                    parent = ProjectAccess.unrestricted(() -> qm.getProject(trimmedParentName, trimmedParentVersion));
                                 }
 
                                 if (parent == null) {
@@ -601,7 +627,17 @@ public class BomResource extends AbstractApiResource {
                                     requireAccess(qm, oldLatest, "Access to the previous latest project version is forbidden");
                                 }
                             }
-                            project = qm.createProject(trimmedProjectName, null, trimmedProjectVersion, requestTags, parent, null, null, isLatest, true);
+                            try {
+                                project = qm.createProject(trimmedProjectName, null, trimmedProjectVersion, requestTags, parent, null, null, isLatest, true);
+                            } catch (RuntimeException e) {
+                                if (isUniqueConstraintViolation(e)) {
+                                    throw new WebApplicationException(Response
+                                            .status(Response.Status.CONFLICT)
+                                            .entity("A project with the specified name and version already exists.")
+                                            .build());
+                                }
+                                throw e;
+                            }
                             Principal principal = getPrincipal();
                             qm.updateNewProjectACL(project, principal);
                             new JdoNotificationEmitter(qm).emit(

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -2055,6 +2055,173 @@ class BomResourceTest extends ResourceTest {
     }
 
     @Test
+    void shouldReturnForbiddenWhenAutoCreateButProjectExistsInaccessible() throws Exception {
+        initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
+        enablePortfolioAccessControl();
+
+        final var existing = new Project();
+        existing.setName("acme-app");
+        existing.setVersion("1.0.0");
+        qm.persist(existing);
+
+        final String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
+        final Response response = jersey.target(V1_BOM).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "projectName": "acme-app",
+                          "projectVersion": "1.0.0",
+                          "autoCreate": true,
+                          "bom": "%s"
+                        }
+                        """.formatted(bomString)));
+        assertThat(response.getStatus()).isEqualTo(403);
+
+        final Project found = qm.getProject("acme-app", "1.0.0");
+        assertThat(found).isNotNull();
+        assertThat(found.getUuid()).isEqualTo(existing.getUuid());
+    }
+
+    @Test
+    void shouldReturnForbiddenWhenMultipartAutoCreateButProjectExistsInaccessible() throws Exception {
+        initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
+        enablePortfolioAccessControl();
+
+        final var existing = new Project();
+        existing.setName("Acme Example");
+        existing.setVersion("1.0");
+        qm.persist(existing);
+
+        final var multiPart = new FormDataMultiPart()
+                .field("bom", resourceToString("/unit/bom-1.xml", StandardCharsets.UTF_8), MediaType.APPLICATION_XML_TYPE)
+                .field("projectName", "Acme Example")
+                .field("projectVersion", "1.0")
+                .field("autoCreate", "true");
+
+        final var client = ClientBuilder.newClient(
+                new ClientConfig()
+                        .register(MultiPartFeature.class)
+                        .connectorProvider(new HttpUrlConnectorProvider()));
+
+        final Response response = client
+                .target(jersey.target(V1_BOM).getUri())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.entity(multiPart, multiPart.getMediaType()));
+        assertThat(response.getStatus()).isEqualTo(403);
+
+        final Project found = qm.getProject("Acme Example", "1.0");
+        assertThat(found).isNotNull();
+        assertThat(found.getUuid()).isEqualTo(existing.getUuid());
+    }
+
+    @Test
+    void shouldMatchExistingProjectWhenNameAndVersionContainSurroundingWhitespace() throws Exception {
+        initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
+
+        final var existing = new Project();
+        existing.setName("acme-app");
+        existing.setVersion("1.0.0");
+        qm.persist(existing);
+
+        final String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
+        final Response response = jersey
+                .target(V1_BOM)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "projectName": "  acme-app  ",
+                          "projectVersion": "  1.0.0  ",
+                          "autoCreate": true,
+                          "bom": "%s"
+                        }
+                        """.formatted(bomString)));
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        final Project found = qm.getProject("acme-app", "1.0.0");
+        assertThat(found).isNotNull();
+        assertThat(found.getUuid()).isEqualTo(existing.getUuid());
+    }
+
+    @Test
+    void shouldReturnForbiddenWhenParentProjectByNameIsInaccessible() throws Exception {
+        initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
+        enablePortfolioAccessControl();
+
+        final var parent = new Project();
+        parent.setName("Acme Parent");
+        parent.setVersion("1.0");
+        qm.persist(parent);
+
+        final String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
+        final Response response = jersey
+                .target(V1_BOM)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "projectName": "Acme Example",
+                          "projectVersion": "1.0",
+                          "parentName": "Acme Parent",
+                          "parentVersion": "1.0",
+                          "autoCreate": true,
+                          "bom": "%s"
+                        }
+                        """.formatted(bomString)));
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 403,
+                  "title": "Project access denied",
+                  "detail": "Access to the specified parent project is forbidden"
+                }
+                """);
+
+        assertThat(qm.getProject("Acme Example", "1.0")).isNull();
+    }
+
+    @Test
+    void shouldReturnForbiddenWhenMultipartParentProjectByNameIsInaccessible() throws Exception {
+        initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
+        enablePortfolioAccessControl();
+
+        final var parent = new Project();
+        parent.setName("Acme Parent");
+        parent.setVersion("1.0");
+        qm.persist(parent);
+
+        final var multiPart = new FormDataMultiPart()
+                .field("bom", resourceToString("/unit/bom-1.xml", StandardCharsets.UTF_8), MediaType.APPLICATION_XML_TYPE)
+                .field("projectName", "Acme Example")
+                .field("projectVersion", "1.0")
+                .field("parentName", "Acme Parent")
+                .field("parentVersion", "1.0")
+                .field("autoCreate", "true");
+
+        final var client = ClientBuilder.newClient(
+                new ClientConfig()
+                        .register(MultiPartFeature.class)
+                        .connectorProvider(new HttpUrlConnectorProvider()));
+
+        final Response response = client
+                .target(jersey.target(V1_BOM).getUri())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.entity(multiPart, multiPart.getMediaType()));
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 403,
+                  "title": "Project access denied",
+                  "detail": "Access to the specified parent project is forbidden"
+                }
+                """);
+
+        assertThat(qm.getProject("Acme Example", "1.0")).isNull();
+    }
+
+    @Test
     void shouldRejectBomUploadForCollectionProject() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
         final var project = new Project();


### PR DESCRIPTION




### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Handle PAC-inaccessible target projects more gracefully for BOM uploads with autoCreate=true

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6368 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

PAC is implemented at the DB query level, so lookups don't even return data that is inaccessible to the authenticated principal.

For BOM uploads with `autoCreate=true` this could lead to situations where projects appear to not exist, and DT trying to create them, only to run into unique constraint violations.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
