### PR TITLE
Decouple repository API from JDO models

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/Repository.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/Repository.java
@@ -18,13 +18,6 @@
  */
 package org.dependencytrack.model;
 
-import alpine.server.json.TrimmedStringDeserializer;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Index;
@@ -43,56 +36,44 @@ import java.util.UUID;
  */
 @PersistenceCapable(table = "REPOSITORY")
 @Unique(name = "REPOSITORY_COMPOUND_IDX", members = {"type", "identifier"})
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Repository implements Serializable {
 
     private static final long serialVersionUID = -3875882921059813747L;
 
     @PrimaryKey
     @Persistent(valueStrategy = IdGeneratorStrategy.NATIVE)
-    @JsonIgnore
     private long id;
 
     @Persistent(defaultFetchGroup = "true")
     @Column(name = "TYPE", jdbcType = "VARCHAR", allowsNull = "false")
-    @NotNull
     private RepositoryType type;
 
     @Persistent
     @Column(name = "IDENTIFIER", allowsNull = "false")
-    @NotBlank
-    @JsonDeserialize(using = TrimmedStringDeserializer.class)
     private String identifier;
 
     @Persistent
     @Column(name = "URL")
-    @NotBlank
-    @JsonDeserialize(using = TrimmedStringDeserializer.class)
     private String url;
 
     @Persistent
     @Column(name = "RESOLUTION_ORDER")
-    @NotNull
     private int resolutionOrder;
 
     @Persistent
     @Column(name = "ENABLED")
-    @NotNull
     private boolean enabled;
 
     @Persistent
     @Column(name = "INTERNAL")
-    @NotNull
     private Boolean internal; // New column, must allow nulls on existing databases
 
     @Persistent
     @Column(name = "AUTHENTICATIONREQUIRED", allowsNull = "false", defaultValue = "false")
-    @NotNull
     private boolean authenticationRequired;
 
     @Persistent
     @Column(name = "USERNAME")
-    @JsonDeserialize(using = TrimmedStringDeserializer.class)
     private String username;
 
     @Persistent
@@ -102,7 +83,6 @@ public class Repository implements Serializable {
     @Persistent(customValueStrategy = "uuid")
     @Index(name = "REPOSITORY_UUID_IDX") // Cannot be @Unique. Microsoft SQL Server throws an exception
     @Column(name = "UUID", sqlType = "UUID", allowsNull = "true")
-    @NotNull
     private UUID uuid;
 
     public long getId() {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/RepositoryResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/RepositoryResource.java
@@ -46,7 +46,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.PackageMetadata;
 import org.dependencytrack.model.Repository;
@@ -57,7 +56,12 @@ import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.persistence.jdbi.PackageMetadataDao;
 import org.dependencytrack.resources.AbstractApiResource;
 import org.dependencytrack.resources.v1.openapi.PaginatedApi;
+import org.dependencytrack.resources.v1.vo.CreateRepositoryRequest;
+import org.dependencytrack.resources.v1.vo.RepositoryResponse;
+import org.dependencytrack.resources.v1.vo.UpdateRepositoryRequest;
 import org.dependencytrack.secret.management.SecretManager;
+
+import java.util.List;
 
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 
@@ -94,15 +98,26 @@ public class RepositoryResource extends AbstractApiResource {
                     responseCode = "200",
                     description = "A list of all repositories",
                     headers = @Header(name = TOTAL_COUNT_HEADER, description = "The total number of repositories", schema = @Schema(type = "integer")),
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = Repository.class)))
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = RepositoryResponse.class)))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
-    @PermissionRequired({Permissions.Constants.SYSTEM_CONFIGURATION, Permissions.Constants.SYSTEM_CONFIGURATION_READ})
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_READ
+    })
     public Response getRepositories() {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             final PaginatedResult result = qm.getRepositories();
-            return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
+            final List<RepositoryResponse> responses =
+                    result.getList(Repository.class).stream()
+                            .map(RepositoryResponse::of)
+                            .toList();
+
+            return Response
+                    .ok(responses)
+                    .header(TOTAL_COUNT_HEADER, result.getTotal())
+                    .build();
         }
     }
 
