### PR TITLE
Decouple violation analysis API from JDO models

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ViolationAnalysisResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ViolationAnalysisResource.java
@@ -49,6 +49,7 @@ import org.dependencytrack.persistence.command.MakeViolationAnalysisCommand;
 import org.dependencytrack.resources.AbstractApiResource;
 import org.dependencytrack.resources.v1.problems.ProblemDetails;
 import org.dependencytrack.resources.v1.vo.ViolationAnalysisRequest;
+import org.dependencytrack.resources.v1.vo.ViolationAnalysisResponse;
 
 /**
  * JAX-RS resources for processing violation analysis decisions.
@@ -74,7 +75,7 @@ public class ViolationAnalysisResource extends AbstractApiResource {
             @ApiResponse(
                     responseCode = "200",
                     description = "A violation analysis trail",
-                    content = @Content(schema = @Schema(implementation = ViolationAnalysis.class))
+                    content = @Content(schema = @Schema(implementation = ViolationAnalysisResponse.class))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(
@@ -92,18 +93,31 @@ public class ViolationAnalysisResource extends AbstractApiResource {
                 new ValidationTask(RegexSequence.Pattern.UUID, componentUuid, "Component is not a valid UUID"),
                 new ValidationTask(RegexSequence.Pattern.UUID, violationUuid, "Policy violation is not a valid UUID")
         );
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
-            final Component component = qm.getObjectByUuid(Component.class, componentUuid);
+
+        try (final var qm = new QueryManager(getAlpineRequest())) {
+            final var component = qm.getObjectByUuid(Component.class, componentUuid);
             if (component == null) {
-                return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();
+                return Response
+                        .status(Response.Status.NOT_FOUND)
+                        .entity("The component could not be found.")
+                        .build();
             }
             requireAccess(qm, component.getProject());
-            final PolicyViolation policyViolation = qm.getObjectByUuid(PolicyViolation.class, violationUuid);
+
+            final var policyViolation = qm.getObjectByUuid(PolicyViolation.class, violationUuid);
             if (policyViolation == null) {
-                return Response.status(Response.Status.NOT_FOUND).entity("The policy violation could not be found.").build();
+                return Response
+                        .status(Response.Status.NOT_FOUND)
+                        .entity("The policy violation could not be found.")
+                        .build();
             }
+
             final ViolationAnalysis analysis = qm.getViolationAnalysis(component, policyViolation);
-            return Response.ok(analysis).build();
+            return Response
+                    .ok(analysis != null
+                            ? ViolationAnalysisResponse.of(analysis)
+                            : null)
+                    .build();
         }
     }
 
@@ -118,7 +132,7 @@ public class ViolationAnalysisResource extends AbstractApiResource {
             @ApiResponse(
                     responseCode = "200",
                     description = "The created violation analysis",
-                    content = @Content(schema = @Schema(implementation = ViolationAnalysis.class))
+                    content = @Content(schema = @Schema(implementation = ViolationAnalysisResponse.class))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
             @ApiResponse(
@@ -136,19 +150,19 @@ public class ViolationAnalysisResource extends AbstractApiResource {
                 validator.validateProperty(request, "analysisState"),
                 validator.validateProperty(request, "comment")
         );
+
         try (final var qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
-                final Component component = qm.getObjectByUuid(Component.class, request.getComponent());
+                final var component = qm.getObjectByUuid(Component.class, request.getComponent());
                 if (component == null) {
                     return Response
                             .status(Response.Status.NOT_FOUND)
                             .entity("The component could not be found.")
                             .build();
                 }
-
                 requireAccess(qm, component.getProject());
 
-                final PolicyViolation violation = qm.getObjectByUuid(PolicyViolation.class, request.getPolicyViolation());
+                final var violation = qm.getObjectByUuid(PolicyViolation.class, request.getPolicyViolation());
                 if (violation == null) {
                     return Response
                             .status(Response.Status.NOT_FOUND)
@@ -162,7 +176,9 @@ public class ViolationAnalysisResource extends AbstractApiResource {
                                 .withSuppress(request.isSuppressed())
                                 .withComment(request.getComment()));
 
-                return Response.ok(qm.getObjectById(ViolationAnalysis.class, analysisId)).build();
+                return Response
+                        .ok(ViolationAnalysisResponse.of(qm.getObjectById(ViolationAnalysis.class, analysisId)))
+                        .build();
             });
         }
     }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/ViolationAnalysisResponse.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/ViolationAnalysisResponse.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.dependencytrack.model.ViolationAnalysis;
+import org.dependencytrack.model.ViolationAnalysisComment;
+import org.dependencytrack.model.ViolationAnalysisState;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Date;
+import java.util.List;
+
+/// @since 5.1.0
+@NullMarked
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ViolationAnalysisResponse(
+        @Schema(description = "The state of the analysis decision", requiredMode = Schema.RequiredMode.REQUIRED)
+        ViolationAnalysisState analysisState,
+
+        @Schema(description = "Audit trail of analysis comments", requiredMode = Schema.RequiredMode.REQUIRED)
+        List<Comment> analysisComments,
+
+        @JsonProperty("isSuppressed")
+        @Schema(description = "Whether the policy violation is suppressed", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean isSuppressed) {
+
+    public static ViolationAnalysisResponse of(ViolationAnalysis analysis) {
+        final List<ViolationAnalysisComment> jdoComments = analysis.getAnalysisComments();
+        final List<Comment> comments = jdoComments != null
+                ? jdoComments.stream().map(Comment::of).toList()
+                : List.of();
+
+        return new ViolationAnalysisResponse(
+                analysis.getAnalysisState(),
+                comments,
+                analysis.isSuppressed());
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Comment(
+            @Schema(description = "Timestamp the comment was recorded at", requiredMode = Schema.RequiredMode.REQUIRED)
+            Date timestamp,
+
+            @Schema(description = "The comment text", requiredMode = Schema.RequiredMode.REQUIRED)
+            String comment,
+
+            @Schema(description = "Identifier of the user who wrote the comment")
+            @Nullable String commenter) {
+
+        public static Comment of(ViolationAnalysisComment jdo) {
+            return new Comment(jdo.getTimestamp(), jdo.getComment(), jdo.getCommenter());
+        }
+
+    }
+}

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ViolationAnalysisResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ViolationAnalysisResourceTest.java
@@ -100,7 +100,8 @@ class ViolationAnalysisResourceTest extends ResourceTest {
         violationAnalysisComment.setTimestamp(new Date());
         qm.persist(violationAnalysisComment);
 
-        final Response response = jersey.target(V1_VIOLATION_ANALYSIS)
+        final Response response = jersey
+                .target(V1_VIOLATION_ANALYSIS)
                 .queryParam("component", component.getUuid())
                 .queryParam("policyViolation", violation.getUuid())
                 .request()
@@ -109,14 +110,67 @@ class ViolationAnalysisResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
         assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
 
-        final JsonObject jsonObject = parseJsonObject(response);
-        assertThat(jsonObject).isNotNull();
-        assertThat(jsonObject.getString("analysisState")).isEqualTo(ViolationAnalysisState.APPROVED.name());
-        assertThat(jsonObject.getJsonArray("analysisComments")).hasSize(1);
-        assertThat(jsonObject.getJsonArray("analysisComments").getJsonObject(0))
-                .hasFieldOrPropertyWithValue("comment", Json.createValue("Analysis comment here"))
-                .hasFieldOrPropertyWithValue("commenter", Json.createValue("Jane Doe"));
-        assertThat(jsonObject.getBoolean("isSuppressed")).isFalse();
+        assertThatJson(getPlainTextBody(response))
+                .isEqualTo(/* language=JSON */ """
+                        {
+                          "analysisState": "APPROVED",
+                          "analysisComments": [
+                            {
+                              "timestamp": "${json-unit.any-number}",
+                              "comment": "Analysis comment here",
+                              "commenter": "Jane Doe"
+                            }
+                          ],
+                          "isSuppressed": false
+                        }
+                        """);
+    }
+
+    @Test
+    void shouldReturnEmptyAnalysisCommentsArrayWhenNoCommentsExist() {
+        initializeWithPermissions(Permissions.VIEW_POLICY_VIOLATION);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("Acme Component");
+        component.setVersion("1.0");
+        component = qm.createComponent(component, false);
+
+        final Policy policy = qm.createPolicy("Blacklisted Version", Policy.Operator.ALL, Policy.ViolationState.FAIL);
+        final PolicyCondition condition = qm.createPolicyCondition(policy, Subject.VERSION, Operator.NUMERIC_EQUAL, "1.0");
+
+        var violation = new PolicyViolation();
+        violation.setType(Type.OPERATIONAL);
+        violation.setComponent(component);
+        violation.setPolicyCondition(condition);
+        violation.setTimestamp(new Date());
+        violation = qm.persist(violation);
+
+        final var violationAnalysis = new ViolationAnalysis();
+        violationAnalysis.setComponent(component);
+        violationAnalysis.setPolicyViolation(violation);
+        violationAnalysis.setViolationAnalysisState(ViolationAnalysisState.APPROVED);
+        qm.persist(violationAnalysis);
+
+        final Response response = jersey
+                .target(V1_VIOLATION_ANALYSIS)
+                .queryParam("component", component.getUuid())
+                .queryParam("policyViolation", violation.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+
+        assertThatJson(getPlainTextBody(response))
+                .isEqualTo(/* language=JSON */ """
+                        {
+                          "analysisState": "APPROVED",
+                          "analysisComments": [],
+                          "isSuppressed": false
+                        }
+                        """);
     }
 
     @Test

--- a/apiserver/src/test/resources/archunit_store/67305ac9-6039-403a-8a4c-ada073ef9b6d
+++ b/apiserver/src/test/resources/archunit_store/67305ac9-6039-403a-8a4c-ada073ef9b6d
@@ -66,8 +66,6 @@ org.dependencytrack.resources.v1.UserResource.removeTeamFromUser(java.lang.Strin
 org.dependencytrack.resources.v1.UserResource.setUserTeams(org.dependencytrack.resources.v1.vo.TeamsSetRequest) declares JDO model class alpine.model.User as Swagger response schema
 org.dependencytrack.resources.v1.UserResource.updateManagedUser(alpine.model.ManagedUser) declares JDO model class alpine.model.ManagedUser as Swagger response schema
 org.dependencytrack.resources.v1.UserResource.updateSelf(alpine.model.ManagedUser) declares JDO model class alpine.model.ManagedUser as Swagger response schema
-org.dependencytrack.resources.v1.ViolationAnalysisResource.retrieveAnalysis(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.ViolationAnalysis as Swagger response schema
-org.dependencytrack.resources.v1.ViolationAnalysisResource.updateAnalysis(org.dependencytrack.resources.v1.vo.ViolationAnalysisRequest) declares JDO model class org.dependencytrack.model.ViolationAnalysis as Swagger response schema
 org.dependencytrack.resources.v1.VulnerabilityResource.createVulnerability(org.dependencytrack.model.Vulnerability) declares JDO model class org.dependencytrack.model.Vulnerability as Swagger response schema
 org.dependencytrack.resources.v1.VulnerabilityResource.getAllVulnerabilities() declares JDO model class org.dependencytrack.model.Vulnerability as Swagger response schema
 org.dependencytrack.resources.v1.VulnerabilityResource.getVulnerabilitiesByComponent(java.lang.String, boolean) declares JDO model class org.dependencytrack.model.Vulnerability as Swagger response schema


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Tackles the technical debt of JDO models being reused for REST DTOs for all endpoints under `/v1/violation/analysis`.

Also makes the generated OpenAPI spec more reliable b/c it no longer advertises fields that are never used / never returned.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
