### PR TITLE
Decouple config property API from JDO models

### DIFF
--- a/alpine/alpine-model/src/main/java/alpine/model/ConfigProperty.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/ConfigProperty.java
@@ -18,13 +18,6 @@
  */
 package alpine.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.PersistenceCapable;
@@ -41,44 +34,32 @@ import java.io.Serializable;
  */
 @PersistenceCapable
 @Unique(members={"groupName", "propertyName"})
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ConfigProperty implements IConfigProperty, Serializable {
 
     private static final long serialVersionUID = 5286421336166302912L;
 
     @PrimaryKey
     @Persistent(valueStrategy = IdGeneratorStrategy.NATIVE)
-    @JsonIgnore
     private long id;
 
     @Persistent
     @Column(name = "GROUPNAME", allowsNull = "false")
-    @NotBlank
-    @Size(min = 1, max = 255)
-    @Pattern(regexp = "[\\P{Cc}]+", message = "The groupName must not contain control characters")
     private String groupName;
 
     @Persistent
     @Column(name = "PROPERTYNAME", allowsNull = "false")
-    @NotBlank
-    @Size(min = 1, max = 255)
-    @Pattern(regexp = "[\\P{Cc}]+", message = "The propertyName must not contain control characters")
     private String propertyName;
 
     @Persistent
     @Column(name = "PROPERTYVALUE", jdbcType = "CLOB")
-    @Pattern(regexp = "[\\P{Cc}]+", message = "The propertyValue must not contain control characters")
     private String propertyValue;
 
     @Persistent
     @Column(name = "PROPERTYTYPE", jdbcType = "VARCHAR", allowsNull = "false")
-    @NotNull
     private PropertyType propertyType;
 
     @Persistent
     @Column(name = "DESCRIPTION")
-    @Size(max = 255)
-    @Pattern(regexp = "[\\P{Cc}]+", message = "The description must not contain control characters")
     private String description;
 
     public long getId() {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
@@ -58,22 +58,6 @@ abstract class AbstractConfigPropertyResource extends AbstractApiResource {
         this.secretManager = secretManager;
     }
 
-    Response updatePropertyValue(IConfigProperty json, @Nullable IConfigProperty property) {
-        if (property == null) {
-            return Response
-                    .status(Response.Status.NOT_FOUND)
-                    .entity("The config property could not be found.")
-                    .build();
-        }
-
-        final Response check = applyPropertyValue(json.getPropertyValue(), property);
-        if (check != null) {
-            return check;
-        }
-
-        return Response.ok(property).build();
-    }
-
     @Nullable Response applyPropertyValue(@Nullable String requestedValue, IConfigProperty property) {
         PersistenceUtil.assertPersistent(property, "property must be persistent");
 

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ConfigPropertyResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ConfigPropertyResource.java
@@ -44,6 +44,8 @@ import jakarta.ws.rs.core.Response;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.resources.v1.vo.ConfigPropertyResponse;
+import org.dependencytrack.resources.v1.vo.UpdateConfigPropertyRequest;
 import org.dependencytrack.secret.management.SecretManager;
 
 import java.util.ArrayList;
@@ -78,7 +80,7 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
             @ApiResponse(
                     responseCode = "200",
                     description = "A list of all ConfigProperties for the specified groupName",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = ConfigProperty.class)))
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = ConfigPropertyResponse.class)))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
@@ -89,7 +91,11 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
     public Response getConfigProperties() {
         try (final var qm = new QueryManager(getAlpineRequest())) {
             final List<ConfigProperty> configProperties = qm.getConfigProperties();
-            return Response.ok(configProperties).build();
+            final List<ConfigPropertyResponse> response =
+                    configProperties.stream()
+                            .map(ConfigPropertyResponse::of)
+                            .toList();
+            return Response.ok(response).build();
         }
     }
 
@@ -103,7 +109,7 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
             @ApiResponse(
                     responseCode = "200",
                     description = "The updated config property",
-                    content = @Content(schema = @Schema(implementation = ConfigProperty.class))
+                    content = @Content(schema = @Schema(implementation = ConfigPropertyResponse.class))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(responseCode = "404", description = "The config property could not be found"),
@@ -112,19 +118,16 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
             Permissions.Constants.SYSTEM_CONFIGURATION,
             Permissions.Constants.SYSTEM_CONFIGURATION_UPDATE
     })
-    public Response updateConfigProperty(ConfigProperty json) {
+    public Response updateConfigProperty(UpdateConfigPropertyRequest request) {
         final Validator validator = super.getValidator();
         failOnValidationError(
-                validator.validateProperty(json, "groupName"),
-                validator.validateProperty(json, "propertyName"),
-                validator.validateProperty(json, "propertyValue")
+                validator.validateProperty(request, "groupName"),
+                validator.validateProperty(request, "propertyName"),
+                validator.validateProperty(request, "propertyValue")
         );
+
         try (final var qm = new QueryManager(getAlpineRequest())) {
-            return qm.callInTransaction(() -> {
-                final ConfigProperty property = qm.getConfigProperty(
-                        json.getGroupName(), json.getPropertyName());
-                return updatePropertyValue(json, property);
-            });
+            return qm.callInTransaction(() -> applyUpdate(qm, request));
         }
     }
 
@@ -139,19 +142,23 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
-                    description = "The updated config properties",
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = ConfigProperty.class)))
+                    description = """
+                            The updated config properties. \
+                            Each array element is either a successfully updated `ConfigPropertyResponse`, \
+                            or an error message string if the entry's property could not be found, \
+                            is read-only, or its requested value is invalid.\
+                            """,
+                    content = @Content(array = @ArraySchema(schema = @Schema(anyOf = {ConfigPropertyResponse.class, String.class})))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "404", description = "One or more config properties could not be found"),
     })
     @PermissionRequired({
             Permissions.Constants.SYSTEM_CONFIGURATION,
             Permissions.Constants.SYSTEM_CONFIGURATION_UPDATE
     })