@@ -119,17 +134,28 @@ public class RepositoryResource extends AbstractApiResource {
                     responseCode = "200",
                     description = "A list of repositories that support the provided type",
                     headers = @Header(description = "The total number of repositories", name = TOTAL_COUNT_HEADER, schema = @Schema(format = "integer")),
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = Repository.class)))
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = RepositoryResponse.class)))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
-    @PermissionRequired({Permissions.Constants.SYSTEM_CONFIGURATION, Permissions.Constants.SYSTEM_CONFIGURATION_READ})
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_READ
+    })
     public Response getRepositoriesByType(
             @Parameter(description = "The type of repositories to retrieve", required = true)
             @PathParam("type") RepositoryType type) {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             final PaginatedResult result = qm.getRepositories(type);
-            return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
+            final List<RepositoryResponse> responses =
+                    result.getList(Repository.class).stream()
+                            .map(RepositoryResponse::of)
+                            .toList();
+
+            return Response
+                    .ok(responses)
+                    .header(TOTAL_COUNT_HEADER, result.getTotal())
+                    .build();
         }
     }
 
@@ -153,21 +179,31 @@ public class RepositoryResource extends AbstractApiResource {
     public Response getRepositoryMetaComponent(
             @Parameter(description = "The Package URL for the component to query", required = true)
             @QueryParam("purl") String purl) {
+        final PackageURL parsedPurl;
         try {
-            final PackageURL packageURL = new PackageURL(purl);
-            final RepositoryType type = RepositoryType.resolve(packageURL);
-            if (RepositoryType.UNSUPPORTED == type) {
-                return Response.noContent().build();
-            }
-            final PackageMetadata pm = withJdbiHandle(
-                    handle -> new PackageMetadataDao(handle).get(packageURL));
-            if (pm == null) {
-                return Response.status(Response.Status.NOT_FOUND).entity("The repository metadata for the specified component cannot be found.").build();
-            }
-            return Response.ok(RepositoryMetaComponent.of(pm)).build();
+            parsedPurl = new PackageURL(purl);
         } catch (MalformedPackageURLException e) {
-            return Response.status(Response.Status.BAD_REQUEST).build();
+            return Response
+                    .status(Response.Status.BAD_REQUEST)
+                    .build();
         }
+
+        final RepositoryType type = RepositoryType.resolve(parsedPurl);
+        if (RepositoryType.UNSUPPORTED == type) {
+            return Response.noContent().build();
+        }
+
+        final PackageMetadata pm = withJdbiHandle(handle -> new PackageMetadataDao(handle).get(parsedPurl));
+        if (pm == null) {
+            return Response
+                    .status(Response.Status.NOT_FOUND)
+                    .entity("The repository metadata for the specified component cannot be found.")
+                    .build();
+        }
+
+        return Response
+                .ok(RepositoryMetaComponent.of(pm))
+                .build();
     }
 
     @PUT
@@ -181,49 +217,57 @@ public class RepositoryResource extends AbstractApiResource {
             @ApiResponse(
                     responseCode = "201",
                     description = "The created repository",
-                    content = @Content(schema = @Schema(implementation = Repository.class))
+                    content = @Content(schema = @Schema(implementation = RepositoryResponse.class))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(responseCode = "409", description = "A repository with the specified identifier already exists")
     })
-    @PermissionRequired({Permissions.Constants.SYSTEM_CONFIGURATION, Permissions.Constants.SYSTEM_CONFIGURATION_CREATE})
-    public Response createRepository(Repository jsonRepository) {
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_CREATE
+    })
+    public Response createRepository(CreateRepositoryRequest request) {
         final Validator validator = super.getValidator();
-        failOnValidationError(
-                validator.validateProperty(jsonRepository, "identifier"),
-                validator.validateProperty(jsonRepository, "url")
-        );
-        final String passwordSecretName = StringUtils.trimToNull(jsonRepository.getPassword());
-        if (jsonRepository.isAuthenticationRequired() && passwordSecretName == null) {
-            return Response.status(Response.Status.BAD_REQUEST)
+        failOnValidationError(validator.validate(request));
+
+        if (request.authenticationRequired() && request.password() == null) {
+            return Response
+                    .status(Response.Status.BAD_REQUEST)
                     .entity("A password secret name is required when authentication is enabled.")
                     .build();
         }
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
-                final boolean exists = qm.repositoryExist(jsonRepository.getType(), StringUtils.trimToNull(jsonRepository.getIdentifier()));
+                final boolean exists = qm.repositoryExist(request.type(), request.identifier());
                 if (!exists) {
-                    if (passwordSecretName != null
-                            && secretManager.getSecretMetadata(passwordSecretName) == null) {
+                    if (request.password() != null
+                            && secretManager.getSecretMetadata(request.password()) == null) {
                         return Response
                                 .status(Response.Status.BAD_REQUEST)
-                                .entity("The secret with name \"%s\" could not be found.".formatted(passwordSecretName))
+                                .entity("The secret with name \"%s\" could not be found.".formatted(request.password()))
                                 .build();
                     }
 
                     final Repository repository = qm.createRepository(
-                            jsonRepository.getType(),
-                            StringUtils.trimToNull(jsonRepository.getIdentifier()),
-                            StringUtils.trimToNull(jsonRepository.getUrl()),
-                            jsonRepository.isEnabled(),
-                            jsonRepository.isInternal(),
-                            jsonRepository.isAuthenticationRequired(),
-                            jsonRepository.getUsername(),
-                            passwordSecretName);
+                            request.type(),
+                            request.identifier(),
+                            request.url(),
+                            request.enabled(),
+                            Boolean.TRUE.equals(request.internal()),
+                            request.authenticationRequired(),
+                            request.username(),
+                            request.password());
 
-                    return Response.status(Response.Status.CREATED).entity(repository).build();
+                    return Response
+                            .status(Response.Status.CREATED)
+                            .entity(RepositoryResponse.of(repository))
+                            .build();
                 } else {
-                    return Response.status(Response.Status.CONFLICT).entity("A repository with the specified identifier already exists.").build();
+                    return Response
+                            .status(Response.Status.CONFLICT)
+                            .entity("A repository with the specified identifier already exists.")
+                            .build();
                 }
             });
         }
