### PR TITLE
Forward group_by parameter to DefectDojo, v5 version

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoClient.java
+++ b/apiserver/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoClient.java
@@ -60,7 +60,8 @@ public class DefectDojoClient {
             final String engagementId,
             final InputStream findingsJson,
             final Boolean verifyFindings,
-            final @Nullable String testTitle) {
+            final @Nullable String testTitle,
+            final @Nullable String groupBy) {
         LOGGER.debug("Uploading Dependency-Track findings to DefectDojo");
 
         final var multipart = new MultipartBodyPublisher()
@@ -75,6 +76,9 @@ public class DefectDojoClient {
                 .addFormField("scan_date", DATE_FORMAT.format(new Date()));
         if (testTitle != null) {
             multipart.addFormField("test_title", testTitle);
+        }
+        if (groupBy != null) {
+            multipart.addFormField("group_by", groupBy);
         }
 
         final var request = HttpRequest.newBuilder()
@@ -187,7 +191,8 @@ public class DefectDojoClient {
             final String testId,
             final Boolean doNotReactivate,
             final Boolean verifyFindings,
-            final @Nullable String testTitle) {
+            final @Nullable String testTitle,
+            final @Nullable String groupBy) {
         LOGGER.debug("Re-reimport Dependency-Track findings to DefectDojo per Engagement");
 
         final var multipart = new MultipartBodyPublisher()
@@ -204,6 +209,9 @@ public class DefectDojoClient {
                 .addFormField("scan_date", DATE_FORMAT.format(new Date()));
         if (testTitle != null) {
             multipart.addFormField("test_title", testTitle);
+        }
+        if (groupBy != null) {
+            multipart.addFormField("group_by", groupBy);
         }
 
         final var request = HttpRequest.newBuilder()

--- a/apiserver/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploader.java
+++ b/apiserver/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploader.java
@@ -53,6 +53,7 @@ public class DefectDojoUploader extends AbstractIntegrationPoint implements Proj
     private static final String DO_NOT_REACTIVATE_PROPERTY = "defectdojo.doNotReactivate";
     private static final String VERIFIED_PROPERTY = "defectdojo.verified";
     private static final String TEST_TITLE_PROPERTY = "defectdojo.testTitle";
+    private static final String GROUP_BY_PROPERTY = "defectdojo.groupBy";
 
     private final HttpClient httpClient;
     private final SecretManager secretManager;
@@ -94,6 +95,14 @@ public class DefectDojoUploader extends AbstractIntegrationPoint implements Proj
         final ProjectProperty testName = qm.getProjectProperty(project, DEFECTDOJO_ENABLED.getGroupName(), TEST_TITLE_PROPERTY);
         if (testName != null && testName.getPropertyValue() != null) {
             return testName.getPropertyValue();
+        }
+        return null;
+    }
+
+    public String getGroupBy(final Project project) {
+        final ProjectProperty groupBy = qm.getProjectProperty(project, DEFECTDOJO_ENABLED.getGroupName(), GROUP_BY_PROPERTY);
+        if (groupBy != null && groupBy.getPropertyValue() != null) {
+            return groupBy.getPropertyValue();
         }
         return null;
     }
@@ -142,6 +151,8 @@ public class DefectDojoUploader extends AbstractIntegrationPoint implements Proj
         final boolean globalReimportEnabled = qm.isEnabled(DEFECTDOJO_REIMPORT_ENABLED);
         final ProjectProperty engagementId = qm.getProjectProperty(project, DEFECTDOJO_ENABLED.getGroupName(), ENGAGEMENTID_PROPERTY);
         final boolean verifyFindings = isVerifiedConfigured(project);
+        final String testTitle = getTestTitle(project);
+        final String groupBy = getGroupBy(project);
         try {
             final String apiKeyValue = secretManager.getSecretValue(apiKeySecretName);
             if (apiKeyValue == null) {
@@ -160,7 +171,8 @@ public class DefectDojoUploader extends AbstractIntegrationPoint implements Proj
                             engagementId.getPropertyValue(),
                             payload,
                             verifyFindings,
-                            testTitle);
+                            testTitle,
+                            groupBy);
                 } else {
                     client.reimportDependencyTrackFindings(
                             apiKeyValue,
@@ -169,7 +181,8 @@ public class DefectDojoUploader extends AbstractIntegrationPoint implements Proj
                             testId,
                             isDoNotReactivateConfigured(project),
                             verifyFindings,
-                            testTitle);
+                            testTitle,
+                            groupBy);
                 }
             } else {
                 client.uploadDependencyTrackFindings(
@@ -177,7 +190,8 @@ public class DefectDojoUploader extends AbstractIntegrationPoint implements Proj
                         engagementId.getPropertyValue(),
                         payload,
                         verifyFindings,
-                        testTitle);
+                        testTitle,
+                        groupBy);
             }
         } catch (Exception e) {
             LOGGER.error("An error occurred attempting to upload findings to DefectDojo", e);

--- a/apiserver/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploader.java
+++ b/apiserver/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploader.java
@@ -99,7 +99,7 @@ public class DefectDojoUploader extends AbstractIntegrationPoint implements Proj
         return null;
     }
 