-    public Response updateConfigProperty(List<ConfigProperty> list) {
+    public Response updateConfigProperty(List<UpdateConfigPropertyRequest> requests) {
         final Validator validator = super.getValidator();
-        for (ConfigProperty item : list) {
+        for (final UpdateConfigPropertyRequest item : requests) {
             failOnValidationError(
                     validator.validateProperty(item, "groupName"),
                     validator.validateProperty(item, "propertyName"),
@@ -162,10 +169,9 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
         final var returnList = new ArrayList<>();
         try (final var qm = new QueryManager(getAlpineRequest())) {
             qm.runInTransaction(() -> {
-                for (ConfigProperty item : list) {
-                    final ConfigProperty property = qm.getConfigProperty(
-                            item.getGroupName(), item.getPropertyName());
-                    returnList.add(updatePropertyValue(item, property).getEntity());
+                for (final UpdateConfigPropertyRequest request : requests) {
+                    final Response itemResponse = applyUpdate(qm, request);
+                    returnList.add(itemResponse.getEntity());
                 }
             });
         }
@@ -178,8 +184,9 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Returns a public ConfigProperty", description = "<p></p>")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Public ConfigProperty returned", content = @Content(schema = @Schema(implementation = ConfigProperty.class))),
-            @ApiResponse(responseCode = "403", description = "This is not a public visible ConfigProperty")
+            @ApiResponse(responseCode = "200", description = "Public ConfigProperty returned", content = @Content(schema = @Schema(implementation = ConfigPropertyResponse.class))),
+            @ApiResponse(responseCode = "403", description = "This is not a public visible ConfigProperty"),
+            @ApiResponse(responseCode = "404", description = "The config property could not be found")
     })
     @AuthenticationNotRequired
     public Response getPublicConfigProperty(
@@ -187,18 +194,43 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
             @PathParam("groupName") String groupName,
             @Parameter(description = "The property name of the value to retrieve", required = true)
             @PathParam("propertyName") String propertyName) {
-        final var configProperty = new ConfigProperty();
-        configProperty.setGroupName(groupName);
-        configProperty.setPropertyName(propertyName);
+        final var lookup = new ConfigProperty();
+        lookup.setGroupName(groupName);
+        lookup.setPropertyName(propertyName);
 
-        final var publicConfigProperty = ConfigPropertyConstants.ofProperty(configProperty);
-        if (!publicConfigProperty.getIsPublic()) {
+        final var wellKnownProperty = ConfigPropertyConstants.ofProperty(lookup);
+        if (wellKnownProperty == null || !wellKnownProperty.getIsPublic()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
 
         try (final var qm = new QueryManager(getAlpineRequest())) {
-            ConfigProperty property = qm.getConfigProperty(groupName, propertyName);
-            return Response.ok(property).build();
+            final ConfigProperty property = qm.getConfigProperty(groupName, propertyName);
+            if (property == null) {
+                return Response
+                        .status(Response.Status.NOT_FOUND)
+                        .entity("The config property could not be found.")
+                        .build();
+            }
+
+            return Response.ok(ConfigPropertyResponse.of(property)).build();
         }
     }
+
+    private Response applyUpdate(QueryManager qm, UpdateConfigPropertyRequest request) {
+        final ConfigProperty property = qm.getConfigProperty(request.groupName(), request.propertyName());
+        if (property == null) {
+            return Response
+                    .status(Response.Status.NOT_FOUND)
+                    .entity("The config property could not be found.")
+                    .build();
+        }
+
+        final Response validationError = applyPropertyValue(request.propertyValue(), property);
+        if (validationError != null) {
+            return validationError;
+        }
+
+        return Response.ok(ConfigPropertyResponse.of(property)).build();
+    }
+
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/ConfigPropertyResponse.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/ConfigPropertyResponse.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import alpine.model.IConfigProperty;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/// @since 5.1.0
+@NullMarked
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ConfigPropertyResponse(
+        @Schema(description = "Group the property belongs to", requiredMode = Schema.RequiredMode.REQUIRED)
+        String groupName,
+
+        @Schema(description = "Name of the property", requiredMode = Schema.RequiredMode.REQUIRED)
+        String propertyName,
+
+        @Schema(description = "Value of the property")
+        @Nullable String propertyValue,
+
+        @Schema(description = "Type of the property", requiredMode = Schema.RequiredMode.REQUIRED)
+        IConfigProperty.PropertyType propertyType,
+
+        @Schema(description = "Description of the property")
+        @Nullable String description) {
+
+    public static ConfigPropertyResponse of(IConfigProperty property) {
+        return new ConfigPropertyResponse(
+                property.getGroupName(),
+                property.getPropertyName(),
+                property.getPropertyValue(),
+                property.getPropertyType(),
+                property.getDescription());
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/UpdateConfigPropertyRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/UpdateConfigPropertyRequest.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import alpine.server.json.TrimmedStringDeserializer;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/// @since 5.1.0
+@NullMarked
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record UpdateConfigPropertyRequest(
+        @NotBlank
+        @Size(min = 1, max = 255)
+        @Pattern(regexp = "\\P{Cc}+", message = "The groupName must not contain control characters")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Group the property belongs to", requiredMode = Schema.RequiredMode.REQUIRED)
+        String groupName,
+
+        @NotBlank
+        @Size(min = 1, max = 255)
+        @Pattern(regexp = "\\P{Cc}+", message = "The propertyName must not contain control characters")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Name of the property", requiredMode = Schema.RequiredMode.REQUIRED)
+        String propertyName,
+
+        @Pattern(regexp = "\\P{Cc}+", message = "The propertyValue must not contain control characters")
+        @JsonDeserialize(using = TrimmedStringDeserializer.class)
+        @Schema(description = "Value of the property")
+        @Nullable String propertyValue) {
+}

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
@@ -18,14 +18,10 @@
  */
 package org.dependencytrack.resources.v1;
 
-import alpine.model.ConfigProperty;
-import alpine.model.IConfigProperty;
+import alpine.model.IConfigProperty.PropertyType;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthFeature;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
@@ -35,11 +31,8 @@ import org.dependencytrack.secret.management.SecretManager;
 import org.dependencytrack.secret.management.SecretMetadata;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-
-import java.util.Arrays;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,11 +41,10 @@ import static org.dependencytrack.model.ConfigPropertyConstants.CUSTOM_RISK_SCOR
 import static org.dependencytrack.model.ConfigPropertyConstants.CUSTOM_RISK_SCORE_LOW;
 import static org.dependencytrack.model.ConfigPropertyConstants.CUSTOM_RISK_SCORE_MEDIUM;
 import static org.dependencytrack.model.ConfigPropertyConstants.CUSTOM_RISK_SCORE_UNASSIGNED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ConfigPropertyResourceTest extends ResourceTest {
+class ConfigPropertyResourceTest extends ResourceTest {
 
     private static final SecretManager secretManager = mock(SecretManager.class);
 
@@ -69,132 +61,191 @@ public class ConfigPropertyResourceTest extends ResourceTest {
                     }));
 
     @Test
-    public void getConfigPropertiesTest() {
+    void shouldReturnFullJsonForGetConfigProperties() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
 
-        qm.createConfigProperty("my.group", "my.string", "ABC", IConfigProperty.PropertyType.STRING, "A string");
-        qm.createConfigProperty("my.group", "my.integer", "1", IConfigProperty.PropertyType.INTEGER, "A integer");
-        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
+        qm.createConfigProperty("my.group", "my.string", "ABC", PropertyType.STRING, "A string");
+        qm.createConfigProperty("my.group", "my.integer", "1", PropertyType.INTEGER, "A integer");
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
                 .header(X_API_KEY, apiKey)
-                .get(Response.class);
-        assertEquals(200, response.getStatus(), 0);
-        JsonArray json = parseJsonArray(response);
-        Assertions.assertNotNull(json);
-        assertEquals(2, json.size());
-        assertEquals("my.group", json.getJsonObject(0).getString("groupName"));
-        assertEquals("my.integer", json.getJsonObject(0).getString("propertyName"));
-        assertEquals("1", json.getJsonObject(0).getString("propertyValue"));
-        assertEquals("INTEGER", json.getJsonObject(0).getString("propertyType"));
-        assertEquals("A integer", json.getJsonObject(0).getString("description"));
-        assertEquals("my.group", json.getJsonObject(1).getString("groupName"));
-        assertEquals("my.string", json.getJsonObject(1).getString("propertyName"));
-        assertEquals("ABC", json.getJsonObject(1).getString("propertyValue"));
-        assertEquals("STRING", json.getJsonObject(1).getString("propertyType"));
-        assertEquals("A string", json.getJsonObject(1).getString("description"));
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                [
+                  {
+                    "groupName": "my.group",
+                    "propertyName": "my.integer",
+                    "propertyValue": "1",
+                    "propertyType": "INTEGER",
+                    "description": "A integer"
+                  },
+                  {
+                    "groupName": "my.group",
+                    "propertyName": "my.string",
+                    "propertyValue": "ABC",
+                    "propertyType": "STRING",
+                    "description": "A string"
+                  }
+                ]
+                """);
     }
 
     @Test
-    public void updateConfigPropertyStringTest() {
+    void shouldUpdateStringProperty() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
 
-        ConfigProperty property = qm.createConfigProperty("my.group", "my.string", "ABC", IConfigProperty.PropertyType.STRING, "A string");
-        ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
-        request.setPropertyValue("DEF");
-        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
+        qm.createConfigProperty("my.group", "my.string", "ABC", PropertyType.STRING, "A string");
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        assertEquals(200, response.getStatus(), 0);
-        JsonObject json = parseJsonObject(response);
-        Assertions.assertNotNull(json);
-        assertEquals("my.group", json.getString("groupName"));
-        assertEquals("my.string", json.getString("propertyName"));
-        assertEquals("DEF", json.getString("propertyValue"));
-        assertEquals("STRING", json.getString("propertyType"));
-        assertEquals("A string", json.getString("description"));
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "groupName": "my.group",
+                          "propertyName": "my.string",
+                          "propertyValue": "DEF"
+                        }
+                        """));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "groupName": "my.group",
+                  "propertyName": "my.string",
+                  "propertyValue": "DEF",
+                  "propertyType": "STRING",
+                  "description": "A string"
+                }
+                """);
     }
 
     @Test
-    public void updateConfigPropertyBooleanTest() {
+    void shouldUpdateBooleanProperty() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
 
-        ConfigProperty property = qm.createConfigProperty("my.group", "my.boolean", "false", IConfigProperty.PropertyType.BOOLEAN, "A boolean");
-        ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
-        request.setPropertyValue("true");
-        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
+        qm.createConfigProperty("my.group", "my.boolean", "false", PropertyType.BOOLEAN, "A boolean");
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        assertEquals(200, response.getStatus(), 0);
-        JsonObject json = parseJsonObject(response);
-        Assertions.assertNotNull(json);
-        assertEquals("my.group", json.getString("groupName"));
-        assertEquals("my.boolean", json.getString("propertyName"));
-        assertEquals("true", json.getString("propertyValue"));
-        assertEquals("BOOLEAN", json.getString("propertyType"));
-        assertEquals("A boolean", json.getString("description"));
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "groupName": "my.group",
+                          "propertyName": "my.boolean",
+                          "propertyValue": "true"
+                        }
+                        """));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "groupName": "my.group",
+                  "propertyName": "my.boolean",
+                  "propertyValue": "true",
+                  "propertyType": "BOOLEAN",
+                  "description": "A boolean"
+                }
+                """);
     }
 
     @Test
-    public void updateConfigPropertyNumberTest() {
+    void shouldUpdateNumberProperty() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
 
-        ConfigProperty property = qm.createConfigProperty("my.group", "my.number", "7.75", IConfigProperty.PropertyType.NUMBER, "A number");
-        ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
-        request.setPropertyValue("5.50");
-        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
+        qm.createConfigProperty("my.group", "my.number", "7.75", PropertyType.NUMBER, "A number");
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        assertEquals(200, response.getStatus(), 0);
-        JsonObject json = parseJsonObject(response);
-        Assertions.assertNotNull(json);
-        assertEquals("my.group", json.getString("groupName"));
-        assertEquals("my.number", json.getString("propertyName"));
-        assertEquals("5.50", json.getString("propertyValue"));
-        assertEquals("NUMBER", json.getString("propertyType"));
-        assertEquals("A number", json.getString("description"));
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "groupName": "my.group",
+                          "propertyName": "my.number",
+                          "propertyValue": "5.50"
+                        }
+                        """));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "groupName": "my.group",
+                  "propertyName": "my.number",
+                  "propertyValue": "5.50",
+                  "propertyType": "NUMBER",
+                  "description": "A number"
+                }
+                """);
     }
 
     @Test
-    public void updateConfigPropertyUrlTest() {
+    void shouldUpdateUrlProperty() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
 
-        ConfigProperty property = qm.createConfigProperty("my.group", "my.url", "http://localhost", IConfigProperty.PropertyType.URL, "A url");
-        ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
-        request.setPropertyValue("http://localhost/path");
-        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
+        qm.createConfigProperty("my.group", "my.url", "http://localhost", PropertyType.URL, "A url");
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        assertEquals(200, response.getStatus(), 0);
-        JsonObject json = parseJsonObject(response);
-        Assertions.assertNotNull(json);
-        assertEquals("my.group", json.getString("groupName"));
-        assertEquals("my.url", json.getString("propertyName"));
-        assertEquals("http://localhost/path", json.getString("propertyValue"));
-        assertEquals("URL", json.getString("propertyType"));
-        assertEquals("A url", json.getString("description"));
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "groupName": "my.group",
+                          "propertyName": "my.url",
+                          "propertyValue": "http://localhost/path"
+                        }
+                        """));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "groupName": "my.group",
+                  "propertyName": "my.url",
+                  "propertyValue": "http://localhost/path",
+                  "propertyType": "URL",
+                  "description": "A url"
+                }
+                """);
     }
 
     @Test
-    public void updateConfigPropertyUuidTest() {
+    void shouldUpdateUuidProperty() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
 
-        ConfigProperty property = qm.createConfigProperty("my.group", "my.uuid", "a496cabc-749d-4751-b9e5-3b49b656d018", IConfigProperty.PropertyType.UUID, "A uuid");
-        ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
-        request.setPropertyValue("fe03c401-b5a1-4b86-bc3b-1b7a68f0f78d");
-        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
+        qm.createConfigProperty("my.group", "my.uuid", "a496cabc-749d-4751-b9e5-3b49b656d018", PropertyType.UUID, "A uuid");
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        assertEquals(200, response.getStatus(), 0);
-        JsonObject json = parseJsonObject(response);
-        Assertions.assertNotNull(json);
-        assertEquals("my.group", json.getString("groupName"));
-        assertEquals("my.uuid", json.getString("propertyName"));
-        assertEquals("fe03c401-b5a1-4b86-bc3b-1b7a68f0f78d", json.getString("propertyValue"));
-        assertEquals("UUID", json.getString("propertyType"));
-        assertEquals("A uuid", json.getString("description"));
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "groupName": "my.group",
+                          "propertyName": "my.uuid",
+                          "propertyValue": "fe03c401-b5a1-4b86-bc3b-1b7a68f0f78d"
+                        }
+                        """));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "groupName": "my.group",
+                  "propertyName": "my.uuid",
+                  "propertyValue": "fe03c401-b5a1-4b86-bc3b-1b7a68f0f78d",
+                  "propertyType": "UUID",
+                  "description": "A uuid"
+                }
+                """);
     }
 
     @Test
-    public void updateConfigPropertyReadOnlyTest() {
+    void shouldRejectUpdateOfReadOnlyProperty() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
 
         qm.createConfigProperty(
@@ -202,164 +253,179 @@ public class ConfigPropertyResourceTest extends ResourceTest {
                 ConfigPropertyConstants.INTERNAL_CLUSTER_ID.getPropertyName(),
                 ConfigPropertyConstants.INTERNAL_CLUSTER_ID.getDefaultPropertyValue(),
                 ConfigPropertyConstants.INTERNAL_CLUSTER_ID.getPropertyType(),
-                ConfigPropertyConstants.INTERNAL_CLUSTER_ID.getDescription()
-        );
+                ConfigPropertyConstants.INTERNAL_CLUSTER_ID.getDescription());
 
-        final Response response = jersey.target(V1_CONFIG_PROPERTY).request()
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.entity("""
+                .post(Entity.json(/* language=JSON */ """
                         {
                           "groupName": "internal",
                           "propertyName": "cluster.id",
                           "propertyValue": "foobar"
                         }
-                        """, MediaType.APPLICATION_JSON));
+                        """));
 
         assertThat(response.getStatus()).isEqualTo(400);
         assertThat(getPlainTextBody(response)).isEqualTo("The property internal.cluster.id can not be modified");
     }
 
     @Test
-    public void testRiskScoreInvalid(){
+    void shouldRejectInvalidRiskScore() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
 
-        qm.createConfigProperty(
-                CUSTOM_RISK_SCORE_CRITICAL.getGroupName(),
-                CUSTOM_RISK_SCORE_CRITICAL.getPropertyName(),
-                CUSTOM_RISK_SCORE_CRITICAL.getDefaultPropertyValue(),
-                CUSTOM_RISK_SCORE_CRITICAL.getPropertyType(),
-                CUSTOM_RISK_SCORE_CRITICAL.getDescription()
-            );
-            qm.createConfigProperty(
-                CUSTOM_RISK_SCORE_HIGH.getGroupName(),
-                CUSTOM_RISK_SCORE_HIGH.getPropertyName(),
-                CUSTOM_RISK_SCORE_HIGH.getDefaultPropertyValue(),
-                CUSTOM_RISK_SCORE_HIGH.getPropertyType(),
-                CUSTOM_RISK_SCORE_HIGH.getDescription()
-            );
-            qm.createConfigProperty(
-                CUSTOM_RISK_SCORE_MEDIUM.getGroupName(),
-                CUSTOM_RISK_SCORE_MEDIUM.getPropertyName(),
-                CUSTOM_RISK_SCORE_MEDIUM.getDefaultPropertyValue(),
-                CUSTOM_RISK_SCORE_MEDIUM.getPropertyType(),
-                CUSTOM_RISK_SCORE_MEDIUM.getDescription()
-            );
-            qm.createConfigProperty(
-                CUSTOM_RISK_SCORE_LOW.getGroupName(),
-                CUSTOM_RISK_SCORE_LOW.getPropertyName(),
-                CUSTOM_RISK_SCORE_LOW.getDefaultPropertyValue(),
-                CUSTOM_RISK_SCORE_LOW.getPropertyType(),
-                CUSTOM_RISK_SCORE_LOW.getDescription()
-            );
-            qm.createConfigProperty(
-                CUSTOM_RISK_SCORE_UNASSIGNED.getGroupName(),
-                CUSTOM_RISK_SCORE_UNASSIGNED.getPropertyName(),
-                CUSTOM_RISK_SCORE_UNASSIGNED.getDefaultPropertyValue(),
-                CUSTOM_RISK_SCORE_UNASSIGNED.getPropertyType(),
-                CUSTOM_RISK_SCORE_UNASSIGNED.getDescription()
-            );
+        createRiskScoreProperties();
 
-        final Response response = jersey.target(V1_CONFIG_PROPERTY).request()
-        .header(X_API_KEY, apiKey)
-        .post(Entity.entity("""
-                {
-                  "groupName": "risk-score",
-                  "propertyName": "weight.critical",
-                  "propertyValue": "11"
-                }
-                """, MediaType.APPLICATION_JSON));
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "groupName": "risk-score",
+                          "propertyName": "weight.critical",
+                          "propertyValue": "11"
+                        }
+                        """));
 
         assertThat(response.getStatus()).isEqualTo(400);