@@ -240,45 +284,54 @@ public class RepositoryResource extends AbstractApiResource {
             @ApiResponse(
                     responseCode = "200",
                     description = "The updated repository",
-                    content = @Content(schema = @Schema(implementation = Repository.class))
+                    content = @Content(schema = @Schema(implementation = RepositoryResponse.class))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(responseCode = "404", description = "The UUID of the repository could not be found")
     })
-    @PermissionRequired({Permissions.Constants.SYSTEM_CONFIGURATION, Permissions.Constants.SYSTEM_CONFIGURATION_UPDATE})
-    public Response updateRepository(Repository jsonRepository) {
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_UPDATE
+    })
+    public Response updateRepository(UpdateRepositoryRequest request) {
         final Validator validator = super.getValidator();
-        failOnValidationError(validator.validateProperty(jsonRepository, "identifier"),
-                validator.validateProperty(jsonRepository, "url")
-        );
-        final String passwordSecretName = StringUtils.trimToNull(jsonRepository.getPassword());
-        if (jsonRepository.isAuthenticationRequired() && passwordSecretName == null) {
-            return Response.status(Response.Status.BAD_REQUEST)
+        failOnValidationError(validator.validate(request));
+
+        if (request.authenticationRequired() && request.password() == null) {
+            return Response
+                    .status(Response.Status.BAD_REQUEST)
                     .entity("A password secret name is required when authentication is enabled.")
                     .build();
         }
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
-                Repository repository = qm.getObjectByUuid(Repository.class, jsonRepository.getUuid());
+                var repository = qm.getObjectByUuid(Repository.class, request.uuid());
                 if (repository != null) {
-                    if (passwordSecretName != null && secretManager.getSecretMetadata(passwordSecretName) == null) {
+                    if (request.password() != null && secretManager.getSecretMetadata(request.password()) == null) {
                         return Response.status(Response.Status.BAD_REQUEST)
-                                .entity("The secret with name \"%s\" could not be found.".formatted(passwordSecretName))
+                                .entity("The secret with name \"%s\" could not be found.".formatted(request.password()))
                                 .build();
                     }
 
                     repository = qm.updateRepository(
-                            jsonRepository.getUuid(),
+                            request.uuid(),
                             repository.getIdentifier(),
-                            StringUtils.trimToNull(jsonRepository.getUrl()),
-                            jsonRepository.isInternal(),
-                            jsonRepository.isAuthenticationRequired(),
-                            jsonRepository.getUsername(),
-                            passwordSecretName,
-                            jsonRepository.isEnabled());
-                    return Response.ok(repository).build();
+                            request.url(),
+                            Boolean.TRUE.equals(request.internal()),
+                            request.authenticationRequired(),
+                            request.username(),
+                            request.password(),
+                            request.enabled());
+
+                    return Response
+                            .ok(RepositoryResponse.of(repository))
+                            .build();
                 } else {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the repository could not be found.").build();
+                    return Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The UUID of the repository could not be found.")
+                            .build();
                 }
             });
         }
