### PR TITLE
Resolve analysis rating overrides per method in findings and notifications

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -138,54 +138,54 @@ public interface FindingDao {
                  , v."REFERENCES" AS "vulnReferences"
                  , v."PUBLISHED" AS "vulnPublished"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV2SCORE" IS NOT NULL OR a."CVSSV2VECTOR" IS NOT NULL
                      THEN a."CVSSV2SCORE"
                      ELSE v."CVSSV2BASESCORE"
                    END AS "cvssV2BaseScore"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV3SCORE" IS NOT NULL OR a."CVSSV3VECTOR" IS NOT NULL
                      THEN a."CVSSV3SCORE"
                      ELSE v."CVSSV3BASESCORE"
                    END AS "cvssV3BaseScore"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV4SCORE" IS NOT NULL OR a."CVSSV4VECTOR" IS NOT NULL
                      THEN a."CVSSV4SCORE"
                      ELSE v."CVSSV4SCORE"
                    END AS "cvssV4Score"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV2SCORE" IS NOT NULL OR a."CVSSV2VECTOR" IS NOT NULL
                      THEN a."CVSSV2VECTOR"
                      ELSE v."CVSSV2VECTOR"
                    END AS "cvssV2Vector"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV3SCORE" IS NOT NULL OR a."CVSSV3VECTOR" IS NOT NULL
                      THEN a."CVSSV3VECTOR"
                      ELSE v."CVSSV3VECTOR"
                    END AS "cvssV3Vector"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV4SCORE" IS NOT NULL OR a."CVSSV4VECTOR" IS NOT NULL
                      THEN a."CVSSV4VECTOR"
                      ELSE v."CVSSV4VECTOR"
                    END AS "cvssV4Vector"
                  -- TODO: Analysis only has a single score, but OWASP RR defines multiple.
                  --  How to handle this?
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
                      THEN a."OWASPSCORE"
                      ELSE v."OWASPRRBUSINESSIMPACTSCORE"
                    END AS "owaspRRBusinessImpactScore"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
                      THEN a."OWASPSCORE"
                      ELSE v."OWASPRRLIKELIHOODSCORE"
                    END AS "owaspRRLikelihoodScore"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
                      THEN a."OWASPSCORE"
                      ELSE v."OWASPRRTECHNICALIMPACTSCORE"
                    END AS "owaspRRTechnicalImpactScore"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
                      THEN a."OWASPVECTOR"
                      ELSE v."OWASPRRVECTOR"
                    END AS "owaspRRVector"
@@ -356,54 +356,54 @@ public interface FindingDao {
                  , v."REFERENCES" AS "vulnReferences"
                  , v."PUBLISHED" AS "vulnPublished"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV2SCORE" IS NOT NULL OR a."CVSSV2VECTOR" IS NOT NULL
                      THEN a."CVSSV2SCORE"
                      ELSE v."CVSSV2BASESCORE"
                    END AS "cvssV2BaseScore"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV3SCORE" IS NOT NULL OR a."CVSSV3VECTOR" IS NOT NULL
                      THEN a."CVSSV3SCORE"
                      ELSE v."CVSSV3BASESCORE"
                    END AS "cvssV3BaseScore"
                  , CASE
-                    WHEN a."SEVERITY" IS NOT NULL
-                    THEN a."CVSSV4SCORE"
-                    ELSE v."CVSSV4SCORE"
+                     WHEN a."CVSSV4SCORE" IS NOT NULL OR a."CVSSV4VECTOR" IS NOT NULL
+                     THEN a."CVSSV4SCORE"
+                     ELSE v."CVSSV4SCORE"
                    END AS "cvssV4Score"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV2SCORE" IS NOT NULL OR a."CVSSV2VECTOR" IS NOT NULL
                      THEN a."CVSSV2VECTOR"
                      ELSE v."CVSSV2VECTOR"
                    END AS "cvssV2Vector"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV3SCORE" IS NOT NULL OR a."CVSSV3VECTOR" IS NOT NULL
                      THEN a."CVSSV3VECTOR"
                      ELSE v."CVSSV3VECTOR"
                    END AS "cvssV3Vector"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV4SCORE" IS NOT NULL OR a."CVSSV4VECTOR" IS NOT NULL
                      THEN a."CVSSV4VECTOR"
                      ELSE v."CVSSV4VECTOR"
                    END AS "cvssV4Vector"
                  -- TODO: Analysis only has a single score, but OWASP RR defines multiple.
                  --  How to handle this?
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
                      THEN a."OWASPSCORE"
                      ELSE v."OWASPRRBUSINESSIMPACTSCORE"
                    END AS "owaspRRBusinessImpactScore"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
                      THEN a."OWASPSCORE"
                      ELSE v."OWASPRRLIKELIHOODSCORE"
                    END AS "owaspRRLikelihoodScore"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
                      THEN a."OWASPSCORE"
                      ELSE v."OWASPRRTECHNICALIMPACTSCORE"
                    END AS "owaspRRTechnicalImpactScore"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
                      THEN a."OWASPVECTOR"
                      ELSE v."OWASPRRVECTOR"
                    END AS "owaspRRVector"
@@ -540,17 +540,17 @@ public interface FindingDao {
                  , v."TITLE" AS "vulnTitle"
                  , COALESCE(a."SEVERITY", v."SEVERITY") AS "vulnSeverity"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV2SCORE" IS NOT NULL OR a."CVSSV2VECTOR" IS NOT NULL
                      THEN a."CVSSV2SCORE"
                      ELSE v."CVSSV2BASESCORE"
                    END AS "cvssV2BaseScore"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV3SCORE" IS NOT NULL OR a."CVSSV3VECTOR" IS NOT NULL
                      THEN a."CVSSV3SCORE"
                      ELSE v."CVSSV3BASESCORE"
                    END AS "cvssV3BaseScore"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV4SCORE" IS NOT NULL OR a."CVSSV4VECTOR" IS NOT NULL
                      THEN a."CVSSV4SCORE"
                      ELSE v."CVSSV4SCORE"
                    END AS "cvssV4Score"

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -91,54 +91,54 @@ public interface NotificationSubjectDao extends SqlObject {
                  , v."DESCRIPTION" AS "vulnDescription"
                  , v."RECOMMENDATION" AS "vulnRecommendation"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV2SCORE" IS NOT NULL OR a."CVSSV2VECTOR" IS NOT NULL
                      THEN a."CVSSV2SCORE"
                      ELSE v."CVSSV2BASESCORE"
                    END AS "vulnCvssV2BaseScore"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV3SCORE" IS NOT NULL OR a."CVSSV3VECTOR" IS NOT NULL
                      THEN a."CVSSV3SCORE"
                      ELSE v."CVSSV3BASESCORE"
                    END AS "vulnCvssV3BaseScore"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV4SCORE" IS NOT NULL OR a."CVSSV4VECTOR" IS NOT NULL
                      THEN a."CVSSV4SCORE"
                      ELSE v."CVSSV4SCORE"
                    END AS "vulnCvssV4Score"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV2SCORE" IS NOT NULL OR a."CVSSV2VECTOR" IS NOT NULL
                      THEN a."CVSSV2VECTOR"
                      ELSE v."CVSSV2VECTOR"
                    END AS "vulnCvssV2Vector"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV3SCORE" IS NOT NULL OR a."CVSSV3VECTOR" IS NOT NULL
                      THEN a."CVSSV3VECTOR"
                      ELSE v."CVSSV3VECTOR"
                    END AS "vulnCvssV3Vector"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."CVSSV4SCORE" IS NOT NULL OR a."CVSSV4VECTOR" IS NOT NULL
                      THEN a."CVSSV4VECTOR"
                      ELSE v."CVSSV4VECTOR"
                    END AS "vulnCvssV4Vector"
                   -- TODO: Analysis only has a single score, but OWASP RR defines multiple.
                   --  How to handle this?
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
                      THEN a."OWASPSCORE"
                      ELSE v."OWASPRRBUSINESSIMPACTSCORE"
                    END AS "vulnOwaspRrBusinessImpactScore"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
                      THEN a."OWASPSCORE"
                      ELSE v."OWASPRRLIKELIHOODSCORE"
                    END AS "vulnOwaspRrLikelihoodScore"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
                      THEN a."OWASPSCORE"
                      ELSE v."OWASPRRTECHNICALIMPACTSCORE"
                    END AS "vulnOwaspRrTechnicalImpactScore"
                  , CASE
-                     WHEN a."SEVERITY" IS NOT NULL
+                     WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
                      THEN a."OWASPVECTOR"
                      ELSE v."OWASPRRVECTOR"
                    END AS "vulnOwaspRrVector"
@@ -207,52 +207,52 @@ public interface NotificationSubjectDao extends SqlObject {
                              , v."DESCRIPTION" AS "vulnDescription"
                              , v."RECOMMENDATION" AS "vulnRecommendation"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL
+                                 WHEN a."CVSSV2SCORE" IS NOT NULL OR a."CVSSV2VECTOR" IS NOT NULL
                                  THEN a."CVSSV2SCORE"
                                  ELSE v."CVSSV2BASESCORE"
                                END AS "vulnCvssV2BaseScore"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL
+                                 WHEN a."CVSSV3SCORE" IS NOT NULL OR a."CVSSV3VECTOR" IS NOT NULL
                                  THEN a."CVSSV3SCORE"
                                  ELSE v."CVSSV3BASESCORE"
                                END AS "vulnCvssV3BaseScore"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL
+                                 WHEN a."CVSSV4SCORE" IS NOT NULL OR a."CVSSV4VECTOR" IS NOT NULL
                                  THEN a."CVSSV4SCORE"
                                  ELSE v."CVSSV4SCORE"
                                END AS "vulnCvssV4Score"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL
+                                 WHEN a."CVSSV2SCORE" IS NOT NULL OR a."CVSSV2VECTOR" IS NOT NULL
                                  THEN a."CVSSV2VECTOR"
                                  ELSE v."CVSSV2VECTOR"
                                END AS "vulnCvssV2Vector"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL
+                                 WHEN a."CVSSV3SCORE" IS NOT NULL OR a."CVSSV3VECTOR" IS NOT NULL
                                  THEN a."CVSSV3VECTOR"
                                  ELSE v."CVSSV3VECTOR"
                                END AS "vulnCvssV3Vector"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL
+                                 WHEN a."CVSSV4SCORE" IS NOT NULL OR a."CVSSV4VECTOR" IS NOT NULL
                                  THEN a."CVSSV4VECTOR"
                                  ELSE v."CVSSV4VECTOR"
                                END AS "vulnCvssV4Vector"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL
+                                 WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
                                  THEN a."OWASPSCORE"
                                  ELSE v."OWASPRRBUSINESSIMPACTSCORE"
                                END AS "vulnOwaspRrBusinessImpactScore"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL
+                                 WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
                                  THEN a."OWASPSCORE"
                                  ELSE v."OWASPRRLIKELIHOODSCORE"
                                END AS "vulnOwaspRrLikelihoodScore"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL
+                                 WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
                                  THEN a."OWASPSCORE"
                                  ELSE v."OWASPRRTECHNICALIMPACTSCORE"
                                END AS "vulnOwaspRrTechnicalImpactScore"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL
+                                 WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
                                  THEN a."OWASPVECTOR"
                                  ELSE v."OWASPRRVECTOR"
                                END AS "vulnOwaspRrVector"
@@ -353,43 +353,53 @@ public interface NotificationSubjectDao extends SqlObject {
                              , v."DESCRIPTION" AS "vulnDescription"
                              , v."RECOMMENDATION" AS "vulnRecommendation"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."CVSSV2SCORE"
+                                 WHEN a."CVSSV2SCORE" IS NOT NULL OR a."CVSSV2VECTOR" IS NOT NULL
+                                 THEN a."CVSSV2SCORE"
                                  ELSE v."CVSSV2BASESCORE"
                                END AS "vulnCvssV2BaseScore"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."CVSSV3SCORE"
+                                 WHEN a."CVSSV3SCORE" IS NOT NULL OR a."CVSSV3VECTOR" IS NOT NULL
+                                 THEN a."CVSSV3SCORE"
                                  ELSE v."CVSSV3BASESCORE"
                                END AS "vulnCvssV3BaseScore"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."CVSSV4SCORE"
+                                 WHEN a."CVSSV4SCORE" IS NOT NULL OR a."CVSSV4VECTOR" IS NOT NULL
+                                 THEN a."CVSSV4SCORE"
                                  ELSE v."CVSSV4SCORE"
                                END AS "vulnCvssV4Score"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."CVSSV2VECTOR"
+                                 WHEN a."CVSSV2SCORE" IS NOT NULL OR a."CVSSV2VECTOR" IS NOT NULL
+                                 THEN a."CVSSV2VECTOR"
                                  ELSE v."CVSSV2VECTOR"
                                END AS "vulnCvssV2Vector"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."CVSSV3VECTOR"
+                                 WHEN a."CVSSV3SCORE" IS NOT NULL OR a."CVSSV3VECTOR" IS NOT NULL
+                                 THEN a."CVSSV3VECTOR"
                                  ELSE v."CVSSV3VECTOR"
                                END AS "vulnCvssV3Vector"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."CVSSV4VECTOR"
+                                 WHEN a."CVSSV4SCORE" IS NOT NULL OR a."CVSSV4VECTOR" IS NOT NULL
+                                 THEN a."CVSSV4VECTOR"
                                  ELSE v."CVSSV4VECTOR"
                                END AS "vulnCvssV4Vector"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."OWASPSCORE"
+                                 WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
+                                 THEN a."OWASPSCORE"
                                  ELSE v."OWASPRRBUSINESSIMPACTSCORE"
                                END AS "vulnOwaspRrBusinessImpactScore"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."OWASPSCORE"
+                                 WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
+                                 THEN a."OWASPSCORE"
                                  ELSE v."OWASPRRLIKELIHOODSCORE"
                                END AS "vulnOwaspRrLikelihoodScore"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."OWASPSCORE"
+                                 WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
+                                 THEN a."OWASPSCORE"
                                  ELSE v."OWASPRRTECHNICALIMPACTSCORE"
                                END AS "vulnOwaspRrTechnicalImpactScore"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."OWASPVECTOR"
+                                 WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
+                                 THEN a."OWASPVECTOR"
                                  ELSE v."OWASPRRVECTOR"
                                END AS "vulnOwaspRrVector"
                              , COALESCE(a."SEVERITY", v."SEVERITY") AS "vulnSeverity"
@@ -533,43 +543,53 @@ public interface NotificationSubjectDao extends SqlObject {
                              , v."DESCRIPTION" AS "vulnDescription"
                              , v."RECOMMENDATION" AS "vulnRecommendation"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."CVSSV2SCORE"
+                                 WHEN a."CVSSV2SCORE" IS NOT NULL OR a."CVSSV2VECTOR" IS NOT NULL
+                                 THEN a."CVSSV2SCORE"
                                  ELSE v."CVSSV2BASESCORE"
                                END AS "vulnCvssV2BaseScore"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."CVSSV3SCORE"
+                                 WHEN a."CVSSV3SCORE" IS NOT NULL OR a."CVSSV3VECTOR" IS NOT NULL
+                                 THEN a."CVSSV3SCORE"
                                  ELSE v."CVSSV3BASESCORE"
                                END AS "vulnCvssV3BaseScore"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."CVSSV4SCORE"
+                                 WHEN a."CVSSV4SCORE" IS NOT NULL OR a."CVSSV4VECTOR" IS NOT NULL
+                                 THEN a."CVSSV4SCORE"
                                  ELSE v."CVSSV4SCORE"
                                END AS "vulnCvssV4Score"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."CVSSV2VECTOR"
+                                 WHEN a."CVSSV2SCORE" IS NOT NULL OR a."CVSSV2VECTOR" IS NOT NULL
+                                 THEN a."CVSSV2VECTOR"
                                  ELSE v."CVSSV2VECTOR"
                                END AS "vulnCvssV2Vector"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."CVSSV3VECTOR"
+                                 WHEN a."CVSSV3SCORE" IS NOT NULL OR a."CVSSV3VECTOR" IS NOT NULL
+                                 THEN a."CVSSV3VECTOR"
                                  ELSE v."CVSSV3VECTOR"
                                END AS "vulnCvssV3Vector"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."CVSSV4VECTOR"
+                                 WHEN a."CVSSV4SCORE" IS NOT NULL OR a."CVSSV4VECTOR" IS NOT NULL
+                                 THEN a."CVSSV4VECTOR"
                                  ELSE v."CVSSV4VECTOR"
                                END AS "vulnCvssV4Vector"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."OWASPSCORE"
+                                 WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
+                                 THEN a."OWASPSCORE"
                                  ELSE v."OWASPRRBUSINESSIMPACTSCORE"
                                END AS "vulnOwaspRrBusinessImpactScore"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."OWASPSCORE"
+                                 WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
+                                 THEN a."OWASPSCORE"
                                  ELSE v."OWASPRRLIKELIHOODSCORE"
                                END AS "vulnOwaspRrLikelihoodScore"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."OWASPSCORE"
+                                 WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
+                                 THEN a."OWASPSCORE"
                                  ELSE v."OWASPRRTECHNICALIMPACTSCORE"
                                END AS "vulnOwaspRrTechnicalImpactScore"
                              , CASE
-                                 WHEN a."SEVERITY" IS NOT NULL THEN a."OWASPVECTOR"
+                                 WHEN a."OWASPSCORE" IS NOT NULL OR a."OWASPVECTOR" IS NOT NULL
+                                 THEN a."OWASPVECTOR"
                                  ELSE v."OWASPRRVECTOR"
                                END AS "vulnOwaspRrVector"
                              , COALESCE(a."SEVERITY", v."SEVERITY") AS "vulnSeverity"

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
@@ -262,9 +262,15 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                             "uuid": "${json-unit.matches:vulnUuid}",
                             "vulnId": "CVE-100",
                             "source": "NVD",
+                            "cvssv2": 1.1,
                             "cvssv3": 10.0,
+                            "owaspRRBusinessImpact": 3.1,
+                            "owaspRRLikelihood": 3.2,
+                            "owaspRRTechnicalImpact": 3.3,
                             "severity": "CRITICAL",
-                            "cvssV3Vector": "cvssV3VectorOverwrite"
+                            "cvssV2Vector": "",
+                            "cvssV3Vector": "cvssV3VectorOverwrite",
+                            "owaspRRVector": "owaspRrVector"
                           },
                           "affectedProjects": [
                             {
@@ -475,9 +481,15 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                               "uuid": "${json-unit.matches:vulnUuid}",
                               "vulnId": "CVE-100",
                               "source": "NVD",
+                              "cvssv2": 1.1,
                               "cvssv3": 10.0,
+                              "owaspRRBusinessImpact": 3.1,
+                              "owaspRRLikelihood": 3.2,
+                              "owaspRRTechnicalImpact": 3.3,
                               "severity": "CRITICAL",
-                              "cvssV3Vector": "cvssV3VectorOverwrite"
+                              "cvssV2Vector": "",
+                              "cvssV3Vector": "cvssV3VectorOverwrite",
+                              "owaspRRVector": "owaspRrVector"
                             }
                           ]
                         }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -31,6 +31,7 @@ import jakarta.json.JsonValue;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
+import net.javacrumbs.jsonunit.core.Option;
 import org.apache.commons.lang3.function.TriFunction;
 import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
@@ -777,6 +778,8 @@ public class FindingResourceTest extends ResourceTest {
         Vulnerability v1 = createVulnerability("Vuln-1", Severity.CRITICAL);
         v1.setCvssV2BaseScore(BigDecimal.valueOf(0.2));
         v1.setCvssV2Vector("v-cvssV2-vector");
+        v1.setCvssV3BaseScore(BigDecimal.valueOf(9.8));
+        v1.setCvssV3Vector("v-cvssV3-vector");
         qm.addVulnerability(v1, c1, "none");
 
         var analysis = new Analysis();
@@ -788,17 +791,62 @@ public class FindingResourceTest extends ResourceTest {
         analysis.setSeverity(Severity.HIGH);
         qm.persist(analysis);
 
-        Response response = jersey.target(V1_FINDING + "/project/" + p1.getUuid().toString()).request()
+        final Response response = jersey
+                .target(V1_FINDING + "/project/" + p1.getUuid().toString())
+                .request()
                 .header(X_API_KEY, apiKey)
-                .get(Response.class);
-        assertEquals(200, response.getStatus(), 0);
-        assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
-        JsonArray json = parseJsonArray(response);
-        assertNotNull(json);
-        assertEquals(1, json.size());
-        assertEquals(0.4, json.getJsonObject(0).getJsonObject("vulnerability").getJsonNumber("cvssV2BaseScore").doubleValue(), 0);
-        assertEquals(analysis.getCvssV2Vector(), json.getJsonObject(0).getJsonObject("vulnerability").getString("cvssV2Vector"));
-        assertEquals(analysis.getSeverity().name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+        assertThatJson(getPlainTextBody(response))
+                .withOptions(Option.IGNORING_EXTRA_FIELDS)
+                .inPath("$[0].vulnerability")
+                .isEqualTo(/* language=JSON */ """
+                        {
+                          "cvssV2BaseScore": 0.4,
+                          "cvssV2Vector": "a-cvssV2-vector",
+                          "severity": "HIGH",
+                          "cvssV3BaseScore": 9.8,
+                          "cvssV3Vector": "v-cvssV3-vector"
+                        }
+                        """);
+    }
+
+    @Test
+    public void getFindingsByProjectWithVectorOnlyRatingOverride() {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        final Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
+        final Component c1 = createComponent(p1, "Component A", "1.0");
+        c1.setPurl("pkg:/maven/org.acme/component-a@1.0.0");
+
+        final Vulnerability v1 = createVulnerability("Vuln-1", Severity.CRITICAL);
+        v1.setCvssV3BaseScore(BigDecimal.valueOf(9.8));
+        v1.setCvssV3Vector("v-cvssV3-vector");
+        qm.addVulnerability(v1, c1, "none");
+
+        final var analysis = new Analysis();
+        analysis.setVulnerability(v1);
+        analysis.setComponent(c1);
+        analysis.setAnalysisState(AnalysisState.NOT_AFFECTED);
+        analysis.setCvssV3Vector("a-cvssV3-vector"); // Only vector, not score.
+        analysis.setSeverity(Severity.HIGH);
+        qm.persist(analysis);
+
+        final Response response = jersey
+                .target(V1_FINDING + "/project/" + p1.getUuid().toString())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+        final String body = getPlainTextBody(response);
+        assertThatJson(body)
+                .inPath("$[0].vulnerability.cvssV3Vector")
+                .isEqualTo("a-cvssV3-vector");
+        assertThatJson(body)
+                .inPath("$[0].vulnerability.cvssV3BaseScore")
+                .isAbsent();
     }
 
     @Test


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Resolves analysis rating overrides per method in findings and notifications.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #6210 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Effective CVSS / OWASP ratings on findings and notification subjects were gated by a single `ANALYSIS.SEVERITY IS NOT NULL` switch, so if an analysis set a severity, *all* rating columns were read from the analysis, otherwise all from the vulnerability.

This coupled independent rating families, so a policy that overrode only one method effectively "blanked" the others, and an override that left `SEVERITY` unset was silently never surfaced. This becomes problematic once we allow rating overrides from other sources, e.g. VEX.

Resolve each rating method independently instead, such that a CVSS (or OWASP) rating is taken from the analysis when that method's score *or* vector is present, and falls back to the vulnerability otherwise.

The score / vector of a method are switched together, so a method's vector and score can never be taken from different sources (e.g. an analysis vector shown against the vulnerability's score).

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
