### PR TITLE
Decouple component/project properties APIs from JDO models

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
@@ -30,9 +30,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.model.BomValidationMode;
 import org.dependencytrack.model.ConfigPropertyAccessMode;
 import org.dependencytrack.model.ConfigPropertyConstants;
-import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.AbstractApiResource;
 import org.dependencytrack.secret.management.SecretManager;
+import org.dependencytrack.util.PersistenceUtil;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.owasp.security.logging.SecurityMarkers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,6 +48,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+@NullMarked
 abstract class AbstractConfigPropertyResource extends AbstractApiResource {
 
     private final Logger LOGGER = LoggerFactory.getLogger(this.getClass()); // Use the classes that extend this, not this class itself
@@ -55,31 +58,37 @@ abstract class AbstractConfigPropertyResource extends AbstractApiResource {
         this.secretManager = secretManager;
     }
 
-    Response updatePropertyValue(QueryManager qm, IConfigProperty json, IConfigProperty property) {
-        if (property != null) {
-            final Response check = updatePropertyValueInternal(json, property);
-            if (check != null) {
-                return check;
-            }
-            property = qm.persist(property);
-            IConfigProperty detached = qm.detach(property.getClass(), property.getId());
-            return Response.ok(detached).build();
-        } else {
-            return Response.status(Response.Status.NOT_FOUND).entity("The config property could not be found.").build();
+    Response updatePropertyValue(IConfigProperty json, @Nullable IConfigProperty property) {
+        if (property == null) {
+            return Response
+                    .status(Response.Status.NOT_FOUND)
+                    .entity("The config property could not be found.")
+                    .build();
         }
+
+        final Response check = applyPropertyValue(json.getPropertyValue(), property);
+        if (check != null) {
+            return check;
+        }
+
+        return Response.ok(property).build();
     }
 
-    private Response updatePropertyValueInternal(IConfigProperty json, IConfigProperty property) {
+    @Nullable Response applyPropertyValue(@Nullable String requestedValue, IConfigProperty property) {
+        PersistenceUtil.assertPersistent(property, "property must be persistent");
+
         final var wellKnownProperty = ConfigPropertyConstants.ofProperty(property);
-        if (wellKnownProperty != null && wellKnownProperty.getAccessMode() == ConfigPropertyAccessMode.READ_ONLY) {
+        if (wellKnownProperty != null
+                && wellKnownProperty.getAccessMode() == ConfigPropertyAccessMode.READ_ONLY) {
             return Response
                     .status(Response.Status.BAD_REQUEST)
-                    .entity("The property %s.%s can not be modified".formatted(property.getGroupName(), property.getPropertyName()))
+                    .entity("The property %s.%s can not be modified".formatted(
+                            property.getGroupName(), property.getPropertyName()))
                     .build();
         }
 
         if (wellKnownProperty != null && wellKnownProperty.isSecretName()) {
-            final String secretName = StringUtils.trimToNull(json.getPropertyValue());
+            final String secretName = StringUtils.trimToNull(requestedValue);
             if (secretName != null && secretManager.getSecretMetadata(secretName) == null) {
                 return Response
                         .status(Response.Status.BAD_REQUEST)
@@ -92,67 +101,82 @@ abstract class AbstractConfigPropertyResource extends AbstractApiResource {
         }
 
         if (property.getPropertyType() == IConfigProperty.PropertyType.BOOLEAN) {
-            boolean propertyValue = BooleanUtil.valueOf(json.getPropertyValue());
-            if (ConfigPropertyConstants.CUSTOM_RISK_SCORE_HISTORY_ENABLED.getPropertyName().equals(json.getPropertyName())) {
-                super.logSecurityEvent(LOGGER, SecurityMarkers.SECURITY_AUDIT, "Attribute \"" + json.getPropertyName() + "\" was changed to value: " + String.valueOf(propertyValue) + " by user " + super.getPrincipal().getName());
+            final boolean propertyValue = BooleanUtil.valueOf(requestedValue);
+            if (ConfigPropertyConstants.CUSTOM_RISK_SCORE_HISTORY_ENABLED.getPropertyName().equals(property.getPropertyName())) {
+                super.logSecurityEvent(LOGGER, SecurityMarkers.SECURITY_AUDIT, "Attribute \"" + property.getPropertyName() + "\" was changed to value: " + propertyValue + " by user " + super.getPrincipal().getName());
             }
-            property.setPropertyValue(String.valueOf(BooleanUtil.valueOf(json.getPropertyValue())));
+            property.setPropertyValue(String.valueOf(propertyValue));
         } else if (property.getPropertyType() == IConfigProperty.PropertyType.INTEGER) {
             try {
-                int propertyValue = Integer.parseInt(json.getPropertyValue());
-                if (ConfigPropertyConstants.CUSTOM_RISK_SCORE_CRITICAL.getPropertyName().equals(json.getPropertyName()) ||
-                        ConfigPropertyConstants.CUSTOM_RISK_SCORE_HIGH.getPropertyName().equals(json.getPropertyName()) ||
-                        ConfigPropertyConstants.CUSTOM_RISK_SCORE_MEDIUM.getPropertyName().equals(json.getPropertyName()) ||
-                        ConfigPropertyConstants.CUSTOM_RISK_SCORE_LOW.getPropertyName().equals(json.getPropertyName()) ||
-                        ConfigPropertyConstants.CUSTOM_RISK_SCORE_UNASSIGNED.getPropertyName().equals(json.getPropertyName())
-                ) {
+                final int propertyValue = Integer.parseInt(requestedValue);
+                if (ConfigPropertyConstants.CUSTOM_RISK_SCORE_CRITICAL.getPropertyName().equals(property.getPropertyName())
+                        || ConfigPropertyConstants.CUSTOM_RISK_SCORE_HIGH.getPropertyName().equals(property.getPropertyName())
+                        || ConfigPropertyConstants.CUSTOM_RISK_SCORE_MEDIUM.getPropertyName().equals(property.getPropertyName())
+                        || ConfigPropertyConstants.CUSTOM_RISK_SCORE_LOW.getPropertyName().equals(property.getPropertyName())
+                        || ConfigPropertyConstants.CUSTOM_RISK_SCORE_UNASSIGNED.getPropertyName().equals(property.getPropertyName())) {
                     if (propertyValue < 1 || propertyValue > 10) {
-                        return Response.status(Response.Status.BAD_REQUEST).entity("Risk score \"" + json.getPropertyName() + "\" must be between 1 and 10. An invalid value of " + propertyValue + " was provided.").build();
+                        return Response
+                                .status(Response.Status.BAD_REQUEST)
+                                .entity("Risk score \"" + property.getPropertyName() + "\" must be between 1 and 10. An invalid value of " + propertyValue + " was provided.")
+                                .build();
                     }
-                    super.logSecurityEvent(LOGGER, SecurityMarkers.SECURITY_AUDIT, "Risk score \"" + json.getPropertyName() + "\" changed to value: " + propertyValue + " by user " + super.getPrincipal().getName());
+
+                    super.logSecurityEvent(LOGGER, SecurityMarkers.SECURITY_AUDIT, "Risk score \"" + property.getPropertyName() + "\" changed to value: " + propertyValue + " by user " + super.getPrincipal().getName());
                 }
                 property.setPropertyValue(String.valueOf(propertyValue));
             } catch (NumberFormatException e) {
-                return Response.status(Response.Status.BAD_REQUEST).entity("The property expected an integer and an integer was not sent.").build();
+                return Response
+                        .status(Response.Status.BAD_REQUEST)
+                        .entity("The property expected an integer and an integer was not sent.")
+                        .build();
             }
         } else if (property.getPropertyType() == IConfigProperty.PropertyType.NUMBER) {
             try {
-                new BigDecimal(json.getPropertyValue());  // don't actually use it, just see if it's parses without exception
-                property.setPropertyValue(json.getPropertyValue());
+                new BigDecimal(requestedValue);  // don't actually use it, just see if it's parses without exception
+                property.setPropertyValue(requestedValue);
             } catch (NumberFormatException e) {
-                return Response.status(Response.Status.BAD_REQUEST).entity("The property expected a number and a number was not sent.").build();
+                return Response
+                        .status(Response.Status.BAD_REQUEST)
+                        .entity("The property expected a number and a number was not sent.")
+                        .build();
             }
         } else if (property.getPropertyType() == IConfigProperty.PropertyType.URL) {
-            if (json.getPropertyValue() == null) {
+            if (requestedValue == null) {
                 property.setPropertyValue(null);
             } else {
                 try {
-                    final URL url = new URI(json.getPropertyValue()).toURL();
+                    final URL url = new URI(requestedValue).toURL();
                     property.setPropertyValue(url.toExternalForm());
                 } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
-                    return Response.status(Response.Status.BAD_REQUEST).entity("The property expected a URL but the URL was malformed.").build();
+                    return Response
+                            .status(Response.Status.BAD_REQUEST)
+                            .entity("The property expected a URL but the URL was malformed.")
+                            .build();
                 }
             }
         } else if (property.getPropertyType() == IConfigProperty.PropertyType.UUID) {
-            if (UuidUtil.isValidUUID(json.getPropertyValue())) {
-                property.setPropertyValue(json.getPropertyValue());
+            if (UuidUtil.isValidUUID(requestedValue)) {
+                property.setPropertyValue(requestedValue);
             } else {
-                return Response.status(Response.Status.BAD_REQUEST).entity("The property expected a UUID but a valid UUID was not sent.").build();
+                return Response
+                        .status(Response.Status.BAD_REQUEST)
+                        .entity("The property expected a UUID but a valid UUID was not sent.")
+                        .build();
             }
-        } else if (ConfigPropertyConstants.BOM_VALIDATION_MODE.getPropertyName().equals(json.getPropertyName())) {
+        } else if (ConfigPropertyConstants.BOM_VALIDATION_MODE.getPropertyName().equals(property.getPropertyName())) {
             try {
-                BomValidationMode.valueOf(json.getPropertyValue());
-                property.setPropertyValue(json.getPropertyValue());
+                BomValidationMode.valueOf(requestedValue);
+                property.setPropertyValue(requestedValue);
             } catch (IllegalArgumentException e) {
                 return Response
                         .status(Response.Status.BAD_REQUEST)
                         .entity("Value must be any of: %s".formatted(Arrays.stream(BomValidationMode.values()).map(Enum::name).collect(Collectors.joining(", "))))
                         .build();
             }
-        } else if (ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE.getPropertyName().equals(json.getPropertyName())
-                || ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE.getPropertyName().equals(json.getPropertyName())) {
+        } else if (ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE.getPropertyName().equals(property.getPropertyName())
+                || ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE.getPropertyName().equals(property.getPropertyName())) {
             try {
-                final JsonReader jsonReader = Json.createReader(new StringReader(json.getPropertyValue()));
+                final JsonReader jsonReader = Json.createReader(new StringReader(requestedValue));
                 final JsonArray jsonArray = jsonReader.readArray();
                 jsonArray.getValuesAs(JsonString::getString);
 
@@ -166,8 +190,9 @@ abstract class AbstractConfigPropertyResource extends AbstractApiResource {
                         .build();
             }
         } else {
-            property.setPropertyValue(json.getPropertyValue());
+            property.setPropertyValue(requestedValue);
         }
+
         return null;
     }
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ComponentPropertyResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ComponentPropertyResource.java
@@ -40,13 +40,14 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentProperty;
 import org.dependencytrack.model.validation.ValidUuid;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.v1.problems.ProblemDetails;
+import org.dependencytrack.resources.v1.vo.ComponentPropertyResponse;
+import org.dependencytrack.resources.v1.vo.CreateComponentPropertyRequest;
 import org.dependencytrack.secret.management.SecretManager;
 
 import java.util.List;
@@ -78,7 +79,7 @@ public class ComponentPropertyResource extends AbstractConfigPropertyResource {
             @ApiResponse(
                     responseCode = "200",
                     description = "A list of all properties for the specified component",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = ComponentProperty.class)))
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = ComponentPropertyResponse.class)))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(
@@ -91,14 +92,19 @@ public class ComponentPropertyResource extends AbstractConfigPropertyResource {
     public Response getProperties(
             @Parameter(description = "The UUID of the component to retrieve properties for", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid) {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             final Component component = qm.getObjectByUuid(Component.class, uuid);
             if (component != null) {
                 requireAccess(qm, component.getProject());
                 final List<ComponentProperty> properties = qm.getComponentProperties(component);
-                return Response.ok(properties).build();
+                return Response
+                        .ok(properties.stream().map(ComponentPropertyResponse::of).toList())
+                        .build();
             } else {
-                return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();
+                return Response
+                        .status(Response.Status.NOT_FOUND)
+                        .entity("The component could not be found.")
+                        .build();
             }
         }
     }
@@ -114,7 +120,7 @@ public class ComponentPropertyResource extends AbstractConfigPropertyResource {
             @ApiResponse(
                     responseCode = "201",
                     description = "The created component",
-                    content = @Content(schema = @Schema(implementation = ComponentProperty.class))
+                    content = @Content(schema = @Schema(implementation = ComponentPropertyResponse.class))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(
@@ -124,44 +130,62 @@ public class ComponentPropertyResource extends AbstractConfigPropertyResource {
             @ApiResponse(responseCode = "404", description = "The component could not be found"),
             @ApiResponse(responseCode = "409", description = "A property with the specified component/group/name combination already exists")
     })
-    @PermissionRequired({Permissions.Constants.PORTFOLIO_MANAGEMENT, Permissions.Constants.PORTFOLIO_MANAGEMENT_CREATE})
+    @PermissionRequired({
+            Permissions.Constants.PORTFOLIO_MANAGEMENT,
+            Permissions.Constants.PORTFOLIO_MANAGEMENT_CREATE
+    })
     public Response createProperty(
             @Parameter(description = "The UUID of the component to create a property for", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid,
-            ComponentProperty json) {
+            CreateComponentPropertyRequest request) {
         final Validator validator = super.getValidator();
         failOnValidationError(
-                validator.validateProperty(json, "groupName"),
-                validator.validateProperty(json, "propertyName"),
-                validator.validateProperty(json, "propertyValue"),
-                validator.validateProperty(json, "propertyType")
+                validator.validateProperty(request, "groupName"),
+                validator.validateProperty(request, "propertyName"),
+                validator.validateProperty(request, "propertyValue"),
+                validator.validateProperty(request, "propertyType")
         );
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
                 final Component component = qm.getObjectByUuid(Component.class, uuid);
-                if (component != null) {
-                    requireAccess(qm, component.getProject());
-                    final List<ComponentProperty> existingProperties = qm.getComponentProperties(component,
-                            StringUtils.trimToNull(json.getGroupName()), StringUtils.trimToNull(json.getPropertyName()));
-                    final var jsonPropertyIdentity = new ComponentProperty.Identity(json);
-                    final boolean isDuplicate = existingProperties.stream()
-                            .map(ComponentProperty.Identity::new)
-                            .anyMatch(jsonPropertyIdentity::equals);
-                    if (existingProperties.isEmpty() || !isDuplicate) {
-                        final ComponentProperty property = qm.createComponentProperty(component,
-                                StringUtils.trimToNull(json.getGroupName()),
-                                StringUtils.trimToNull(json.getPropertyName()),
-                                null, // Set value to null - this will be taken care of by updatePropertyValue below
-                                json.getPropertyType(),
-                                StringUtils.trimToNull(json.getDescription()));
-                        updatePropertyValue(qm, json, property);
-                        return Response.status(Response.Status.CREATED).entity(property).build();
-                    } else {
-                        return Response.status(Response.Status.CONFLICT).entity("A property with the specified component/group/name/value combination already exists.").build();
-                    }
-                } else {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();
+                if (component == null) {
+                    return Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The component could not be found.")
+                            .build();
                 }
+                requireAccess(qm, component.getProject());
+
+                final List<ComponentProperty> existingProperties = qm.getComponentProperties(
+                        component, request.groupName(), request.propertyName());
+                final var requestedIdentity = new ComponentProperty.Identity(
+                        request.groupName(), request.propertyName(), request.propertyValue());
+                final boolean isDuplicate = existingProperties.stream()
+                        .map(ComponentProperty.Identity::new)
+                        .anyMatch(requestedIdentity::equals);
+                if (!existingProperties.isEmpty() && isDuplicate) {
+                    return Response
+                            .status(Response.Status.CONFLICT)
+                            .entity("A property with the specified component/group/name/value combination already exists.")
+                            .build();
+                }
+
+                final ComponentProperty property = qm.createComponentProperty(
+                        component,
+                        request.groupName(),
+                        request.propertyName(),
+                        null, // Set value to null - this will be taken care of by applyPropertyValue below
+                        request.propertyType(),
+                        request.description());
+                final Response error = applyPropertyValue(request.propertyValue(), property);
+                if (error != null) {
+                    return error;
+                }
+
+                return Response
+                        .status(Response.Status.CREATED)
+                        .entity(ComponentPropertyResponse.of(property))
+                        .build();
             });
         }
     }
@@ -183,27 +207,40 @@ public class ComponentPropertyResource extends AbstractConfigPropertyResource {
                     content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The component or component property could not be found"),
     })
-    @PermissionRequired({Permissions.Constants.PORTFOLIO_MANAGEMENT, Permissions.Constants.PORTFOLIO_MANAGEMENT_DELETE})
+    @PermissionRequired({
+            Permissions.Constants.PORTFOLIO_MANAGEMENT,
+            Permissions.Constants.PORTFOLIO_MANAGEMENT_DELETE
+    })
     public Response deleteProperty(
             @Parameter(description = "The UUID of the component to delete a property from", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid final String componentUuid,
             @Parameter(description = "The UUID of the component property to delete", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("propertyUuid") @ValidUuid final String propertyUuid) {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
                 final Component component = qm.getObjectByUuid(Component.class, componentUuid);
                 if (component != null) {
                     requireAccess(qm, component.getProject());
-                    final long propertiesDeleted = qm.deleteComponentPropertyByUuid(component, UUID.fromString(propertyUuid));
+                    final long propertiesDeleted = qm.deleteComponentPropertyByUuid(
+                            component, UUID.fromString(propertyUuid));
                     if (propertiesDeleted > 0) {
-                        return Response.status(Response.Status.NO_CONTENT).build();
+                        return Response
+                                .status(Response.Status.NO_CONTENT)
+                                .build();
                     } else {
-                        return Response.status(Response.Status.NOT_FOUND).entity("The component property could not be found.").build();
+                        return Response
+                                .status(Response.Status.NOT_FOUND)
+                                .entity("The component property could not be found.")
+                                .build();
                     }
                 } else {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();
+                    return Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The component could not be found.")
+                            .build();
                 }
             });
         }
     }
+
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ConfigPropertyResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ConfigPropertyResource.java
@@ -82,9 +82,12 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
-    @PermissionRequired({Permissions.Constants.SYSTEM_CONFIGURATION, Permissions.Constants.SYSTEM_CONFIGURATION_READ})
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_READ
+    })
     public Response getConfigProperties() {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             final List<ConfigProperty> configProperties = qm.getConfigProperties();
             return Response.ok(configProperties).build();
         }
@@ -105,7 +108,10 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(responseCode = "404", description = "The config property could not be found"),
     })
-    @PermissionRequired({Permissions.Constants.SYSTEM_CONFIGURATION, Permissions.Constants.SYSTEM_CONFIGURATION_UPDATE})
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_UPDATE
+    })
     public Response updateConfigProperty(ConfigProperty json) {
         final Validator validator = super.getValidator();
         failOnValidationError(
@@ -113,10 +119,11 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
                 validator.validateProperty(json, "propertyName"),
                 validator.validateProperty(json, "propertyValue")
         );
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
-                final ConfigProperty property = qm.getConfigProperty(json.getGroupName(), json.getPropertyName());
-                return updatePropertyValue(qm, json, property);
+                final ConfigProperty property = qm.getConfigProperty(
+                        json.getGroupName(), json.getPropertyName());
+                return updatePropertyValue(json, property);
             });
         }
     }