-        assertThat(getPlainTextBody(response)).isEqualTo("Risk score \"weight.critical\" must be between 1 and 10. An invalid value of 11 was provided.");
+        assertThat(getPlainTextBody(response))
+                .isEqualTo("Risk score \"weight.critical\" must be between 1 and 10. An invalid value of 11 was provided.");
     }
 
     @Test
-    public void testRiskScoreUpdate(){
+    void shouldUpdateRiskScore() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
 
-        qm.createConfigProperty(
-                CUSTOM_RISK_SCORE_CRITICAL.getGroupName(),
-                CUSTOM_RISK_SCORE_CRITICAL.getPropertyName(),
-                CUSTOM_RISK_SCORE_CRITICAL.getDefaultPropertyValue(),
-                CUSTOM_RISK_SCORE_CRITICAL.getPropertyType(),
-                CUSTOM_RISK_SCORE_CRITICAL.getDescription()
-            );
-            qm.createConfigProperty(
-                CUSTOM_RISK_SCORE_HIGH.getGroupName(),
-                CUSTOM_RISK_SCORE_HIGH.getPropertyName(),
-                CUSTOM_RISK_SCORE_HIGH.getDefaultPropertyValue(),
-                CUSTOM_RISK_SCORE_HIGH.getPropertyType(),
-                CUSTOM_RISK_SCORE_HIGH.getDescription()
-            );
-            qm.createConfigProperty(
-                CUSTOM_RISK_SCORE_MEDIUM.getGroupName(),
-                CUSTOM_RISK_SCORE_MEDIUM.getPropertyName(),
-                CUSTOM_RISK_SCORE_MEDIUM.getDefaultPropertyValue(),
-                CUSTOM_RISK_SCORE_MEDIUM.getPropertyType(),
-                CUSTOM_RISK_SCORE_MEDIUM.getDescription()
-            );
-            qm.createConfigProperty(
-                CUSTOM_RISK_SCORE_LOW.getGroupName(),
-                CUSTOM_RISK_SCORE_LOW.getPropertyName(),
-                CUSTOM_RISK_SCORE_LOW.getDefaultPropertyValue(),
-                CUSTOM_RISK_SCORE_LOW.getPropertyType(),
-                CUSTOM_RISK_SCORE_LOW.getDescription()
-            );
-            qm.createConfigProperty(
-                CUSTOM_RISK_SCORE_UNASSIGNED.getGroupName(),
-                CUSTOM_RISK_SCORE_UNASSIGNED.getPropertyName(),
-                CUSTOM_RISK_SCORE_UNASSIGNED.getDefaultPropertyValue(),
-                CUSTOM_RISK_SCORE_UNASSIGNED.getPropertyType(),
-                CUSTOM_RISK_SCORE_UNASSIGNED.getDescription()
-            );
+        createRiskScoreProperties();
 
-        final Response response = jersey.target(V1_CONFIG_PROPERTY).request()
-        .header(X_API_KEY, apiKey)
-        .post(Entity.entity("""
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "groupName": "risk-score",
+                          "propertyName": "weight.critical",
+                          "propertyValue": "8"
+                        }
+                        """));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
                 {
                   "groupName": "risk-score",
                   "propertyName": "weight.critical",
-                  "propertyValue": "8"
+                  "propertyValue": "8",
+                  "propertyType": "INTEGER",
+                  "description": "Critical severity vulnerability weight (between 1-10)"
                 }
-                """, MediaType.APPLICATION_JSON));
-
-        assertThat(response.getStatus()).isEqualTo(200);
-        JsonObject json = parseJsonObject(response);
-        Assertions.assertNotNull(json);
-        assertEquals("risk-score", json.getString("groupName"));
-        assertEquals("weight.critical", json.getString("propertyName"));
-        assertEquals("8", json.getString("propertyValue"));
-        assertEquals("INTEGER", json.getString("propertyType"));
-        assertEquals("Critical severity vulnerability weight (between 1-10)", json.getString("description"));
+                """);
     }
 
     @Test
