### PR TITLE
Decouple license API from JDO models

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/License.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/License.java
@@ -76,6 +76,7 @@ import java.util.UUID;
                 @Persistent(name = "licenseId"),
                 @Persistent(name = "osiApproved"),
                 @Persistent(name = "fsfLibre"),
+                @Persistent(name = "deprecatedLicenseId"),
                 @Persistent(name = "customLicense")
         })
 })

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/LicenseResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/LicenseResource.java
@@ -45,6 +45,10 @@ import org.dependencytrack.model.License;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.AbstractApiResource;
 import org.dependencytrack.resources.v1.openapi.PaginatedApi;
+import org.dependencytrack.resources.v1.vo.ConciseLicenseResponse;
+import org.dependencytrack.resources.v1.vo.CreateLicenseRequest;
+import org.dependencytrack.resources.v1.vo.LicenseResponse;
+import org.owasp.security.logging.SecurityMarkers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,14 +81,22 @@ public class LicenseResource extends AbstractApiResource {
                     responseCode = "200",
                     description = "A list of all licenses with complete metadata for each license",
                     headers = @Header(name = TOTAL_COUNT_HEADER, description = "The total number of licenses", schema = @Schema(format = "integeger")),
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = License.class)))
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = LicenseResponse.class)))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
     public Response getLicenses() {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             final PaginatedResult result = qm.getLicenses();
-            return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
+            final List<LicenseResponse> responses =
+                    result.getList(License.class).stream()
+                            .map(LicenseResponse::of)
+                            .toList();
+
+            return Response
+                    .ok(responses)
+                    .header(TOTAL_COUNT_HEADER, result.getTotal())
+                    .build();
         }
     }
 
@@ -99,14 +111,16 @@ public class LicenseResource extends AbstractApiResource {
                     responseCode = "200",
                     description = "A concise listing of all licenses",
                     headers = @Header(name = TOTAL_COUNT_HEADER, description = "The total number of licenses", schema = @Schema(format = "integer")),
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = License.class)))
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = ConciseLicenseResponse.class)))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
     public Response getLicenseListing() {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             final List<License> result = qm.getAllLicensesConcise();
-            return Response.ok(result).build();
+            return Response
+                    .ok(result.stream().map(ConciseLicenseResponse::of).toList())
+                    .build();
         }
     }
 
@@ -120,7 +134,7 @@ public class LicenseResource extends AbstractApiResource {
             @ApiResponse(
                     responseCode = "200",
                     description = "A specific license",
-                    content = @Content(schema = @Schema(implementation = License.class))
+                    content = @Content(schema = @Schema(implementation = LicenseResponse.class))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(responseCode = "404", description = "The license could not be found")
@@ -128,12 +142,17 @@ public class LicenseResource extends AbstractApiResource {
     public Response getLicense(
             @Parameter(description = "The SPDX License ID of the license to retrieve", required = true)
             @PathParam("licenseId") String licenseId) {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             final License license = qm.getLicense(licenseId);
             if (license != null) {
-                return Response.ok(license).build();
+                return Response
+                        .ok(LicenseResponse.of(license))
+                        .build();
             } else {
-                return Response.status(Response.Status.NOT_FOUND).entity("The license could not be found.").build();
+                return Response
+                        .status(Response.Status.NOT_FOUND)
+                        .entity("The license could not be found.")
+                        .build();
             }
         }
     }
@@ -148,28 +167,39 @@ public class LicenseResource extends AbstractApiResource {
             @ApiResponse(
                     responseCode = "201",
                     description = "The created license",
-                    content = @Content(schema = @Schema(implementation = License.class))
+                    content = @Content(schema = @Schema(implementation = LicenseResponse.class))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(responseCode = "409", description = "A license with the specified ID already exists.")
     })
-    @PermissionRequired({Permissions.Constants.SYSTEM_CONFIGURATION, Permissions.Constants.SYSTEM_CONFIGURATION_CREATE})
-    public Response createLicense(License jsonLicense) {
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_CREATE
+    })
+    public Response createLicense(CreateLicenseRequest request) {
         final Validator validator = super.getValidator();
         failOnValidationError(
-                validator.validateProperty(jsonLicense, "name"),
-                validator.validateProperty(jsonLicense, "licenseId")
+                validator.validateProperty(request, "name"),
+                validator.validateProperty(request, "licenseId")
         );
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
-                License license = qm.getLicense(jsonLicense.getLicenseId());
-                if (license == null) {
-                    license = qm.createCustomLicense(jsonLicense, true);
-                    LOGGER.info("License {} created by {}", license.getName(), super.getPrincipal().getName());
-                    return Response.status(Response.Status.CREATED).entity(license).build();
-                } else {
-                    return Response.status(Response.Status.CONFLICT).entity("A license with the specified name already exists.").build();
+                final License existing = qm.getLicense(request.licenseId());
+                if (existing != null) {
+                    return Response
+                            .status(Response.Status.CONFLICT)
+                            .entity("A license with the specified licenseId already exists.")
+                            .build();
                 }
+
+                final License license = qm.createCustomLicense(convert(request), true);
+                LOGGER.info(SecurityMarkers.SECURITY_AUDIT, "Created license {}", license.getName());
+
+                return Response
+                        .status(Response.Status.CREATED)
+                        .entity(LicenseResponse.of(license))
+                        .build();
             });
         }
     }
