### PR TITLE
dex: Fix over-reporting of activity task queue depth metric

### DIFF
--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineMetricsCollector.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineMetricsCollector.java
@@ -150,7 +150,7 @@ final class DexEngineMetricsCollector implements Closeable {
                                  group by workflow_name
                                         , status
                                 """)
-                        .map((rs, ctx) -> MultiGauge.Row.of(
+                        .map((rs, _) -> MultiGauge.Row.of(
                                 Tags.of(
                                         Tag.of("workflowName", rs.getString(1)),
                                         Tag.of("status", rs.getString(2).toLowerCase())),
@@ -167,7 +167,7 @@ final class DexEngineMetricsCollector implements Closeable {
                                      , capacity
                                   from dex_workflow_task_queue
                                 """)
-                        .map((rs, ctx) -> MultiGauge.Row.of(
+                        .map((rs, _) -> MultiGauge.Row.of(
                                 Tags.of(Tag.of("queueName", rs.getString(1))),
                                 rs.getLong(2)))
                         .list());
@@ -181,7 +181,7 @@ final class DexEngineMetricsCollector implements Closeable {
                                   from dex_workflow_task
                                  group by queue_name
                                 """)
-                        .map((rs, ctx) -> MultiGauge.Row.of(
+                        .map((rs, _) -> MultiGauge.Row.of(
                                 Tags.of(Tag.of("queueName", rs.getString(1))),
                                 rs.getLong(2)))
                         .list());
@@ -196,7 +196,7 @@ final class DexEngineMetricsCollector implements Closeable {
                                      , capacity
                                   from dex_activity_task_queue
                                 """)
-                        .map((rs, ctx) -> MultiGauge.Row.of(
+                        .map((rs, _) -> MultiGauge.Row.of(
                                 Tags.of(Tag.of("queueName", rs.getString(1))),
                                 rs.getLong(2)))
                         .list());
@@ -208,9 +208,10 @@ final class DexEngineMetricsCollector implements Closeable {
                                 select queue_name
                                      , count(*)
                                   from dex_activity_task
+                                 where status = 'QUEUED'
                                  group by queue_name
                                 """)
-                        .map((rs, ctx) -> MultiGauge.Row.of(
+                        .map((rs, _) -> MultiGauge.Row.of(
                                 Tags.of(Tag.of("queueName", rs.getString(1))),
                                 rs.getLong(2)))
                         .list());

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineMetricsCollectorTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineMetricsCollectorTest.java
@@ -209,11 +209,11 @@ class DexEngineMetricsCollectorTest {
                     """);
 
             handle.execute("""
-                    insert into dex_activity_task(queue_name, workflow_run_id, created_event_id, activity_name, priority, retry_policy, created_at)
-                    values ('act-queue-a', 'a0000000-0000-0000-0000-000000000001', 1, 'act-a', 0, ''::bytea, now())
-                         , ('act-queue-a', 'a0000000-0000-0000-0000-000000000001', 2, 'act-a', 0, ''::bytea, now())
-                         , ('act-queue-a', 'a0000000-0000-0000-0000-000000000002', 1, 'act-a', 0, ''::bytea, now())
-                         , ('act-queue-b', 'a0000000-0000-0000-0000-000000000002', 2, 'act-b', 0, ''::bytea, now())
+                    insert into dex_activity_task(queue_name, workflow_run_id, created_event_id, activity_name, priority, retry_policy, status, created_at)
+                    values ('act-queue-a', 'a0000000-0000-0000-0000-000000000001', 1, 'act-a', 0, ''::bytea, 'QUEUED', now())
+                         , ('act-queue-a', 'a0000000-0000-0000-0000-000000000001', 2, 'act-a', 0, ''::bytea, 'QUEUED', now())
+                         , ('act-queue-a', 'a0000000-0000-0000-0000-000000000002', 1, 'act-a', 0, ''::bytea, 'CREATED', now())
+                         , ('act-queue-b', 'a0000000-0000-0000-0000-000000000002', 2, 'act-b', 0, ''::bytea, 'QUEUED', now())
                     """);
         });
 
@@ -234,7 +234,7 @@ class DexEngineMetricsCollectorTest {
 
                         assertThat(meterRegistry.get("dt.dex.engine.activity.task.queue.depth")
                                 .tag("queueName", "act-queue-a")
-                                .gauge().value()).isEqualTo(3.0);
+                                .gauge().value()).isEqualTo(2.0);
                         assertThat(meterRegistry.get("dt.dex.engine.activity.task.queue.depth")
                                 .tag("queueName", "act-queue-b")
                                 .gauge().value()).isEqualTo(1.0);


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

dex: Fixes over-reporting of activity task queue depth metric.

The corresponding metrics collector query was erroneously considering ALL rows per queue, but depth should be bounded by queue capacity (i.e. only tasks the scheduler actively queued). We have a separate backlog metric for task count beyond queue capacity.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
