### PR TITLE
Implemented Banner Backend.

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
@@ -68,6 +68,7 @@ public enum ConfigPropertyConstants {
     CUSTOM_RISK_SCORE_UNASSIGNED("risk-score", "weight.unassigned", "5", PropertyType.INTEGER, "Unassigned severity vulnerability weight (between 1-10)", ConfigPropertyAccessMode.READ_WRITE),
     WELCOME_MESSAGE("general", "welcome.message.html", "%3Chtml%3E%3Ch1%3EYour%20Welcome%20Message%3C%2Fh1%3E%3C%2Fhtml%3E", PropertyType.STRING, "Custom HTML Code that is displayed before login", ConfigPropertyAccessMode.READ_WRITE, true),
     IS_WELCOME_MESSAGE("general", "welcome.message.enabled", "false", PropertyType.BOOLEAN, "Bool that says whether to show the welcome message or not", ConfigPropertyAccessMode.READ_WRITE, true),
+    BANNER_CONFIG("banner", "config", "{}", PropertyType.STRING, "JSON configuration for the application banner", ConfigPropertyAccessMode.READ_WRITE),
     DEFAULT_LANGUAGE("general", "default.locale", null, PropertyType.STRING, "Determine the default Language to use", ConfigPropertyAccessMode.READ_WRITE, true),
     TELEMETRY_SUBMISSION_ENABLED("telemetry", "submission.enabled", ConfigProvider.getConfig().getOptionalValue(ConfigKeys.TELEMETRY_SUBMISSION_DEFAULT_ENABLED, boolean.class).map(String::valueOf).orElse("true"), PropertyType.BOOLEAN, "Whether submission of telemetry data is enabled", ConfigPropertyAccessMode.READ_WRITE),
     TELEMETRY_LAST_SUBMISSION_DATA("telemetry", "last.submission.data", null, PropertyType.STRING, "Data of the last telemetry submission", ConfigPropertyAccessMode.READ_ONLY),


### PR DESCRIPTION
### Description
The backend implementation for the application banner is a public config property `banner/config`. The functionality is provided by the generic ConfigProperty endpoints. The JSON value is owned/sanitized by the frontend. 

### Addressed Issue
[1418](https://github.com/DependencyTrack/frontend/issues/1418)

### Additional Details
Corresponding frontend PR: [1612](https://github.com/DependencyTrack/frontend/pull/1612)

### Checklist
- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
