### PR TITLE
Decouple policy condition API from JDO models

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/PolicyConditionResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/PolicyConditionResource.java
@@ -46,6 +46,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
+import org.dependencytrack.model.PolicyViolation;
 import org.dependencytrack.model.validation.ValidUuid;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.policy.cel.CelPolicyCompiler;
@@ -53,6 +54,9 @@ import org.dependencytrack.policy.cel.CelPolicyCompiler.CacheMode;
 import org.dependencytrack.policy.cel.CelPolicyType;
 import org.dependencytrack.resources.AbstractApiResource;
 import org.dependencytrack.resources.v1.vo.CelExpressionError;
+import org.dependencytrack.resources.v1.vo.CreatePolicyConditionRequest;
+import org.dependencytrack.resources.v1.vo.PolicyConditionResponse;
+import org.dependencytrack.resources.v1.vo.UpdatePolicyConditionRequest;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -77,45 +81,61 @@ public class PolicyConditionResource extends AbstractApiResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Creates a new policy condition for an existing policy",
-            description = "<p>Requires permission <strong>POLICY_MANAGEMENT</strong> or <strong>POLICY_MANAGEMENT_UPDATE</strong></p>"
+            description = """
+                    <p>
+                      Requires permission <strong>POLICY_MANAGEMENT</strong>
+                      or <strong>POLICY_MANAGEMENT_UPDATE</strong>
+                    </p>
+                    """
     )
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "201",
                     description = "The created policy condition",
-                    content = @Content(schema = @Schema(implementation = PolicyCondition.class))
+                    content = @Content(schema = @Schema(implementation = PolicyConditionResponse.class))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(responseCode = "404", description = "The UUID of the policy could not be found")
     })
-    @PermissionRequired({Permissions.Constants.POLICY_MANAGEMENT, Permissions.Constants.POLICY_MANAGEMENT_UPDATE})
+    @PermissionRequired({
+            Permissions.Constants.POLICY_MANAGEMENT,
+            Permissions.Constants.POLICY_MANAGEMENT_UPDATE
+    })
     public Response createPolicyCondition(
-            @Parameter(description = "The UUID of the policy", schema = @Schema(type = "string", format = "uuid"), required = true)
+            @Parameter(
+                    description = "The UUID of the policy",
+                    schema = @Schema(type = "string", format = "uuid"),
+                    required = true)
             @PathParam("uuid") @ValidUuid String uuid,
-            PolicyCondition jsonPolicyCondition) {
+            CreatePolicyConditionRequest request) {
         final Validator validator = super.getValidator();
         failOnValidationError(
-                validator.validateProperty(jsonPolicyCondition, "value")
+                validator.validateProperty(request, "value")
         );
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
-            PolicyCondition pcUpdated = qm.callInTransaction(() -> {
-                Policy policy = qm.getObjectByUuid(Policy.class, uuid);
-                if (policy != null) {
-                    maybeValidateExpression(jsonPolicyCondition);
-                    return qm.createPolicyCondition(policy, jsonPolicyCondition.getSubject(),
-                            jsonPolicyCondition.getOperator(), StringUtils.trimToNull(jsonPolicyCondition.getValue()),
-                            jsonPolicyCondition.getViolationType());
-                } else {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
+            final PolicyCondition createdCondition = qm.callInTransaction(() -> {
+                final Policy policy = qm.getObjectByUuid(Policy.class, uuid);
+                if (policy == null) {
                     throw new ClientErrorException(Response
                             .status(Response.Status.NOT_FOUND)
                             .entity("The UUID of the policy could not be found.")
                             .build());
                 }
+
+                maybeValidateExpression(request.subject(), request.violationType(), request.value());
+
+                return qm.createPolicyCondition(
+                        policy,
+                        request.subject(),
+                        request.operator(),
+                        StringUtils.trimToNull(request.value()),
+                        request.violationType());
             });
-            // Prevent infinite recursion during JSON serialization.
-            qm.makeTransient(pcUpdated);
-            pcUpdated.setPolicy(null);
-            return Response.status(Response.Status.CREATED).entity(pcUpdated).build();
+
+            return Response
+                    .status(Response.Status.CREATED)
+                    .entity(PolicyConditionResponse.of(createdCondition))
+                    .build();
         }
     }
 
@@ -125,40 +145,49 @@ public class PolicyConditionResource extends AbstractApiResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Updates a policy condition",
-            description = "<p>Requires permission <strong>POLICY_MANAGEMENT</strong> or <strong>POLICY_MANAGEMENT_UPDATE</strong></p>"
+            description = """
+                    <p>
+                      Requires permission <strong>POLICY_MANAGEMENT</strong>
+                      or <strong>POLICY_MANAGEMENT_UPDATE</strong>
+                    </p>
+                    """
     )
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
                     description = "The updated policy condition",
-                    content = @Content(schema = @Schema(implementation = PolicyCondition.class))
+                    content = @Content(schema = @Schema(implementation = PolicyConditionResponse.class))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(responseCode = "404", description = "The UUID of the policy condition could not be found")
     })