@@ -138,7 +145,10 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(responseCode = "404", description = "One or more config properties could not be found"),
     })
-    @PermissionRequired({Permissions.Constants.SYSTEM_CONFIGURATION, Permissions.Constants.SYSTEM_CONFIGURATION_UPDATE})
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_UPDATE
+    })
     public Response updateConfigProperty(List<ConfigProperty> list) {
         final Validator validator = super.getValidator();
         for (ConfigProperty item : list) {
@@ -148,15 +158,18 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
                     validator.validateProperty(item, "propertyValue")
             );
         }
-        List<Object> returnList = new ArrayList<>();
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+
+        final var returnList = new ArrayList<>();
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             qm.runInTransaction(() -> {
                 for (ConfigProperty item : list) {
-                    final ConfigProperty property = qm.getConfigProperty(item.getGroupName(), item.getPropertyName());
-                    returnList.add(updatePropertyValue(qm, item, property).getEntity());
+                    final ConfigProperty property = qm.getConfigProperty(
+                            item.getGroupName(), item.getPropertyName());
+                    returnList.add(updatePropertyValue(item, property).getEntity());
                 }
             });
         }
+
         return Response.ok(returnList).build();
     }
 
@@ -174,14 +187,16 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
             @PathParam("groupName") String groupName,
             @Parameter(description = "The property name of the value to retrieve", required = true)
             @PathParam("propertyName") String propertyName) {
-        ConfigProperty configProperty = new ConfigProperty();
+        final var configProperty = new ConfigProperty();
         configProperty.setGroupName(groupName);
         configProperty.setPropertyName(propertyName);
-        ConfigPropertyConstants publicConfigProperty = ConfigPropertyConstants.ofProperty(configProperty);
+
+        final var publicConfigProperty = ConfigPropertyConstants.ofProperty(configProperty);
         if (!publicConfigProperty.getIsPublic()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             ConfigProperty property = qm.getConfigProperty(groupName, propertyName);
             return Response.ok(property).build();
         }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectPropertyResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectPropertyResource.java
@@ -41,13 +41,16 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectProperty;
 import org.dependencytrack.model.validation.ValidUuid;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.v1.problems.ProblemDetails;
+import org.dependencytrack.resources.v1.vo.CreateProjectPropertyRequest;
+import org.dependencytrack.resources.v1.vo.DeleteProjectPropertyRequest;
+import org.dependencytrack.resources.v1.vo.ProjectPropertyResponse;
+import org.dependencytrack.resources.v1.vo.UpdateProjectPropertyRequest;
 import org.dependencytrack.secret.management.SecretManager;
 
 import java.util.List;
@@ -81,7 +84,7 @@ public class ProjectPropertyResource extends AbstractConfigPropertyResource {
             @ApiResponse(
                     responseCode = "200",
                     description = "A list of all ProjectProperties for the specified project",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = ProjectProperty.class)))
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = ProjectPropertyResponse.class)))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(
@@ -90,18 +93,26 @@ public class ProjectPropertyResource extends AbstractConfigPropertyResource {
                     content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The project could not be found")
     })