-    public void updateConfigPropertiesAggregateTest() {
+    void shouldUpdateAggregatedProperties() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
 
-        ConfigProperty prop1 = qm.createConfigProperty("my.group", "my.string1", "ABC", IConfigProperty.PropertyType.STRING, "A string");
-        ConfigProperty prop2 = qm.createConfigProperty("my.group", "my.string2", "DEF", IConfigProperty.PropertyType.STRING, "A string");
-        ConfigProperty prop3 = qm.createConfigProperty("my.group", "my.string3", "GHI", IConfigProperty.PropertyType.STRING, "A string");
-        prop1 = qm.detach(ConfigProperty.class, prop1.getId());
-        prop2 = qm.detach(ConfigProperty.class, prop2.getId());
-        prop3 = qm.detach(ConfigProperty.class, prop3.getId());
-        prop3.setPropertyValue("XYZ");
-        Response response = jersey.target(V1_CONFIG_PROPERTY+"/aggregate").request()
+        qm.createConfigProperty("my.group", "my.string1", "ABC", PropertyType.STRING, "A string");
+        qm.createConfigProperty("my.group", "my.string2", "DEF", PropertyType.STRING, "A string");
+        qm.createConfigProperty("my.group", "my.string3", "GHI", PropertyType.STRING, "A string");
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY + "/aggregate")
+                .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.entity(Arrays.asList(prop1, prop2, prop3), MediaType.APPLICATION_JSON));
-        assertEquals(200, response.getStatus(), 0);
-        JsonArray json = parseJsonArray(response);
-        JsonObject modifiedProp = json.getJsonObject(2);
-        Assertions.assertNotNull(modifiedProp);
-        assertEquals("my.group", modifiedProp.getString("groupName"));
-        assertEquals("my.string3", modifiedProp.getString("propertyName"));
-        assertEquals("XYZ", modifiedProp.getString("propertyValue"));
-        assertEquals("STRING", modifiedProp.getString("propertyType"));
-        assertEquals("A string", modifiedProp.getString("description"));
+                .post(Entity.json(/* language=JSON */ """
+                        [
+                          {
+                            "groupName": "my.group",
+                            "propertyName": "my.string1",
+                            "propertyValue": "ABC"
+                          },
+                          {
+                            "groupName": "my.group",
+                            "propertyName": "my.string2",
+                            "propertyValue": "DEF"
+                          },
+                          {
+                            "groupName": "my.group",
+                            "propertyName": "my.string3",
+                            "propertyValue": "XYZ"
+                          }
+                        ]
+                        """));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                [
+                  {
+                    "groupName": "my.group",
+                    "propertyName": "my.string1",
+                    "propertyValue": "ABC",
+                    "propertyType": "STRING",
+                    "description": "A string"
+                  },
+                  {
+                    "groupName": "my.group",
+                    "propertyName": "my.string2",
+                    "propertyValue": "DEF",
+                    "propertyType": "STRING",
+                    "description": "A string"
+                  },
+                  {
+                    "groupName": "my.group",
+                    "propertyName": "my.string3",
+                    "propertyValue": "XYZ",
+                    "propertyType": "STRING",
+                    "description": "A string"
+                  }
+                ]
+                """);
     }
 
     @Test
-    public void updateConfigPropertyBomValidationModeTest() {
+    void shouldPreserveMixedResponseShapeWhenAggregateIncludesUnknownProperty() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        qm.createConfigProperty("my.group", "known", "ABC", PropertyType.STRING, "A string");
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY + "/aggregate")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        [
+                          {
+                            "groupName": "my.group",
+                            "propertyName": "known",
+                            "propertyValue": "DEF"
+                          },
+                          {
+                            "groupName": "my.group",
+                            "propertyName": "unknown",
+                            "propertyValue": "anything"
+                          }
+                        ]
+                        """));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                [
+                  {
+                    "groupName": "my.group",
+                    "propertyName": "known",
+                    "propertyValue": "DEF",
+                    "propertyType": "STRING",
+                    "description": "A string"
+                  },
+                  "The config property could not be found."
+                ]
+                """);
+    }
+
+    @Test
+    void shouldUpdateBomValidationMode() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
 
         qm.createConfigProperty(
@@ -367,18 +433,20 @@ public class ConfigPropertyResourceTest extends ResourceTest {
                 ConfigPropertyConstants.BOM_VALIDATION_MODE.getPropertyName(),
                 ConfigPropertyConstants.BOM_VALIDATION_MODE.getDefaultPropertyValue(),
                 ConfigPropertyConstants.BOM_VALIDATION_MODE.getPropertyType(),
-                ConfigPropertyConstants.BOM_VALIDATION_MODE.getDescription()
-        );
+                ConfigPropertyConstants.BOM_VALIDATION_MODE.getDescription());
 
-        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.entity(/* language=JSON */ """
+                .post(Entity.json(/* language=JSON */ """
                         {
                           "groupName": "artifact",
                           "propertyName": "bom.validation.mode",
                           "propertyValue": "ENABLED_FOR_TAGS"
                         }
-                        """, MediaType.APPLICATION_JSON));
+                        """));
+
         assertThat(response.getStatus()).isEqualTo(200);
         assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
                 {
@@ -389,22 +457,38 @@ public class ConfigPropertyResourceTest extends ResourceTest {
                   "description": "${json-unit.any-string}"
                 }
                 """);
