### PR TITLE
Only truncate tables between tests that have rows

### DIFF
--- a/apiserver/src/test/java/org/dependencytrack/PersistenceCapableTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/PersistenceCapableTest.java
@@ -66,17 +66,24 @@ public abstract class PersistenceCapableTest {
              final Statement statement = connection.createStatement()) {
             statement.execute("""
                     DO $$ DECLARE
-                        table_list TEXT;
+                      rec RECORD;
+                      has_rows BOOLEAN;
+                      table_list TEXT := '';
                     BEGIN
-                        SELECT STRING_AGG(QUOTE_IDENT(tablename), ', ')
-                          INTO table_list
+                      FOR rec IN
+                        SELECT tablename
                           FROM pg_tables
                          WHERE schemaname = CURRENT_SCHEMA()
-                           AND tablename != 'databasechangelog'
-                           AND tablename !~ '^.+schema_history$';
-                        IF table_list IS NOT NULL THEN
-                            EXECUTE 'TRUNCATE TABLE ' || table_list || ' CASCADE';
+                           AND tablename !~ '^.+schema_history$'
+                      LOOP
+                        EXECUTE 'SELECT EXISTS (SELECT 1 FROM ' || QUOTE_IDENT(rec.tablename) || ')' INTO has_rows;
+                        IF has_rows THEN
+                          table_list := table_list || QUOTE_IDENT(rec.tablename) || ', ';
                         END IF;
+                      END LOOP;
+                      IF LENGTH(table_list) > 0 THEN
+                        EXECUTE 'TRUNCATE TABLE ' || LEFT(table_list, -2) || ' CASCADE';
+                      END IF;
                     END $$;
                     """);
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Only truncates tables between tests that have rows.

Blindly calling `TRUNCATE ... CASCADE` on ~80 tables after every single tests is more expensive than initially assumed. Most tests only write to a handful of tables, so there are many redundant `TRUNCATE` calls.

Limiting `TRUNCATE` to only those tables that have at least one records yields a noticeable speed improvement when running the full test suite locally.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
