### PR TITLE
Add arch test for rejecting JDO model usage in REST API v1

### DIFF
--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/V1ResourcePayloadArchitectureTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/V1ResourcePayloadArchitectureTest.java
@@ -1,0 +1,252 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaAnnotation;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaParameter;
+import com.tngtech.archunit.core.domain.JavaParameterizedType;
+import com.tngtech.archunit.core.domain.JavaType;
+import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeJars;
+import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeTests;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.library.freeze.FreezingArchRule;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HEAD;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.OPTIONS;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+
+import javax.jdo.annotations.PersistenceCapable;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+@AnalyzeClasses(
+        packages = "org.dependencytrack.resources.v1",
+        importOptions = {DoNotIncludeTests.class, DoNotIncludeJars.class})
+class V1ResourcePayloadArchitectureTest {
+
+    private static final Set<String> HTTP_METHOD_ANNOTATIONS = Set.of(
+            GET.class.getName(),
+            POST.class.getName(),
+            PUT.class.getName(),
+            DELETE.class.getName(),
+            PATCH.class.getName(),
+            HEAD.class.getName(),
+            OPTIONS.class.getName());
+
+    private static final Set<String> NON_BODY_PARAMETER_ANNOTATIONS = Set.of(
+            PathParam.class.getName(),
+            QueryParam.class.getName(),
+            HeaderParam.class.getName(),
+            FormParam.class.getName(),
+            CookieParam.class.getName(),
+            MatrixParam.class.getName(),
+            BeanParam.class.getName(),
+            Context.class.getName());
+
+    private static final Set<String> WRAPPER_TYPES = Set.of(
+            List.class.getName(),
+            Set.class.getName(),
+            Collection.class.getName(),
+            Optional.class.getName(),
+            Map.class.getName());
+
+    @ArchTest
+    @SuppressWarnings("unused")
+    static final ArchRule v1ResourceHandlerMethodsMustNotAcceptJdoModelsAsRequestBody =
+            FreezingArchRule.freeze(
+                    methods()
+                            .that(new DescribedPredicate<>("are JAX-RS resource handler methods") {
+                                @Override
+                                public boolean test(JavaMethod method) {
+                                    return isHttpHandlerMethod(method);
+                                }
+                            })
+                            .should(new ArchCondition<>("not accept JDO model classes as request body") {
+                                @Override
+                                public void check(JavaMethod method, ConditionEvents events) {
+                                    for (JavaParameter parameter : method.getParameters()) {
+                                        if (!isRequestBodyParameter(parameter)) {
+                                            continue;
+                                        }
+
+                                        for (JavaClass leafType : extractLeafTypes(parameter.getType())) {
+                                            if (isJdoModelClass(leafType)) {
+                                                events.add(violated(
+                                                        method,
+                                                        "%s accepts JDO model class %s as request body".formatted(
+                                                                method.getFullName(), leafType.getName())));
+                                            }
+                                        }
+                                    }
+                                }
+                            }));
+
+    @ArchTest
+    @SuppressWarnings("unused")
+    static final ArchRule v1ResourceSwaggerResponseSchemasMustNotReferenceJdoModels =
+            FreezingArchRule.freeze(
+                    methods()
+                            .that(new DescribedPredicate<>("are JAX-RS resource handler methods") {
+                                @Override
+                                public boolean test(JavaMethod method) {
+                                    return isHttpHandlerMethod(method);
+                                }
+                            })
+                            .should(new ArchCondition<>("not declare JDO model classes in Swagger response schemas") {
+                                @Override
+                                public void check(JavaMethod method, ConditionEvents events) {
+                                    for (JavaAnnotation<?> annotation : method.getAnnotations()) {
+                                        collectSwaggerSchemaImplementations(annotation, method, events);
+                                    }
+                                }
+                            }));
+
+    private static boolean isHttpHandlerMethod(JavaMethod method) {
+        for (JavaAnnotation<?> annotation : method.getAnnotations()) {
+            if (HTTP_METHOD_ANNOTATIONS.contains(annotation.getRawType().getName())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean isRequestBodyParameter(JavaParameter parameter) {
+        for (JavaAnnotation<?> annotation : parameter.getAnnotations()) {
+            if (NON_BODY_PARAMETER_ANNOTATIONS.contains(annotation.getRawType().getName())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean isJdoModelClass(JavaClass javaClass) {
+        return !javaClass.isRecord()
+                && javaClass.isAnnotatedWith(PersistenceCapable.class);
+    }
+
+    private static Set<JavaClass> extractLeafTypes(JavaType type) {
+        final var result = new HashSet<JavaClass>();
+        collectLeafTypes(type, result);
+        return result;
+    }
+
+    private static void collectLeafTypes(JavaType type, Set<JavaClass> result) {
+        if (type instanceof final JavaParameterizedType paramType) {
+            if (WRAPPER_TYPES.contains(paramType.toErasure().getName())) {
+                for (JavaType arg : paramType.getActualTypeArguments()) {
+                    collectLeafTypes(arg, result);
+                }
+            } else {
+                result.add(paramType.toErasure());
+            }
+        } else if (type instanceof JavaClass javaClass) {
+            result.add(javaClass);
+        }
+    }
+
+    private static void collectSwaggerSchemaImplementations(
+            JavaAnnotation<?> annotation,
+            JavaMethod method,
+            ConditionEvents events) {
+        final String annotationType = annotation.getRawType().getName();
+        if (annotationType.equals(ApiResponses.class.getName())) {
+            forEachNestedAnnotation(annotation, "value", inner -> collectSwaggerSchemaImplementations(inner, method, events));
+        } else if (annotationType.equals(ApiResponse.class.getName())) {
+            forEachNestedAnnotation(annotation, "content", inner -> collectSwaggerSchemaImplementations(inner, method, events));
+        } else if (annotationType.equals(Content.class.getName())) {
+            annotation.get("schema").ifPresent(value -> {
+                if (value instanceof final JavaAnnotation<?> schema) {
+                    checkSwaggerSchemaImplementation(schema, method, events);
+                }
+            });
+            annotation.get("array").ifPresent(value -> {
+                if (value instanceof final JavaAnnotation<?> arraySchema) {
+                    arraySchema.get("schema").ifPresent(inner -> {
+                        if (inner instanceof final JavaAnnotation<?> schema) {
+                            checkSwaggerSchemaImplementation(schema, method, events);
+                        }
+                    });
+                }
+            });
+        }
+    }
+
+    private static void checkSwaggerSchemaImplementation(
+            JavaAnnotation<?> schema,
+            JavaMethod method,
+            ConditionEvents events) {
+        schema.get("implementation").ifPresent(value -> {
+            if (value instanceof final JavaClass target
+                    && !target.isEquivalentTo(Void.class)
+                    && isJdoModelClass(target)) {
+                events.add(violated(
+                        method,
+                        "%s declares JDO model class %s as Swagger response schema".formatted(
+                                method.getFullName(), target.getName())));
+            }
+        });
+    }
+
+    private static void forEachNestedAnnotation(
+            JavaAnnotation<?> annotation,
+            String property,
+            Consumer<JavaAnnotation<?>> consumer) {
+        annotation.get(property).ifPresent(value -> {
+            if (value instanceof final JavaAnnotation<?>[] nested) {
+                for (JavaAnnotation<?> inner : nested) {
+                    consumer.accept(inner);
+                }
+            } else if (value instanceof final JavaAnnotation<?> single) {
+                consumer.accept(single);
+            }
+        });
+    }
+
+}

--- a/apiserver/src/test/resources/archunit_store/3e49066c-46b2-40c2-8473-ce4276c1ba12
+++ b/apiserver/src/test/resources/archunit_store/3e49066c-46b2-40c2-8473-ce4276c1ba12
@@ -1,0 +1,32 @@
+org.dependencytrack.resources.v1.ComponentResource.createComponent(java.lang.String, org.dependencytrack.model.Component) accepts JDO model class org.dependencytrack.model.Component as request body
+org.dependencytrack.resources.v1.ComponentResource.updateComponent(org.dependencytrack.model.Component) accepts JDO model class org.dependencytrack.model.Component as request body
+org.dependencytrack.resources.v1.ConfigPropertyResource.updateConfigProperty(alpine.model.ConfigProperty) accepts JDO model class alpine.model.ConfigProperty as request body
+org.dependencytrack.resources.v1.ConfigPropertyResource.updateConfigProperty(java.util.List) accepts JDO model class alpine.model.ConfigProperty as request body
+org.dependencytrack.resources.v1.LicenseGroupResource.createLicenseGroup(org.dependencytrack.model.LicenseGroup) accepts JDO model class org.dependencytrack.model.LicenseGroup as request body
+org.dependencytrack.resources.v1.LicenseGroupResource.updateLicenseGroup(org.dependencytrack.model.LicenseGroup) accepts JDO model class org.dependencytrack.model.LicenseGroup as request body
+org.dependencytrack.resources.v1.LicenseResource.createLicense(org.dependencytrack.model.License) accepts JDO model class org.dependencytrack.model.License as request body
+org.dependencytrack.resources.v1.NotificationRuleResource.deleteNotificationRule(org.dependencytrack.model.NotificationRule) accepts JDO model class org.dependencytrack.model.NotificationRule as request body
+org.dependencytrack.resources.v1.OidcResource.createGroup(alpine.model.OidcGroup) accepts JDO model class alpine.model.OidcGroup as request body
+org.dependencytrack.resources.v1.OidcResource.updateGroup(alpine.model.OidcGroup) accepts JDO model class alpine.model.OidcGroup as request body
+org.dependencytrack.resources.v1.PolicyResource.createPolicy(org.dependencytrack.model.Policy) accepts JDO model class org.dependencytrack.model.Policy as request body
+org.dependencytrack.resources.v1.PolicyResource.updatePolicy(org.dependencytrack.model.Policy) accepts JDO model class org.dependencytrack.model.Policy as request body
+org.dependencytrack.resources.v1.ProjectResource.createProject(org.dependencytrack.model.Project) accepts JDO model class org.dependencytrack.model.Project as request body
+org.dependencytrack.resources.v1.ProjectResource.patchProject(java.lang.String, org.dependencytrack.model.Project) accepts JDO model class org.dependencytrack.model.Project as request body
+org.dependencytrack.resources.v1.ProjectResource.updateProject(org.dependencytrack.model.Project) accepts JDO model class org.dependencytrack.model.Project as request body
+org.dependencytrack.resources.v1.RepositoryResource.createRepository(org.dependencytrack.model.Repository) accepts JDO model class org.dependencytrack.model.Repository as request body
+org.dependencytrack.resources.v1.RepositoryResource.updateRepository(org.dependencytrack.model.Repository) accepts JDO model class org.dependencytrack.model.Repository as request body
+org.dependencytrack.resources.v1.ServiceResource.createService(java.lang.String, org.dependencytrack.model.ServiceComponent) accepts JDO model class org.dependencytrack.model.ServiceComponent as request body
+org.dependencytrack.resources.v1.ServiceResource.updateService(org.dependencytrack.model.ServiceComponent) accepts JDO model class org.dependencytrack.model.ServiceComponent as request body
+org.dependencytrack.resources.v1.TeamResource.createTeam(alpine.model.Team) accepts JDO model class alpine.model.Team as request body
+org.dependencytrack.resources.v1.TeamResource.deleteTeam(alpine.model.Team) accepts JDO model class alpine.model.Team as request body
+org.dependencytrack.resources.v1.TeamResource.updateTeam(alpine.model.Team) accepts JDO model class alpine.model.Team as request body
+org.dependencytrack.resources.v1.UserResource.createLdapUser(alpine.model.LdapUser) accepts JDO model class alpine.model.LdapUser as request body
+org.dependencytrack.resources.v1.UserResource.createManagedUser(alpine.model.ManagedUser) accepts JDO model class alpine.model.ManagedUser as request body
+org.dependencytrack.resources.v1.UserResource.createOidcUser(alpine.model.OidcUser) accepts JDO model class alpine.model.OidcUser as request body
+org.dependencytrack.resources.v1.UserResource.deleteLdapUser(alpine.model.LdapUser) accepts JDO model class alpine.model.LdapUser as request body
+org.dependencytrack.resources.v1.UserResource.deleteManagedUser(alpine.model.ManagedUser) accepts JDO model class alpine.model.ManagedUser as request body
+org.dependencytrack.resources.v1.UserResource.deleteOidcUser(alpine.model.OidcUser) accepts JDO model class alpine.model.OidcUser as request body
+org.dependencytrack.resources.v1.UserResource.updateManagedUser(alpine.model.ManagedUser) accepts JDO model class alpine.model.ManagedUser as request body
+org.dependencytrack.resources.v1.UserResource.updateSelf(alpine.model.ManagedUser) accepts JDO model class alpine.model.ManagedUser as request body
+org.dependencytrack.resources.v1.VulnerabilityResource.createVulnerability(org.dependencytrack.model.Vulnerability) accepts JDO model class org.dependencytrack.model.Vulnerability as request body
+org.dependencytrack.resources.v1.VulnerabilityResource.updateVulnerability(org.dependencytrack.model.Vulnerability) accepts JDO model class org.dependencytrack.model.Vulnerability as request body

--- a/apiserver/src/test/resources/archunit_store/67305ac9-6039-403a-8a4c-ada073ef9b6d
+++ b/apiserver/src/test/resources/archunit_store/67305ac9-6039-403a-8a4c-ada073ef9b6d
@@ -1,0 +1,100 @@
+org.dependencytrack.resources.v1.AnalysisResource.retrieveAnalysis(java.lang.String, java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.Analysis as Swagger response schema
+org.dependencytrack.resources.v1.AnalysisResource.updateAnalysis(org.dependencytrack.resources.v1.vo.AnalysisRequest) declares JDO model class org.dependencytrack.model.Analysis as Swagger response schema
+org.dependencytrack.resources.v1.ComponentResource.createComponent(java.lang.String, org.dependencytrack.model.Component) declares JDO model class org.dependencytrack.model.Component as Swagger response schema
+org.dependencytrack.resources.v1.ComponentResource.getAllComponents(java.lang.String, boolean, boolean) declares JDO model class org.dependencytrack.model.Component as Swagger response schema
+org.dependencytrack.resources.v1.ComponentResource.getComponentByHash(java.lang.String) declares JDO model class org.dependencytrack.model.Component as Swagger response schema
+org.dependencytrack.resources.v1.ComponentResource.getComponentByIdentity(java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, boolean, boolean) declares JDO model class org.dependencytrack.model.Component as Swagger response schema
+org.dependencytrack.resources.v1.ComponentResource.getComponentByUuid(java.lang.String, boolean) declares JDO model class org.dependencytrack.model.Component as Swagger response schema
+org.dependencytrack.resources.v1.ComponentResource.getOccurrences(java.util.UUID) declares JDO model class org.dependencytrack.model.ComponentOccurrence as Swagger response schema
+org.dependencytrack.resources.v1.ComponentResource.updateComponent(org.dependencytrack.model.Component) declares JDO model class org.dependencytrack.model.Component as Swagger response schema
+org.dependencytrack.resources.v1.ConfigPropertyResource.getConfigProperties() declares JDO model class alpine.model.ConfigProperty as Swagger response schema
+org.dependencytrack.resources.v1.ConfigPropertyResource.getPublicConfigProperty(java.lang.String, java.lang.String) declares JDO model class alpine.model.ConfigProperty as Swagger response schema
+org.dependencytrack.resources.v1.ConfigPropertyResource.updateConfigProperty(alpine.model.ConfigProperty) declares JDO model class alpine.model.ConfigProperty as Swagger response schema
+org.dependencytrack.resources.v1.ConfigPropertyResource.updateConfigProperty(java.util.List) declares JDO model class alpine.model.ConfigProperty as Swagger response schema
+org.dependencytrack.resources.v1.LdapResource.addMapping(org.dependencytrack.resources.v1.vo.MappedLdapGroupRequest) declares JDO model class alpine.model.MappedLdapGroup as Swagger response schema
+org.dependencytrack.resources.v1.LdapResource.retrieveLdapGroups(java.lang.String) declares JDO model class alpine.model.MappedLdapGroup as Swagger response schema
+org.dependencytrack.resources.v1.LicenseGroupResource.addLicenseToLicenseGroup(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.LicenseGroup as Swagger response schema
+org.dependencytrack.resources.v1.LicenseGroupResource.createLicenseGroup(org.dependencytrack.model.LicenseGroup) declares JDO model class org.dependencytrack.model.LicenseGroup as Swagger response schema
+org.dependencytrack.resources.v1.LicenseGroupResource.getLicenseGroup(java.lang.String) declares JDO model class org.dependencytrack.model.LicenseGroup as Swagger response schema
+org.dependencytrack.resources.v1.LicenseGroupResource.getLicenseGroups() declares JDO model class org.dependencytrack.model.LicenseGroup as Swagger response schema
+org.dependencytrack.resources.v1.LicenseGroupResource.removeLicenseFromLicenseGroup(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.LicenseGroup as Swagger response schema
+org.dependencytrack.resources.v1.LicenseGroupResource.updateLicenseGroup(org.dependencytrack.model.LicenseGroup) declares JDO model class org.dependencytrack.model.LicenseGroup as Swagger response schema
+org.dependencytrack.resources.v1.LicenseResource.createLicense(org.dependencytrack.model.License) declares JDO model class org.dependencytrack.model.License as Swagger response schema
+org.dependencytrack.resources.v1.LicenseResource.getLicense(java.lang.String) declares JDO model class org.dependencytrack.model.License as Swagger response schema
+org.dependencytrack.resources.v1.LicenseResource.getLicenseListing() declares JDO model class org.dependencytrack.model.License as Swagger response schema
+org.dependencytrack.resources.v1.LicenseResource.getLicenses() declares JDO model class org.dependencytrack.model.License as Swagger response schema
+org.dependencytrack.resources.v1.NotificationPublisherResource.createNotificationPublisher(org.dependencytrack.resources.v1.vo.CreateNotificationPublisherRequest) declares JDO model class org.dependencytrack.model.NotificationPublisher as Swagger response schema
+org.dependencytrack.resources.v1.NotificationPublisherResource.getAllNotificationPublishers() declares JDO model class org.dependencytrack.model.NotificationPublisher as Swagger response schema
+org.dependencytrack.resources.v1.NotificationPublisherResource.updateNotificationPublisher(org.dependencytrack.resources.v1.vo.UpdateNotificationPublisherRequest) declares JDO model class org.dependencytrack.model.NotificationPublisher as Swagger response schema
+org.dependencytrack.resources.v1.NotificationRuleResource.addProjectToRule(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
+org.dependencytrack.resources.v1.NotificationRuleResource.addTeamToRule(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
+org.dependencytrack.resources.v1.NotificationRuleResource.createNotificationRule(org.dependencytrack.resources.v1.vo.CreateNotificationRuleRequest) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
+org.dependencytrack.resources.v1.NotificationRuleResource.createScheduledNotificationRule(org.dependencytrack.resources.v1.vo.CreateScheduledNotificationRuleRequest) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
+org.dependencytrack.resources.v1.NotificationRuleResource.getAllNotificationRules(org.dependencytrack.model.NotificationTriggerType) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
+org.dependencytrack.resources.v1.NotificationRuleResource.removeProjectFromRule(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
+org.dependencytrack.resources.v1.NotificationRuleResource.removeTeamFromRule(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
+org.dependencytrack.resources.v1.NotificationRuleResource.updateNotificationRule(org.dependencytrack.resources.v1.vo.UpdateNotificationRuleRequest) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
+org.dependencytrack.resources.v1.OidcResource.addMapping(org.dependencytrack.resources.v1.vo.MappedOidcGroupRequest) declares JDO model class alpine.model.MappedOidcGroup as Swagger response schema
+org.dependencytrack.resources.v1.OidcResource.createGroup(alpine.model.OidcGroup) declares JDO model class alpine.model.OidcGroup as Swagger response schema
+org.dependencytrack.resources.v1.OidcResource.retrieveGroups() declares JDO model class alpine.model.OidcGroup as Swagger response schema
+org.dependencytrack.resources.v1.OidcResource.retrieveTeamsMappedToGroup(java.lang.String) declares JDO model class alpine.model.Team as Swagger response schema
+org.dependencytrack.resources.v1.OidcResource.updateGroup(alpine.model.OidcGroup) declares JDO model class alpine.model.OidcGroup as Swagger response schema
+org.dependencytrack.resources.v1.PermissionResource.addPermissionToTeam(java.lang.String, java.lang.String) declares JDO model class alpine.model.Team as Swagger response schema
+org.dependencytrack.resources.v1.PermissionResource.addPermissionToUser(java.lang.String, java.lang.String) declares JDO model class alpine.model.User as Swagger response schema
+org.dependencytrack.resources.v1.PermissionResource.removePermissionFromTeam(java.lang.String, java.lang.String) declares JDO model class alpine.model.Team as Swagger response schema
+org.dependencytrack.resources.v1.PermissionResource.removePermissionFromUser(java.lang.String, java.lang.String) declares JDO model class alpine.model.User as Swagger response schema
+org.dependencytrack.resources.v1.PermissionResource.setTeamPermissions(org.dependencytrack.resources.v1.vo.TeamPermissionsSetRequest) declares JDO model class alpine.model.Team as Swagger response schema
+org.dependencytrack.resources.v1.PermissionResource.setUserPermissions(org.dependencytrack.resources.v1.vo.UserPermissionsSetRequest) declares JDO model class alpine.model.User as Swagger response schema
+org.dependencytrack.resources.v1.PolicyResource.addProjectToPolicy(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.Policy as Swagger response schema
+org.dependencytrack.resources.v1.PolicyResource.createPolicy(org.dependencytrack.model.Policy) declares JDO model class org.dependencytrack.model.Policy as Swagger response schema
+org.dependencytrack.resources.v1.PolicyResource.getPolicies() declares JDO model class org.dependencytrack.model.Policy as Swagger response schema
+org.dependencytrack.resources.v1.PolicyResource.getPolicy(java.lang.String) declares JDO model class org.dependencytrack.model.Policy as Swagger response schema
+org.dependencytrack.resources.v1.PolicyResource.removeProjectFromPolicy(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.Policy as Swagger response schema
+org.dependencytrack.resources.v1.PolicyResource.updatePolicy(org.dependencytrack.model.Policy) declares JDO model class org.dependencytrack.model.Policy as Swagger response schema
+org.dependencytrack.resources.v1.PolicyViolationResource.getViolations(boolean, boolean, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.PolicyViolation as Swagger response schema
+org.dependencytrack.resources.v1.PolicyViolationResource.getViolationsByComponent(java.lang.String, boolean) declares JDO model class org.dependencytrack.model.PolicyViolation as Swagger response schema
+org.dependencytrack.resources.v1.PolicyViolationResource.getViolationsByProject(java.lang.String, boolean) declares JDO model class org.dependencytrack.model.PolicyViolation as Swagger response schema
+org.dependencytrack.resources.v1.ProjectResource.createProject(org.dependencytrack.model.Project) declares JDO model class org.dependencytrack.model.Project as Swagger response schema
+org.dependencytrack.resources.v1.ProjectResource.getLatestProjectByName(java.lang.String) declares JDO model class org.dependencytrack.model.Project as Swagger response schema
+org.dependencytrack.resources.v1.ProjectResource.getProject(java.lang.String) declares JDO model class org.dependencytrack.model.Project as Swagger response schema
+org.dependencytrack.resources.v1.ProjectResource.getProject(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.Project as Swagger response schema
+org.dependencytrack.resources.v1.ProjectResource.patchProject(java.lang.String, org.dependencytrack.model.Project) declares JDO model class org.dependencytrack.model.Project as Swagger response schema
+org.dependencytrack.resources.v1.ProjectResource.updateProject(org.dependencytrack.model.Project) declares JDO model class org.dependencytrack.model.Project as Swagger response schema
+org.dependencytrack.resources.v1.RepositoryResource.createRepository(org.dependencytrack.model.Repository) declares JDO model class org.dependencytrack.model.Repository as Swagger response schema
+org.dependencytrack.resources.v1.RepositoryResource.getRepositories() declares JDO model class org.dependencytrack.model.Repository as Swagger response schema
+org.dependencytrack.resources.v1.RepositoryResource.getRepositoriesByType(org.dependencytrack.model.RepositoryType) declares JDO model class org.dependencytrack.model.Repository as Swagger response schema
+org.dependencytrack.resources.v1.RepositoryResource.updateRepository(org.dependencytrack.model.Repository) declares JDO model class org.dependencytrack.model.Repository as Swagger response schema
+org.dependencytrack.resources.v1.ServiceResource.createService(java.lang.String, org.dependencytrack.model.ServiceComponent) declares JDO model class org.dependencytrack.model.ServiceComponent as Swagger response schema
+org.dependencytrack.resources.v1.ServiceResource.getAllServices(java.lang.String) declares JDO model class org.dependencytrack.model.ServiceComponent as Swagger response schema
+org.dependencytrack.resources.v1.ServiceResource.getServiceByUuid(java.lang.String) declares JDO model class org.dependencytrack.model.ServiceComponent as Swagger response schema
+org.dependencytrack.resources.v1.ServiceResource.updateService(org.dependencytrack.model.ServiceComponent) declares JDO model class org.dependencytrack.model.ServiceComponent as Swagger response schema
+org.dependencytrack.resources.v1.TagResource.getTagsForPolicy(java.lang.String) declares JDO model class org.dependencytrack.model.Tag as Swagger response schema
+org.dependencytrack.resources.v1.TeamResource.createTeam(alpine.model.Team) declares JDO model class alpine.model.Team as Swagger response schema
+org.dependencytrack.resources.v1.TeamResource.generateApiKey(java.lang.String) declares JDO model class alpine.model.ApiKey as Swagger response schema
+org.dependencytrack.resources.v1.TeamResource.getTeam(java.lang.String) declares JDO model class alpine.model.Team as Swagger response schema
+org.dependencytrack.resources.v1.TeamResource.getTeams() declares JDO model class alpine.model.Team as Swagger response schema
+org.dependencytrack.resources.v1.TeamResource.regenerateApiKey(java.lang.String) declares JDO model class alpine.model.ApiKey as Swagger response schema
+org.dependencytrack.resources.v1.TeamResource.updateApiKeyComment(java.lang.String, java.lang.String) declares JDO model class alpine.model.ApiKey as Swagger response schema
+org.dependencytrack.resources.v1.TeamResource.updateTeam(alpine.model.Team) declares JDO model class alpine.model.Team as Swagger response schema
+org.dependencytrack.resources.v1.UserResource.addTeamToUser(java.lang.String, org.dependencytrack.model.IdentifiableObject) declares JDO model class alpine.model.User as Swagger response schema
+org.dependencytrack.resources.v1.UserResource.createLdapUser(alpine.model.LdapUser) declares JDO model class alpine.model.LdapUser as Swagger response schema
+org.dependencytrack.resources.v1.UserResource.createManagedUser(alpine.model.ManagedUser) declares JDO model class alpine.model.ManagedUser as Swagger response schema
+org.dependencytrack.resources.v1.UserResource.createOidcUser(alpine.model.OidcUser) declares JDO model class alpine.model.OidcUser as Swagger response schema
+org.dependencytrack.resources.v1.UserResource.getLdapUsers() declares JDO model class alpine.model.LdapUser as Swagger response schema
+org.dependencytrack.resources.v1.UserResource.getManagedUsers() declares JDO model class alpine.model.ManagedUser as Swagger response schema
+org.dependencytrack.resources.v1.UserResource.getSelf() declares JDO model class alpine.model.User as Swagger response schema
+org.dependencytrack.resources.v1.UserResource.removeTeamFromUser(java.lang.String, org.dependencytrack.model.IdentifiableObject) declares JDO model class alpine.model.User as Swagger response schema
+org.dependencytrack.resources.v1.UserResource.setUserTeams(org.dependencytrack.resources.v1.vo.TeamsSetRequest) declares JDO model class alpine.model.User as Swagger response schema
+org.dependencytrack.resources.v1.UserResource.updateManagedUser(alpine.model.ManagedUser) declares JDO model class alpine.model.ManagedUser as Swagger response schema
+org.dependencytrack.resources.v1.UserResource.updateSelf(alpine.model.ManagedUser) declares JDO model class alpine.model.ManagedUser as Swagger response schema
+org.dependencytrack.resources.v1.ViolationAnalysisResource.retrieveAnalysis(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.ViolationAnalysis as Swagger response schema
+org.dependencytrack.resources.v1.ViolationAnalysisResource.updateAnalysis(org.dependencytrack.resources.v1.vo.ViolationAnalysisRequest) declares JDO model class org.dependencytrack.model.ViolationAnalysis as Swagger response schema
+org.dependencytrack.resources.v1.VulnerabilityResource.createVulnerability(org.dependencytrack.model.Vulnerability) declares JDO model class org.dependencytrack.model.Vulnerability as Swagger response schema
+org.dependencytrack.resources.v1.VulnerabilityResource.getAllVulnerabilities() declares JDO model class org.dependencytrack.model.Vulnerability as Swagger response schema
+org.dependencytrack.resources.v1.VulnerabilityResource.getVulnerabilitiesByComponent(java.lang.String, boolean) declares JDO model class org.dependencytrack.model.Vulnerability as Swagger response schema
+org.dependencytrack.resources.v1.VulnerabilityResource.getVulnerabilitiesByProject(java.lang.String, boolean) declares JDO model class org.dependencytrack.model.Vulnerability as Swagger response schema
+org.dependencytrack.resources.v1.VulnerabilityResource.getVulnerabilitiesByTag(java.lang.String) declares JDO model class org.dependencytrack.model.Vulnerability as Swagger response schema
+org.dependencytrack.resources.v1.VulnerabilityResource.getVulnerabilityByUuid(java.lang.String) declares JDO model class org.dependencytrack.model.Vulnerability as Swagger response schema
+org.dependencytrack.resources.v1.VulnerabilityResource.getVulnerabilityByVulnId(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.Vulnerability as Swagger response schema
+org.dependencytrack.resources.v1.VulnerabilityResource.updateVulnerability(org.dependencytrack.model.Vulnerability) declares JDO model class org.dependencytrack.model.Vulnerability as Swagger response schema
+org.dependencytrack.resources.v1.VulnerabilityResource.updateVulnerabilityTags(java.util.List, java.lang.String) declares JDO model class org.dependencytrack.model.Vulnerability as Swagger response schema

--- a/apiserver/src/test/resources/archunit_store/stored.rules
+++ b/apiserver/src/test/resources/archunit_store/stored.rules
@@ -1,5 +1,7 @@
 #
-#Tue Apr 14 11:35:31 CEST 2026
+#Sun Jun 14 12:34:14 CEST 2026
 classes\ that\ have\ simple\ name\ ending\ with\ 'Dao'\ and\ reside\ in\ a\ package\ 'org.dependencytrack.persistence.jdbi'\ should\ not\ use\ @RegisterBeanMapper\ with\ model\ classes=214fb774-c145-436c-bd1c-d442e8e4fe26
 classes\ that\ reside\ in\ a\ package\ 'org.dependencytrack.persistence.jdbi..'\ and\ implement\ org.jdbi.v3.core.mapper.RowMapper\ should\ not\ target\ model\ classes=f3b37c20-3a23-4355-a1a0-626adddec514
+methods\ that\ are\ JAX-RS\ resource\ handler\ methods\ should\ not\ accept\ JDO\ model\ classes\ as\ request\ body=3e49066c-46b2-40c2-8473-ce4276c1ba12
+methods\ that\ are\ JAX-RS\ resource\ handler\ methods\ should\ not\ declare\ JDO\ model\ classes\ in\ Swagger\ response\ schemas=67305ac9-6039-403a-8a4c-ada073ef9b6d
 methods\ that\ are\ declared\ in\ classes\ that\ have\ simple\ name\ ending\ with\ 'Dao'\ and\ are\ declared\ in\ classes\ that\ reside\ in\ a\ package\ 'org.dependencytrack.persistence.jdbi'\ and\ are\ not\ annotated\ with\ @SqlUpdate\ and\ are\ not\ annotated\ with\ @SqlBatch\ should\ not\ return\ model\ classes=abb951d9-b11c-45d0-a35c-0d8977fd78e3


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds architecture test for rejecting JDO model usage in REST API v1.

Freezes the status quo of violations that we can chip away on over time, and prevents new violations being added.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