+    }
 
-        response = jersey.target(V1_CONFIG_PROPERTY).request()
+    @Test
+    void shouldRejectInvalidBomValidationMode() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        qm.createConfigProperty(
+                ConfigPropertyConstants.BOM_VALIDATION_MODE.getGroupName(),
+                ConfigPropertyConstants.BOM_VALIDATION_MODE.getPropertyName(),
+                ConfigPropertyConstants.BOM_VALIDATION_MODE.getDefaultPropertyValue(),
+                ConfigPropertyConstants.BOM_VALIDATION_MODE.getPropertyType(),
+                ConfigPropertyConstants.BOM_VALIDATION_MODE.getDescription());
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.entity(/* language=JSON */ """
+                .post(Entity.json(/* language=JSON */ """
                         {
                           "groupName": "artifact",
                           "propertyName": "bom.validation.mode",
                           "propertyValue": "foo"
                         }
-                        """, MediaType.APPLICATION_JSON));
+                        """));
+
         assertThat(response.getStatus()).isEqualTo(400);
-        assertThat(getPlainTextBody(response)).isEqualTo("Value must be any of: ENABLED, DISABLED, ENABLED_FOR_TAGS, DISABLED_FOR_TAGS");
+        assertThat(getPlainTextBody(response))
+                .isEqualTo("Value must be any of: ENABLED, DISABLED, ENABLED_FOR_TAGS, DISABLED_FOR_TAGS");
     }
 
     @Test
