### PR TITLE
Backport: Fix duplicate project name/version handling for /v1/project POST and PATCH endpoints

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -774,9 +774,6 @@ public class ProjectResource extends AbstractApiResource {
                             .status(Response.Status.CONFLICT)
                             .entity(e.getMessage())
                             .build());
-                } catch (RuntimeException e) {
-                    LOGGER.error("Failed to update project %s".formatted(jsonProject.getUuid()), e);
-                    throw new ServerErrorException(Response.Status.INTERNAL_SERVER_ERROR);
                 }
             });
 
@@ -943,16 +940,6 @@ public class ProjectResource extends AbstractApiResource {
                             .status(Response.Status.CONFLICT)
                             .entity(e.getMessage())
                             .build());
-                } catch (RuntimeException e) {
-                    if (isUniqueConstraintViolation(e)) {
-                        throw new ClientErrorException(Response
-                                .status(Response.Status.CONFLICT)
-                                .entity("A project with the specified name and version already exists.")
-                                .build());
-                    }
-
-                    LOGGER.error("Failed to patch project %s".formatted(uuid), e);
-                    throw new ServerErrorException(Response.Status.INTERNAL_SERVER_ERROR);
                 }
             });
 
@@ -967,6 +954,14 @@ public class ProjectResource extends AbstractApiResource {
                 LOGGER.info("Project {} updated by {}", updatedProject, super.getPrincipal().getName());
             }
             return Response.ok(updatedProject).build();
+        } catch (RuntimeException e) {
+            if (isUniqueConstraintViolation(e)) {
+                throw new ClientErrorException(Response
+                        .status(Response.Status.CONFLICT)
+                        .entity("A project with the specified name and version already exists.")
+                        .build());
+            }
+            throw e;
         }
     }
 

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -2527,6 +2527,56 @@ class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
+    void shouldReturnConflictWhenUpdatingChildProjectToDuplicateSibling() {
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_UPDATE);
+
+        final Project parent = qm.createProject("A", null, "1.0", null, null, null, null, false);
+        final Project child = qm.createProject("a", null, "a", null, parent, null, null, false);
+        qm.createProject("a", null, "b", null, parent, null, null, false);
+
+        final Response response = jersey
+                .target(V1_PROJECT)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "uuid": "%s",
+                          "name": "a",
+                          "version": "b",
+                          "parent": {
+                            "uuid": "%s"
+                          }
+                        }
+                        """.formatted(child.getUuid(), parent.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(409);
+        assertThat(getPlainTextBody(response))
+                .isEqualTo("A project with the specified name and version already exists.");
+    }
+
+    @Test
+    void shouldReturnConflictWhenPatchingChildProjectToDuplicateSibling() {
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_UPDATE);
+
+        final Project parent = qm.createProject("A", null, "1.0", null, null, null, null, false);
+        final Project child = qm.createProject("a", null, "a", null, parent, null, null, false);
+        qm.createProject("a", null, "b", null, parent, null, null, false);
+
+        final Response response = jersey
+                .target(V1_PROJECT + "/" + child.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
+                .method("PATCH", Entity.json(/* language=JSON */ """
+                        {
+                          "version": "b"
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(409);
+        assertThat(getPlainTextBody(response))
+                .isEqualTo("A project with the specified name and version already exists.");
+    }
+
+    @Test
     void updateProjectInaccessibleParentTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_UPDATE);
         enablePortfolioAccessControl();


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes duplicate project name/version handling for /v1/project POST and PATCH endpoints.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6405
Backports #6445

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