@@ -187,25 +217,60 @@ public class LicenseResource extends AbstractApiResource {
             @ApiResponse(responseCode = "404", description = "The license could not be found"),
             @ApiResponse(responseCode = "409", description = "Only custom licenses can be deleted.")
     })
-    @PermissionRequired({Permissions.Constants.SYSTEM_CONFIGURATION, Permissions.Constants.SYSTEM_CONFIGURATION_DELETE})
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_DELETE
+    })
     public Response deleteLicense(
             @Parameter(description = "The SPDX License ID of the license to delete", required = true)
             @PathParam("licenseId") String licenseId) {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
                 final License license = qm.getLicense(licenseId);
                 if (license != null) {
                     if (Boolean.TRUE.equals(license.isCustomLicense())) {
-                        LOGGER.info("License {} deletion request by {}", license, super.getPrincipal().getName());
+                        final String licenseName = license.getName();
                         qm.deleteLicense(license, true);
+                        LOGGER.info(SecurityMarkers.SECURITY_AUDIT, "Deleted license {}", licenseName);
                         return Response.status(Response.Status.NO_CONTENT).build();
                     } else {
-                        return Response.status(Response.Status.CONFLICT).entity("Only custom licenses can be deleted.").build();
+                        return Response
+                                .status(Response.Status.CONFLICT)
+                                .entity("Only custom licenses can be deleted.")
+                                .build();
                     }
                 } else {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The license could not be found.").build();
+                    return Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The license could not be found.")
+                            .build();
                 }
             });
         }
     }