-    private @Nullable String getGroupBy(final Project project) {
+    @Nullable String getGroupBy(final Project project) {
         final ProjectProperty groupBy = qm.getProjectProperty(project, DEFECTDOJO_ENABLED.getGroupName(), GROUP_BY_PROPERTY);
         if (groupBy != null && groupBy.getPropertyValue() != null) {
             return groupBy.getPropertyValue();

--- a/apiserver/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploader.java
+++ b/apiserver/src/main/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploader.java
@@ -99,7 +99,7 @@ public class DefectDojoUploader extends AbstractIntegrationPoint implements Proj
         return null;
     }
 
-    public String getGroupBy(final Project project) {
+    private @Nullable String getGroupBy(final Project project) {
         final ProjectProperty groupBy = qm.getProjectProperty(project, DEFECTDOJO_ENABLED.getGroupName(), GROUP_BY_PROPERTY);
         if (groupBy != null && groupBy.getPropertyValue() != null) {
             return groupBy.getPropertyValue();
@@ -159,7 +159,6 @@ public class DefectDojoUploader extends AbstractIntegrationPoint implements Proj
                 LOGGER.warn("DefectDojo API key secret '%s' could not be resolved. Aborting".formatted(apiKeySecretName));
                 return;
             }
-            final String testTitle = getTestTitle(project);
             final DefectDojoClient client = new DefectDojoClient(httpClient, this, URI.create(defectDojoUrl.getPropertyValue()).toURL());
             if (isReimportConfigured(project) || globalReimportEnabled) {
                 final ArrayList<String> testsIds = client.getDojoTestIds(apiKeyValue, engagementId.getPropertyValue());

--- a/apiserver/src/test/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploaderTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploaderTest.java
@@ -93,4 +93,28 @@ class DefectDojoUploaderTest extends PersistenceCapableTest {
         Assertions.assertFalse(extension.isProjectConfigured(project));
     }
 
+    @Test
+    void testGetGroupByReturnsNullWhenNotConfigured() {
+        Project project = qm.createProject("ACME Example", null, "1.0", null, null, null, true, false);
+        DefectDojoUploader extension = new DefectDojoUploader(httpClient, secretManager);
+        extension.setQueryManager(qm);
+        Assertions.assertNull(extension.getGroupBy(project));
+    }
+
+    @Test
+    void testGetGroupByReturnsValueWhenConfigured() {
+        Project project = qm.createProject("ACME Example", null, "1.0", null, null, null, true, false);
+        qm.createProjectProperty(
+                project,
+                DEFECTDOJO_ENABLED.getGroupName(),
+                "defectdojo.groupBy",
+                "component_name",
+                IConfigProperty.PropertyType.STRING,
+                null
+        );
+        DefectDojoUploader extension = new DefectDojoUploader(httpClient, secretManager);
+        extension.setQueryManager(qm);
+        Assertions.assertEquals("component_name", extension.getGroupBy(project));
+    }
+
 }

--- a/apiserver/src/test/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploaderTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploaderTest.java
@@ -95,7 +95,7 @@ class DefectDojoUploaderTest extends PersistenceCapableTest {
 
     @Test
     void testGetGroupByReturnsNullWhenNotConfigured() {
-        Project project = qm.createProject("ACME Example", null, "1.0", null, null, null, true, false);
+        Project project = qm.createProject("ACME Example", null, "1.0", null, null, null, null, false);
         DefectDojoUploader extension = new DefectDojoUploader(httpClient, secretManager);
         extension.setQueryManager(qm);
         Assertions.assertNull(extension.getGroupBy(project));
@@ -103,7 +103,7 @@ class DefectDojoUploaderTest extends PersistenceCapableTest {
 
     @Test
     void testGetGroupByReturnsValueWhenConfigured() {
-        Project project = qm.createProject("ACME Example", null, "1.0", null, null, null, true, false);
+        Project project = qm.createProject("ACME Example", null, "1.0", null, null, null, null, false);
         qm.createProjectProperty(
                 project,
                 DEFECTDOJO_ENABLED.getGroupName(),

--- a/apiserver/src/test/java/org/dependencytrack/tasks/DefectDojoUploadTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/DefectDojoUploadTaskTest.java
@@ -932,7 +932,7 @@ class DefectDojoUploadTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testUploadWithGroupBy() {
+    void testUploadWithGroupBy(WireMockRuntimeInfo wmRuntimeInfo) {
         qm.createConfigProperty(
                 DEFECTDOJO_ENABLED.getGroupName(),
                 DEFECTDOJO_ENABLED.getPropertyName(),
@@ -950,7 +950,7 @@ class DefectDojoUploadTaskTest extends PersistenceCapableTest {
         qm.createConfigProperty(
                 DEFECTDOJO_API_KEY.getGroupName(),
                 DEFECTDOJO_API_KEY.getPropertyName(),
-                "dojoApiKey",
+                "apiKeySecretName",
                 DEFECTDOJO_API_KEY.getPropertyType(),
                 null
         );
@@ -982,7 +982,10 @@ class DefectDojoUploadTaskTest extends PersistenceCapableTest {
         qm.createProjectProperty(project, "integrations", "defectdojo.groupBy",
                 "component_name", IConfigProperty.PropertyType.STRING, null);
 
-        new DefectDojoUploadTask().inform(new DefectDojoUploadEventAbstract());
+        new DefectDojoUploadTask(
+                HttpClient.newHttpClient(),
+                new TestSecretManager(Map.of("apiKeySecretName", "dojoApiKey")))
+                .run();
 
         verify(postRequestedFor(urlPathEqualTo("/api/v2/import-scan/"))
                 .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Token dojoApiKey"))
@@ -995,7 +998,7 @@ class DefectDojoUploadTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testUploadWithReimportAndGroupBy() {
+    void testUploadWithReimportAndGroupBy(WireMockRuntimeInfo wmRuntimeInfo) {
         qm.createConfigProperty(
                 DEFECTDOJO_ENABLED.getGroupName(),
                 DEFECTDOJO_ENABLED.getPropertyName(),
@@ -1013,7 +1016,7 @@ class DefectDojoUploadTaskTest extends PersistenceCapableTest {
         qm.createConfigProperty(
                 DEFECTDOJO_API_KEY.getGroupName(),
                 DEFECTDOJO_API_KEY.getPropertyName(),
-                "dojoApiKey",
+                "apiKeySecretName",
                 DEFECTDOJO_API_KEY.getPropertyType(),
                 null
         );
@@ -1092,7 +1095,10 @@ class DefectDojoUploadTaskTest extends PersistenceCapableTest {
         qm.createProjectProperty(project, "integrations", "defectdojo.groupBy",
                 "component_name+component_version", IConfigProperty.PropertyType.STRING, null);
 
-        new DefectDojoUploadTask().inform(new DefectDojoUploadEventAbstract());
+        new DefectDojoUploadTask(
+                HttpClient.newHttpClient(),
+                new TestSecretManager(Map.of("apiKeySecretName", "dojoApiKey")))
+                .run();
 
         verify(1, getRequestedFor(urlPathEqualTo("/api/v2/tests/")));
 

--- a/apiserver/src/test/java/org/dependencytrack/tasks/DefectDojoUploadTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/DefectDojoUploadTaskTest.java
@@ -931,6 +931,184 @@ class DefectDojoUploadTaskTest extends PersistenceCapableTest {
                                 """, true, false))));
     }
 
+    @Test
+    void testUploadWithGroupBy() {
+        qm.createConfigProperty(
+                DEFECTDOJO_ENABLED.getGroupName(),
+                DEFECTDOJO_ENABLED.getPropertyName(),
+                "true",
+                DEFECTDOJO_ENABLED.getPropertyType(),
+                null
+        );
+        qm.createConfigProperty(
+                DEFECTDOJO_URL.getGroupName(),
+                DEFECTDOJO_URL.getPropertyName(),
+                wmRuntimeInfo.getHttpBaseUrl(),
+                DEFECTDOJO_URL.getPropertyType(),
+                null
+        );
+        qm.createConfigProperty(
+                DEFECTDOJO_API_KEY.getGroupName(),
+                DEFECTDOJO_API_KEY.getPropertyName(),
+                "dojoApiKey",
+                DEFECTDOJO_API_KEY.getPropertyType(),
+                null
+        );
+        qm.createConfigProperty(
+                DEFECTDOJO_REIMPORT_ENABLED.getGroupName(),
+                DEFECTDOJO_REIMPORT_ENABLED.getPropertyName(),
+                DEFECTDOJO_REIMPORT_ENABLED.getDefaultPropertyValue(),
+                DEFECTDOJO_REIMPORT_ENABLED.getPropertyType(),
+                null
+        );
+
+        stubFor(post(urlPathEqualTo("/api/v2/import-scan/"))
+                .willReturn(aResponse()
+                        .withStatus(201)));
+
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("1.2.3");
+        qm.persist(component);
+
+        qm.createProjectProperty(project, "integrations", "defectdojo.engagementId",
+                "666", IConfigProperty.PropertyType.STRING, null);
+        qm.createProjectProperty(project, "integrations", "defectdojo.groupBy",
+                "component_name", IConfigProperty.PropertyType.STRING, null);
+
+        new DefectDojoUploadTask().inform(new DefectDojoUploadEventAbstract());
+
+        verify(postRequestedFor(urlPathEqualTo("/api/v2/import-scan/"))
+                .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Token dojoApiKey"))
+                .withAnyRequestBodyPart(aMultipart()
+                        .withName("engagement")
+                        .withBody(equalTo("666")))
+                .withAnyRequestBodyPart(aMultipart()
+                        .withName("group_by")
+                        .withBody(equalTo("component_name"))));
+    }
+
+    @Test
+    void testUploadWithReimportAndGroupBy() {
+        qm.createConfigProperty(
+                DEFECTDOJO_ENABLED.getGroupName(),
+                DEFECTDOJO_ENABLED.getPropertyName(),
+                "true",
+                DEFECTDOJO_ENABLED.getPropertyType(),
+                null
+        );
+        qm.createConfigProperty(
+                DEFECTDOJO_URL.getGroupName(),
+                DEFECTDOJO_URL.getPropertyName(),
+                wmRuntimeInfo.getHttpBaseUrl(),
+                DEFECTDOJO_URL.getPropertyType(),
+                null
+        );
+        qm.createConfigProperty(
+                DEFECTDOJO_API_KEY.getGroupName(),
+                DEFECTDOJO_API_KEY.getPropertyName(),
+                "dojoApiKey",
+                DEFECTDOJO_API_KEY.getPropertyType(),
+                null
+        );
+        qm.createConfigProperty(
+                DEFECTDOJO_REIMPORT_ENABLED.getGroupName(),
+                DEFECTDOJO_REIMPORT_ENABLED.getPropertyName(),
+                "false",
+                DEFECTDOJO_REIMPORT_ENABLED.getPropertyType(),
+                null
+        );
+
+        stubFor(get(urlPathEqualTo("/api/v2/tests/"))
+                .withQueryParam("engagement", equalTo("666"))
+                .withQueryParam("limit", equalTo("100"))
+                .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Token dojoApiKey"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                        .withBody("""
+                                {
+                                   "count": 1,
+                                   "next": null,
+                                   "previous": null,
+                                   "results": [
+                                     {
+                                       "id": 1,
+                                       "tags": [],
+                                       "test_type_name": "Dependency Track Finding Packaging Format (FPF) Export",
+                                       "finding_groups": [],
+                                       "scan_type": "Dependency Track Finding Packaging Format (FPF) Export",
+                                       "title": null,
+                                       "description": null,
+                                       "target_start": "2023-04-29T00:00:00Z",
+                                       "target_end": "2023-04-29T21:39:21.513481Z",
+                                       "estimated_time": null,
+                                       "actual_time": null,
+                                       "percent_complete": 100,
+                                       "updated": "2023-04-29T21:39:21.617857Z",
+                                       "created": "2023-04-29T21:39:21.516216Z",
+                                       "version": "",
+                                       "build_id": "",
+                                       "commit_hash": "",
+                                       "branch_tag": "",
+                                       "engagement": 666,
+                                       "lead": 1,
+                                       "test_type": 63,
+                                       "environment": 7,
+                                       "api_scan_configuration": null,
+                                       "notes": [],
+                                       "files": []
+                                     }
+                                   ],
+                                   "prefetch": {}
+                                 }
+                                """)));
+
+        stubFor(post(urlPathEqualTo("/api/v2/reimport-scan/"))
+                .willReturn(aResponse()
+                        .withStatus(201)));
+
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("1.2.3");
+        qm.persist(component);
+
+        qm.createProjectProperty(project, "integrations", "defectdojo.engagementId",
+                "666", IConfigProperty.PropertyType.STRING, null);
+        qm.createProjectProperty(project, "integrations", "defectdojo.reimport",
+                "true", IConfigProperty.PropertyType.BOOLEAN, null);
+        qm.createProjectProperty(project, "integrations", "defectdojo.groupBy",
+                "component_name+component_version", IConfigProperty.PropertyType.STRING, null);
+
+        new DefectDojoUploadTask().inform(new DefectDojoUploadEventAbstract());
+
+        verify(1, getRequestedFor(urlPathEqualTo("/api/v2/tests/")));
+
+        verify(postRequestedFor(urlPathEqualTo("/api/v2/reimport-scan/"))
+                .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Token dojoApiKey"))
+                .withAnyRequestBodyPart(aMultipart()
+                        .withName("engagement")
+                        .withBody(equalTo("666")))
+                .withAnyRequestBodyPart(aMultipart()
+                        .withName("test")
+                        .withBody(equalTo("1")))
+                .withAnyRequestBodyPart(aMultipart()
+                        .withName("group_by")
+                        .withBody(equalTo("component_name+component_version"))));
+    }
+
     /**
      * Un-ignore this test to test the integration against a local DefectDojo deployment.
      * <p>


### PR DESCRIPTION
### Description

DefectDojo's import-scan and reimport-scan endpoints accept a `group_by` parameter that clusters findings into Finding Groups on import, but Dependency-Track never forwarded it. Operators who rely on Finding Groups for triage had to set `group_by` outside of DT or give it up entirely.

This adds a per-project property `defectdojo.groupBy` that, when set, is sent as `group_by` in the multipart form body for both import and reimport requests. When not set, behavior is unchanged.

This is the v5 companion to #6130, which makes the same change for `4.14.x`. Adapted for the `MultipartBodyPublisher`-based `DefectDojoClient` in the `apiserver` module.
<img width="1808" height="611" alt="dtrack-groupby" src="https://github.com/user-attachments/assets/4ce95c75-4c73-4c6f-9b18-4439af220c73" />
<img width="1818" height="432" alt="defectdojo-groupby" src="https://github.com/user-attachments/assets/8598d8c5-6e3b-402a-a053-8d373e9e82df" />


### Addressed Issue

Related to #6061. v5 companion to #6130 (same change targeting `4.14.x`).

### Additional Details

The implementation follows the same pattern as `defectdojo.testTitle`: a per-project `ProjectProperty` is read in `DefectDojoUploader` and forwarded as a form field via `MultipartBodyPublisher.addFormField`. No new abstraction was introduced.

The dead `.build()` fix included in the v4 PR does not apply here. The v5 `DefectDojoClient` uses `MultipartBodyPublisher` rather than Apache HttpClient's `MultipartEntityBuilder`, so there is no equivalent dead call to remove.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/main/apiserver/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/main/docs) accordingly