### PR TITLE
Backport: Fix MIME type of email notification templates not being set correctly

### DIFF
--- a/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/email/EmailNotificationPublisher.java
+++ b/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/email/EmailNotificationPublisher.java
@@ -23,9 +23,7 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
 import jakarta.mail.Transport;
 import jakarta.mail.internet.InternetAddress;
-import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
-import jakarta.mail.internet.MimeMultipart;
 import org.dependencytrack.notification.api.publishing.NotificationPublishContext;
 import org.dependencytrack.notification.api.publishing.NotificationPublisher;
 import org.dependencytrack.notification.api.publishing.NotificationRuleContact;
@@ -37,6 +35,7 @@ import org.eclipse.angus.mail.util.MailConnectException;
 
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
@@ -87,14 +86,8 @@ final class EmailNotificationPublisher implements NotificationPublisher {
             final var message = new MimeMessage(session);
             message.setFrom(new InternetAddress(senderAddress));
             message.setRecipients(Message.RecipientType.TO, recipients);
-            message.setSubject(messageSubject);
-
-            final var bodyPart = new MimeBodyPart();
-            bodyPart.setText(renderedTemplate.content());
-
-            final var multipart = new MimeMultipart();
-            multipart.addBodyPart(bodyPart);
-            message.setContent(multipart, renderedTemplate.mimeType());
+            message.setSubject(messageSubject, StandardCharsets.UTF_8.name());
+            message.setContent(renderedTemplate.content(), renderedTemplate.mimeType());
 
             Transport.send(message);
         } catch (MessagingException e) {

--- a/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/email/EmailNotificationPublisherFactory.java
+++ b/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/email/EmailNotificationPublisherFactory.java
@@ -174,7 +174,7 @@ public final class EmailNotificationPublisherFactory implements NotificationPubl
 
     @Override
     public NotificationTemplate defaultTemplate() {
-        return new NotificationTemplate(loadDefaultTemplate(extensionClass()), "text/plain");
+        return new NotificationTemplate(loadDefaultTemplate(extensionClass()), "text/plain; charset=utf-8");
     }
 
     private Session createSession(EmailNotificationPublisherGlobalConfigV1 config) {

--- a/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/email/EmailNotificationPublisherTest.java
+++ b/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/email/EmailNotificationPublisherTest.java
@@ -22,13 +22,16 @@ import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.util.ServerSetup;
 import jakarta.mail.Address;
 import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
-import jakarta.mail.internet.MimeMultipart;
+import org.dependencytrack.notification.api.publishing.NotificationPublishContext;
 import org.dependencytrack.notification.api.publishing.NotificationPublisherFactory;
+import org.dependencytrack.notification.api.templating.NotificationTemplate;
+import org.dependencytrack.notification.api.templating.NotificationTemplateRenderer;
 import org.dependencytrack.notification.proto.v1.Notification;
 import org.dependencytrack.notification.publishing.AbstractNotificationPublisherTest;
+import org.dependencytrack.notification.templating.pebble.PebbleNotificationTemplateRendererFactory;
 import org.dependencytrack.plugin.api.config.RuntimeConfig;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
@@ -40,6 +43,7 @@ import java.util.Set;
 
 import static com.icegreen.greenmail.configuration.GreenMailConfiguration.aConfig;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.notification.api.TestNotificationFactory.createBomConsumedTestNotification;
 
 class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
 
@@ -108,7 +112,7 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
                 
                 --------------------------------------------------------------------------------
                 
-                2006-06-06T06:06:06.666Z
+                2006-06-06T06:06:06.666Z\
                 """);
     }
 
@@ -137,7 +141,7 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
                 
                 --------------------------------------------------------------------------------
                 
-                2006-06-06T06:06:06.666Z
+                2006-06-06T06:06:06.666Z\
                 """);
     }
 
@@ -170,7 +174,7 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
                 
                 --------------------------------------------------------------------------------
                 
-                2006-06-06T06:06:06.666Z
+                2006-06-06T06:06:06.666Z\
                 """);
     }
 
@@ -203,7 +207,7 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
                 
                 --------------------------------------------------------------------------------
                 
-                2006-06-06T06:06:06.666Z
+                2006-06-06T06:06:06.666Z\
                 """);
     }
 
@@ -238,7 +242,7 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
                 
                 --------------------------------------------------------------------------------
                 
-                2006-06-06T06:06:06.666Z
+                2006-06-06T06:06:06.666Z\
                 """);
     }
 
@@ -289,7 +293,7 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
                 
                 --------------------------------------------------------------------------------
                 
-                2006-06-06T06:06:06.666Z
+                2006-06-06T06:06:06.666Z\
                 """);
     }
 
@@ -340,7 +344,35 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
                 
                 --------------------------------------------------------------------------------
                 
-                2006-06-06T06:06:06.666Z
+                2006-06-06T06:06:06.666Z\
+                """);
+    }
+
+    @Test
+    void shouldSendHtmlBodyWhenTemplateMimeTypeIsHtml() throws Exception {
+        final var htmlTemplate = new NotificationTemplate(/* language=HTML */ """
+                <html><body><p>{{ notification.title }}</p></body></html>\
+                """,
+                "text/html; charset=utf-8");
+        final NotificationTemplateRenderer htmlRenderer =
+                new PebbleNotificationTemplateRendererFactory(
+                        Map.of("baseUrl", () -> "https://example.com"))
+                        .createRenderer(htmlTemplate);
+        final var publishCtx =
+                new NotificationPublishContext(
+                        publishContext.ruleConfig(),
+                        htmlRenderer);
+
+        publisher.publish(publishCtx, createBomConsumedTestNotification());
+
+        final MimeMessage[] messages = GREEN_MAIL.getReceivedMessages();
+        assertThat(messages).hasSize(1);
+
+        final MimeMessage message = messages[0];
+        assertThat(message.getContentType()).isEqualToIgnoringCase("text/html; charset=utf-8");
+        assertThat(message.isMimeType("text/html")).isTrue();
+        assertThat((String) message.getContent()).isEqualTo(/* language=HTML */ """
+                <html><body><p>Bill of Materials Consumed</p></body></html>\
                 """);
     }
 
@@ -353,11 +385,7 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
 
         try {
             final MimeMessage message = messages[0];
-            assertThat(message.getContent()).isInstanceOf(MimeMultipart.class);
-
-            final MimeMultipart content = (MimeMultipart) message.getContent();
-            assertThat(content.getCount()).isEqualTo(1);
-            assertThat(content.getBodyPart(0)).isInstanceOf(MimeBodyPart.class);
+            assertThat(message.isMimeType("text/plain")).isTrue();
 
             final Address[] from = message.getFrom();
             return new ReceivedMessage(
@@ -365,7 +393,7 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
                             ? Arrays.stream(from).map(Address::toString).toList()
                             : List.of(),
                     message.getSubject(),
-                    (String) content.getBodyPart(0).getContent());
+                    (String) message.getContent());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         } catch (MessagingException e) {


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes MIME type of email notification templates not being set correctly.

Turns out the whole multipart dance is a wash, since we only ever support a single representation of an email. Setting the content directly on the `MimeMessage` object resolves the issue and is easier to understand as well.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6452
Backports #6454 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