@@ -297,20 +350,29 @@ public class RepositoryResource extends AbstractApiResource {
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(responseCode = "404", description = "The UUID of the repository could not be found")
     })
-    @PermissionRequired({Permissions.Constants.SYSTEM_CONFIGURATION, Permissions.Constants.SYSTEM_CONFIGURATION_DELETE})
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_DELETE
+    })
     public Response deleteRepository(
             @Parameter(description = "The UUID of the repository to delete", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid) {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
-                final Repository repository = qm.getObjectByUuid(Repository.class, uuid);
+                final var repository = qm.getObjectByUuid(Repository.class, uuid);
                 if (repository != null) {
                     qm.delete(repository);
-                    return Response.status(Response.Status.NO_CONTENT).build();
+                    return Response
+                            .status(Response.Status.NO_CONTENT)
+                            .build();
                 } else {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the repository could not be found.").build();
+                    return Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The UUID of the repository could not be found.")
+                            .build();
                 }
             });
         }
     }
+
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/CreateRepositoryRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/CreateRepositoryRequest.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import alpine.server.json.TrimmedStringDeserializer;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.dependencytrack.model.RepositoryType;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/// @since 5.1.0
+@NullMarked
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CreateRepositoryRequest(
+        @NotNull
+        @Schema(description = "Type of the repository", requiredMode = Schema.RequiredMode.REQUIRED)
+        RepositoryType type,
+        @NotBlank
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Unique identifier of the repository within its type", requiredMode = Schema.RequiredMode.REQUIRED)
+        String identifier,
+        @NotBlank
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "URL of the repository", requiredMode = Schema.RequiredMode.REQUIRED)
+        String url,
+        @Schema(description = "Whether the repository is enabled", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean enabled,
+        @Schema(description = "Whether the repository is internal to the organization")
+        @Nullable Boolean internal,
+        @Schema(description = "Whether the repository requires authentication", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean authenticationRequired,
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Username to authenticate with")
+        @Nullable String username,
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Name of the secret holding the password or token")
+        @Nullable String password) {
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/RepositoryResponse.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/RepositoryResponse.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.dependencytrack.model.Repository;
+import org.dependencytrack.model.RepositoryType;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.UUID;
+
+/// @since 5.1.0
+@NullMarked
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RepositoryResponse(
+        @Schema(description = "Type of the repository", requiredMode = Schema.RequiredMode.REQUIRED)
+        RepositoryType type,
+        @Schema(description = "Unique identifier of the repository within its type", requiredMode = Schema.RequiredMode.REQUIRED)
+        String identifier,
+        @Schema(description = "URL of the repository", requiredMode = Schema.RequiredMode.REQUIRED)
+        String url,
+        @Schema(description = "Order in which the repository is queried during version resolution", requiredMode = Schema.RequiredMode.REQUIRED)
+        int resolutionOrder,
+        @Schema(description = "Whether the repository is enabled", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean enabled,
+        @Schema(description = "Whether the repository is internal to the organization")
+        @Nullable Boolean internal,
+        @Schema(description = "Whether the repository requires authentication", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean authenticationRequired,
+        @Schema(description = "Username to authenticate with")
+        @Nullable String username,
+        @Schema(description = "Name of the secret holding the password or token")
+        @Nullable String password,
+        @Schema(description = "UUID of the repository", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID uuid) {
+
+    public static RepositoryResponse of(Repository repository) {
+        return new RepositoryResponse(
+                repository.getType(),
+                repository.getIdentifier(),
+                repository.getUrl(),
+                repository.getResolutionOrder(),
+                repository.isEnabled(),
+                repository.isInternal(),
+                repository.isAuthenticationRequired(),
+                repository.getUsername(),
+                repository.getPassword(),
+                repository.getUuid());
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/UpdateRepositoryRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/UpdateRepositoryRequest.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import alpine.server.json.TrimmedStringDeserializer;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.UUID;
+
+/// @since 5.1.0
+@NullMarked
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record UpdateRepositoryRequest(
+        @NotNull
+        @Schema(description = "UUID of the repository to update", requiredMode = Schema.RequiredMode.REQUIRED, format = "uuid")
+        UUID uuid,
+        @NotBlank
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "URL of the repository", requiredMode = Schema.RequiredMode.REQUIRED)
+        String url,
+        @Schema(description = "Whether the repository is enabled", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean enabled,
+        @Schema(description = "Whether the repository is internal to the organization")
+        @Nullable Boolean internal,
+        @Schema(description = "Whether the repository requires authentication", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean authenticationRequired,
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Username to authenticate with")
+        @Nullable String username,
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Name of the secret holding the password or token")
+        @Nullable String password) {
+}

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/RepositoryResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/RepositoryResourceTest.java
@@ -85,46 +85,53 @@ public class RepositoryResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getRepositoriesTest() {
+    public void shouldListAllSeededRepositories() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
 
-        Response response = jersey.target(V1_REPOSITORY).request()
+        final Response response = jersey.target(V1_REPOSITORY).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assertions.assertEquals(200, response.getStatus(), 0);
-        Assertions.assertEquals(String.valueOf(17), response.getHeaderString(TOTAL_COUNT_HEADER));
-        JsonArray json = parseJsonArray(response);
-        Assertions.assertNotNull(json);
-        Assertions.assertEquals(17, json.size());
-        for (int i = 0; i < json.size(); i++) {
-            Assertions.assertNotNull(json.getJsonObject(i).getString("type"));
-            Assertions.assertNotNull(json.getJsonObject(i).getString("identifier"));
-            Assertions.assertNotNull(json.getJsonObject(i).getString("url"));
-            Assertions.assertTrue(json.getJsonObject(i).getInt("resolutionOrder") > 0);
-            Assertions.assertTrue(json.getJsonObject(i).getBoolean("enabled"));
-        }
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("17");
+        assertThatJson(getPlainTextBody(response))
+                .node("[0]")
+                .isEqualTo(/* language=JSON */ """
+                        {
+                          "type": "CARGO",
+                          "identifier": "crates.io",
+                          "url": "https://crates.io",
+                          "resolutionOrder": 1,
+                          "enabled": true,
+                          "internal": false,
+                          "authenticationRequired": false,
+                          "uuid": "${json-unit.any-string}"
+                        }
+                        """);
     }
 
     @Test
-    public void getRepositoriesByTypeTest() {
+    public void shouldListSeededRepositoriesFilteredByType() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
 
-        Response response = jersey.target(V1_REPOSITORY + "/MAVEN").request()
+        final Response response = jersey.target(V1_REPOSITORY + "/MAVEN").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assertions.assertEquals(200, response.getStatus(), 0);
-        Assertions.assertEquals(String.valueOf(5), response.getHeaderString(TOTAL_COUNT_HEADER));
-        JsonArray json = parseJsonArray(response);
-        Assertions.assertNotNull(json);
-        Assertions.assertEquals(5, json.size());
-        for (int i = 0; i < json.size(); i++) {
-            Assertions.assertEquals("MAVEN", json.getJsonObject(i).getString("type"));
-            Assertions.assertFalse(json.getJsonObject(i).getBoolean("authenticationRequired"));
-            Assertions.assertNotNull(json.getJsonObject(i).getString("identifier"));
-            Assertions.assertNotNull(json.getJsonObject(i).getString("url"));
-            Assertions.assertTrue(json.getJsonObject(i).getInt("resolutionOrder") > 0);
-            Assertions.assertTrue(json.getJsonObject(i).getBoolean("enabled"));
-        }
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("5");
+        assertThatJson(getPlainTextBody(response))
+                .node("[0]")
+                .isEqualTo(/* language=JSON */ """
+                        {
+                          "type": "MAVEN",
+                          "identifier": "atlassian-public",
+                          "url": "https://packages.atlassian.com/content/repositories/atlassian-public/",
+                          "resolutionOrder": 2,
+                          "enabled": true,
+                          "internal": false,
+                          "authenticationRequired": false,
+                          "uuid": "${json-unit.any-string}"
+                        }
+                        """);
     }
 
     @Test

--- a/apiserver/src/test/resources/archunit_store/3e49066c-46b2-40c2-8473-ce4276c1ba12
+++ b/apiserver/src/test/resources/archunit_store/3e49066c-46b2-40c2-8473-ce4276c1ba12
@@ -11,8 +11,6 @@ org.dependencytrack.resources.v1.PolicyResource.updatePolicy(org.dependencytrack
 org.dependencytrack.resources.v1.ProjectResource.createProject(org.dependencytrack.model.Project) accepts JDO model class org.dependencytrack.model.Project as request body
 org.dependencytrack.resources.v1.ProjectResource.patchProject(java.lang.String, org.dependencytrack.model.Project) accepts JDO model class org.dependencytrack.model.Project as request body
 org.dependencytrack.resources.v1.ProjectResource.updateProject(org.dependencytrack.model.Project) accepts JDO model class org.dependencytrack.model.Project as request body
-org.dependencytrack.resources.v1.RepositoryResource.createRepository(org.dependencytrack.model.Repository) accepts JDO model class org.dependencytrack.model.Repository as request body
-org.dependencytrack.resources.v1.RepositoryResource.updateRepository(org.dependencytrack.model.Repository) accepts JDO model class org.dependencytrack.model.Repository as request body
 org.dependencytrack.resources.v1.ServiceResource.createService(java.lang.String, org.dependencytrack.model.ServiceComponent) accepts JDO model class org.dependencytrack.model.ServiceComponent as request body
 org.dependencytrack.resources.v1.ServiceResource.updateService(org.dependencytrack.model.ServiceComponent) accepts JDO model class org.dependencytrack.model.ServiceComponent as request body
 org.dependencytrack.resources.v1.TeamResource.createTeam(alpine.model.Team) accepts JDO model class alpine.model.Team as request body

--- a/apiserver/src/test/resources/archunit_store/67305ac9-6039-403a-8a4c-ada073ef9b6d
+++ b/apiserver/src/test/resources/archunit_store/67305ac9-6039-403a-8a4c-ada073ef9b6d
@@ -51,10 +51,6 @@ org.dependencytrack.resources.v1.ProjectResource.getProject(java.lang.String) de
 org.dependencytrack.resources.v1.ProjectResource.getProject(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.Project as Swagger response schema
 org.dependencytrack.resources.v1.ProjectResource.patchProject(java.lang.String, org.dependencytrack.model.Project) declares JDO model class org.dependencytrack.model.Project as Swagger response schema
 org.dependencytrack.resources.v1.ProjectResource.updateProject(org.dependencytrack.model.Project) declares JDO model class org.dependencytrack.model.Project as Swagger response schema
-org.dependencytrack.resources.v1.RepositoryResource.createRepository(org.dependencytrack.model.Repository) declares JDO model class org.dependencytrack.model.Repository as Swagger response schema
-org.dependencytrack.resources.v1.RepositoryResource.getRepositories() declares JDO model class org.dependencytrack.model.Repository as Swagger response schema
-org.dependencytrack.resources.v1.RepositoryResource.getRepositoriesByType(org.dependencytrack.model.RepositoryType) declares JDO model class org.dependencytrack.model.Repository as Swagger response schema
-org.dependencytrack.resources.v1.RepositoryResource.updateRepository(org.dependencytrack.model.Repository) declares JDO model class org.dependencytrack.model.Repository as Swagger response schema
 org.dependencytrack.resources.v1.ServiceResource.createService(java.lang.String, org.dependencytrack.model.ServiceComponent) declares JDO model class org.dependencytrack.model.ServiceComponent as Swagger response schema
 org.dependencytrack.resources.v1.ServiceResource.getAllServices(java.lang.String) declares JDO model class org.dependencytrack.model.ServiceComponent as Swagger response schema
 org.dependencytrack.resources.v1.ServiceResource.getServiceByUuid(java.lang.String) declares JDO model class org.dependencytrack.model.ServiceComponent as Swagger response schema


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Tackles the technical debt of JDO models being reused for REST DTOs for all endpoints under `/v1/repository`.

Also makes the generated OpenAPI spec more reliable b/c it no longer advertises fields that are never used / never returned.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
