### PR TITLE
v4-migrator: Don't migrate obsolete notification groups for notification rules

### DIFF
--- a/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/TableRegistry.java
+++ b/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/TableRegistry.java
@@ -1584,7 +1584,22 @@ public final class TableRegistry {
              , r."NAME"
              , r."NOTIFICATION_LEVEL"
              , r."NOTIFY_CHILDREN"
-             , CASE WHEN r."NOTIFY_ON" IS NULL THEN NULL ELSE string_to_array(r."NOTIFY_ON", ',') END
+             -- Drop obsolete notification groups (e.g. INDEXING_SERVICE) that were valid in v4
+             -- but no longer exist in v5; leaving them would break enum deserialization at runtime.
+             -- Keep the value list in sync with
+             -- apiserver/src/main/java/org/dependencytrack/notification/NotificationGroup.java.
+             , CASE WHEN r."NOTIFY_ON" IS NULL THEN NULL ELSE ARRAY(
+                   SELECT elem
+                     FROM unnest(string_to_array(r."NOTIFY_ON", ',')) AS elem
+                    WHERE elem IN (
+                        'CONFIGURATION', 'DATASOURCE_MIRRORING', 'REPOSITORY', 'INTEGRATION',
+                        'FILE_SYSTEM', 'ANALYZER', 'NEW_VULNERABILITY', 'NEW_VULNERABLE_DEPENDENCY',
+                        'VULNERABILITY_RETRACTED', 'PROJECT_AUDIT_CHANGE', 'BOM_CONSUMED', 'BOM_PROCESSED',
+                        'BOM_PROCESSING_FAILED', 'BOM_VALIDATION_FAILED', 'VEX_CONSUMED', 'VEX_PROCESSED',
+                        'POLICY_VIOLATION', 'PROJECT_CREATED', 'USER_CREATED', 'USER_DELETED',
+                        'NEW_VULNERABILITIES_SUMMARY', 'NEW_POLICY_VIOLATIONS_SUMMARY'
+                    )
+               ) END
              , m.canonical_id
              , CASE p."EXTENSION_NAME" WHEN 'console' THEN NULL::jsonb WHEN 'email' THEN CASE WHEN COALESCE("%1$s".try_jsonb(r."PUBLISHER_CONFIG") ->> 'destination', '') = '' THEN jsonb_build_object('recipientAddresses', jsonb_build_array()) ELSE jsonb_build_object('recipientAddresses', jsonb_build_array("%1$s".try_jsonb(r."PUBLISHER_CONFIG") ->> 'destination')) END WHEN 'jira' THEN jsonb_build_object( 'projectKey', COALESCE("%1$s".try_jsonb(r."PUBLISHER_CONFIG") ->> 'destination', 'EXAMPLE'), 'issueType',  COALESCE("%1$s".try_jsonb(r."PUBLISHER_CONFIG") ->> 'jiraTicketType', 'TASK')) WHEN 'mattermost' THEN jsonb_build_object( 'destinationUrl', COALESCE("%1$s".try_jsonb(r."PUBLISHER_CONFIG") ->> 'destination', 'https://example.com')) WHEN 'msteams' THEN jsonb_build_object( 'destinationUrl', COALESCE("%1$s".try_jsonb(r."PUBLISHER_CONFIG") ->> 'destination', 'https://example.com')) WHEN 'slack' THEN jsonb_build_object( 'destinationUrl', COALESCE("%1$s".try_jsonb(r."PUBLISHER_CONFIG") ->> 'destination', 'https://example.com')) WHEN 'webex' THEN jsonb_build_object( 'destinationUrl', COALESCE("%1$s".try_jsonb(r."PUBLISHER_CONFIG") ->> 'destination', 'https://example.com')) WHEN 'webhook' THEN jsonb_build_object( 'destinationUrl', COALESCE("%1$s".try_jsonb(r."PUBLISHER_CONFIG") ->> 'destination', 'https://example.com')) ELSE NULL::jsonb END
              , r."SCOPE"

--- a/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/NotificationRuleStubIT.java
+++ b/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/NotificationRuleStubIT.java
@@ -87,7 +87,7 @@ class NotificationRuleStubIT {
                 )
                 VALUES (10, TRUE, TRUE, 'Hello', 'Good Rule',
                         'INFORMATIONAL', TRUE,
-                        'BOM_PROCESSED,NEW_VULNERABILITY', 1,
+                        'BOM_PROCESSED,INDEXING_SERVICE,NEW_VULNERABILITY', 1,
                         '{"destination": "https://hooks.slack.com/abc"}',
                         'PORTFOLIO',
                         'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
@@ -125,6 +125,20 @@ class NotificationRuleStubIT {
                         TIMESTAMP WITH TIME ZONE '2026-06-05 06:00:00+00',
                         TRUE)
                 """);
+            // Rule whose NOTIFY_ON contains only an obsolete group — must end up as an empty array.
+            h.execute("""
+                INSERT INTO "NOTIFICATIONRULE" (
+                    "ID", "ENABLED", "LOG_SUCCESSFUL_PUBLISH", "MESSAGE", "NAME",
+                    "NOTIFICATION_LEVEL", "NOTIFY_CHILDREN", "NOTIFY_ON", "PUBLISHER",
+                    "PUBLISHER_CONFIG", "SCOPE", "UUID"
+                )
+                VALUES (13, TRUE, TRUE, 'Obsolete', 'Obsolete Rule',
+                        'INFORMATIONAL', TRUE,
+                        'INDEXING_SERVICE', 1,
+                        '{"destination": "https://hooks.slack.com/obsolete"}',
+                        'PORTFOLIO',
+                        'dddddddd-dddd-dddd-dddd-dddddddddddd')
+                """);
         });
 
         runPipeline();
@@ -144,7 +158,7 @@ class NotificationRuleStubIT {
                      ORDER BY "ID"
                     """).mapToMap().list());
 
-        assertThat(rows).hasSize(3);
+        assertThat(rows).hasSize(4);
 
         final Map<String, Object> good = rows.get(0);
         assertThat(good).containsEntry("id", 10L)
@@ -187,6 +201,12 @@ class NotificationRuleStubIT {
             .isEqualTo(Instant.parse("2026-06-05T06:00:00Z"));
         assertThat((String[]) ((java.sql.Array) scheduled.get("notify_on")).getArray())
             .containsExactly("NEW_VULNERABILITIES_SUMMARY");
+
+        final Map<String, Object> obsolete = rows.get(3);
+        assertThat(obsolete).containsEntry("id", 13L)
+            .containsEntry("name", "Obsolete Rule");
+        assertThat((String[]) ((java.sql.Array) obsolete.get("notify_on")).getArray())
+            .isEmpty();
     }
 
     private void runPipeline() throws Exception {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Don't migrate obsolete notification groups for notification rules.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6437

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
