### PR TITLE
Fix bad CPE query performance for internal vuln analyzer

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/VulnerableSoftware.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/VulnerableSoftware.java
@@ -28,7 +28,6 @@ import javax.jdo.annotations.Element;
 import javax.jdo.annotations.Extension;
 import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
-import javax.jdo.annotations.Index;
 import javax.jdo.annotations.Join;
 import javax.jdo.annotations.Order;
 import javax.jdo.annotations.PersistenceCapable;
@@ -51,8 +50,6 @@ import java.util.UUID;
  */
 @PersistenceCapable
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Index(name = "VULNERABLESOFTWARE_CPE23_VERSION_RANGE_IDX", members = {"cpe23", "versionEndExcluding", "versionEndIncluding", "versionStartExcluding", "versionStartIncluding"})
-@Index(name = "VULNERABLESOFTWARE_PART_VENDOR_PRODUCT_IDX", members = {"part", "vendor", "product"})
 public class VulnerableSoftware implements ICpe, Serializable {
 
     private static final long serialVersionUID = -3987946408457131098L;

--- a/migration/src/main/resources/org/dependencytrack/migration/V202606171210__vulnerablesoftware_cpe_match_idx.sql
+++ b/migration/src/main/resources/org/dependencytrack/migration/V202606171210__vulnerablesoftware_cpe_match_idx.sql
@@ -1,0 +1,12 @@
+-- Restore index supporting internal CPE vulnerability matching.
+--
+-- V202605051201__drop_unused_vulnerablesoftware_indexes dropped VULNERABLESOFTWARE_CPE_PURL_PARTS_IDX,
+-- assuming a VULNERABLESOFTWARE_PART_VENDOR_PRODUCT_IDX existed to cover (PART, VENDOR, PRODUCT)
+-- lookups. That index only ever existed in the v4 schema and was never created here,
+-- so CPE matching was left with no usable index and sequentially scanned VULNERABLESOFTWARE on every batch.
+--
+-- NB: Index columns are specified from most selective to least selective.
+-- Conditional on "PART" which is never set for PURL rows.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "VULNERABLESOFTWARE_CPE_PRODUCT_VENDOR_PART_IDX"
+    ON "VULNERABLESOFTWARE" ("PRODUCT", "VENDOR", "PART")
+ WHERE "PART" IS NOT NULL;

--- a/migration/src/main/resources/org/dependencytrack/migration/V202606171210__vulnerablesoftware_cpe_match_idx.sql.conf
+++ b/migration/src/main/resources/org/dependencytrack/migration/V202606171210__vulnerablesoftware_cpe_match_idx.sql.conf
@@ -1,0 +1,1 @@
+executeInTransaction=false

--- a/support/flyway/src/main/java/org/dependencytrack/support/flyway/MigrationExecutor.java
+++ b/support/flyway/src/main/java/org/dependencytrack/support/flyway/MigrationExecutor.java
@@ -23,6 +23,7 @@ import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.jspecify.annotations.Nullable;
 
 import javax.sql.DataSource;
+import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
@@ -57,6 +58,14 @@ public class MigrationExecutor {
                 .cleanDisabled(true)
                 .placeholderReplacement(false)
                 .outOfOrder(outOfOrder)
+                // Acquire the migration lock via a session-level advisory lock instead of a
+                // transactional lock. Required for CREATE INDEX CONCURRENTLY to work.
+                // https://documentation.red-gate.com/fd/flyway-postgresql-transactional-lock-setting-277579114.html
+                //
+                // Note that our init task executors also use session-level locks for exactly
+                // this reason, and the user-facing contract clearly states that a direct DB
+                // connection is required for it (i.e., no PgBouncer in transaction mode).
+                .configuration(Map.of("flyway.postgresql.transactional.lock", "false"))
                 .loggers("slf4j");
         if (schemaHistoryTable != null) {
             config.table(schemaHistoryTable);

--- a/vuln-analysis/internal/src/main/java/org/dependencytrack/vulnanalysis/internal/CpeAttribute.java
+++ b/vuln-analysis/internal/src/main/java/org/dependencytrack/vulnanalysis/internal/CpeAttribute.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.internal;
+
+enum CpeAttribute {
+
+    PART,
+    VENDOR,
+    PRODUCT
+
+}

--- a/vuln-analysis/internal/src/main/java/org/dependencytrack/vulnanalysis/internal/CpeFilterCondition.java
+++ b/vuln-analysis/internal/src/main/java/org/dependencytrack/vulnanalysis/internal/CpeFilterCondition.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.internal;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+record CpeFilterCondition(CpeAttribute attribute, Operator operator, @Nullable String value) {
+
+    private enum Operator {
+
+        EQUALS("="),
+        IS_NOT("IS NOT");
+
+        private final String sql;
+
+        Operator(final String sql) {
+            this.sql = sql;
+        }
+
+    }
+
+    String toSql(String parameterName) {
+        return value != null
+                ? "\"%s\" %s :%s".formatted(attribute, operator.sql, parameterName)
+                : "\"%s\" %s NULL".formatted(attribute, operator.sql);
+    }
+
+    static List<CpeFilterCondition> of(CpeAttribute attribute, String attributeValue) {
+        final var conditions = new ArrayList<CpeFilterCondition>();
+
+        // The query composition below represents a partial implementation of the CPE
+        // matching logic. It makes references to table 6-2 of the CPE name matching
+        // specification: https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7696.pdf
+        //
+        // In CPE matching terms, the parameters of this method represent the target,
+        // and the `VulnerableSoftware`s in the database represent the source.
+        //
+        // While the source *can* contain wildcards ("*", "?"), there is currently (Oct. 2023)
+        // no occurrence of part, vendor, or product with wildcards in the NVD database.
+        // Evaluating wildcards in the source can only be done in-memory. If we wanted to do that,
+        // we'd have to fetch *all* records, which is not practical.
+
+        if (!"*".equals(attributeValue) && !"-".equals(attributeValue)) {
+            // | No. | Source A-V      | Target A-V | Relation             |
+            // | :-- | :-------------- | :--------- | :------------------- |
+            // | 3   | ANY             | i          | SUPERSET             |
+            // | 7   | NA              | i          | DISJOINT             |
+            // | 9   | i               | i          | EQUAL                |
+            // | 10  | i               | k          | DISJOINT             |
+            // | 14  | m1 + wild cards | m2         | SUPERSET or DISJOINT |
+            conditions.add(new CpeFilterCondition(attribute, CpeFilterCondition.Operator.EQUALS, "*"));
+            conditions.add(new CpeFilterCondition(attribute, CpeFilterCondition.Operator.EQUALS, attributeValue));
+
+            // NOTE: Target *could* include wildcard, but the relation
+            // for those cases is undefined:
+            //
+            // | No. | Source A-V      | Target A-V      | Relation   |
+            // | :-- | :-------------- | :-------------- | :--------- |
+            // | 4   | ANY             | m + wild cards  | undefined  |
+            // | 8   | NA              | m + wild cards  | undefined  |
+            // | 11  | i               | m + wild cards  | undefined  |
+            // | 17  | m1 + wild cards | m2 + wild cards | undefined  |
+        } else if ("-".equals(attributeValue)) {
+            // | No. | Source A-V     | Target A-V | Relation |
+            // | :-- | :------------- | :--------- | :------- |
+            // | 2   | ANY            | NA         | SUPERSET |
+            // | 6   | NA             | NA         | EQUAL    |
+            // | 12  | i              | NA         | DISJOINT |
+            // | 16  | m + wild cards | NA         | DISJOINT |
+            conditions.add(new CpeFilterCondition(attribute, CpeFilterCondition.Operator.EQUALS, "*"));
+            conditions.add(new CpeFilterCondition(attribute, CpeFilterCondition.Operator.EQUALS, "-"));
+        } else {
+            // | No. | Source A-V     | Target A-V | Relation |
+            // | :-- | :------------- | :--------- | :------- |
+            // | 1   | ANY            | ANY        | EQUAL    |
+            // | 5   | NA             | ANY        | SUBSET   |
+            // | 13  | i              | ANY        | SUBSET   |
+            // | 15  | m + wild cards | ANY        | SUBSET   |
+            conditions.add(new CpeFilterCondition(attribute, CpeFilterCondition.Operator.IS_NOT, null));
+        }
+
+        return conditions;
+    }
+
+}

--- a/vuln-analysis/internal/src/main/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzer.java
+++ b/vuln-analysis/internal/src/main/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzer.java
@@ -36,6 +36,7 @@ import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
 import org.dependencytrack.vulnanalysis.internal.Coordinate.CpeCoordinate;
 import org.dependencytrack.vulnanalysis.internal.Coordinate.PurlCoordinate;
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.Query;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +53,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Gatherers;
@@ -162,120 +164,173 @@ final class InternalVulnAnalyzer implements VulnAnalyzer {
     }
 
     private Map<Coordinate, List<MatchingCriteria>> queryCpeMatchingCriteria(List<CpeCoordinate> coordinates) {
-        final var parts = new String[coordinates.size()];
-        final var vendors = new String[coordinates.size()];
-        final var products = new String[coordinates.size()];
-        final var indexes = new int[coordinates.size()];
+        // Assemble multiple queries and join their results using UNION.
+        // This ensures that the database is able to leverage indexes properly,
+        // which use of OR can prevent from happening: https://dba.stackexchange.com/a/293838
+        //
+        // i.e., what usually would've been:
+        //   SELECT ... WHERE ("PART" = '*' OR "PART" = 'foo') ...
+        // now becomes:
+        //   SELECT ... WHERE "PART" = '*' ...
+        //   UNION
+        //   SELECT ... WHERE "PART" = 'foo' ...
+        final var queryBranches = new ArrayList<String>();
+        final var queryParams = new HashMap<String, Object>();
+        int queryConditionIdx = 0;
 
-        for (int i = 0; i < coordinates.size(); i++) {
-            final CpeCoordinate coordinate = coordinates.get(i);
-            parts[i] = coordinate.part();
-            vendors[i] = coordinate.vendor();
-            products[i] = coordinate.product();
-            indexes[i] = i;
+        for (int coordinateIdx = 0; coordinateIdx < coordinates.size(); coordinateIdx++) {
+            final CpeCoordinate coordinate = coordinates.get(coordinateIdx);
+            for (final var partCondition : CpeFilterCondition.of(CpeAttribute.PART, coordinate.part())) {
+                for (final var vendorCondition : CpeFilterCondition.of(CpeAttribute.VENDOR, coordinate.vendor())) {
+                    for (final var productCondition : CpeFilterCondition.of(CpeAttribute.PRODUCT, coordinate.product())) {
+                        final int idx = queryConditionIdx++;
+                        final var partParam = "part" + idx;
+                        final var vendorParam = "vendor" + idx;
+                        final var productParam = "product" + idx;
+
+                        queryBranches.add(/* language=SQL */ """
+                                SELECT "ID" AS vs_id
+                                     , %d AS coordinate_index
+                                  FROM "VULNERABLESOFTWARE"
+                                 WHERE %s
+                                   AND %s
+                                   AND %s\
+                                """.formatted(
+                                coordinateIdx,
+                                partCondition.toSql(partParam),
+                                vendorCondition.toSql(vendorParam),
+                                productCondition.toSql(productParam)));
+                        if (partCondition.value() != null) {
+                            queryParams.put(partParam, partCondition.value());
+                        }
+                        if (vendorCondition.value() != null) {
+                            queryParams.put(vendorParam, vendorCondition.value());
+                        }
+                        if (productCondition.value() != null) {
+                            queryParams.put(productParam, productCondition.value());
+                        }
+                    }
+                }
+            }
         }
 
-        // The query composition below represents a partial implementation of the CPE
-        // matching logic. It makes references to table 6-2 of the CPE name matching
-        // specification: https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7696.pdf
-        //
-        // In CPE matching terms, the parameters of this method represent the target,
-        // and the VULNERABLESOFTWARE records in the database represent the source.
-        //
-        // While the source *can* contain wildcards ("*", "?"), there is currently (Oct. 2023)
-        // no occurrence of part, vendor, or product with wildcards in the NVD database.
-        // Evaluating wildcards in the source can only be done in-memory. If we wanted to do that,
-        // we'd have to fetch *all* records, which is not practical.
-
-        return jdbi.withHandle(handle -> handle
-                .createQuery(/* language=SQL */ """
-                        SELECT vs.*
-                             , v."ID" AS vuln_db_id
-                             , v."VULNID" AS vuln_id
-                             , v."SOURCE" AS vuln_source
-                             , t.idx AS coordinate_index
-                          FROM UNNEST(:parts, :vendors, :products, :indexes)
-                            AS t(part, vendor, product, idx)
-                         INNER JOIN "VULNERABLESOFTWARE" AS vs
-                            ON (
-                                -- | No. | Source A-V     | Target A-V | Relation |
-                                -- | :-- | :------------- | :--------- | :------- |
-                                -- | 1   | ANY            | ANY        | EQUAL    |
-                                -- | 5   | NA             | ANY        | SUBSET   |
-                                -- | 13  | i              | ANY        | SUBSET   |
-                                -- | 15  | m + wild cards | ANY        | SUBSET   |
-                                (t.part = '*' AND vs."PART" IS NOT NULL)
-                                -- | No. | Source A-V      | Target A-V | Relation             |
-                                -- | :-- | :-------------- | :--------- | :------------------- |
-                                -- | 2   | ANY             | NA         | SUPERSET             |
-                                -- | 6   | NA              | NA         | EQUAL                |
-                                -- | 12  | i               | NA         | DISJOINT             |
-                                -- | 16  | m + wild cards  | NA         | DISJOINT             |
-                                -- | 3   | ANY             | i          | SUPERSET             |
-                                -- | 7   | NA              | i          | DISJOINT             |
-                                -- | 9   | i               | i          | EQUAL                |
-                                -- | 10  | i               | k          | DISJOINT             |
-                                -- | 14  | m1 + wild cards | m2         | SUPERSET or DISJOINT |
-                                OR vs."PART" IN ('*', t.part)
-                               )
-                           -- VENDOR and PRODUCT follow the same matching logic as PART above.
-                           AND ((t.vendor  = '*' AND vs."VENDOR" IS NOT NULL) OR vs."VENDOR" IN ('*', t.vendor))
-                           AND ((t.product = '*' AND vs."PRODUCT" IS NOT NULL) OR vs."PRODUCT" IN ('*', t.product))
-                         INNER JOIN "VULNERABLESOFTWARE_VULNERABILITIES" AS vsv
-                            ON vsv."VULNERABLESOFTWARE_ID" = vs."ID"
-                         INNER JOIN "VULNERABILITY" AS v
-                            ON v."ID" = vsv."VULNERABILITY_ID"
-                           AND v."REJECTED" IS NULL
-                        """)
-                .bind("parts", parts)
-                .bind("vendors", vendors)
-                .bind("products", products)
-                .bind("indexes", indexes)
-                .mapTo(MatchingCriteria.class)
-                .collect(Collectors.groupingBy(
-                        criteria -> coordinates.get(criteria.coordinateIndex()))));
+        return queryMatchingCriteria(
+                String.join("\nUNION ALL\n", queryBranches),
+                query -> query.bindMap(queryParams),
+                coordinates);
     }
 
     private Map<Coordinate, List<MatchingCriteria>> queryPurlMatchingCriteria(List<PurlCoordinate> coordinates) {
-        final var types = new String[coordinates.size()];
-        final var namespaces = new String[coordinates.size()];
-        final var names = new String[coordinates.size()];
-        final var indexes = new int[coordinates.size()];
+        // PURL namespace is nullable, and the naive `"PURL_NAMESPACE" IS NOT DISTINCT FROM ?`
+        // can't use BTree indexes. Postgres 18 shipped with Skip Scans which still leads to
+        // an index to be leveraged, but still in a suboptimal way.
+        //
+        // To combat this, we use a UNION query that branches on whether the coordinates
+        // have a `null` namespace. This allows explicit usage of `IS NULL` and `=`,
+        // which the query planner can use reliably for index scans.
+        //
+        // On contrast to the more complex CPE queries, the query branches here
+        // are still batched.
+
+        final var nsTypes = new ArrayList<String>();
+        final var namespaces = new ArrayList<String>();
+        final var nsNames = new ArrayList<String>();
+        final var nsIndexes = new ArrayList<Integer>();
+
+        final var nullNsTypes = new ArrayList<String>();
+        final var nullNsNames = new ArrayList<String>();
+        final var nullNsIndexes = new ArrayList<Integer>();
 
         for (int i = 0; i < coordinates.size(); i++) {
             final PurlCoordinate coordinate = coordinates.get(i);
-            types[i] = coordinate.type();
-            namespaces[i] = coordinate.namespace();
-            names[i] = coordinate.name();
-            indexes[i] = i;
+            if (coordinate.namespace() != null) {
+                nsTypes.add(coordinate.type());
+                namespaces.add(coordinate.namespace());
+                nsNames.add(coordinate.name());
+                nsIndexes.add(i);
+            } else {
+                nullNsTypes.add(coordinate.type());
+                nullNsNames.add(coordinate.name());
+                nullNsIndexes.add(i);
+            }
         }
 
-        return jdbi.withHandle(handle -> handle
-                .createQuery(/* language=SQL */ """
-                        SELECT vs.*
-                             , v."ID" AS vuln_db_id
-                             , v."VULNID" AS vuln_id
-                             , v."SOURCE" AS vuln_source
-                             , t.idx AS coordinate_index
-                          FROM UNNEST(:types, :namespaces, :names, :indexes)
-                            AS t(purl_type, purl_namespace, purl_name, idx)
-                         INNER JOIN "VULNERABLESOFTWARE" AS vs
-                            ON vs."PURL_TYPE" = t.purl_type
-                           AND vs."PURL_NAMESPACE" IS NOT DISTINCT FROM t.purl_namespace
-                           AND vs."PURL_NAME" = t.purl_name
-                         INNER JOIN "VULNERABLESOFTWARE_VULNERABILITIES" AS vsv
-                            ON vsv."VULNERABLESOFTWARE_ID" = vs."ID"
-                         INNER JOIN "VULNERABILITY" AS v
-                            ON v."ID" = vsv."VULNERABILITY_ID"
-                           AND v."REJECTED" IS NULL
-                        """)
-                .bind("types", types)
-                .bind("namespaces", namespaces)
-                .bind("names", names)
-                .bind("indexes", indexes)
-                .mapTo(MatchingCriteria.class)
-                .collect(Collectors.groupingBy(
-                        criteria -> coordinates.get(criteria.coordinateIndex()))));
+        final var queryBranches = new ArrayList<String>(2);
+
+        if (!nullNsIndexes.isEmpty()) {
+            queryBranches.add(/* language=SQL */ """
+                    SELECT vs."ID" AS vs_id
+                         , t.idx AS coordinate_index
+                      FROM UNNEST(:nullNsTypes, :nullNsNames, :nullNsIndexes)
+                        AS t(purl_type, purl_name, idx)
+                     INNER JOIN "VULNERABLESOFTWARE" AS vs
+                        ON vs."PURL_TYPE" = t.purl_type
+                       AND vs."PURL_NAMESPACE" IS NULL
+                       AND vs."PURL_NAME" = t.purl_name\
+                    """);
+        }
+
+        if (!nsIndexes.isEmpty()) {
+            queryBranches.add(/* language=SQL */ """
+                    SELECT vs."ID" AS vs_id
+                         , t.idx AS coordinate_index
+                      FROM UNNEST(:nsTypes, :nsNamespaces, :nsNames, :nsIndexes)
+                        AS t(purl_type, purl_namespace, purl_name, idx)
+                     INNER JOIN "VULNERABLESOFTWARE" AS vs
+                        ON vs."PURL_TYPE" = t.purl_type
+                       AND vs."PURL_NAMESPACE" = t.purl_namespace
+                       AND vs."PURL_NAME" = t.purl_name\
+                    """);
+        }
+
+        return queryMatchingCriteria(
+                String.join("\nUNION ALL\n", queryBranches),
+                query -> {
+                    if (!nullNsIndexes.isEmpty()) {
+                        query
+                                .bind("nullNsTypes", nullNsTypes.toArray(String[]::new))
+                                .bind("nullNsNames", nullNsNames.toArray(String[]::new))
+                                .bind("nullNsIndexes", nullNsIndexes.stream().mapToInt(Integer::intValue).toArray());
+                    }
+                    if (!nsIndexes.isEmpty()) {
+                        query
+                                .bind("nsTypes", nsTypes.toArray(String[]::new))
+                                .bind("nsNamespaces", namespaces.toArray(String[]::new))
+                                .bind("nsNames", nsNames.toArray(String[]::new))
+                                .bind("nsIndexes", nsIndexes.stream().mapToInt(Integer::intValue).toArray());
+                    }
+                },
+                coordinates);
+    }
+
+    private Map<Coordinate, List<MatchingCriteria>> queryMatchingCriteria(
+            String innerSql,
+            Consumer<Query> binder,
+            List<? extends Coordinate> coordinates) {
+        final String sql = /* language=SQL */ """
+                SELECT vs.*
+                     , v."ID" AS vuln_db_id
+                     , v."VULNID" AS vuln_id
+                     , v."SOURCE" AS vuln_source
+                     , m.coordinate_index
+                  FROM (%s) AS m
+                 INNER JOIN "VULNERABLESOFTWARE" AS vs
+                    ON vs."ID" = m.vs_id
+                 INNER JOIN "VULNERABLESOFTWARE_VULNERABILITIES" AS vsv
+                    ON vsv."VULNERABLESOFTWARE_ID" = vs."ID"
+                 INNER JOIN "VULNERABILITY" AS v
+                    ON v."ID" = vsv."VULNERABILITY_ID"
+                   AND v."REJECTED" IS NULL
+                """.formatted(innerSql);
+
+        return jdbi.withHandle(handle -> {
+            final Query query = handle.createQuery(sql);
+            binder.accept(query);
+            return query
+                    .mapTo(MatchingCriteria.class)
+                    .collect(Collectors.groupingBy(
+                            criteria -> coordinates.get(criteria.coordinateIndex())));
+        });
     }
 
     private void processCriteria(


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes bad CPE query performance for internal vuln analyzer.

Refactors the querying mechanism to align more with what we did in v4, namely spreading out queries over multiple `UNION`-ed subqueries that each individually would be able to be satisfiable using performant index scans.

Also resolved a lingering issue where Flyway would acquire a transactional advisory lock, which would prevent `CREATE INDEX CONCURRENTLY` from running.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #6436

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
