### PR TITLE
Decouple notification publisher API from JDO models

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/NotificationPublisherResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/NotificationPublisherResource.java
@@ -63,6 +63,7 @@ import org.dependencytrack.plugin.runtime.PluginManager;
 import org.dependencytrack.proto.internal.workflow.v1.PublishNotificationWorkflowArg;
 import org.dependencytrack.resources.AbstractApiResource;
 import org.dependencytrack.resources.v1.vo.CreateNotificationPublisherRequest;
+import org.dependencytrack.resources.v1.vo.NotificationPublisherResponse;
 import org.dependencytrack.resources.v1.vo.UpdateNotificationPublisherRequest;
 import org.jspecify.annotations.Nullable;
 import org.owasp.security.logging.SecurityMarkers;
@@ -113,7 +114,7 @@ public class NotificationPublisherResource extends AbstractApiResource {
             @ApiResponse(
                     responseCode = "200",
                     description = "A list of all notification publishers",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = NotificationPublisher.class)))
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = NotificationPublisherResponse.class)))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
@@ -122,8 +123,11 @@ public class NotificationPublisherResource extends AbstractApiResource {
             Permissions.Constants.SYSTEM_CONFIGURATION_READ
     })
     public Response getAllNotificationPublishers() {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
-            final List<NotificationPublisher> publishers = qm.getAllNotificationPublishers();
+        try (final var qm = new QueryManager(getAlpineRequest())) {
+            final List<NotificationPublisherResponse> publishers =
+                    qm.getAllNotificationPublishers().stream()
+                            .map(NotificationPublisherResponse::of)
+                            .toList();
             return Response.ok(publishers).build();
         }
     }
@@ -139,7 +143,7 @@ public class NotificationPublisherResource extends AbstractApiResource {
             @ApiResponse(
                     responseCode = "201",
                     description = "The created notification publisher",
-                    content = @Content(schema = @Schema(implementation = NotificationPublisher.class))
+                    content = @Content(schema = @Schema(implementation = NotificationPublisherResponse.class))
             ),
             @ApiResponse(responseCode = "400", description = "Invalid notification class or trying to modify a default publisher"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
@@ -173,9 +177,15 @@ public class NotificationPublisherResource extends AbstractApiResource {
             });
         }
 
-        LOGGER.info(SecurityMarkers.SECURITY_AUDIT, "Created notification publisher '{}'", createdPublisher.getName());
+        LOGGER.info(
+                SecurityMarkers.SECURITY_AUDIT,
+                "Created notification publisher '{}'",
+                createdPublisher.getName());
 
-        return Response.status(Response.Status.CREATED).entity(createdPublisher).build();
+        return Response
+                .status(Response.Status.CREATED)
+                .entity(NotificationPublisherResponse.of(createdPublisher))
+                .build();
     }
 
     @POST
@@ -189,7 +199,7 @@ public class NotificationPublisherResource extends AbstractApiResource {
             @ApiResponse(
                     responseCode = "200",
                     description = "The updated notification publisher",
-                    content = @Content(schema = @Schema(implementation = NotificationPublisher.class))
+                    content = @Content(schema = @Schema(implementation = NotificationPublisherResponse.class))
             ),
             @ApiResponse(responseCode = "400", description = "Invalid notification class or trying to modify a default publisher"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
@@ -238,9 +248,14 @@ public class NotificationPublisherResource extends AbstractApiResource {
             });
         }
 
-        LOGGER.info(SecurityMarkers.SECURITY_AUDIT, "Updated notification publisher '{}'", updatedPublisher.getName());
+        LOGGER.info(
+                SecurityMarkers.SECURITY_AUDIT,
+                "Updated notification publisher '{}'",
+                updatedPublisher.getName());
 
-        return Response.ok(updatedPublisher).build();
+        return Response
+                .ok(NotificationPublisherResponse.of(updatedPublisher))
+                .build();
     }
 
     @DELETE