-    public void updateConfigPropertyBomValidationTagsExclusiveTest() {
+    void shouldUpdateBomValidationTagsExclusive() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
 
         qm.createConfigProperty(
@@ -412,18 +496,20 @@ public class ConfigPropertyResourceTest extends ResourceTest {
                 ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE.getPropertyName(),
                 ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE.getDefaultPropertyValue(),
                 ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE.getPropertyType(),
-                ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE.getDescription()
-        );
+                ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE.getDescription());
 
-        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.entity(/* language=JSON */ """
+                .post(Entity.json(/* language=JSON */ """
                         {
                           "groupName": "artifact",
                           "propertyName": "bom.validation.tags.exclusive",
                           "propertyValue": "[\\"foo\\"]"
                         }
-                        """, MediaType.APPLICATION_JSON));
+                        """));
+
         assertThat(response.getStatus()).isEqualTo(200);
         assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
                 {
@@ -434,22 +520,37 @@ public class ConfigPropertyResourceTest extends ResourceTest {
                   "description": "${json-unit.any-string}"
                 }
                 """);
+    }
 
-        response = jersey.target(V1_CONFIG_PROPERTY).request()
+    @Test
+    void shouldRejectInvalidBomValidationTagsExclusive() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        qm.createConfigProperty(
+                ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE.getGroupName(),
+                ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE.getPropertyName(),
+                ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE.getDefaultPropertyValue(),
+                ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE.getPropertyType(),
+                ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE.getDescription());
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.entity(/* language=JSON */ """
+                .post(Entity.json(/* language=JSON */ """
                         {
                           "groupName": "artifact",
                           "propertyName": "bom.validation.tags.exclusive",
                           "propertyValue": "foo"
                         }
-                        """, MediaType.APPLICATION_JSON));
+                        """));
+
         assertThat(response.getStatus()).isEqualTo(400);
         assertThat(getPlainTextBody(response)).isEqualTo("Value must be a valid JSON array of strings");
     }
 
     @Test
-    public void updateConfigPropertyBomValidationTagsInclusiveTest() {
+    void shouldUpdateBomValidationTagsInclusive() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
 
         qm.createConfigProperty(
@@ -457,18 +558,20 @@ public class ConfigPropertyResourceTest extends ResourceTest {
                 ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE.getPropertyName(),
                 ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE.getDefaultPropertyValue(),
                 ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE.getPropertyType(),
-                ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE.getDescription()
-        );
+                ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE.getDescription());
 
-        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.entity(/* language=JSON */ """
+                .post(Entity.json(/* language=JSON */ """
                         {
                           "groupName": "artifact",
                           "propertyName": "bom.validation.tags.inclusive",
                           "propertyValue": "[\\"foo\\"]"
                         }
-                        """, MediaType.APPLICATION_JSON));
+                        """));
+
         assertThat(response.getStatus()).isEqualTo(200);
         assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
                 {
@@ -479,22 +582,37 @@ public class ConfigPropertyResourceTest extends ResourceTest {
                   "description": "${json-unit.any-string}"
                 }
                 """);
