### PR TITLE
Leverage build cache for tests in CI

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -69,6 +69,15 @@ jobs:
           java-version: '25'
           cache: 'maven'
 
+      - name: Restore Maven build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # tag=v5.0.5
+        with:
+          path: ~/.m2/build-cache
+          key: maven-build-cache-test-${{ hashFiles('.mvn/maven-build-cache-config.xml') }}-${{ github.run_id }}
+          restore-keys: |
+            maven-build-cache-test-${{ hashFiles('.mvn/maven-build-cache-config.xml') }}-
+            maven-build-cache-test-
+
       - name: Execute unit tests
         env:
           TESTCONTAINERS_REUSE_ENABLE: "true"

--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -66,6 +66,36 @@
                         <goal>install</goal>
                     </goals>
                 </goalsList>
+
+                <!--
+                    Always run test goals to ensure that test coverage reporting in CI works:
+
+                      * The build cache doesn't include test classes and resources,
+                        so naively restoring from cache would cause surefire to find no tests to run.
+                      * We can't cache JaCoCo coverage reports because they'd go stale.
+                      * Running all tests is the only way to get accurate coverage reports
+                        across all modules.
+                -->
+                <goalsList artifactId="maven-resources-plugin">
+                    <goals>
+                        <goal>testResources</goal>
+                    </goals>
+                </goalsList>
+                <goalsList artifactId="maven-compiler-plugin">
+                    <goals>
+                        <goal>testCompile</goal>
+                    </goals>
+                </goalsList>
+                <goalsList artifactId="jacoco-maven-plugin">
+                    <goals>
+                        <goal>prepare-agent</goal>
+                    </goals>
+                </goalsList>
+                <goalsList artifactId="maven-surefire-plugin">
+                    <goals>
+                        <goal>test</goal>
+                    </goals>
+                </goalsList>
             </goalsLists>
         </runAlways>
     </executionControl>

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,6 @@ test:
 
 test-single:
 	$(MVND) $(MVN_FLAGS) test \
-		-Dmaven.build.cache.enabled=false \
 		-Dcheckstyle.skip \
 		-Dcyclonedx.skip \
 		-pl "$(MODULE)" \


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Leverages build cache for tests in CI.

Restores (and stores) the build cache for the `Test` job. Note that this only affects codegen and compilation (for now), not actual test execution. Tests and test coverage reporting always run.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