-    @PermissionRequired({Permissions.Constants.POLICY_MANAGEMENT, Permissions.Constants.POLICY_MANAGEMENT_UPDATE})
-    public Response updatePolicyCondition(PolicyCondition jsonPolicyCondition) {
+    @PermissionRequired({
+            Permissions.Constants.POLICY_MANAGEMENT,
+            Permissions.Constants.POLICY_MANAGEMENT_UPDATE
+    })
+    public Response updatePolicyCondition(UpdatePolicyConditionRequest request) {
         final Validator validator = super.getValidator();
         failOnValidationError(
-                validator.validateProperty(jsonPolicyCondition, "value")
+                validator.validateProperty(request, "value")
         );
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
-            PolicyCondition pcUpdated = qm.callInTransaction(() -> {
-                PolicyCondition pc = qm.getObjectByUuid(PolicyCondition.class, jsonPolicyCondition.getUuid());
-                if (pc != null) {
-                    maybeValidateExpression(jsonPolicyCondition);
-                    return qm.updatePolicyCondition(jsonPolicyCondition);
-                } else {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
+            final PolicyCondition updatedCondition = qm.callInTransaction(() -> {
+                final PolicyCondition existing = qm.getObjectByUuid(PolicyCondition.class, request.uuid());
+                if (existing == null) {
                     throw new ClientErrorException(Response
                             .status(Response.Status.NOT_FOUND)
                             .entity("The UUID of the policy condition could not be found.")
                             .build());
                 }
+
+                maybeValidateExpression(request.subject(), request.violationType(), request.value());
+
+                return qm.updatePolicyCondition(convert(request));
             });
-            // Prevent infinite recursion during JSON serialization.
-            qm.makeTransient(pcUpdated);
-            pcUpdated.setPolicy(null);
-            return Response.status(Response.Status.OK).entity(pcUpdated).build();
+
+            return Response
+                    .ok(PolicyConditionResponse.of(updatedCondition))
+                    .build();
         }
     }
 
@@ -168,41 +197,70 @@ public class PolicyConditionResource extends AbstractApiResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Deletes a policy condition from an existing policy",
-            description = "<p>Requires permission <strong>POLICY_MANAGEMENT</strong> or <strong>POLICY_MANAGEMENT_UPDATE</strong></p>"
+            description = """
+                    <p>
+                      Requires permission <strong>POLICY_MANAGEMENT</strong>
+                      or <strong>POLICY_MANAGEMENT_UPDATE</strong>
+                    </p>
+                    """
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "Policy condition removed successfully"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(responseCode = "404", description = "The UUID of the policy condition could not be found")
     })
-    @PermissionRequired({Permissions.Constants.POLICY_MANAGEMENT, Permissions.Constants.POLICY_MANAGEMENT_UPDATE})
+    @PermissionRequired({
+            Permissions.Constants.POLICY_MANAGEMENT,
+            Permissions.Constants.POLICY_MANAGEMENT_UPDATE
+    })
     public Response deletePolicyCondition(
             @Parameter(description = "The UUID of the policy condition to delete", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid) {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
                 final PolicyCondition pc = qm.getObjectByUuid(PolicyCondition.class, uuid);
                 if (pc != null) {
                     qm.delete(pc);
-                    return Response.status(Response.Status.NO_CONTENT).build();
+                    return Response
+                            .status(Response.Status.NO_CONTENT)
+                            .build();
                 } else {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the policy condition could not be found.").build();
+                    return Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The UUID of the policy condition could not be found.")
+                            .build();
                 }
             });
         }
     }
 