+    }
 
-        response = jersey.target(V1_CONFIG_PROPERTY).request()
+    @Test
+    void shouldRejectInvalidBomValidationTagsInclusive() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        qm.createConfigProperty(
+                ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE.getGroupName(),
+                ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE.getPropertyName(),
+                ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE.getDefaultPropertyValue(),
+                ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE.getPropertyType(),
+                ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE.getDescription());
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.entity(/* language=JSON */ """
+                .post(Entity.json(/* language=JSON */ """
                         {
                           "groupName": "artifact",
                           "propertyName": "bom.validation.tags.inclusive",
                           "propertyValue": "foo"
                         }
-                        """, MediaType.APPLICATION_JSON));
+                        """));
+
         assertThat(response.getStatus()).isEqualTo(400);
         assertThat(getPlainTextBody(response)).isEqualTo("Value must be a valid JSON array of strings");
     }
 
     @Test
-    public void updateConfigPropertySecretNameNotFoundTest() {
+    void shouldRejectUnknownSecretName() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
 
         qm.createConfigProperty(
@@ -502,27 +620,29 @@ public class ConfigPropertyResourceTest extends ResourceTest {
                 ConfigPropertyConstants.FORTIFY_SSC_TOKEN.getPropertyName(),
                 ConfigPropertyConstants.FORTIFY_SSC_TOKEN.getDefaultPropertyValue(),
                 ConfigPropertyConstants.FORTIFY_SSC_TOKEN.getPropertyType(),
-                ConfigPropertyConstants.FORTIFY_SSC_TOKEN.getDescription()
-        );
+                ConfigPropertyConstants.FORTIFY_SSC_TOKEN.getDescription());
 
         when(secretManager.getSecretMetadata("nonexistent-secret")).thenReturn(null);
 
-        final Response response = jersey.target(V1_CONFIG_PROPERTY).request()
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.entity("""
+                .post(Entity.json(/* language=JSON */ """
                         {
                           "groupName": "integrations",
                           "propertyName": "fortify.ssc.token",
                           "propertyValue": "nonexistent-secret"
                         }
-                        """, MediaType.APPLICATION_JSON));
+                        """));
 
         assertThat(response.getStatus()).isEqualTo(400);
-        assertThat(getPlainTextBody(response)).isEqualTo("The secret with name \"nonexistent-secret\" could not be found.");
+        assertThat(getPlainTextBody(response))
+                .isEqualTo("The secret with name \"nonexistent-secret\" could not be found.");
     }
 
     @Test
-    public void updateConfigPropertySecretNameFoundTest() {
+    void shouldAcceptKnownSecretName() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
 
         qm.createConfigProperty(
@@ -530,43 +650,171 @@ public class ConfigPropertyResourceTest extends ResourceTest {
                 ConfigPropertyConstants.KENNA_TOKEN.getPropertyName(),
                 ConfigPropertyConstants.KENNA_TOKEN.getDefaultPropertyValue(),
                 ConfigPropertyConstants.KENNA_TOKEN.getPropertyType(),
-                ConfigPropertyConstants.KENNA_TOKEN.getDescription()
-        );
+                ConfigPropertyConstants.KENNA_TOKEN.getDescription());
 
-        when(secretManager.getSecretMetadata("my-secret")).thenReturn(new SecretMetadata("my-secret", null, null, null));
+        when(secretManager.getSecretMetadata("my-secret"))
+                .thenReturn(new SecretMetadata("my-secret", null, null, null));
 
-        final Response response = jersey.target(V1_CONFIG_PROPERTY).request()
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.entity("""
+                .post(Entity.json(/* language=JSON */ """
                         {
                           "groupName": "integrations",
                           "propertyName": "kenna.token",
                           "propertyValue": "my-secret"
                         }
-                        """, MediaType.APPLICATION_JSON));
+                        """));
 
         assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "groupName": "integrations",
+                  "propertyName": "kenna.token",
+                  "propertyValue": "my-secret",
+                  "propertyType": "STRING",
+                  "description": "${json-unit.any-string}"
+                }
+                """);
     }
 
     @Test
-    public void getPublicAllPropertiesTest() {
+    void shouldReturn404WhenUpdatingUnknownConfigProperty() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "groupName": "my.group",
+                          "propertyName": "does.not.exist",
+                          "propertyValue": "anything"
+                        }
+                        """));
+
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(getPlainTextBody(response)).isEqualTo("The config property could not be found.");
+    }
+
+    @Test
+    void shouldReturnFullJsonForPublicConfigProperty() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
 