-    @PermissionRequired({Permissions.Constants.PORTFOLIO_MANAGEMENT, Permissions.Constants.PORTFOLIO_MANAGEMENT_READ})
+    @PermissionRequired({
+            Permissions.Constants.PORTFOLIO_MANAGEMENT,
+            Permissions.Constants.PORTFOLIO_MANAGEMENT_READ
+    })
     public Response getProperties(
             @Parameter(description = "The UUID of the project to retrieve properties for", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid) {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             final Project project = qm.getObjectByUuid(Project.class, uuid);
             if (project != null) {
                 requireAccess(qm, project);
                 final List<ProjectProperty> properties = qm.getProjectProperties(project);
-                return Response.ok(properties).build();
+                return Response
+                        .ok(properties.stream().map(ProjectPropertyResponse::of).toList())
+                        .build();
             } else {
-                return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();
+                return Response
+                        .status(Response.Status.NOT_FOUND)
+                        .entity("The project could not be found.")
+                        .build();
             }
         }
     }
@@ -117,7 +128,7 @@ public class ProjectPropertyResource extends AbstractConfigPropertyResource {
             @ApiResponse(
                     responseCode = "201",
                     description = "The created project property",
-                    content = @Content(schema = @Schema(implementation = ProjectProperty.class))
+                    content = @Content(schema = @Schema(implementation = ProjectPropertyResponse.class))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(
@@ -127,41 +138,56 @@ public class ProjectPropertyResource extends AbstractConfigPropertyResource {
             @ApiResponse(responseCode = "404", description = "The project could not be found"),
             @ApiResponse(responseCode = "409", description = "A property with the specified project/group/name combination already exists")
     })
-    @PermissionRequired({Permissions.Constants.PORTFOLIO_MANAGEMENT, Permissions.Constants.PORTFOLIO_MANAGEMENT_CREATE})
+    @PermissionRequired({
+            Permissions.Constants.PORTFOLIO_MANAGEMENT,
+            Permissions.Constants.PORTFOLIO_MANAGEMENT_CREATE
+    })
     public Response createProperty(
             @Parameter(description = "The UUID of the project to create a property for", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid,
-            ProjectProperty json) {
+            CreateProjectPropertyRequest request) {
         final Validator validator = super.getValidator();
         failOnValidationError(
-                validator.validateProperty(json, "groupName"),
-                validator.validateProperty(json, "propertyName"),
-                validator.validateProperty(json, "propertyValue"),
-                validator.validateProperty(json, "propertyType")
+                validator.validateProperty(request, "groupName"),
+                validator.validateProperty(request, "propertyName"),
+                validator.validateProperty(request, "propertyValue"),
+                validator.validateProperty(request, "propertyType")
         );
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
                 final Project project = qm.getObjectByUuid(Project.class, uuid);
-                if (project != null) {
-                    requireAccess(qm, project);
-                    final ProjectProperty existing = qm.getProjectProperty(project,
-                            StringUtils.trimToNull(json.getGroupName()), StringUtils.trimToNull(json.getPropertyName()));
-                    if (existing == null) {
-                        final ProjectProperty property = qm.createProjectProperty(project,
-                                StringUtils.trimToNull(json.getGroupName()),
-                                StringUtils.trimToNull(json.getPropertyName()),
-                                null, // Set value to null - this will be taken care of by updatePropertyValue below
-                                json.getPropertyType(),
-                                StringUtils.trimToNull(json.getDescription()));
-                        updatePropertyValue(qm, json, property);
-                        qm.getPersistenceManager().detachCopy(project);
-                        return Response.status(Response.Status.CREATED).entity(property).build();
-                    } else {
-                        return Response.status(Response.Status.CONFLICT).entity("A property with the specified project/group/name combination already exists.").build();
-                    }
-                } else {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();
+                if (project == null) {
+                    return Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The project could not be found.")
+                            .build();
                 }
+                requireAccess(qm, project);
+
+                final ProjectProperty existing = qm.getProjectProperty(project, request.groupName(), request.propertyName());
+                if (existing != null) {
+                    return Response
+                            .status(Response.Status.CONFLICT)
+                            .entity("A property with the specified project/group/name combination already exists.")
+                            .build();
+                }
+
+                final ProjectProperty property = qm.createProjectProperty(project,
+                        request.groupName(),
+                        request.propertyName(),
+                        null, // Set value to null - this will be taken care of by applyPropertyValue below
+                        request.propertyType(),
+                        request.description());
+
+                final Response error = applyPropertyValue(request.propertyValue(), property);
+                if (error != null) {
+                    return error;
+                }
+
+                return Response
+                        .status(Response.Status.CREATED)
+                        .entity(ProjectPropertyResponse.of(property))
+                        .build();
             });
         }
     }
@@ -177,7 +203,7 @@ public class ProjectPropertyResource extends AbstractConfigPropertyResource {
             @ApiResponse(
                     responseCode = "200",
                     description = "The updated project property",
-                    content = @Content(schema = @Schema(implementation = ProjectProperty.class))
+                    content = @Content(schema = @Schema(implementation = ProjectPropertyResponse.class))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(
@@ -186,31 +212,48 @@ public class ProjectPropertyResource extends AbstractConfigPropertyResource {
                     content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The project could not be found"),
     })
-    @PermissionRequired({Permissions.Constants.PORTFOLIO_MANAGEMENT, Permissions.Constants.PORTFOLIO_MANAGEMENT_UPDATE})
+    @PermissionRequired({
+            Permissions.Constants.PORTFOLIO_MANAGEMENT,
+            Permissions.Constants.PORTFOLIO_MANAGEMENT_UPDATE
+    })
     public Response updateProperty(
             @Parameter(description = "The UUID of the project to create a property for", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid,
-            ProjectProperty json) {
+            UpdateProjectPropertyRequest request) {
         final Validator validator = super.getValidator();
         failOnValidationError(
-                validator.validateProperty(json, "groupName"),
-                validator.validateProperty(json, "propertyName"),
-                validator.validateProperty(json, "propertyValue")
+                validator.validateProperty(request, "groupName"),
+                validator.validateProperty(request, "propertyName"),
+                validator.validateProperty(request, "propertyValue")
         );
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
                 final Project project = qm.getObjectByUuid(Project.class, uuid);
-                if (project != null) {
-                    requireAccess(qm, project);
-                    final ProjectProperty property = qm.getProjectProperty(project, json.getGroupName(), json.getPropertyName());
-                    if (property != null) {
-                        return updatePropertyValue(qm, json, property);
-                    } else {
-                        return Response.status(Response.Status.NOT_FOUND).entity("A property with the specified project/group/name combination could not be found.").build();
-                    }
-                } else {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();
+                if (project == null) {
+                    return Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The project could not be found.")
+                            .build();
                 }
+                requireAccess(qm, project);
+
+                final ProjectProperty property = qm.getProjectProperty(
+                        project, request.groupName(), request.propertyName());
+                if (property == null) {
+                    return Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("A property with the specified project/group/name combination could not be found.")
+                            .build();
+                }
+
+                final Response error = applyPropertyValue(request.propertyValue(), property);
+                if (error != null) {
+                    return error;
+                }
+
+                return Response
+                        .ok(ProjectPropertyResponse.of(property))
+                        .build();
             });
         }
     }
@@ -231,32 +274,45 @@ public class ProjectPropertyResource extends AbstractConfigPropertyResource {
                     content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The project or project property could not be found"),
     })
-    @PermissionRequired({Permissions.Constants.PORTFOLIO_MANAGEMENT, Permissions.Constants.PORTFOLIO_MANAGEMENT_DELETE})
+    @PermissionRequired({
+            Permissions.Constants.PORTFOLIO_MANAGEMENT,
+            Permissions.Constants.PORTFOLIO_MANAGEMENT_DELETE
+    })
     public Response deleteProperty(
             @Parameter(description = "The UUID of the project to delete a property from", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid,
-            ProjectProperty json) {
+            DeleteProjectPropertyRequest request) {
         final Validator validator = super.getValidator();
         failOnValidationError(
-                validator.validateProperty(json, "groupName"),
-                validator.validateProperty(json, "propertyName")
+                validator.validateProperty(request, "groupName"),
+                validator.validateProperty(request, "propertyName")
         );
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
                 final Project project = qm.getObjectByUuid(Project.class, uuid);
-                if (project != null) {
-                    requireAccess(qm, project);
-                    final ProjectProperty property = qm.getProjectProperty(project, json.getGroupName(), json.getPropertyName());
-                    if (property != null) {
-                        qm.delete(property);
-                        return Response.status(Response.Status.NO_CONTENT).build();
-                    } else {
-                        return Response.status(Response.Status.NOT_FOUND).entity("The project property could not be found.").build();
-                    }
-                } else {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();
+                if (project == null) {
+                    return Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The project could not be found.")
+                            .build();
                 }
+                requireAccess(qm, project);
+
+                final ProjectProperty property = qm.getProjectProperty(
+                        project, request.groupName(), request.propertyName());
+                if (property == null) {
+                    return Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The project property could not be found.")
+                            .build();
+                }
+
+                qm.delete(property);
+                return Response
+                        .status(Response.Status.NO_CONTENT)
+                        .build();
             });
         }
     }
