### PR TITLE
Eliminate more unnecessary wait times in tests

### DIFF
--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/support/Buffer.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/support/Buffer.java
@@ -189,6 +189,10 @@ public final class Buffer<T> implements Closeable {
         LOGGER.debug("{}: Closing", name);
         setStatus(Status.STOPPING);
 
+        // Wake up the flush thread so it sees stop being requested
+        // immediately instead of waiting for its interval to elapse.
+        boolean _ = flushRequestQueue.offer(true);
+
         if (flushThread.isAlive()) {
             LOGGER.debug("{}: Waiting for flush thread to stop", name);
             try {

--- a/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
+++ b/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
@@ -23,6 +23,8 @@ import io.smallrye.config.SmallRyeConfigBuilder;
 import org.dependencytrack.filestorage.api.FileStorage;
 import org.dependencytrack.filestorage.proto.v1.FileMetadata;
 import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
@@ -139,56 +141,54 @@ class S3FileStorageTest {
     @Nested
     class WhenHostIsUnavailable {
 
-        @Container
-        private final S3MockContainer ephemeralContainer =
-                new S3MockContainer("5.0.0")
-                        .withInitialBuckets("test");
+        private static S3MockContainer ephemeralContainer;
+        private static FileStorage storage;
+        private static FileMetadata storedFileMetadata;
 
-        @Test
-        void storeShouldThrowWhenHostIsUnavailable() throws Exception {
-            try (final FileStorage storage = createEphemeralStorage()) {
-                ephemeralContainer.stop();
+        @BeforeAll
+        static void beforeAll() throws Exception {
+            ephemeralContainer = new S3MockContainer("5.0.0").withInitialBuckets("test");
+            ephemeralContainer.start();
 
-                assertThatExceptionOfType(IOException.class)
-                        .isThrownBy(() -> storage.store("foo", new ByteArrayInputStream("bar".getBytes())));
-            }
-        }
-
-        @Test
-        void getShouldThrowWhenHostIsUnavailable() throws Exception {
-            try (final FileStorage storage = createEphemeralStorage()) {
-                final FileMetadata fileMetadata = storage.store("foo", new ByteArrayInputStream("bar".getBytes()));
-
-                ephemeralContainer.stop();
-
-                assertThatExceptionOfType(IOException.class)
-                        .isThrownBy(() -> storage.get(fileMetadata))
-                        .withRootCauseInstanceOf(ConnectException.class);
-            }
-        }
-
-        @Test
-        void deleteShouldThrowWhenHostIsUnavailable() throws Exception {
-            try (final FileStorage storage = createEphemeralStorage()) {
-                final FileMetadata fileMetadata = storage.store("foo", new ByteArrayInputStream("bar".getBytes()));
-
-                ephemeralContainer.stop();
-
-                assertThatExceptionOfType(IOException.class)
-                        .isThrownBy(() -> storage.delete(fileMetadata))
-                        .withRootCauseInstanceOf(ConnectException.class);
-            }
-        }
-
-        private FileStorage createEphemeralStorage() {
-            return createStorage(Map.ofEntries(
+            storage = createStorage(Map.ofEntries(
                     Map.entry("dt.file-storage.s3.endpoint", ephemeralContainer.getHttpEndpoint()),
                     Map.entry("dt.file-storage.s3.access-key", "foo"),
                     Map.entry("dt.file-storage.s3.secret-key", "bar"),
-                    Map.entry("dt.file-storage.s3.bucket", "test"),
-                    Map.entry("dt.file-storage.s3.connect-timeout-ms", "5000"),
-                    Map.entry("dt.file-storage.s3.read-timeout-ms", "5000"),
-                    Map.entry("dt.file-storage.s3.write-timeout-ms", "5000")));
+                    Map.entry("dt.file-storage.s3.bucket", "test")));
+
+            storedFileMetadata = storage.store("foo", new ByteArrayInputStream("bar".getBytes()));
+
+            ephemeralContainer.stop();
+        }
+
+        @AfterAll
+        static void afterAll() throws Exception {
+            if (storage != null) {
+                storage.close();
+            }
+            if (ephemeralContainer != null) {
+                ephemeralContainer.close();
+            }
+        }
+
+        @Test
+        void storeShouldThrowWhenHostIsUnavailable() {
+            assertThatExceptionOfType(IOException.class)
+                    .isThrownBy(() -> storage.store("foo", new ByteArrayInputStream("bar".getBytes())));
+        }
+
+        @Test
+        void getShouldThrowWhenHostIsUnavailable() {
+            assertThatExceptionOfType(IOException.class)
+                    .isThrownBy(() -> storage.get(storedFileMetadata))
+                    .withRootCauseInstanceOf(ConnectException.class);
+        }
+
+        @Test
+        void deleteShouldThrowWhenHostIsUnavailable() {
+            assertThatExceptionOfType(IOException.class)
+                    .isThrownBy(() -> storage.delete(storedFileMetadata))
+                    .withRootCauseInstanceOf(ConnectException.class);
         }
 
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Eliminate more unnecessary wait times in tests:

* Wakes up dex buffers when close is requested, to prevent every single test's `@AfterEach` having to wait up to 100ms per buffer for them to realize they should stop. This compounds the more dex tests we have.
* Uses a single shared testcontainer to test the "host unavailable" scenarios for the S3 file storage provider.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