-        for (ConfigPropertyConstants configProperty : ConfigPropertyConstants.values()) {
-            String groupName = configProperty.getGroupName();
-            String propertyName = configProperty.getPropertyName();
+        qm.createConfigProperty(
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
+                "true",
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyType(),
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getDescription());
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY
+                        + "/public/" + ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName()
+                        + "/" + ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "groupName": "access-management",
+                  "propertyName": "acl.enabled",
+                  "propertyValue": "true",
+                  "propertyType": "BOOLEAN",
+                  "description": "${json-unit.any-string}"
+                }
+                """);
+    }
+
+    @Test
+    void shouldReturn403ForNonPublicConfigProperty() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        for (final ConfigPropertyConstants configProperty : ConfigPropertyConstants.values()) {
             qm.createConfigProperty(
-                    groupName,
-                    propertyName,
+                    configProperty.getGroupName(),
+                    configProperty.getPropertyName(),
                     configProperty.getDefaultPropertyValue(),
                     configProperty.getPropertyType(),
                     configProperty.getDescription());
 
-            Response response = jersey.target(V1_CONFIG_PROPERTY + "/public/" + groupName + "/" + propertyName)
+            final Response response = jersey
+                    .target(V1_CONFIG_PROPERTY
+                            + "/public/" + configProperty.getGroupName()
+                            + "/" + configProperty.getPropertyName())
                     .request()
-                    .header(X_API_KEY, apiKey).get();
-            int status = configProperty.getIsPublic() ? 200 : 403;
-            assertEquals(status, response.getStatus());
+                    .header(X_API_KEY, apiKey)
+                    .get();
+
+            final int expectedStatus = configProperty.getIsPublic() ? 200 : 403;
+            assertThat(response.getStatus()).isEqualTo(expectedStatus);
         }
     }
+
+    @Test
+    void shouldReturn403WhenPublicEndpointPathParamsDoNotMatchKnownProperty() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY + "/public/unknown.group/unknown.property")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void shouldReturn404WhenPublicConfigPropertyDoesNotExist() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY
+                        + "/public/" + ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName()
+                        + "/" + ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(getPlainTextBody(response)).isEqualTo("The config property could not be found.");
+    }
+
+    private void createRiskScoreProperties() {
+        qm.createConfigProperty(
+                CUSTOM_RISK_SCORE_CRITICAL.getGroupName(),
+                CUSTOM_RISK_SCORE_CRITICAL.getPropertyName(),
+                CUSTOM_RISK_SCORE_CRITICAL.getDefaultPropertyValue(),
+                CUSTOM_RISK_SCORE_CRITICAL.getPropertyType(),
+                CUSTOM_RISK_SCORE_CRITICAL.getDescription());
+        qm.createConfigProperty(
+                CUSTOM_RISK_SCORE_HIGH.getGroupName(),
+                CUSTOM_RISK_SCORE_HIGH.getPropertyName(),
+                CUSTOM_RISK_SCORE_HIGH.getDefaultPropertyValue(),
+                CUSTOM_RISK_SCORE_HIGH.getPropertyType(),
+                CUSTOM_RISK_SCORE_HIGH.getDescription());
+        qm.createConfigProperty(
+                CUSTOM_RISK_SCORE_MEDIUM.getGroupName(),
+                CUSTOM_RISK_SCORE_MEDIUM.getPropertyName(),
+                CUSTOM_RISK_SCORE_MEDIUM.getDefaultPropertyValue(),
+                CUSTOM_RISK_SCORE_MEDIUM.getPropertyType(),
+                CUSTOM_RISK_SCORE_MEDIUM.getDescription());
+        qm.createConfigProperty(
+                CUSTOM_RISK_SCORE_LOW.getGroupName(),
+                CUSTOM_RISK_SCORE_LOW.getPropertyName(),
+                CUSTOM_RISK_SCORE_LOW.getDefaultPropertyValue(),
+                CUSTOM_RISK_SCORE_LOW.getPropertyType(),
+                CUSTOM_RISK_SCORE_LOW.getDescription());
+        qm.createConfigProperty(
+                CUSTOM_RISK_SCORE_UNASSIGNED.getGroupName(),
+                CUSTOM_RISK_SCORE_UNASSIGNED.getPropertyName(),
+                CUSTOM_RISK_SCORE_UNASSIGNED.getDefaultPropertyValue(),
+                CUSTOM_RISK_SCORE_UNASSIGNED.getPropertyType(),
+                CUSTOM_RISK_SCORE_UNASSIGNED.getDescription());
+    }
+
 }

--- a/apiserver/src/test/resources/archunit_store/3e49066c-46b2-40c2-8473-ce4276c1ba12
+++ b/apiserver/src/test/resources/archunit_store/3e49066c-46b2-40c2-8473-ce4276c1ba12
@@ -1,7 +1,5 @@
 org.dependencytrack.resources.v1.ComponentResource.createComponent(java.lang.String, org.dependencytrack.model.Component) accepts JDO model class org.dependencytrack.model.Component as request body
 org.dependencytrack.resources.v1.ComponentResource.updateComponent(org.dependencytrack.model.Component) accepts JDO model class org.dependencytrack.model.Component as request body
-org.dependencytrack.resources.v1.ConfigPropertyResource.updateConfigProperty(alpine.model.ConfigProperty) accepts JDO model class alpine.model.ConfigProperty as request body
-org.dependencytrack.resources.v1.ConfigPropertyResource.updateConfigProperty(java.util.List) accepts JDO model class alpine.model.ConfigProperty as request body
 org.dependencytrack.resources.v1.NotificationRuleResource.deleteNotificationRule(org.dependencytrack.model.NotificationRule) accepts JDO model class org.dependencytrack.model.NotificationRule as request body
 org.dependencytrack.resources.v1.OidcResource.createGroup(alpine.model.OidcGroup) accepts JDO model class alpine.model.OidcGroup as request body
 org.dependencytrack.resources.v1.OidcResource.updateGroup(alpine.model.OidcGroup) accepts JDO model class alpine.model.OidcGroup as request body

--- a/apiserver/src/test/resources/archunit_store/67305ac9-6039-403a-8a4c-ada073ef9b6d
+++ b/apiserver/src/test/resources/archunit_store/67305ac9-6039-403a-8a4c-ada073ef9b6d
@@ -7,10 +7,6 @@ org.dependencytrack.resources.v1.ComponentResource.getComponentByIdentity(java.l
 org.dependencytrack.resources.v1.ComponentResource.getComponentByUuid(java.lang.String, boolean) declares JDO model class org.dependencytrack.model.Component as Swagger response schema
 org.dependencytrack.resources.v1.ComponentResource.getOccurrences(java.util.UUID) declares JDO model class org.dependencytrack.model.ComponentOccurrence as Swagger response schema
 org.dependencytrack.resources.v1.ComponentResource.updateComponent(org.dependencytrack.model.Component) declares JDO model class org.dependencytrack.model.Component as Swagger response schema
-org.dependencytrack.resources.v1.ConfigPropertyResource.getConfigProperties() declares JDO model class alpine.model.ConfigProperty as Swagger response schema
-org.dependencytrack.resources.v1.ConfigPropertyResource.getPublicConfigProperty(java.lang.String, java.lang.String) declares JDO model class alpine.model.ConfigProperty as Swagger response schema
-org.dependencytrack.resources.v1.ConfigPropertyResource.updateConfigProperty(alpine.model.ConfigProperty) declares JDO model class alpine.model.ConfigProperty as Swagger response schema
-org.dependencytrack.resources.v1.ConfigPropertyResource.updateConfigProperty(java.util.List) declares JDO model class alpine.model.ConfigProperty as Swagger response schema
 org.dependencytrack.resources.v1.LdapResource.addMapping(org.dependencytrack.resources.v1.vo.MappedLdapGroupRequest) declares JDO model class alpine.model.MappedLdapGroup as Swagger response schema
 org.dependencytrack.resources.v1.LdapResource.retrieveLdapGroups(java.lang.String) declares JDO model class alpine.model.MappedLdapGroup as Swagger response schema
 org.dependencytrack.resources.v1.NotificationRuleResource.addProjectToRule(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Tackles the technical debt of JDO models being reused for REST DTOs for all endpoints under `/v1/configProperty`.

Also makes the generated OpenAPI spec more reliable b/c it no longer advertises fields that are never used / never returned.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