+
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/ComponentPropertyResponse.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/ComponentPropertyResponse.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import alpine.model.IConfigProperty;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.dependencytrack.model.ComponentProperty;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.UUID;
+
+/// @since 5.1.0
+@NullMarked
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ComponentPropertyResponse(
+        @Schema(description = "Group the property belongs to")
+        @Nullable String groupName,
+
+        @Schema(description = "Name of the property", requiredMode = Schema.RequiredMode.REQUIRED)
+        String propertyName,
+
+        @Schema(description = "Value of the property")
+        @Nullable String propertyValue,
+
+        @Schema(description = "Type of the property", requiredMode = Schema.RequiredMode.REQUIRED)
+        IConfigProperty.PropertyType propertyType,
+
+        @Schema(description = "Description of the property")
+        @Nullable String description,
+
+        @Schema(description = "UUID of the property", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID uuid) {
+
+    public static ComponentPropertyResponse of(ComponentProperty property) {
+        return new ComponentPropertyResponse(
+                property.getGroupName(),
+                property.getPropertyName(),
+                property.getPropertyValue(),
+                property.getPropertyType(),
+                property.getDescription(),
+                property.getUuid());
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/CreateComponentPropertyRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/CreateComponentPropertyRequest.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import alpine.model.IConfigProperty;
+import alpine.server.json.TrimmedStringDeserializer;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/// @since 5.1.0
+@NullMarked
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CreateComponentPropertyRequest(
+        @Size(min = 1, max = 255)
+        @Pattern(regexp = "\\P{Cc}+", message = "The groupName must not contain control characters")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Group the property belongs to")
+        @Nullable String groupName,
+
+        @NotBlank
+        @Size(min = 1, max = 255)
+        @Pattern(regexp = "\\P{Cc}+", message = "The propertyName must not contain control characters")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Name of the property", requiredMode = Schema.RequiredMode.REQUIRED)
+        String propertyName,
+
+        @Size(max = 1024)
+        @Pattern(regexp = "\\P{Cc}+", message = "The propertyValue must not contain control characters")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Value of the property")
+        @Nullable String propertyValue,
+
+        @NotNull
+        @Schema(description = "Type of the property", requiredMode = Schema.RequiredMode.REQUIRED)
+        IConfigProperty.PropertyType propertyType,
+
+        @Size(max = 255)
+        @Pattern(regexp = "\\P{Cc}+", message = "The description must not contain control characters")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Description of the property")
+        @Nullable String description) {
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/CreateProjectPropertyRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/CreateProjectPropertyRequest.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import alpine.model.IConfigProperty;
+import alpine.server.json.TrimmedStringDeserializer;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/// @since 5.1.0
+@NullMarked
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CreateProjectPropertyRequest(
+        @NotBlank
+        @Size(min = 1, max = 255)
+        @Pattern(regexp = "\\P{Cc}+", message = "The groupName must not contain control characters")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Group the property belongs to", requiredMode = Schema.RequiredMode.REQUIRED)
+        String groupName,
+
+        @NotBlank
+        @Size(min = 1, max = 255)
+        @Pattern(regexp = "\\P{Cc}+", message = "The propertyName must not contain control characters")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Name of the property", requiredMode = Schema.RequiredMode.REQUIRED)
+        String propertyName,
+
+        @Size(max = 1024)
+        @Pattern(regexp = "\\P{Cc}+", message = "The propertyValue must not contain control characters")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Value of the property")
+        @Nullable String propertyValue,
+
+        @NotNull
+        @Schema(description = "Type of the property", requiredMode = Schema.RequiredMode.REQUIRED)
+        IConfigProperty.PropertyType propertyType,
+
+        @Size(max = 255)
+        @Pattern(regexp = "\\P{Cc}+", message = "The description must not contain control characters")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Description of the property")
+        @Nullable String description) {
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/DeleteProjectPropertyRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/DeleteProjectPropertyRequest.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import alpine.server.json.TrimmedStringDeserializer;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.jspecify.annotations.NullMarked;
+
+/// @since 5.1.0
+@NullMarked
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DeleteProjectPropertyRequest(
+        @NotBlank
+        @Size(min = 1, max = 255)
+        @Pattern(regexp = "\\P{Cc}+", message = "The groupName must not contain control characters")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Group the property belongs to", requiredMode = Schema.RequiredMode.REQUIRED)
+        String groupName,
+
+        @NotBlank
+        @Size(min = 1, max = 255)
+        @Pattern(regexp = "\\P{Cc}+", message = "The propertyName must not contain control characters")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Name of the property", requiredMode = Schema.RequiredMode.REQUIRED)
+        String propertyName) {
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/ProjectPropertyResponse.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/ProjectPropertyResponse.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import alpine.model.IConfigProperty;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.dependencytrack.model.ProjectProperty;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/// @since 5.1.0
+@NullMarked
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ProjectPropertyResponse(
+        @Schema(description = "Group the property belongs to", requiredMode = Schema.RequiredMode.REQUIRED)
+        String groupName,
+
+        @Schema(description = "Name of the property", requiredMode = Schema.RequiredMode.REQUIRED)
+        String propertyName,
+
+        @Schema(description = "Value of the property")
+        @Nullable String propertyValue,
+
+        @Schema(description = "Type of the property", requiredMode = Schema.RequiredMode.REQUIRED)
+        IConfigProperty.PropertyType propertyType,
+
+        @Schema(description = "Description of the property")
+        @Nullable String description) {
+
+    public static ProjectPropertyResponse of(ProjectProperty property) {
+        return new ProjectPropertyResponse(
+                property.getGroupName(),
+                property.getPropertyName(),
+                property.getPropertyValue(),
+                property.getPropertyType(),
+                property.getDescription());
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/UpdateProjectPropertyRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/UpdateProjectPropertyRequest.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import alpine.server.json.TrimmedStringDeserializer;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/// @since 5.1.0
+@NullMarked
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record UpdateProjectPropertyRequest(
+        @NotBlank
+        @Size(min = 1, max = 255)
+        @Pattern(regexp = "\\P{Cc}+", message = "The groupName must not contain control characters")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Group the property belongs to", requiredMode = Schema.RequiredMode.REQUIRED)
+        String groupName,
+
+        @NotBlank
+        @Size(min = 1, max = 255)
+        @Pattern(regexp = "\\P{Cc}+", message = "The propertyName must not contain control characters")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Name of the property", requiredMode = Schema.RequiredMode.REQUIRED)
+        String propertyName,
+
+        @Size(max = 1024)
+        @Pattern(regexp = "\\P{Cc}+", message = "The propertyValue must not contain control characters")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Value of the property")
+        @Nullable String propertyValue) {
+}

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectPropertyResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectPropertyResourceTest.java
@@ -21,8 +21,6 @@ package org.dependencytrack.resources.v1;
 import alpine.model.IConfigProperty.PropertyType;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthFeature;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -72,21 +70,26 @@ public class ProjectPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_PROJECT + "/" + project.getUuid().toString() + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assertions.assertEquals(200, response.getStatus(), 0);
-        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
-        JsonArray json = parseJsonArray(response);
-        Assertions.assertNotNull(json);
-        Assertions.assertEquals(2, json.size());
-        Assertions.assertEquals("mygroup", json.getJsonObject(0).getString("groupName"));
-        Assertions.assertEquals("prop1", json.getJsonObject(0).getString("propertyName"));
-        Assertions.assertEquals("value1", json.getJsonObject(0).getString("propertyValue"));
-        Assertions.assertEquals("STRING", json.getJsonObject(0).getString("propertyType"));
-        Assertions.assertEquals("Test Property 1", json.getJsonObject(0).getString("description"));
-        Assertions.assertEquals("mygroup", json.getJsonObject(1).getString("groupName"));
-        Assertions.assertEquals("prop2", json.getJsonObject(1).getString("propertyName"));
-        Assertions.assertEquals("value2", json.getJsonObject(1).getString("propertyValue"));
-        Assertions.assertEquals("STRING", json.getJsonObject(1).getString("propertyType"));
-        Assertions.assertEquals("Test Property 2", json.getJsonObject(1).getString("description"));
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                [
+                  {
+                    "groupName": "mygroup",
+                    "propertyName": "prop1",
+                    "propertyValue": "value1",
+                    "propertyType": "STRING",
+                    "description": "Test Property 1"
+                  },
+                  {
+                    "groupName": "mygroup",
+                    "propertyName": "prop2",
+                    "propertyValue": "value2",
+                    "propertyType": "STRING",
+                    "description": "Test Property 2"
+                  }
+                ]
+                """);
     }
 
     @Test
@@ -148,14 +151,16 @@ public class ProjectPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_PROJECT + "/" + project.getUuid().toString() + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(property, MediaType.APPLICATION_JSON));
-        Assertions.assertEquals(201, response.getStatus(), 0);
-        JsonObject json = parseJsonObject(response);
-        Assertions.assertNotNull(json);
-        Assertions.assertEquals("mygroup", json.getString("groupName"));
-        Assertions.assertEquals("prop1", json.getString("propertyName"));
-        Assertions.assertEquals("value1", json.getString("propertyValue"));
-        Assertions.assertEquals("STRING", json.getString("propertyType"));
-        Assertions.assertEquals("Test Property 1", json.getString("description"));
+        assertThat(response.getStatus()).isEqualTo(201);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "groupName": "mygroup",
+                  "propertyName": "prop1",
+                  "propertyValue": "value1",
+                  "propertyType": "STRING",
+                  "description": "Test Property 1"
+                }
+                """);
     }
 
     @Test
@@ -254,13 +259,15 @@ public class ProjectPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_PROJECT + "/" + uuid + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(property, MediaType.APPLICATION_JSON));
-        Assertions.assertEquals(200, response.getStatus(), 0);
-        JsonObject json = parseJsonObject(response);
-        Assertions.assertNotNull(json);
-        Assertions.assertEquals("mygroup", json.getString("groupName"));
-        Assertions.assertEquals("prop1", json.getString("propertyName"));
-        Assertions.assertEquals("updatedValue", json.getString("propertyValue"));
-        Assertions.assertEquals("STRING", json.getString("propertyType"));
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "groupName": "mygroup",
+                  "propertyName": "prop1",
+                  "propertyValue": "updatedValue",
+                  "propertyType": "STRING"
+                }
+                """);
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Tackles the technical debt of JDO models being reused for REST DTOs for all endpoints under `/v1/component/{uuid}/property` and `/v1/project/{uuid}/property`.

Also makes the generated OpenAPI spec more reliable b/c it no longer advertises fields that are never used / never returned.

Note that the existing tests for `/v1/component/{uuid}/property` already asserted full JSON responses, so no new regression tests were necessary there.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
