### PR TITLE
Fix admin re-seeding when USER table is populated

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/DatabaseSeedingInitTask.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/DatabaseSeedingInitTask.java
@@ -195,11 +195,17 @@ public final class DatabaseSeedingInitTask implements InitTask {
     }
 
     public static void seedDefaultUsers(final Handle jdbiHandle) {
+        // Only seed the default 'admin' user when no users exist at all.
+        // Checking solely for an existing 'admin' username is not sufficient:
+        // an upgraded v4 instance whose admin user was renamed (e.g. to avoid
+        // collisions with OIDC users) would otherwise get a fresh 'admin' user
+        // with the default password, despite already having users. See #6392.
         final Optional<Long> adminUserId = jdbiHandle.createUpdate("""
                         INSERT INTO "USER" (
                           "TYPE", "USERNAME", "EMAIL", "PASSWORD", "LAST_PASSWORD_CHANGE"
                         , "FORCE_PASSWORD_CHANGE", "NON_EXPIRY_PASSWORD", "SUSPENDED")
-                        VALUES ('MANAGED', 'admin', 'admin@localhost', :password, NOW(), TRUE, TRUE, FALSE)
+                        SELECT 'MANAGED', 'admin', 'admin@localhost', :password, NOW(), TRUE, TRUE, FALSE
+                        WHERE NOT EXISTS (SELECT 1 FROM "USER")
                         ON CONFLICT ("USERNAME") DO NOTHING
                         RETURNING "ID"
                         """)
@@ -209,7 +215,7 @@ public final class DatabaseSeedingInitTask implements InitTask {
                 .findOne();
 
         if (adminUserId.isEmpty()) {
-            LOGGER.debug("Default 'admin' user already exists; skipping team/permission seeding");
+            LOGGER.debug("Users already exist; skipping default 'admin' user seeding");
             return;
         }
 

--- a/apiserver/src/test/java/org/dependencytrack/persistence/DatabaseSeedingInitTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/DatabaseSeedingInitTaskTest.java
@@ -145,6 +145,19 @@ public class DatabaseSeedingInitTaskTest extends PersistenceCapableTest {
     }
 
     @Test
+    public void testDoesNotSeedAdminWhenUsersAlreadyExist() throws Exception {
+        // Simulate an upgraded instance whose original 'admin' user was renamed
+        // (e.g. to "disabled__admin"), leaving the USER table populated but
+        // without a user named 'admin'. See #6392.
+        final var existingUser = qm.createManagedUser("disabled__admin", "hashed-password");
+
+        new DatabaseSeedingInitTask().execute(new InitTaskContext(ConfigProvider.getConfig(), dataSource));
+
+        final List<ManagedUser> users = qm.getManagedUsers();
+        assertThat(users).extracting(ManagedUser::getUsername).containsExactly(existingUser.getUsername());
+    }
+
+    @Test
     public void testLoadDefaultLicensesUpdatesExistingLicenses() throws Exception {
         final var license = new License();
         license.setLicenseId("LGPL-2.1+");


### PR DESCRIPTION
seedDefaultUsers checked only for an existing 'admin' username conflict. After a v4->v5 migration where the admin was renamed (e.g. to 'disabled__admin'), the table is populated but has no user named 'admin', causing a new MANAGED admin with the default password to be created unexpectedly.

Fix by replacing VALUES with SELECT...WHERE NOT EXISTS to skip seeding entirely when any user already exists. Retain ON CONFLICT DO NOTHING as a safety net for concurrent inserts.

Add a regression test covering the renamed-admin scenario.

Closes #6392

"

### Description

Fix admin re-seeding when USER table is already populated.
The seedDefaultUsers method only checked for a username conflict,
causing a new MANAGED admin to be created after v4->v5 migration
when the original admin was renamed (e.g. to 'disabled__admin').

### Addressed Issue

Closes #6392

### Additional Details

Changed the INSERT...VALUES to INSERT...SELECT...WHERE NOT EXISTS
to skip seeding entirely when any user already exists. Retained
ON CONFLICT DO NOTHING as a safety net for concurrent inserts.
Added a regression test covering the renamed-admin scenario.

### Checklist

- [x] I have read and understand the contributing guidelines
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] ~This PR implements an enhancement~
- [ ] ~This PR introduces changes to the database model~
- [ ] ~This PR introduces new or alters existing behavior~
- [ ] ~This PR is a substantial change~