+
+    private static License convert(CreateLicenseRequest request) {
+        final License license = new License();
+        license.setName(request.name());
+        license.setLicenseId(request.licenseId());
+        license.setText(request.licenseText());
+        license.setHeader(request.standardLicenseHeader());
+        license.setTemplate(request.standardLicenseTemplate());
+        license.setComment(request.licenseComments());
+        if (request.seeAlso() != null) {
+            license.setSeeAlso(request.seeAlso().toArray(String[]::new));
+        }
+        if (request.isOsiApproved() != null) {
+            license.setOsiApproved(request.isOsiApproved());
+        }
+        if (request.isFsfLibre() != null) {
+            license.setFsfLibre(request.isFsfLibre());
+        }
+        if (request.isDeprecatedLicenseId() != null) {
+            license.setDeprecatedLicenseId(request.isDeprecatedLicenseId());
+        }
+
+        return license;
+    }
+
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/ConciseLicenseResponse.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/ConciseLicenseResponse.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.dependencytrack.model.License;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.UUID;
+
+/// @since 5.1.0
+@NullMarked
+public record ConciseLicenseResponse(
+        @Schema(description = "Display name of the license", requiredMode = Schema.RequiredMode.REQUIRED)
+        String name,
+
+        @Schema(description = "Identifier of the license", requiredMode = Schema.RequiredMode.REQUIRED)
+        String licenseId,
+
+        @Schema(description = "Whether the license is approved by the OSI", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean isOsiApproved,
+
+        @Schema(description = "Whether the license is FSF libre", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean isFsfLibre,
+
+        @Schema(description = "Whether the licenseId has been deprecated by SPDX", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean isDeprecatedLicenseId,
+
+        @Schema(description = "Whether the license is a custom license created by a user", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean isCustomLicense,
+
+        @Schema(description = "UUID of the license", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID uuid) {
+
+    public static ConciseLicenseResponse of(License license) {
+        return new ConciseLicenseResponse(
+                license.getName(),
+                license.getLicenseId(),
+                license.isOsiApproved(),
+                license.isFsfLibre(),
+                license.isDeprecatedLicenseId(),
+                license.isCustomLicense(),
+                license.getUuid());
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/CreateLicenseRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/CreateLicenseRequest.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import alpine.common.validation.RegexSequence;
+import alpine.server.json.TrimmedStringDeserializer;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+/// @since 5.1.0
+@NullMarked
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CreateLicenseRequest(
+        @NotBlank
+        @Size(min = 1, max = 255)
+        @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The name may only contain printable characters")
+        @Schema(description = "Display name of the license", requiredMode = Schema.RequiredMode.REQUIRED)
+        String name,
+
+        @NotBlank
+        @Size(min = 1, max = 255)
+        @Pattern(regexp = RegexSequence.Definition.STRING_IDENTIFIER, message = "The licenseId may only contain alpha, numeric, and specific symbols _-.+")
+        @JsonAlias("licenseExceptionId")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Identifier of the license", requiredMode = Schema.RequiredMode.REQUIRED)
+        String licenseId,
+
+        @JsonAlias("licenseExceptionText")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Full license text")
+        @Nullable String licenseText,
+
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Standard license header typically added to the top of source code")
+        @Nullable String standardLicenseHeader,
+
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Standard license template used to derive the license text")
+        @Nullable String standardLicenseTemplate,
+
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Comments about the license")
+        @Nullable String licenseComments,
+
+        @JsonDeserialize(contentUsing = TrimmedStringDeserializer.class)
+        @Schema(description = "Additional URLs with information about the license")
+        @Nullable List<String> seeAlso,
+
+        @Schema(description = "Whether the license is approved by the OSI")
+        @Nullable Boolean isOsiApproved,
+
+        @Schema(description = "Whether the license is FSF libre")
+        @Nullable Boolean isFsfLibre,
+
+        @Schema(description = "Whether the licenseId has been deprecated by SPDX")
+        @Nullable Boolean isDeprecatedLicenseId) {
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/LicenseResponse.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/LicenseResponse.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.dependencytrack.model.License;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.UUID;
+
+/// @since 5.1.0
+@NullMarked
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LicenseResponse(
+        @Schema(description = "Display name of the license", requiredMode = Schema.RequiredMode.REQUIRED)
+        String name,
+
+        @Schema(description = "Identifier of the license", requiredMode = Schema.RequiredMode.REQUIRED)
+        String licenseId,
+
+        @Schema(description = "Full license text")
+        @Nullable String licenseText,
+
+        @Schema(description = "Standard license template used to derive the license text")
+        @Nullable String standardLicenseTemplate,
+
+        @Schema(description = "Standard license header typically added to the top of source code")
+        @Nullable String standardLicenseHeader,
+
+        @Schema(description = "Comments about the license")
+        @Nullable String licenseComments,
+
+        @Schema(description = "Whether the license is approved by the OSI", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean isOsiApproved,
+
+        @Schema(description = "Whether the license is FSF libre", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean isFsfLibre,
+
+        @Schema(description = "Whether the licenseId has been deprecated by SPDX", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean isDeprecatedLicenseId,
+
+        @Schema(description = "Whether the license is a custom license created by a user", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean isCustomLicense,
+
+        @Schema(description = "Additional URLs with information about the license")
+        @Nullable List<String> seeAlso,
+
+        @Schema(description = "License groups the license belongs to", requiredMode = Schema.RequiredMode.REQUIRED)
+        List<LicenseGroup> licenseGroups,
+
+        @Schema(description = "UUID of the license", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID uuid) {
+
+    public record LicenseGroup(
+            @Schema(description = "UUID of the license group", requiredMode = Schema.RequiredMode.REQUIRED)
+            UUID uuid,
+
+            @Schema(description = "Name of the license group", requiredMode = Schema.RequiredMode.REQUIRED)
+            String name) {
+
+        public static LicenseGroup of(org.dependencytrack.model.LicenseGroup licenseGroup) {
+            return new LicenseGroup(licenseGroup.getUuid(), licenseGroup.getName());
+        }
+
+    }
+
+    public static LicenseResponse of(License license) {
+        // NB: The API originally returned JDO models directly, and JDO populates loaded-but-empty
+        // fields as empty lists, not null. This DTO replicates that behaviour for backward-compat.
+        final List<org.dependencytrack.model.LicenseGroup> jdoGroups = license.getLicenseGroups();
+        final List<LicenseGroup> groups = jdoGroups != null
+                ? jdoGroups.stream().map(LicenseGroup::of).toList()
+                : List.of();
+
+        return new LicenseResponse(
+                license.getName(),
+                license.getLicenseId(),
+                license.getText(),
+                license.getTemplate(),
+                license.getHeader(),
+                license.getComment(),
+                license.isOsiApproved(),
+                license.isFsfLibre(),
+                license.isDeprecatedLicenseId(),
+                license.isCustomLicense(),
+                license.getSeeAlso() != null
+                        ? List.of(license.getSeeAlso())
+                        : null,
+                groups,
+                license.getUuid());
+    }
+
+}

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/LicenseResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/LicenseResourceTest.java
@@ -18,25 +18,25 @@
  */
 package org.dependencytrack.resources.v1;
 
-import alpine.common.util.UuidUtil;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthFeature;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.License;
+import org.dependencytrack.model.LicenseGroup;
 import org.dependencytrack.persistence.DatabaseSeedingInitTask;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.util.List;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiTransaction;
 
 public class LicenseResourceTest extends ResourceTest {
@@ -56,152 +56,294 @@ public class LicenseResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getLicensesTest() {
-        Response response = jersey.target(V1_LICENSE).request()
-                .header(X_API_KEY, apiKey)
-                .get(Response.class);
-        Assertions.assertEquals(200, response.getStatus(), 0);
-        Assertions.assertEquals(String.valueOf(811), response.getHeaderString(TOTAL_COUNT_HEADER));
-        JsonArray json = parseJsonArray(response);
-        Assertions.assertNotNull(json);
-        Assertions.assertEquals(100, json.size());
-        Assertions.assertNotNull(json.getJsonObject(0).getString("name"));
-        Assertions.assertNotNull(json.getJsonObject(0).getString("licenseText"));
-        Assertions.assertNotNull(json.getJsonObject(0).getString("licenseComments"));
-        Assertions.assertNotNull(json.getJsonObject(0).getString("licenseId"));
-    }
-
-    @Test
-    public void getLicensesConciseTest() {
-        Response response = jersey.target(V1_LICENSE + "/concise").request()
-                .header(X_API_KEY, apiKey)
-                .get(Response.class);
-        Assertions.assertEquals(200, response.getStatus(), 0);
-        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
-        JsonArray json = parseJsonArray(response);
-        Assertions.assertNotNull(json);
-        Assertions.assertEquals(811, json.size());
-        Assertions.assertNotNull(json.getJsonObject(0).getString("name"));
-        Assertions.assertNull(json.getJsonObject(0).getString("licenseText", null));
-        Assertions.assertNull(json.getJsonObject(0).getString("licenseComments", null));
-        Assertions.assertNotNull(json.getJsonObject(0).getString("licenseId"));
-    }
-
-    @Test
-    public void getLicense() {
-        Response response = jersey.target(V1_LICENSE + "/Apache-2.0").request()
-                .header(X_API_KEY, apiKey)
-                .get(Response.class);
-        Assertions.assertEquals(200, response.getStatus(), 0);
-        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
-        JsonObject json = parseJsonObject(response);
-        Assertions.assertNotNull(json);
-        Assertions.assertEquals("Apache License 2.0", json.getString("name"));
-        Assertions.assertNotNull(json.getString("licenseText", null));
-        Assertions.assertNotNull(json.getString("licenseComments", null));
-        Assertions.assertNotNull(json.getString("licenseId"));
-    }
-
-    @Test
-    public void getLicenseInvalid() {
-        Response response = jersey.target(V1_LICENSE + "/blah").request()
-                .header(X_API_KEY, apiKey)
-                .get(Response.class);
-        Assertions.assertEquals(404, response.getStatus(), 0);
-        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
-        String body = getPlainTextBody(response);
-        Assertions.assertEquals("The license could not be found.", body);
-    }
-
-    @Test
-    public void createCustomLicense() {
-        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_CREATE);
-
-        License license = new License();
-        license.setName("Acme Example");
-        license.setLicenseId("Acme-Example-License");
-        Response response = jersey.target(V1_LICENSE)
+    public void shouldReturnFullLicenseJsonForKnownSpdxIdentifier() {
+        final Response response = jersey
+                .target(V1_LICENSE + "/Apache-2.0")
                 .request()
                 .header(X_API_KEY, apiKey)
-                .put(Entity.entity(license, MediaType.APPLICATION_JSON));
-        Assertions.assertEquals(201, response.getStatus(), 0);
-        JsonObject json = parseJsonObject(response);
-        Assertions.assertNotNull(json);
-        Assertions.assertEquals("Acme Example", json.getString("name"));
-        Assertions.assertEquals("Acme-Example-License", json.getString("licenseId"));
-        Assertions.assertFalse(json.getBoolean("isOsiApproved"));
-        Assertions.assertFalse(json.getBoolean("isFsfLibre"));
-        Assertions.assertFalse(json.getBoolean("isDeprecatedLicenseId"));
-        Assertions.assertTrue(json.getBoolean("isCustomLicense"));
-        Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+        final String body = getPlainTextBody(response);
+        assertThatJson(body)
+                .isEqualTo(/* language=JSON */ """
+                        {
+                          "name": "Apache License 2.0",
+                          "licenseId": "Apache-2.0",
+                          "licenseText": "${json-unit.any-string}",
+                          "standardLicenseTemplate": "${json-unit.any-string}",
+                          "standardLicenseHeader": "${json-unit.any-string}",
+                          "licenseComments": "${json-unit.any-string}",
+                          "isOsiApproved": true,
+                          "isFsfLibre": true,
+                          "isDeprecatedLicenseId": false,
+                          "isCustomLicense": false,
+                          "seeAlso": "${json-unit.ignore}",
+                          "licenseGroups": [],
+                          "uuid": "${json-unit.any-string}"
+                        }
+                        """);
+        assertThatJson(body).node("seeAlso").isArray().isNotEmpty();
     }
 
     @Test
-    public void createCustomLicenseDuplicate() {
-        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_CREATE);
+    public void shouldTruncateLicenseGroupsToUuidAndName() {
+        // NB: The legacy JDO-backed response embedded the entire LicenseGroup entity
+        // (including licenses, riskWeight, etc.). With the migration to dedicated DTOs,
+        // we truncated it to only UUID and name.
 
-        License license = new License();
-        license.setName("Apache License 2.0");
-        license.setLicenseId("Apache-2.0");
-        Response response = jersey.target(V1_LICENSE)
+        final License license = qm.getLicense("Apache-2.0");
+        final LicenseGroup group = qm.createLicenseGroup("Copyleft");
+        group.setLicenses(List.of(license));
+        qm.persist(group);
+
+        final Response response = jersey
+                .target(V1_LICENSE + "/Apache-2.0")
                 .request()
                 .header(X_API_KEY, apiKey)
-                .put(Entity.entity(license, MediaType.APPLICATION_JSON));
-        Assertions.assertEquals(409, response.getStatus(), 0);
-        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
-        String body = getPlainTextBody(response);
-        Assertions.assertEquals("A license with the specified name already exists.", body);
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .node("licenseGroups")
+                .isEqualTo(/* language=JSON */ """
+                        [
+                          {
+                            "uuid": "${json-unit.any-string}",
+                            "name": "Copyleft"
+                          }
+                        ]
+                        """);
     }
 
     @Test
-    public void createCustomLicenseWithoutLicenseId() {
-        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_CREATE);
-
-        License license = new License();
-        license.setName("Acme Example");
-        Response response = jersey.target(V1_LICENSE)
+    public void shouldReturn404WhenLicenseIdDoesNotExist() {
+        final Response response = jersey
+                .target(V1_LICENSE + "/blah")
                 .request()
                 .header(X_API_KEY, apiKey)
-                .put(Entity.entity(license, MediaType.APPLICATION_JSON));
-        Assertions.assertEquals(400, response.getStatus(), 0);
-        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+                .get();
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+        assertThat(getPlainTextBody(response)).isEqualTo("The license could not be found.");
     }
 
     @Test
-    public void deleteCustomLicense() {
+    public void shouldReturnPaginatedFullLicenseListing() {
+        final Response response = jersey
+                .target(V1_LICENSE)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("811");
+        final String body = getPlainTextBody(response);
+        assertThatJson(body).isArray().hasSize(100);
+        assertThatJson(body)
+                .node("[0]")
+                .isEqualTo(/* language=JSON */ """
+                        {
+                          "name": "${json-unit.any-string}",
+                          "licenseId": "${json-unit.any-string}",
+                          "licenseText": "${json-unit.ignore}",
+                          "licenseComments": "${json-unit.ignore}",
+                          "isOsiApproved": "${json-unit.ignore}",
+                          "isFsfLibre": "${json-unit.ignore}",
+                          "isDeprecatedLicenseId": "${json-unit.ignore}",
+                          "isCustomLicense": false,
+                          "seeAlso": "${json-unit.ignore}",
+                          "licenseGroups": "${json-unit.ignore}",
+                          "uuid": "${json-unit.any-string}"
+                        }
+                        """);
+    }
+
+    @Test
+    public void shouldReturnConciseLicenseListingWithoutClobFields() {
+        final Response response = jersey
+                .target(V1_LICENSE + "/concise")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+        final String body = getPlainTextBody(response);
+        assertThatJson(body).isArray().hasSize(811);
+        assertThatJson(body)
+                .node("[0]")
+                .isEqualTo(/* language=JSON */ """
+                        {
+                          "name": "${json-unit.any-string}",
+                          "licenseId": "${json-unit.any-string}",
+                          "isOsiApproved": "${json-unit.ignore}",
+                          "isFsfLibre": "${json-unit.ignore}",
+                          "isDeprecatedLicenseId": "${json-unit.ignore}",
+                          "isCustomLicense": false,
+                          "uuid": "${json-unit.any-string}"
+                        }
+                        """);
+    }
+
+    @Test
+    public void shouldRoundTripAllOptionalFieldsOnCreate() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_CREATE);
+
+        final Response response = jersey
+                .target(V1_LICENSE)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "name": "Acme Example",
+                          "licenseId": "Acme-Example-License",
+                          "licenseText": "All rights reserved.",
+                          "standardLicenseHeader": "Copyright (c) Acme",
+                          "standardLicenseTemplate": "<<beginOptional>>Acme<<endOptional>>",
+                          "licenseComments": "Internal use only.",
+                          "seeAlso": ["https://acme.example/a", "https://acme.example/b"],
+                          "isOsiApproved": true,
+                          "isFsfLibre": true,
+                          "isDeprecatedLicenseId": true
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(201);
+        assertThatJson(getPlainTextBody(response))
+                .isEqualTo(/* language=JSON */ """
+                        {
+                          "name": "Acme Example",
+                          "licenseId": "Acme-Example-License",
+                          "licenseText": "All rights reserved.",
+                          "standardLicenseHeader": "Copyright (c) Acme",
+                          "standardLicenseTemplate": "<<beginOptional>>Acme<<endOptional>>",
+                          "licenseComments": "Internal use only.",
+                          "seeAlso": ["https://acme.example/a", "https://acme.example/b"],
+                          "isOsiApproved": true,
+                          "isFsfLibre": true,
+                          "isDeprecatedLicenseId": true,
+                          "isCustomLicense": true,
+                          "licenseGroups": [],
+                          "uuid": "${json-unit.any-string}"
+                        }
+                        """);
+    }
+
+    @Test
+    public void shouldForceCustomLicenseFlagOnCreate() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_CREATE);
+
+        final Response response = jersey
+                .target(V1_LICENSE)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "name": "Sneaky Example",
+                          "licenseId": "Sneaky-Example-License",
+                          "isCustomLicense": false
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(201);
+        assertThatJson(getPlainTextBody(response))
+                .node("isCustomLicense")
+                .isEqualTo(true);
+    }
+
+    @Test
+    public void shouldReject400WhenCreatingLicenseWithoutName() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_CREATE);
+
+        final Response response = jersey
+                .target(V1_LICENSE)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "licenseId": "Acme-Example-License"
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+    }
+
+    @Test
+    public void shouldReject400WhenCreatingLicenseWithoutLicenseId() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_CREATE);
+
+        final Response response = jersey
+                .target(V1_LICENSE)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "name": "Acme Example"
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+    }
+
+    @Test
+    public void shouldReject409WhenLicenseAlreadyExists() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_CREATE);
+
+        final Response response = jersey
+                .target(V1_LICENSE)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "name": "Apache License 2.0",
+                          "licenseId": "Apache-2.0"
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(409);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+        assertThat(getPlainTextBody(response))
+                .isEqualTo("A license with the specified licenseId already exists.");
+    }
+
+    @Test
+    public void shouldDeleteCustomLicense() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_DELETE);
 
-        License license = new License();
+        final License license = new License();
         license.setLicenseId("Acme-Example-License");
         license.setName("Acme Example");
         license.setCustomLicense(true);
         qm.createCustomLicense(license, false);
 
-        Response response = jersey.target(V1_LICENSE + "/" + license.getLicenseId())
+        final Response response = jersey
+                .target(V1_LICENSE + "/Acme-Example-License")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assertions.assertEquals(204, response.getStatus(), 0);
-        Assertions.assertTrue(license.isCustomLicense());
+        assertThat(response.getStatus()).isEqualTo(204);
     }
 
     @Test
-    public void deleteNotCustomLicense() {
+    public void shouldReject409WhenDeletingNonCustomLicense() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_DELETE);
 
-        License license1 = new License();
-        license1.setLicenseId("Acme-Example-License");
-        license1.setName("Acme Example");
-        License license2 = qm.createCustomLicense(license1, false);
-        license1.setCustomLicense(false);
-        Response response = jersey.target(V1_LICENSE + "/" + license1.getLicenseId())
+        final Response response = jersey
+                .target(V1_LICENSE + "/Apache-2.0")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .delete();
-        Assertions.assertEquals(409, response.getStatus(), 0);
-        Assertions.assertFalse(license2.isCustomLicense());
-        Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
-        String body = getPlainTextBody(response);
-        Assertions.assertEquals("Only custom licenses can be deleted.", body);
+        assertThat(response.getStatus()).isEqualTo(409);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+        assertThat(getPlainTextBody(response)).isEqualTo("Only custom licenses can be deleted.");
     }
+
+    @Test
+    public void shouldReturn404WhenDeletingUnknownLicense() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_DELETE);
+
+        final Response response = jersey
+                .target(V1_LICENSE + "/does-not-exist")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(getPlainTextBody(response)).isEqualTo("The license could not be found.");
+    }
+
 }