-    private void maybeValidateExpression(final PolicyCondition policyCondition) {
-        if (policyCondition.getSubject() != PolicyCondition.Subject.EXPRESSION) {
+    private static PolicyCondition convert(UpdatePolicyConditionRequest request) {
+        final var pc = new PolicyCondition();
+        pc.setUuid(request.uuid());
+        pc.setSubject(request.subject());
+        pc.setOperator(request.operator());
+        pc.setValue(request.value());
+        pc.setViolationType(request.violationType());
+        return pc;
+    }
+
+    private void maybeValidateExpression(
+            PolicyCondition.Subject subject,
+            PolicyViolation.Type violationType,
+            String value) {
+        if (subject != PolicyCondition.Subject.EXPRESSION) {
             return;
         }
 
-        if (policyCondition.getViolationType() == null) {
-            throw new BadRequestException(Response.status(Response.Status.BAD_REQUEST).entity("Expression conditions must define a violation type").build());
+        if (violationType == null) {
+            throw new BadRequestException(Response
+                    .status(Response.Status.BAD_REQUEST)
+                    .entity("Expression conditions must define a violation type")
+                    .build());
         }
 
         try {
-            CelPolicyCompiler.getInstance(CelPolicyType.COMPONENT).compile(policyCondition.getValue(), CacheMode.NO_CACHE);
+            CelPolicyCompiler.getInstance(CelPolicyType.COMPONENT).compile(value, CacheMode.NO_CACHE);
         } catch (CelValidationException e) {
             final var celErrors = new ArrayList<CelExpressionError>();
             for (final CelIssue issue : e.getErrors()) {
@@ -212,7 +270,11 @@ public class PolicyConditionResource extends AbstractApiResource {
                         issue.getMessage()));
             }
 
-            throw new BadRequestException(Response.status(Response.Status.BAD_REQUEST).entity(Map.of("celErrors", celErrors)).build());
+            throw new BadRequestException(Response
+                    .status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("celErrors", celErrors))
+                    .build());
         }
     }
+
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/CreatePolicyConditionRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/CreatePolicyConditionRequest.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import org.dependencytrack.model.PolicyCondition;
+import org.dependencytrack.model.PolicyViolation;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/// @since 5.1.0
+@NullMarked
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CreatePolicyConditionRequest(
+        @Schema(description = "Subject the condition evaluates", requiredMode = Schema.RequiredMode.REQUIRED)
+        PolicyCondition.Subject subject,
+        @Schema(description = "Operator used to compare the subject to the value", requiredMode = Schema.RequiredMode.REQUIRED)
+        PolicyCondition.Operator operator,
+        @NotBlank
+        @Schema(description = "Value the subject is compared to", requiredMode = Schema.RequiredMode.REQUIRED)
+        String value,
+        @Schema(description = "Violation type produced when the condition matches. Required for `EXPRESSION` subjects")
+        PolicyViolation.@Nullable Type violationType) {
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/PolicyConditionResponse.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/PolicyConditionResponse.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.dependencytrack.model.PolicyCondition;
+import org.dependencytrack.model.PolicyViolation;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.UUID;
+
+/// @since 5.1.0
+@NullMarked
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record PolicyConditionResponse(
+        @Schema(description = "UUID of the policy condition", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID uuid,
+        @Schema(description = "Subject the condition evaluates", requiredMode = Schema.RequiredMode.REQUIRED)
+        PolicyCondition.Subject subject,
+        @Schema(description = "Operator used to compare the subject to the value", requiredMode = Schema.RequiredMode.REQUIRED)
+        PolicyCondition.Operator operator,
+        @Schema(description = "Value the subject is compared to", requiredMode = Schema.RequiredMode.REQUIRED)
+        String value,
+        @Schema(description = "Violation type produced when the condition matches")
+        PolicyViolation.@Nullable Type violationType) {
+
+    public static PolicyConditionResponse of(PolicyCondition condition) {
+        return new PolicyConditionResponse(
+                condition.getUuid(),
+                condition.getSubject(),
+                condition.getOperator(),
+                condition.getValue(),
+                condition.getViolationType());
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/UpdatePolicyConditionRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/UpdatePolicyConditionRequest.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.dependencytrack.model.PolicyCondition;
+import org.dependencytrack.model.PolicyViolation;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.UUID;
+
+/// @since 5.1.0
+@NullMarked
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record UpdatePolicyConditionRequest(
+        @NotNull
+        @Schema(description = "UUID of the policy condition to update", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID uuid,
+        @Schema(description = "Subject the condition evaluates", requiredMode = Schema.RequiredMode.REQUIRED)
+        PolicyCondition.Subject subject,
+        @Schema(description = "Operator used to compare the subject to the value", requiredMode = Schema.RequiredMode.REQUIRED)
+        PolicyCondition.Operator operator,
+        @NotBlank
+        @Schema(description = "Value the subject is compared to", requiredMode = Schema.RequiredMode.REQUIRED)
+        String value,
+        @Schema(description = "Violation type produced when the condition matches. Required for `EXPRESSION` subjects")
+        PolicyViolation.@Nullable Type violationType) {
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Tackles the technical debt of JDO models being reused for REST DTOs for all endpoints under `/v1/policy/{uuid}/condition`.

Also makes the generated OpenAPI spec more reliable b/c it no longer advertises fields that are never used / never returned.

Note that the existing tests already asserted full JSON responses, so no new regression tests were necessary.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
