### PR TITLE
Add server release version to the OpenAPI spec info block

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/OpenApiSpecEnricher.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/OpenApiSpecEnricher.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import java.io.IOException;
+
+/**
+ * Enriches an OpenAPI spec's {@code info} block with the server release version.
+ *
+ * <p>The OpenAPI {@code version} field is part of the API contract and is intentionally left
+ * untouched. Instead, the server version is appended to the {@code title} (so it is visible in
+ * frontends such as Swagger UI / Redocly, which ignore custom fields) and exposed as a
+ * machine-readable {@code x-server-version} extension.
+ *
+ * @see <a href="https://github.com/DependencyTrack/dependency-track/issues/6414">Issue 6414</a>
+ */
+public final class OpenApiSpecEnricher {
+
+    private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
+
+    private OpenApiSpecEnricher() {
+    }
+
+    /**
+     * Enriches the {@code info} block of the given spec with the server version.
+     *
+     * @param specYaml      the OpenAPI spec as YAML
+     * @param serverVersion the server release version (e.g. {@code 5.0.1})
+     * @return the enriched spec as YAML, or the spec unchanged when {@code serverVersion} is blank
+     * @throws IOException when the spec cannot be parsed
+     */
+    public static String enrich(final String specYaml, final String serverVersion) throws IOException {
+        if (serverVersion == null || serverVersion.isBlank()) {
+            return specYaml;
+        }
+
+        final JsonNode spec = YAML_MAPPER.readTree(specYaml);
+        if (spec instanceof ObjectNode specNode && specNode.get("info") instanceof ObjectNode info) {
+            final String title = info.path("title").asText("OWASP Dependency-Track");
+            info.put("title", title + " (Server v" + serverVersion + ")");
+            info.put("x-server-version", serverVersion);
+        }
+
+        return YAML_MAPPER.writeValueAsString(spec);
+    }
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/OpenApiResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/OpenApiResource.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.resources.v1;
 
+import alpine.model.About;
 import alpine.server.auth.AuthenticationNotRequired;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,6 +30,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.dependencytrack.resources.OpenApiSpecEnricher;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -109,7 +111,8 @@ public class OpenApiResource {
         try (final InputStream inputStream = OpenApiResource.class
                 .getResourceAsStream("/org/dependencytrack/api/v1/openapi.yaml")) {
             requireNonNull(inputStream, "OpenAPI spec not found on classpath");
-            return new String(inputStream.readAllBytes());
+            return OpenApiSpecEnricher.enrich(
+                    new String(inputStream.readAllBytes()), new About().getVersion());
         }
     }
 

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/OpenApiResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/OpenApiResource.java
@@ -18,12 +18,14 @@
  */
 package org.dependencytrack.resources.v2;
 
+import alpine.model.About;
 import alpine.server.auth.AuthenticationNotRequired;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import org.dependencytrack.resources.AbstractApiResource;
+import org.dependencytrack.resources.OpenApiSpecEnricher;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -71,7 +73,8 @@ public class OpenApiResource extends AbstractApiResource {
                      OpenApiResource.class.getResourceAsStream(
                              "/org/dependencytrack/api/v2/openapi.yaml")) {
             requireNonNull(inputStream, "inputStream must not be null");
-            return new String(inputStream.readAllBytes());
+            return OpenApiSpecEnricher.enrich(
+                    new String(inputStream.readAllBytes()), new About().getVersion());
         }
     }
 

--- a/apiserver/src/test/java/org/dependencytrack/resources/OpenApiSpecEnricherTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/OpenApiSpecEnricherTest.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.Test;
+
+class OpenApiSpecEnricherTest {
+
+    private static final String SPEC_YAML =
+            """
+            openapi: 3.0.1
+            info:
+              title: OWASP Dependency-Track API
+              version: 2.0.0
+            paths: {}
+            """;
+
+    @Test
+    void shouldAppendServerVersionToTitleAndAddExtensionWithoutChangingApiVersion() throws Exception {
+        final String enriched = OpenApiSpecEnricher.enrich(SPEC_YAML, "5.0.1");
+
+        final JsonNode info = new ObjectMapper(new YAMLFactory()).readTree(enriched).get("info");
+        assertThat(info.get("title").asText())
+                .isEqualTo("OWASP Dependency-Track API (Server v5.0.1)");
+        assertThat(info.get("x-server-version").asText()).isEqualTo("5.0.1");
+        assertThat(info.get("version").asText()).isEqualTo("2.0.0");
+    }
+
+    @Test
+    void shouldReturnSpecUnchangedWhenServerVersionIsBlank() throws Exception {
+        assertThat(OpenApiSpecEnricher.enrich(SPEC_YAML, null)).isEqualTo(SPEC_YAML);
+        assertThat(OpenApiSpecEnricher.enrich(SPEC_YAML, "   ")).isEqualTo(SPEC_YAML);
+    }
+}


### PR DESCRIPTION
### Description

Surfaces the server release version in the OpenAPI documents. The OpenAPI `version` field is part of the API contract and is intentionally left unchanged; instead, each spec's `info` block is enriched at load time with the server version appended to the `title` (visible in frontends such as Swagger UI / Redocly, which ignore custom fields) and exposed as a machine-readable `x-server-version` extension.

Example for `/api/v2/openapi.yaml`:

```yaml
info:
  title: OWASP Dependency-Track API (Server v5.0.1)
  version: 2.0.0
  x-server-version: 5.0.1
```

### Addressed Issue

Closes #6414

### Additional Details

Following the approach agreed in the issue, the enrichment is applied during the existing one-time spec load in both the v1 and v2 `OpenApiResource`, via a small reusable `OpenApiSpecEnricher`. The server version comes from `new About().getVersion()`; when it is unavailable the spec is returned unchanged. Unit tests cover the title / `x-server-version` enrichment and verify the API `version` is left untouched.

### Checklist

- [x] I have read and understand the contributing guidelines
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] ~This PR fixes a defect~
- [ ] ~This PR introduces changes to the database model~
- [ ] ~This PR alters existing behavior and requires documentation updates~ (no user-facing docs cover the OpenAPI `info` block)
- [ ] ~This PR is a substantial change per the ADR criteria~