@@ -263,19 +278,27 @@ public class NotificationPublisherResource extends AbstractApiResource {
     })
     public Response deleteNotificationPublisher(
             @Parameter(description = "The UUID of the notification publisher to delete", schema = @Schema(type = "string", format = "uuid"), required = true)
-            @PathParam("notificationPublisherUuid") @ValidUuid String notificationPublisherUuid) {
+            @PathParam("notificationPublisherUuid") @ValidUuid String uuid) {
         try (final var qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
-                final NotificationPublisher notificationPublisher = qm.getObjectByUuid(NotificationPublisher.class, notificationPublisherUuid);
-                if (notificationPublisher != null) {
-                    if (notificationPublisher.isDefaultPublisher()) {
-                        return Response.status(Response.Status.BAD_REQUEST).entity("Deleting a default notification publisher is forbidden.").build();
+                final var publisher = qm.getObjectByUuid(NotificationPublisher.class, uuid);
+                if (publisher != null) {
+                    if (publisher.isDefaultPublisher()) {
+                        return Response
+                                .status(Response.Status.BAD_REQUEST)
+                                .entity("Deleting a default notification publisher is forbidden.")
+                                .build();
                     } else {
-                        qm.delete(notificationPublisher);
-                        return Response.status(Response.Status.NO_CONTENT).build();
+                        qm.delete(publisher);
+                        return Response
+                                .status(Response.Status.NO_CONTENT)
+                                .build();
                     }
                 } else {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the notification rule could not be found.").build();
+                    return Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The UUID of the notification rule could not be found.")
+                            .build();
                 }
             });
         }
@@ -344,7 +367,7 @@ public class NotificationPublisherResource extends AbstractApiResource {
             @Parameter(description = "The UUID of the rule to test", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String ruleUuid) {
         try (final var qm = new QueryManager(getAlpineRequest())) {
-            final NotificationRule rule = qm.getObjectByUuid(NotificationRule.class, ruleUuid);
+            final var rule = qm.getObjectByUuid(NotificationRule.class, ruleUuid);
             if (rule == null) {
                 return Response.status(Response.Status.NOT_FOUND).build();
             }
@@ -384,7 +407,10 @@ public class NotificationPublisherResource extends AbstractApiResource {
             return Response.ok().build();
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Exception occured while sending the notification.").build();
+            return Response
+                    .status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("Exception occurred while sending the notification.")
+                    .build();
         }
     }
 

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/NotificationPublisherResponse.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/NotificationPublisherResponse.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.dependencytrack.model.NotificationPublisher;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.UUID;
+
+/// @since 5.1.0
+@NullMarked
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record NotificationPublisherResponse(
+        @Schema(description = "Name of the notification publisher", requiredMode = Schema.RequiredMode.REQUIRED)
+        String name,
+        @Schema(description = "Description of the notification publisher")
+        @Nullable String description,
+        @Schema(description = "Name of the publisher extension that handles delivery", requiredMode = Schema.RequiredMode.REQUIRED)
+        String extensionName,
+        @Schema(description = "Template used to render the notification payload")
+        @Nullable String template,
+        @Schema(description = "MIME type of the rendered template", requiredMode = Schema.RequiredMode.REQUIRED)
+        String templateMimeType,
+        @Schema(description = "Whether the publisher is one of the built-in defaults", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean defaultPublisher,
+        @Schema(description = "UUID of the notification publisher", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID uuid) {
+
+    public static NotificationPublisherResponse of(NotificationPublisher publisher) {
+        return new NotificationPublisherResponse(
+                publisher.getName(),
+                publisher.getDescription(),
+                publisher.getExtensionName(),
+                publisher.getTemplate(),
+                publisher.getTemplateMimeType(),
+                publisher.isDefaultPublisher(),
+                publisher.getUuid());
+    }
+
+}

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
@@ -21,7 +21,6 @@ package org.dependencytrack.resources.v1;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthFeature;
 import io.smallrye.config.SmallRyeConfigBuilder;
-import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -260,25 +259,27 @@ class NotificationPublisherResourceTest extends ResourceTest {
     void updateNotificationPublisherTest() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
 
-        NotificationPublisher notificationPublisher = qm.createNotificationPublisher(
+        final NotificationPublisher notificationPublisher = qm.createNotificationPublisher(
                 "Example Publisher", "Publisher description",
                 "slack", "template", "text/html",
                 false
         );
         notificationPublisher.setName("Updated Publisher name");
-        Response response = jersey.target(V1_NOTIFICATION_PUBLISHER).request()
+        final Response response = jersey.target(V1_NOTIFICATION_PUBLISHER).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(notificationPublisher, MediaType.APPLICATION_JSON));
-        Assertions.assertEquals(200, response.getStatus(), 0);
-        JsonObject json = parseJsonObject(response);
-        Assertions.assertNotNull(json);
-        Assertions.assertEquals("Updated Publisher name", json.getString("name"));
-        Assertions.assertFalse(json.getBoolean("defaultPublisher"));
-        Assertions.assertEquals("Publisher description", json.getString("description"));
-        Assertions.assertEquals("template", json.getString("template"));
-        Assertions.assertEquals("text/html", json.getString("templateMimeType"));
-        Assertions.assertEquals(notificationPublisher.getUuid().toString(), json.getString("uuid"));
-        Assertions.assertEquals("slack", json.getString("extensionName"));
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "name": "Updated Publisher name",
+                  "description": "Publisher description",
+                  "extensionName": "slack",
+                  "template": "template",
+                  "templateMimeType": "text/html",
+                  "defaultPublisher": false,
+                  "uuid": "%s"
+                }
+                """.formatted(notificationPublisher.getUuid()));
     }
 
     @Test

--- a/apiserver/src/test/resources/archunit_store/67305ac9-6039-403a-8a4c-ada073ef9b6d
+++ b/apiserver/src/test/resources/archunit_store/67305ac9-6039-403a-8a4c-ada073ef9b6d
@@ -23,9 +23,6 @@ org.dependencytrack.resources.v1.LicenseResource.createLicense(org.dependencytra
 org.dependencytrack.resources.v1.LicenseResource.getLicense(java.lang.String) declares JDO model class org.dependencytrack.model.License as Swagger response schema
 org.dependencytrack.resources.v1.LicenseResource.getLicenseListing() declares JDO model class org.dependencytrack.model.License as Swagger response schema
 org.dependencytrack.resources.v1.LicenseResource.getLicenses() declares JDO model class org.dependencytrack.model.License as Swagger response schema
-org.dependencytrack.resources.v1.NotificationPublisherResource.createNotificationPublisher(org.dependencytrack.resources.v1.vo.CreateNotificationPublisherRequest) declares JDO model class org.dependencytrack.model.NotificationPublisher as Swagger response schema
-org.dependencytrack.resources.v1.NotificationPublisherResource.getAllNotificationPublishers() declares JDO model class org.dependencytrack.model.NotificationPublisher as Swagger response schema
-org.dependencytrack.resources.v1.NotificationPublisherResource.updateNotificationPublisher(org.dependencytrack.resources.v1.vo.UpdateNotificationPublisherRequest) declares JDO model class org.dependencytrack.model.NotificationPublisher as Swagger response schema
 org.dependencytrack.resources.v1.NotificationRuleResource.addProjectToRule(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
 org.dependencytrack.resources.v1.NotificationRuleResource.addTeamToRule(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
 org.dependencytrack.resources.v1.NotificationRuleResource.createNotificationRule(org.dependencytrack.resources.v1.vo.CreateNotificationRuleRequest) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Tackles the technical debt of JDO models being reused for REST DTOs for all endpoints under `/v1/notification/publisher`.

Also makes the generated OpenAPI spec more reliable b/c it no longer advertises fields that are never used / never returned.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