--- a/apiserver/src/test/resources/archunit_store/3e49066c-46b2-40c2-8473-ce4276c1ba12
+++ b/apiserver/src/test/resources/archunit_store/3e49066c-46b2-40c2-8473-ce4276c1ba12
@@ -2,7 +2,6 @@ org.dependencytrack.resources.v1.ComponentResource.createComponent(java.lang.Str
 org.dependencytrack.resources.v1.ComponentResource.updateComponent(org.dependencytrack.model.Component) accepts JDO model class org.dependencytrack.model.Component as request body
 org.dependencytrack.resources.v1.ConfigPropertyResource.updateConfigProperty(alpine.model.ConfigProperty) accepts JDO model class alpine.model.ConfigProperty as request body
 org.dependencytrack.resources.v1.ConfigPropertyResource.updateConfigProperty(java.util.List) accepts JDO model class alpine.model.ConfigProperty as request body
-org.dependencytrack.resources.v1.LicenseResource.createLicense(org.dependencytrack.model.License) accepts JDO model class org.dependencytrack.model.License as request body
 org.dependencytrack.resources.v1.NotificationRuleResource.deleteNotificationRule(org.dependencytrack.model.NotificationRule) accepts JDO model class org.dependencytrack.model.NotificationRule as request body
 org.dependencytrack.resources.v1.OidcResource.createGroup(alpine.model.OidcGroup) accepts JDO model class alpine.model.OidcGroup as request body
 org.dependencytrack.resources.v1.OidcResource.updateGroup(alpine.model.OidcGroup) accepts JDO model class alpine.model.OidcGroup as request body

--- a/apiserver/src/test/resources/archunit_store/67305ac9-6039-403a-8a4c-ada073ef9b6d
+++ b/apiserver/src/test/resources/archunit_store/67305ac9-6039-403a-8a4c-ada073ef9b6d
@@ -13,10 +13,6 @@ org.dependencytrack.resources.v1.ConfigPropertyResource.updateConfigProperty(alp
 org.dependencytrack.resources.v1.ConfigPropertyResource.updateConfigProperty(java.util.List) declares JDO model class alpine.model.ConfigProperty as Swagger response schema
 org.dependencytrack.resources.v1.LdapResource.addMapping(org.dependencytrack.resources.v1.vo.MappedLdapGroupRequest) declares JDO model class alpine.model.MappedLdapGroup as Swagger response schema
 org.dependencytrack.resources.v1.LdapResource.retrieveLdapGroups(java.lang.String) declares JDO model class alpine.model.MappedLdapGroup as Swagger response schema
-org.dependencytrack.resources.v1.LicenseResource.createLicense(org.dependencytrack.model.License) declares JDO model class org.dependencytrack.model.License as Swagger response schema
-org.dependencytrack.resources.v1.LicenseResource.getLicense(java.lang.String) declares JDO model class org.dependencytrack.model.License as Swagger response schema
-org.dependencytrack.resources.v1.LicenseResource.getLicenseListing() declares JDO model class org.dependencytrack.model.License as Swagger response schema
-org.dependencytrack.resources.v1.LicenseResource.getLicenses() declares JDO model class org.dependencytrack.model.License as Swagger response schema
 org.dependencytrack.resources.v1.NotificationRuleResource.addProjectToRule(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
 org.dependencytrack.resources.v1.NotificationRuleResource.addTeamToRule(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
 org.dependencytrack.resources.v1.NotificationRuleResource.createNotificationRule(org.dependencytrack.resources.v1.vo.CreateNotificationRuleRequest) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Tackles the technical debt of JDO models being reused for REST DTOs for all endpoints under `/v1/license`.

Also makes the generated OpenAPI spec more reliable b/c it no longer advertises fields that are never used / never returned.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
