### PR TITLE
Optimize portfolio-wide findings queries

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -42,7 +42,7 @@ import java.util.UUID;
 
 import static org.dependencytrack.resources.v1.FindingResource.mapComponentLatestVersion;
 
-public interface FindingDao {
+public interface FindingDao extends PaginationSupport {
 
     record FindingRow(
             UUID projectUuid,
@@ -313,20 +313,39 @@ public interface FindingDao {
             @Bind BigDecimal epssFrom,
             @Bind BigDecimal epssTo);
 
-    default List<Finding> getFindings(final long projectId, final boolean includeSuppressed) {
-        List<FindingRow> findingRows = getFindingsByProject(
-                projectId,
-                /* includeInactive */ false,
-                includeSuppressed,
-                /* searchText */ null,
-                /* hasAnalysis */ null,
-                /* source */ null,
-                /* epssFrom */ null,
-                /* epssTo */ null);
+    default List<Finding> getFindings(long projectId, boolean includeSuppressed) {
+        // NB: JIT is disabled explicitly because it tends to take >=50% of query planning and
+        // execution time. JIT is almost always detrimental to query performance here.
+        List<FindingRow> findingRows = withJitDisabled(
+                () -> getFindingsByProject(
+                        projectId,
+                        /* includeInactive */ false,
+                        includeSuppressed,
+                        /* searchText */ null,
+                        /* hasAnalysis */ null,
+                        /* source */ null,
+                        /* epssFrom */ null,
+                        /* epssTo */ null));
         List<Finding> findings = findingRows.stream().map(Finding::new).toList();
         return mapComponentLatestVersion(findings);
     }
 
+    /// Queries all findings across the entire portfolio.
+    ///
+    /// The query is split into an inner `page` CTE that resolves only the row
+    /// identity plus the columns needed for filtering and ordering, and an outer
+    /// `SELECT` that enriches just the paginated rows with the expensive columns
+    /// (e.g. aliases, EPSS, descriptions, vectors).
+    /// This keeps `COUNT(*) OVER()` and all enrichment off the full, pre-pagination row set.
+    ///
+    /// EPSS is only resolved before pagination when needed. An EPSS score filter is
+    /// pushed down as an `EXISTS`, while EPSS ordering or an EPSS percentile filter
+    /// joins a per-vulnerability `epss_dedup` CTE. Otherwise, EPSS is resolved only
+    /// during enrichment of the paginated rows.
+    ///
+    /// Note: every `queryName` in [AllowApiOrdering] must resolve in **both**
+    /// the inner `page` CTE **and** the outer `SELECT`, because the ordering clause
+    /// is applied at both levels.
     @SqlQuery(/* language=InjectedFreeMarker */ """
             <#-- @ftlvariable name="apiProjectAclCondition" type="String" -->
             <#-- @ftlvariable name="apiOrderByClause" type="String" -->
@@ -335,6 +354,149 @@ public interface FindingDao {
             <#-- @ftlvariable name="includeInactiveFindings" type="Boolean" -->
             <#-- @ftlvariable name="suppressedFilter" type="Boolean" -->
             <#-- @ftlvariable name="apiOffsetLimitClause" type="String" -->
+            <#-- @ftlvariable name="epssInPage" type="boolean" -->
+            <#-- @ftlvariable name="epssScoreFrom" type="boolean" -->
+            <#-- @ftlvariable name="epssScoreTo" type="boolean" -->
+            <#macro epssCandidates vulnSource vulnId>
+                SELECT ee."CVE"
+                     , ee."SCORE"
+                     , ee."PERCENTILE"
+                  FROM "EPSS" AS ee
+                 WHERE ${vulnSource} = 'NVD'
+                   AND ee."CVE" = ${vulnId}
+                UNION ALL
+                SELECT ee."CVE"
+                     , ee."SCORE"
+                     , ee."PERCENTILE"
+                  FROM "VULNERABILITY_ALIAS" AS va
+                 INNER JOIN "VULNERABILITY_ALIAS" AS cve_a
+                    ON cve_a."GROUP_ID" = va."GROUP_ID"
+                   AND cve_a."SOURCE" = 'NVD'
+                 INNER JOIN "EPSS" AS ee
+                    ON ee."CVE" = cve_a."VULN_ID"
+                 WHERE ${vulnSource} != 'NVD'
+                   AND va."SOURCE" = ${vulnSource}
+                   AND va."VULN_ID" = ${vulnId}
+            </#macro>
+            <#macro epssBestRow vulnSource vulnId>
+                SELECT "SCORE"
+                     , "PERCENTILE"
+                  FROM (
+                    <@epssCandidates vulnSource=vulnSource vulnId=vulnId/>
+                  ) AS candidates
+                 ORDER BY "SCORE" DESC NULLS LAST
+                        , "PERCENTILE" DESC NULLS LAST
+                        , "CVE"
+                 LIMIT 1
+            </#macro>
+            WITH
+            <#if epssInPage>
+            epss_dedup AS (
+              SELECT dv."ID" AS "vulnerabilityId"
+                   , ep."SCORE"
+                   , ep."PERCENTILE"
+                FROM (
+                  SELECT DISTINCT
+                         v."ID"
+                       , v."SOURCE"
+                       , v."VULNID"
+                    FROM "VULNERABILITY" AS v
+                   WHERE v."ID" IN (
+                     SELECT "VULNERABILITY_ID"
+                       FROM "COMPONENTS_VULNERABILITIES"
+                   )
+                ) AS dv
+                LEFT JOIN LATERAL (
+                  <@epssBestRow vulnSource='dv."SOURCE"' vulnId='dv."VULNID"'/>
+                ) AS ep ON TRUE
+            ),
+            </#if>
+            page AS (
+              SELECT c."ID" AS "componentId"
+                   , v."ID" AS "vulnerabilityId"
+                   , COALESCE(a."SEVERITY", v."SEVERITY") AS "vulnSeverity"
+                   , CASE
+                       WHEN a."CVSSV2SCORE" IS NOT NULL OR a."CVSSV2VECTOR" IS NOT NULL
+                       THEN a."CVSSV2SCORE"
+                       ELSE v."CVSSV2BASESCORE"
+                     END AS "cvssV2BaseScore"
+                   , CASE
+                       WHEN a."CVSSV3SCORE" IS NOT NULL OR a."CVSSV3VECTOR" IS NOT NULL
+                       THEN a."CVSSV3SCORE"
+                       ELSE v."CVSSV3BASESCORE"
+                     END AS "cvssV3BaseScore"
+                   , CASE
+                       WHEN a."CVSSV4SCORE" IS NOT NULL OR a."CVSSV4VECTOR" IS NOT NULL
+                       THEN a."CVSSV4SCORE"
+                       ELSE v."CVSSV4SCORE"
+                     END AS "cvssV4Score"
+            <#if epssInPage>
+                   , ed."SCORE" AS "epssScore"
+                   , ed."PERCENTILE" AS "epssPercentile"
+            </#if>
+                   , COUNT(*) OVER() AS "totalCount"
+                FROM "COMPONENT" AS c
+               INNER JOIN "COMPONENTS_VULNERABILITIES" AS cv
+                  ON c."ID" = cv."COMPONENT_ID"
+               INNER JOIN "VULNERABILITY" AS v
+                  ON cv."VULNERABILITY_ID" = v."ID"
+               INNER JOIN LATERAL (
+                 SELECT *
+                   FROM "FINDINGATTRIBUTION" AS fa
+                  WHERE c."ID" = fa."COMPONENT_ID"
+                    AND v."ID" = fa."VULNERABILITY_ID"
+            <#if !includeInactiveFindings>
+                    AND fa."DELETED_AT" IS NULL
+            </#if>
+                  ORDER BY fa."DELETED_AT" DESC NULLS FIRST
+                         , fa."ID"
+                  LIMIT 1
+               ) AS fa ON TRUE
+            <#if epssInPage>
+                LEFT JOIN epss_dedup AS ed
+                  ON ed."vulnerabilityId" = v."ID"
+            </#if>
+                LEFT JOIN "ANALYSIS" AS a
+                  ON c."ID" = a."COMPONENT_ID"
+                 AND v."ID" = a."VULNERABILITY_ID"
+                 AND c."PROJECT_ID" = a."PROJECT_ID"
+               INNER JOIN "PROJECT" AS p
+                  ON c."PROJECT_ID" = p."ID"
+               WHERE ${apiProjectAclCondition}
+            <#if !activeFilter>
+                 AND p."INACTIVE_SINCE" IS NULL
+            </#if>
+            <#if !suppressedFilter>
+                 AND a."SUPPRESSED" IS DISTINCT FROM TRUE
+            </#if>
+            <#if epssScoreFrom || epssScoreTo>
+                 AND EXISTS (
+                   SELECT 1
+                     FROM (
+                       <@epssCandidates vulnSource='v."SOURCE"' vulnId='v."VULNID"'/>
+                     ) AS candidates
+                   HAVING
+            <#if epssScoreFrom>
+                     MAX(candidates."SCORE") >= :epssScoreFrom
+            </#if>
+            <#if epssScoreFrom && epssScoreTo>
+                     AND
+            </#if>
+            <#if epssScoreTo>
+                     MAX(candidates."SCORE") <= :epssScoreTo
+            </#if>
+                 )
+            </#if>
+            <#if queryFilter??>
+                 ${queryFilter}
+            </#if>
+            <#if apiOrderByClause??>
+               ${apiOrderByClause}
+            <#else>
+               ORDER BY c."ID", v."ID"
+            </#if>
+               ${apiOffsetLimitClause!}
+            )
             SELECT p."UUID" AS "projectUuid"
                  , p."NAME" AS "projectName"
                  , p."VERSION" AS "projectVersion"
@@ -410,50 +572,31 @@ public interface FindingDao {
                  , COALESCE(a."SEVERITY", v."SEVERITY") AS "vulnSeverity"
                  , CAST(STRING_TO_ARRAY(v."CWES", ',') AS INT[]) AS "CWES"
                  , JSONB_VULN_ALIASES(v."SOURCE", v."VULNID") AS "vulnAliasesJson"
+            <#if epssInPage>
+                 , page."epssScore"
+                 , page."epssPercentile"
+            <#else>
                  , ep."SCORE" AS "epssScore"
                  , ep."PERCENTILE" AS "epssPercentile"
+            </#if>
                  , fa."ANALYZERIDENTITY"
                  , fa."ATTRIBUTED_ON"
                  , fa."ALT_ID"
                  , fa."REFERENCE_URL"
                  , a."STATE" AS "analysisState"
                  , a."SUPPRESSED"
-                 , COUNT(*) OVER() AS "totalCount"
-              FROM "COMPONENT" AS c
-             INNER JOIN "COMPONENTS_VULNERABILITIES" AS cv
-                ON c."ID" = cv."COMPONENT_ID"
+                 , page."totalCount"
+              FROM page
+             INNER JOIN "COMPONENT" AS c
+                ON c."ID" = page."componentId"
              INNER JOIN "VULNERABILITY" AS v
-                ON cv."VULNERABILITY_ID" = v."ID"
-             LEFT JOIN LATERAL (
-                SELECT "CVE"
-                     , "SCORE"
-                     , "PERCENTILE"
-                  FROM (
-                    SELECT ee."CVE"
-                         , ee."SCORE"
-                         , ee."PERCENTILE"
-                      FROM "EPSS" AS ee
-                     WHERE v."SOURCE" = 'NVD'
-                       AND ee."CVE" = v."VULNID"
-                    UNION ALL
-                    SELECT ee."CVE"
-                         , ee."SCORE"
-                         , ee."PERCENTILE"
-                      FROM "VULNERABILITY_ALIAS" AS va
-                     INNER JOIN "VULNERABILITY_ALIAS" AS cve_a
-                        ON cve_a."GROUP_ID" = va."GROUP_ID"
-                       AND cve_a."SOURCE" = 'NVD'
-                     INNER JOIN "EPSS" AS ee
-                        ON ee."CVE" = cve_a."VULN_ID"
-                     WHERE v."SOURCE" != 'NVD'
-                       AND va."SOURCE" = v."SOURCE"
-                       AND va."VULN_ID" = v."VULNID"
-                  ) candidates
-                 ORDER BY "SCORE" DESC NULLS LAST
-                        , "PERCENTILE" DESC NULLS LAST
-                        , "CVE"
-                 LIMIT 1
-             ) AS ep ON TRUE
+                ON v."ID" = page."vulnerabilityId"
+             INNER JOIN "PROJECT" AS p
+                ON c."PROJECT_ID" = p."ID"
+              LEFT JOIN "ANALYSIS" AS a
+                ON c."ID" = a."COMPONENT_ID"
+               AND v."ID" = a."VULNERABILITY_ID"
+               AND c."PROJECT_ID" = a."PROJECT_ID"
              INNER JOIN LATERAL (
                SELECT *
                  FROM "FINDINGATTRIBUTION" AS fa
@@ -466,28 +609,16 @@ public interface FindingDao {
                        , fa."ID"
                 LIMIT 1
              ) AS fa ON TRUE
-              LEFT JOIN "ANALYSIS" AS a
-                ON c."ID" = a."COMPONENT_ID"
-               AND v."ID" = a."VULNERABILITY_ID"
-               AND c."PROJECT_ID" = a."PROJECT_ID"
-             INNER JOIN "PROJECT" AS p
-                ON c."PROJECT_ID" = p."ID"
-             WHERE ${apiProjectAclCondition}
-             <#if !activeFilter>
-                AND p."INACTIVE_SINCE" IS NULL
-             </#if>
-             <#if !suppressedFilter>
-                AND a."SUPPRESSED" IS DISTINCT FROM TRUE
-             </#if>
-             <#if queryFilter??>
-                ${queryFilter}
-             </#if>
-             <#if apiOrderByClause??>
+            <#if !epssInPage>
+              LEFT JOIN LATERAL (
+                <@epssBestRow vulnSource='v."SOURCE"' vulnId='v."VULNID"'/>
+              ) AS ep ON TRUE
+            </#if>
+            <#if apiOrderByClause??>
               ${apiOrderByClause}
-             <#else>
+            <#else>
               ORDER BY c."ID", v."ID"
-             </#if>
-             ${apiOffsetLimitClause!}
+            </#if>
             """)
     @AllowApiOrdering(alwaysBy = @AllowApiOrdering.AlwaysBy(queryName = "c.\"ID\", v.\"ID\""), by = {
             @AllowApiOrdering.Column(name = "vulnerability.title", queryName = "v.\"TITLE\""),
@@ -496,6 +627,8 @@ public interface FindingDao {
             @AllowApiOrdering.Column(name = "vulnerability.cvssV4Score", queryName = "\"cvssV4Score\""),
             @AllowApiOrdering.Column(name = "vulnerability.cvssV3BaseScore", queryName = "\"cvssV3BaseScore\""),
             @AllowApiOrdering.Column(name = "vulnerability.cvssV2BaseScore", queryName = "\"cvssV2BaseScore\""),
+            @AllowApiOrdering.Column(name = "vulnerability.epssScore", queryName = "\"epssScore\""),
+            @AllowApiOrdering.Column(name = "vulnerability.epssPercentile", queryName = "\"epssPercentile\""),
             @AllowApiOrdering.Column(name = "vulnerability.published", queryName = "v.\"PUBLISHED\""),
             @AllowApiOrdering.Column(name = "attribution.analyzerIdentity", queryName = "fa.\"ANALYZERIDENTITY\""),
             @AllowApiOrdering.Column(name = "component.projectName", queryName = "concat(p.\"NAME\", ' ', p.\"VERSION\")"),
@@ -509,32 +642,114 @@ public interface FindingDao {
     @AllowUnusedBindings
     @DefineApiProjectAclCondition(projectIdColumn = "p.\"ID\"")
     @RegisterConstructorMapper(FindingRow.class)
-    List<FindingRow> getAllFindings(@Define String queryFilter,
-                                    @Define boolean activeFilter,
-                                    @Define boolean includeInactiveFindings,
-                                    @Define boolean suppressedFilter,
-                                    @BindMap Map<String, Object> params);
+    List<FindingRow> getAllFindings(
+            @Define String queryFilter,
+            @Define boolean activeFilter,
+            @Define boolean includeInactiveFindings,
+            @Define boolean suppressedFilter,
+            @Define boolean epssInPage,
+            @Bind BigDecimal epssScoreFrom,
+            @Bind BigDecimal epssScoreTo,
+            @BindMap Map<String, Object> params);
 
     /**
      * Returns a List of all Finding objects filtered by ACL and other optional filters.
+     *
      * @param filters        determines the filters to apply on the list of Finding objects
      * @param showSuppressed determines if suppressed vulnerabilities should be included or not
      * @param showInactive   determines if inactive projects should be included or not
+     * @param orderBy        the requested ordering field, or {@code null} for the default ordering
      * @return a List of Finding objects
      */
-    default List<FindingRow> getAllFindings(final Map<String, String> filters, final boolean showSuppressed, final boolean showInactive) {
-        StringBuilder queryFilter = new StringBuilder();
-        Map<String, Object> params = new HashMap<>();
-        processFilters(filters, queryFilter, params);
-        return getAllFindings(String.valueOf(queryFilter), showInactive, /* includeInactiveFindings */ false, showSuppressed, params);
+    default List<FindingRow> getAllFindings(
+            Map<String, String> filters,
+            boolean showSuppressed,
+            boolean showInactive,
+            @Nullable String orderBy) {
+        final StringBuilder queryFilter = new StringBuilder();
+        final Map<String, Object> params = new HashMap<>();
+
+        final boolean isEpssOrdering = "vulnerability.epssScore".equals(orderBy)
+                || "vulnerability.epssPercentile".equals(orderBy);
+        final boolean isEpssInPage = isEpssOrdering
+                || hasValue(filters, "epssPercentileFrom")
+                || hasValue(filters, "epssPercentileTo");
+        processFilters(filters, queryFilter, params, /* epssScoreViaExists */ true);
+
+        final BigDecimal epssScoreFrom = maybeParseDecimal(filters.get("epssFrom"));
+        final BigDecimal epssScoreTo = maybeParseDecimal(filters.get("epssTo"));
+
+        // NB: JIT is disabled explicitly because it tends to take >=50% of query planning and
+        // execution time. JIT is almost always detrimental to query performance here.
+        return withJitDisabled(
+                () -> getAllFindings(
+                        String.valueOf(queryFilter),
+                        showInactive,
+                        /* includeInactiveFindings */ false,
+                        showSuppressed,
+                        isEpssInPage,
+                        epssScoreFrom,
+                        epssScoreTo,
+                        params));
     }
 
+    /// Queries all findings in the portfolio, grouped by vulnerability.
+    ///
+    /// EPSS is resolved once per distinct vulnerability via the `epss_dedup` CTE rather
+    /// than per finding, since the result is grouped by vulnerability anyway.
+    /// EPSS score and percentile values are functionally dependent on the vulnerability but,
+    /// since they're being sourced from a join, **must** remain in the `GROUP BY`.
     @SqlQuery(/* language=InjectedFreeMarker */ """
             <#-- @ftlvariable name="apiProjectAclCondition" type="String" -->
             <#-- @ftlvariable name="apiOrderByClause" type="String" -->
             <#-- @ftlvariable name="activeFilter" type="Boolean" -->
             <#-- @ftlvariable name="includeInactiveFindings" type="Boolean" -->
             <#-- @ftlvariable name="apiOffsetLimitClause" type="String" -->
+            WITH epss_dedup AS (
+              SELECT dv."ID" AS "vulnerabilityId"
+                   , ep."SCORE"
+                   , ep."PERCENTILE"
+                FROM (
+                  SELECT DISTINCT
+                         v."ID"
+                       , v."SOURCE"
+                       , v."VULNID"
+                    FROM "VULNERABILITY" AS v
+                   WHERE v."ID" IN (
+                     SELECT "VULNERABILITY_ID"
+                       FROM "COMPONENTS_VULNERABILITIES"
+                   )
+                ) AS dv
+                LEFT JOIN LATERAL (
+                  SELECT "SCORE"
+                       , "PERCENTILE"
+                    FROM (
+                      SELECT ee."CVE"
+                           , ee."SCORE"
+                           , ee."PERCENTILE"
+                        FROM "EPSS" AS ee
+                       WHERE dv."SOURCE" = 'NVD'
+                         AND ee."CVE" = dv."VULNID"
+                      UNION ALL
+                      SELECT ee."CVE"
+                           , ee."SCORE"
+                           , ee."PERCENTILE"
+                        FROM "VULNERABILITY_ALIAS" AS va
+                       INNER JOIN "VULNERABILITY_ALIAS" AS cve_a
+                          ON cve_a."GROUP_ID" = va."GROUP_ID"
+                         AND cve_a."SOURCE" = 'NVD'
+                       INNER JOIN "EPSS" AS ee
+                          ON ee."CVE" = cve_a."VULN_ID"
+                       WHERE dv."SOURCE" != 'NVD'
+                         AND va."SOURCE" = dv."SOURCE"
+                         AND va."VULN_ID" = dv."VULNID"
+                    ) AS candidates
+                   ORDER BY "SCORE" DESC NULLS LAST
+                          , "PERCENTILE" DESC NULLS LAST
+                          , "CVE"
+                   LIMIT 1
+                ) AS ep ON TRUE
+            )
             SELECT v."SOURCE" AS "vulnSource"
                  , v."VULNID"
                  , v."TITLE" AS "vulnTitle"
@@ -554,8 +769,8 @@ public interface FindingDao {
                      THEN a."CVSSV4SCORE"
                      ELSE v."CVSSV4SCORE"
                    END AS "cvssV4Score"
-                 , ep."SCORE" AS "epssScore"
-                 , ep."PERCENTILE" AS "epssPercentile"
+                 , ed."SCORE" AS "epssScore"
+                 , ed."PERCENTILE" AS "epssPercentile"
                  , v."PUBLISHED" AS "vulnPublished"
                  , CAST(STRING_TO_ARRAY(v."CWES", ',') AS INT[]) AS "CWES"
                  , fa."ANALYZERIDENTITY"
@@ -578,36 +793,8 @@ public interface FindingDao {
                        , fa."ID"
                 LIMIT 1
              ) AS fa ON TRUE
-              LEFT JOIN LATERAL (
-                SELECT "CVE"
-                     , "SCORE"
-                     , "PERCENTILE"
-                  FROM (
-                    SELECT ee."CVE"
-                         , ee."SCORE"
-                         , ee."PERCENTILE"
-                      FROM "EPSS" AS ee
-                     WHERE v."SOURCE" = 'NVD'
-                       AND ee."CVE" = v."VULNID"
-                    UNION ALL
-                    SELECT ee."CVE"
-                         , ee."SCORE"
-                         , ee."PERCENTILE"
-                      FROM "VULNERABILITY_ALIAS" AS va
-                     INNER JOIN "VULNERABILITY_ALIAS" AS cve_a
-                        ON cve_a."GROUP_ID" = va."GROUP_ID"
-                       AND cve_a."SOURCE" = 'NVD'
-                     INNER JOIN "EPSS" AS ee
-                        ON ee."CVE" = cve_a."VULN_ID"
-                     WHERE v."SOURCE" != 'NVD'
-                       AND va."SOURCE" = v."SOURCE"
-                       AND va."VULN_ID" = v."VULNID"
-                  ) candidates
-                 ORDER BY "SCORE" DESC NULLS LAST
-                        , "PERCENTILE" DESC NULLS LAST
-                        , "CVE"
-                 LIMIT 1
-              ) AS ep ON TRUE
+              LEFT JOIN epss_dedup AS ed
+                ON ed."vulnerabilityId" = v."ID"
               LEFT JOIN "ANALYSIS" AS a
                 ON c."ID" = a."COMPONENT_ID"
                AND v."ID" = a."VULNERABILITY_ID"
@@ -629,8 +816,8 @@ public interface FindingDao {
                   , "cvssV2BaseScore"
                   , "cvssV3BaseScore"
                   , "cvssV4Score"
-                  , ep."SCORE"
-                  , ep."PERCENTILE"
+                  , ed."SCORE"
+                  , ed."PERCENTILE"
                   , fa."ANALYZERIDENTITY"
                   , v."PUBLISHED"
                   , v."CWES"
@@ -657,29 +844,44 @@ public interface FindingDao {
     @DefineNamedBindings
     @DefineApiProjectAclCondition(projectIdColumn = "p.\"ID\"")
     @RegisterConstructorMapper(GroupedFindingRow.class)
-    List<GroupedFindingRow> getGroupedFindings(@Define String queryFilter,
-                                               @Define boolean activeFilter,
-                                               @Define boolean includeInactiveFindings,
-                                               @Define String aggregateFilter,
-                                               @BindMap Map<String, Object> params);
+    List<GroupedFindingRow> getGroupedFindings(
+            @Define String queryFilter,
+            @Define boolean activeFilter,
+            @Define boolean includeInactiveFindings,
+            @Define String aggregateFilter,
+            @BindMap Map<String, Object> params);
 
     /**
      * Returns a List of all Finding objects filtered by ACL and other optional filters. The resulting list is grouped by vulnerability.
      *
-     * @param filters       determines the filters to apply on the list of Finding objects
-     * @param showInactive  determines if inactive projects should be included or not
+     * @param filters      determines the filters to apply on the list of Finding objects
+     * @param showInactive determines if inactive projects should be included or not
      * @return a List of Finding objects
      */
-    default List<GroupedFindingRow> getGroupedFindings(final Map<String, String> filters, final boolean showInactive) {
-        StringBuilder queryFilter = new StringBuilder();
-        Map<String, Object> params = new HashMap<>();
-        processFilters(filters, queryFilter, params);
-        StringBuilder aggregateFilter = new StringBuilder();
+    default List<GroupedFindingRow> getGroupedFindings(Map<String, String> filters, boolean showInactive) {
+        final StringBuilder queryFilter = new StringBuilder();
+        final Map<String, Object> params = new HashMap<>();
+
+        processFilters(filters, queryFilter, params, /* epssScoreViaExists */ false);
+        final StringBuilder aggregateFilter = new StringBuilder();
         processAggregateFilters(filters, aggregateFilter, params);
-        return getGroupedFindings(String.valueOf(queryFilter), showInactive, /* includeInactiveFindings */ false, String.valueOf(aggregateFilter), params);
+
+        // NB: JIT is disabled explicitly because it tends to take >=50% of query planning and
+        // execution time. JIT is almost always detrimental to query performance here.
+        return withJitDisabled(
+                () -> getGroupedFindings(
+                        String.valueOf(queryFilter),
+                        showInactive,
+                        /* includeInactiveFindings */ false,
+                        String.valueOf(aggregateFilter),
+                        params));
     }
 
-    private void processFilters(Map<String, String> filters, StringBuilder queryFilter, Map<String, Object> params) {
+    private void processFilters(
+            Map<String, String> filters,
+            StringBuilder queryFilter,
+            Map<String, Object> params,
+            boolean epssScoreViaExists) {
         for (String filter : filters.keySet()) {
             switch (filter) {
                 case "severity" ->
@@ -710,19 +912,28 @@ public interface FindingDao {
                         processRangeFilter(queryFilter, params, filter, filters.get(filter), "v.\"CVSSV4SCORE\"", true, false, false);
                 case "cvssv4To" ->
                         processRangeFilter(queryFilter, params, filter, filters.get(filter), "v.\"CVSSV4SCORE\"", false, false, false);
-                case "epssFrom" ->
-                        processRangeFilter(queryFilter, params, filter, filters.get(filter), "ep.\"SCORE\"", true, false, false);
-                case "epssTo" ->
-                        processRangeFilter(queryFilter, params, filter, filters.get(filter), "ep.\"SCORE\"", false, false, false);
+                case "epssFrom" -> {
+                    if (!epssScoreViaExists) {
+                        processRangeFilter(queryFilter, params, filter, filters.get(filter), "ed.\"SCORE\"", true, false, false);
+                    }
+                }
+                case "epssTo" -> {
+                    if (!epssScoreViaExists) {
+                        processRangeFilter(queryFilter, params, filter, filters.get(filter), "ed.\"SCORE\"", false, false, false);
+                    }
+                }
                 case "epssPercentileFrom" ->
-                        processRangeFilter(queryFilter, params, filter, filters.get(filter), "ep.\"PERCENTILE\"", true, false, false);
+                        processRangeFilter(queryFilter, params, filter, filters.get(filter), "ed.\"PERCENTILE\"", true, false, false);
                 case "epssPercentileTo" ->
-                        processRangeFilter(queryFilter, params, filter, filters.get(filter), "ep.\"PERCENTILE\"", false, false, false);
+                        processRangeFilter(queryFilter, params, filter, filters.get(filter), "ed.\"PERCENTILE\"", false, false, false);
             }
         }
     }
 
-    private void processAggregateFilters(Map<String, String> filters, StringBuilder queryFilter, Map<String, Object> params) {
+    private void processAggregateFilters(
+            Map<String, String> filters,
+            StringBuilder queryFilter,
+            Map<String, Object> params) {
         for (String filter : filters.keySet()) {
             switch (filter) {
                 case "occurrencesFrom" ->
@@ -733,7 +944,12 @@ public interface FindingDao {
         }
     }
 
-    private void processArrayFilter(StringBuilder queryFilter, Map<String, Object> params, String paramName, String filter, String column) {
+    private void processArrayFilter(
+            StringBuilder queryFilter,
+            Map<String, Object> params,
+            String paramName,
+            String filter,
+            String column) {
         if (filter != null && !filter.isEmpty()) {
             queryFilter.append(" AND (");
             String[] filters = filter.split(",");
@@ -754,7 +970,15 @@ public interface FindingDao {
         }
     }
 
-    private void processRangeFilter(StringBuilder queryFilter, Map<String, Object> params, String paramName, String filter, String column, boolean fromValue, boolean isDate, boolean isAggregateFilter) {
+    private void processRangeFilter(
+            StringBuilder queryFilter,
+            Map<String, Object> params,
+            String paramName,
+            String filter,
+            String column,
+            boolean fromValue,
+            boolean isDate,
+            boolean isAggregateFilter) {
         if (filter != null && !filter.isEmpty()) {
             if (queryFilter.isEmpty()) {
                 queryFilter.append(isAggregateFilter ? " HAVING (" : " AND (");
@@ -775,7 +999,12 @@ public interface FindingDao {
         }
     }
 
-    private void processInputFilter(StringBuilder queryFilter, Map<String, Object> params, String paramName, String filter, String input) {
+    private void processInputFilter(
+            StringBuilder queryFilter,
+            Map<String, Object> params,
+            String paramName,
+            String filter,
+            String input) {
         if (filter != null && !filter.isEmpty() && input != null && !input.isEmpty()) {
             queryFilter.append(" AND (");
             String[] filters = filter.split(",");
@@ -785,8 +1014,7 @@ public interface FindingDao {
                     case "VULNERABILITY_TITLE" -> queryFilter.append("v.\"TITLE\"");
                     case "COMPONENT_NAME" -> queryFilter.append("c.\"NAME\"");
                     case "COMPONENT_VERSION" -> queryFilter.append("c.\"VERSION\"");
-                    case "PROJECT_NAME" ->
-                            queryFilter.append("concat(p.\"NAME\", ' ', p.\"VERSION\")");
+                    case "PROJECT_NAME" -> queryFilter.append("concat(p.\"NAME\", ' ', p.\"VERSION\")");
                 }
                 queryFilter.append(" LIKE :").append(paramName);
                 if (i < length - 1) {
@@ -799,4 +1027,14 @@ public interface FindingDao {
             queryFilter.append(")");
         }
     }
+
+    private static boolean hasValue(Map<String, String> filters, String key) {
+        final String value = filters.get(key);
+        return value != null && !value.isEmpty();
+    }
+
+    private static @Nullable BigDecimal maybeParseDecimal(@Nullable String value) {
+        return value == null || value.isEmpty() ? null : new BigDecimal(value);
+    }
+
 }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/PaginationSupport.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/PaginationSupport.java
@@ -26,6 +26,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -155,6 +156,17 @@ public interface PaginationSupport extends SqlObject {
                 count > threshold
                         ? TotalCount.Type.AT_LEAST
                         : TotalCount.Type.EXACT);
+    }
+
+    default <T> T withJitDisabled(Supplier<T> supplier) {
+        return getHandle().inTransaction(trx -> {
+            trx.createUpdate("SET LOCAL jit = OFF")
+                    // The handle may carry bindings from ApiRequestStatementCustomizer
+                    // (e.g. pagination offset / limit) that this statement doesn't consume.
+                    .configure(SqlStatements.class, cfg -> cfg.setUnusedBindingAllowed(true))
+                    .execute();
+            return supplier.get();
+        });
     }
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
@@ -35,7 +35,6 @@ import org.dependencytrack.persistence.jdbi.query.ListProjectsConciseQuery;
 import org.dependencytrack.persistence.jdbi.query.ListProjectsQuery;
 import org.jdbi.v3.core.mapper.reflect.ColumnName;
 import org.jdbi.v3.core.statement.Query;
-import org.jdbi.v3.core.statement.SqlStatements;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.jdbi.v3.json.Json;
 import org.jdbi.v3.sqlobject.SqlObject;
@@ -60,7 +59,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Supplier;
 
 import static org.dependencytrack.util.PersistenceUtil.escapeLikePattern;
 
@@ -870,16 +868,5 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
              WHERE "UUID" = :uuid
             """)
     void updateLastVulnAnalysis(@Bind UUID uuid);
-
-    default <T> T withJitDisabled(Supplier<T> supplier) {
-        return getHandle().inTransaction(trx -> {
-            trx.createUpdate("SET LOCAL jit = OFF")
-                    // The handle may carry bindings from ApiRequestStatementCustomizer
-                    // (e.g. pagination offset / limit) that this statement doesn't consume.
-                    .configure(SqlStatements.class, cfg -> cfg.setUnusedBindingAllowed(true))
-                    .execute();
-            return supplier.get();
-        });
-    }
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
@@ -169,16 +169,19 @@ public class FindingResource extends AbstractApiResource {
                         (rawFilter != null && !rawFilter.isBlank())
                                 ? PersistenceUtil.escapeLikePattern(rawFilter)
                                 : null;
-                List<FindingDao.FindingRow> findingRows = withJdbiHandle(getAlpineRequest(), handle ->
-                        handle.attach(FindingDao.class).getFindingsByProject(
-                                project.getId(),
-                                /* includeInactive */ false,
-                                suppressed,
-                                searchText,
-                                hasAnalysis,
-                                source != null ? source.name() : null,
-                                epssFrom,
-                                epssTo));
+                List<FindingDao.FindingRow> findingRows = withJdbiHandle(getAlpineRequest(), handle -> {
+                    final var dao = handle.attach(FindingDao.class);
+                    return dao.withJitDisabled(
+                            () -> dao.getFindingsByProject(
+                                    project.getId(),
+                                    /* includeInactive */ false,
+                                    suppressed,
+                                    searchText,
+                                    hasAnalysis,
+                                    source != null ? source.name() : null,
+                                    epssFrom,
+                                    epssTo));
+                });
                 final long totalCount = findingRows.isEmpty() ? 0 : findingRows.getFirst().totalCount();
                 List<Finding> findings = findingRows.stream().map(Finding::new).toList();
                 findings = mapComponentLatestVersion(findings);
@@ -368,7 +371,7 @@ public class FindingResource extends AbstractApiResource {
         filters.put("epssPercentileFrom", epssPercentileFrom);
         filters.put("epssPercentileTo", epssPercentileTo);
         List<FindingDao.FindingRow> findingRows = withJdbiHandle(getAlpineRequest(), handle -> handle.attach(FindingDao.class)
-                .getAllFindings(filters, showSuppressed, showInactive));
+                .getAllFindings(filters, showSuppressed, showInactive, getAlpineRequest().getOrderBy()));
         final long totalCount = findingRows.isEmpty() ? 0 : findingRows.getFirst().totalCount();
         List<Finding> findings = findingRows.stream().map(Finding::new).toList();
         findings = mapComponentLatestVersion(findings);
@@ -484,7 +487,7 @@ public class FindingResource extends AbstractApiResource {
         }
     }
 
-    public static List<Finding> mapComponentLatestVersion(List<Finding> findingList){
+    public static List<Finding> mapComponentLatestVersion(List<Finding> findingList) {
         final Map<String, List<Finding>> findingsByPurlPackage = findingList.stream()
                 .filter(finding -> finding.getComponent().get("purl") != null)
                 .map(finding -> {

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -61,6 +61,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -759,10 +760,10 @@ public class FindingResourceTest extends ResourceTest {
         JsonArray jsonArray = parseJsonArray(response);
         assertNotNull(jsonArray);
         assertEquals(2, jsonArray.size());
-        JsonObject json  = jsonArray.getJsonObject(0);
+        JsonObject json = jsonArray.getJsonObject(0);
         assertEquals("Component A", json.getJsonObject("component").getString("name"));
         assertEquals(false, json.getJsonObject("component").getBoolean("hasOccurrences"));
-        json  = jsonArray.getJsonObject(1);
+        json = jsonArray.getJsonObject(1);
         assertEquals("Component B", json.getJsonObject("component").getString("name"));
         assertEquals(true, json.getJsonObject("component").getBoolean("hasOccurrences"));
     }
@@ -926,24 +927,24 @@ public class FindingResourceTest extends ResourceTest {
         assertNotNull(json);
         assertEquals(5, json.size());
         assertEquals(date.getTime(), json.getJsonObject(0).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        assertEquals(p1.getName() ,json.getJsonObject(0).getJsonObject("component").getString("projectName"));
-        assertEquals(p1.getVersion() ,json.getJsonObject(0).getJsonObject("component").getString("projectVersion"));
+        assertEquals(p1.getName(), json.getJsonObject(0).getJsonObject("component").getString("projectName"));
+        assertEquals(p1.getVersion(), json.getJsonObject(0).getJsonObject("component").getString("projectVersion"));
         assertEquals(p1.getUuid().toString(), json.getJsonObject(0).getJsonObject("component").getString("project"));
         assertEquals(date.getTime(), json.getJsonObject(1).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        assertEquals(p1.getName() ,json.getJsonObject(1).getJsonObject("component").getString("projectName"));
-        assertEquals(p1.getVersion() ,json.getJsonObject(1).getJsonObject("component").getString("projectVersion"));
+        assertEquals(p1.getName(), json.getJsonObject(1).getJsonObject("component").getString("projectName"));
+        assertEquals(p1.getVersion(), json.getJsonObject(1).getJsonObject("component").getString("projectVersion"));
         assertEquals(p1.getUuid().toString(), json.getJsonObject(1).getJsonObject("component").getString("project"));
         assertEquals(date.getTime(), json.getJsonObject(2).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        assertEquals(p1.getName() ,json.getJsonObject(2).getJsonObject("component").getString("projectName"));
-        assertEquals(p1.getVersion() ,json.getJsonObject(2).getJsonObject("component").getString("projectVersion"));
+        assertEquals(p1.getName(), json.getJsonObject(2).getJsonObject("component").getString("projectName"));
+        assertEquals(p1.getVersion(), json.getJsonObject(2).getJsonObject("component").getString("projectVersion"));
         assertEquals(p1.getUuid().toString(), json.getJsonObject(2).getJsonObject("component").getString("project"));
         assertEquals(date.getTime(), json.getJsonObject(3).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        assertEquals(p1_child.getName() ,json.getJsonObject(3).getJsonObject("component").getString("projectName"));
-        assertEquals(p1_child.getVersion() ,json.getJsonObject(3).getJsonObject("component").getString("projectVersion"));
+        assertEquals(p1_child.getName(), json.getJsonObject(3).getJsonObject("component").getString("projectName"));
+        assertEquals(p1_child.getVersion(), json.getJsonObject(3).getJsonObject("component").getString("projectVersion"));
         assertEquals(p1_child.getUuid().toString(), json.getJsonObject(3).getJsonObject("component").getString("project"));
         assertEquals(date.getTime(), json.getJsonObject(4).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        assertEquals(p2.getName() ,json.getJsonObject(4).getJsonObject("component").getString("projectName"));
-        assertEquals(p2.getVersion() ,json.getJsonObject(4).getJsonObject("component").getString("projectVersion"));
+        assertEquals(p2.getName(), json.getJsonObject(4).getJsonObject("component").getString("projectName"));
+        assertEquals(p2.getVersion(), json.getJsonObject(4).getJsonObject("component").getString("projectVersion"));
         assertEquals(p2.getUuid().toString(), json.getJsonObject(4).getJsonObject("component").getString("project"));
     }
 
@@ -1067,16 +1068,16 @@ public class FindingResourceTest extends ResourceTest {
         assertNotNull(json);
         assertEquals(4, json.size());
         assertEquals(date.getTime(), json.getJsonObject(0).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        assertEquals(p1.getName() ,json.getJsonObject(0).getJsonObject("component").getString("projectName"));
-        assertEquals(p1.getVersion() ,json.getJsonObject(0).getJsonObject("component").getString("projectVersion"));
+        assertEquals(p1.getName(), json.getJsonObject(0).getJsonObject("component").getString("projectName"));
+        assertEquals(p1.getVersion(), json.getJsonObject(0).getJsonObject("component").getString("projectVersion"));
         assertEquals(p1.getUuid().toString(), json.getJsonObject(0).getJsonObject("component").getString("project"));
         assertEquals(date.getTime(), json.getJsonObject(1).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        assertEquals(p1.getName() ,json.getJsonObject(1).getJsonObject("component").getString("projectName"));
-        assertEquals(p1.getVersion() ,json.getJsonObject(1).getJsonObject("component").getString("projectVersion"));
+        assertEquals(p1.getName(), json.getJsonObject(1).getJsonObject("component").getString("projectName"));
+        assertEquals(p1.getVersion(), json.getJsonObject(1).getJsonObject("component").getString("projectVersion"));
         assertEquals(p1.getUuid().toString(), json.getJsonObject(1).getJsonObject("component").getString("project"));
         assertEquals(date.getTime(), json.getJsonObject(2).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        assertEquals(p1.getName() ,json.getJsonObject(2).getJsonObject("component").getString("projectName"));
-        assertEquals(p1.getVersion() ,json.getJsonObject(2).getJsonObject("component").getString("projectVersion"));
+        assertEquals(p1.getName(), json.getJsonObject(2).getJsonObject("component").getString("projectName"));
+        assertEquals(p1.getVersion(), json.getJsonObject(2).getJsonObject("component").getString("projectVersion"));
         assertEquals(p1.getUuid().toString(), json.getJsonObject(2).getJsonObject("component").getString("project"));
 
         // Findings of p1_child are returned because team was given access to its parent project p1.
@@ -1115,10 +1116,10 @@ public class FindingResourceTest extends ResourceTest {
         JsonArray jsonArray = parseJsonArray(response);
         assertNotNull(jsonArray);
         assertEquals(2, jsonArray.size());
-        JsonObject json  = jsonArray.getJsonObject(0);
+        JsonObject json = jsonArray.getJsonObject(0);
         assertEquals("Component A", json.getJsonObject("component").getString("name"));
         assertEquals(false, json.getJsonObject("component").getBoolean("hasOccurrences"));
-        json  = jsonArray.getJsonObject(1);
+        json = jsonArray.getJsonObject(1);
         assertEquals("Component B", json.getJsonObject("component").getString("name"));
         assertEquals(true, json.getJsonObject("component").getBoolean("hasOccurrences"));
     }
@@ -1453,6 +1454,167 @@ public class FindingResourceTest extends ResourceTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = {
+            "component.name",
+            "component.version",
+            "vulnerability.cvssV2BaseScore",
+            "vulnerability.cvssV3BaseScore",
+            "vulnerability.cvssV4Score",
+            "vulnerability.epssPercentile",
+            "vulnerability.epssScore",
+            "vulnerability.published",
+            "vulnerability.severity",
+            "vulnerability.title",
+            "vulnerability.vulnId"
+    })
+    void shouldOrderAllFindingsByEachSortableColumn(String sortName) {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        createOrderedFindings();
+
+        Response response = jersey
+                .target(V1_FINDING)
+                .queryParam("sortName", sortName)
+                .queryParam("sortOrder", "desc")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].vulnerability.vulnId")
+                .isArray()
+                .containsExactly("Vuln-2", "Vuln-1");
+
+        response = jersey
+                .target(V1_FINDING)
+                .queryParam("sortName", sortName)
+                .queryParam("sortOrder", "asc")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].vulnerability.vulnId")
+                .isArray()
+                .containsExactly("Vuln-1", "Vuln-2");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "vulnerability.cvssV2BaseScore",
+            "vulnerability.cvssV3BaseScore",
+            "vulnerability.cvssV4Score",
+            "vulnerability.published",
+            "vulnerability.severity",
+            "vulnerability.title",
+            "vulnerability.vulnId",
+    })
+    void shouldOrderGroupedFindingsByEachSortableColumn(String sortName) {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        createOrderedFindings();
+
+        Response response = jersey
+                .target(V1_FINDING + "/grouped")
+                .queryParam("sortName", sortName)
+                .queryParam("sortOrder", "desc")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].vulnerability.vulnId")
+                .isArray()
+                .containsExactly("Vuln-2", "Vuln-1");
+
+        response = jersey
+                .target(V1_FINDING + "/grouped")
+                .queryParam("sortName", sortName)
+                .queryParam("sortOrder", "asc")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].vulnerability.vulnId")
+                .isArray()
+                .containsExactly("Vuln-1", "Vuln-2");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "analysis.isSuppressed",
+            "analysis.state",
+            "attribution.analyzerIdentity",
+            "attribution.attributedOn",
+            "component.projectName"
+    })
+    void shouldAcceptAdditionalSortableColumnForAllFindings(String sortName) {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        createOrderedFindings();
+
+        final Response response = jersey
+                .target(V1_FINDING)
+                .queryParam("sortName", sortName)
+                .queryParam("sortOrder", "desc")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].vulnerability.vulnId")
+                .isArray()
+                .containsExactlyInAnyOrder("Vuln-1", "Vuln-2");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "attribution.analyzerIdentity",
+            "vulnerability.affectedProjectCount"
+    })
+    void shouldAcceptAdditionalSortableColumnForGroupedFindings(String sortName) {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        createOrderedFindings();
+
+        final Response response = jersey
+                .target(V1_FINDING + "/grouped")
+                .queryParam("sortName", sortName)
+                .queryParam("sortOrder", "desc")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].vulnerability.vulnId")
+                .isArray()
+                .containsExactlyInAnyOrder("Vuln-1", "Vuln-2");
+    }
+
+    @Test
+    void shouldGetAllFindingsOrderedByEpssScoreWithEpssScoreFilter() {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        createOrderedFindings();
+
+        final Response response = jersey
+                .target(V1_FINDING)
+                .queryParam("sortName", "vulnerability.epssScore")
+                .queryParam("sortOrder", "desc")
+                .queryParam("epssFrom", "0.5")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].vulnerability.vulnId")
+                .isArray()
+                .containsExactly("Vuln-2");
+    }
+
+    @ParameterizedTest
     @MethodSource("getSARIFFindingsByProjectTestParameters")
     public void getSARIFFindingsByProjectTest(String query, String expectedResponsePath) throws Exception {
         initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
@@ -1504,12 +1666,12 @@ public class FindingResourceTest extends ResourceTest {
         Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
 
         for (int i = 0; i < 5; i++) {
-            Component component = createComponent(p1, "Component "+i, "1.0."+i);
-            Vulnerability vulnerability = createVulnerability("Vuln-"+i, Severity.LOW);
+            Component component = createComponent(p1, "Component " + i, "1.0." + i);
+            Vulnerability vulnerability = createVulnerability("Vuln-" + i, Severity.LOW);
             qm.addVulnerability(vulnerability, component, "none");
         }
 
-        Response response = jersey.target(V1_FINDING  + "/project/" + p1.getUuid())
+        Response response = jersey.target(V1_FINDING + "/project/" + p1.getUuid())
                 .queryParam("pageNumber", "1")
                 .queryParam("pageSize", "3")
                 .request()
@@ -1545,8 +1707,8 @@ public class FindingResourceTest extends ResourceTest {
         Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
 
         for (int i = 0; i < 5; i++) {
-            Component component = createComponent(p1, "Component "+i, "1.0."+i);
-            Vulnerability vulnerability = createVulnerability("Vuln-"+i, Severity.LOW);
+            Component component = createComponent(p1, "Component " + i, "1.0." + i);
+            Vulnerability vulnerability = createVulnerability("Vuln-" + i, Severity.LOW);
             qm.addVulnerability(vulnerability, component, "none");
         }
 
@@ -1586,8 +1748,8 @@ public class FindingResourceTest extends ResourceTest {
         Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
 
         for (int i = 0; i < 5; i++) {
-            Component component = createComponent(p1, "Component "+i, "1.0."+i);
-            Vulnerability vulnerability = createVulnerability("Vuln-"+i, Severity.LOW);
+            Component component = createComponent(p1, "Component " + i, "1.0." + i);
+            Vulnerability vulnerability = createVulnerability("Vuln-" + i, Severity.LOW);
             qm.addVulnerability(vulnerability, component, "none");
         }
 
@@ -1682,6 +1844,44 @@ public class FindingResourceTest extends ResourceTest {
                 .createOrUpdateAll(List.of(new Epss(vulnId, null, epssPercentile))));
 
         return vulnerability;
+    }
+
+    /// Creates two findings on distinct components for `Vuln-1` and `Vuln-2` respectively,
+    /// such that `Vuln-2` holds the higher value for every orderable column.
+    /// To be used by ordering tests to assert the exact sequence for both sort directions.
+    private void createOrderedFindings() {
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
+        final Component low = createComponent(project, "Component A", "1.0");
+        final Component high = createComponent(project, "Component B", "2.0");
+
+        final var vulnLow = new Vulnerability();
+        vulnLow.setVulnId("Vuln-1");
+        vulnLow.setSource(Vulnerability.Source.NVD);
+        vulnLow.setSeverity(Severity.LOW);
+        vulnLow.setTitle("Title A");
+        vulnLow.setCwes(List.of(80, 666));
+        vulnLow.setCvssV2BaseScore(new BigDecimal("1.1"));
+        vulnLow.setCvssV3BaseScore(new BigDecimal("1.2"));
+        vulnLow.setCvssV4Score(new BigDecimal("1.3"));
+        vulnLow.setPublished(Date.from(Instant.parse("2020-01-01T00:00:00Z")));
+
+        final var vulnHigh = new Vulnerability();
+        vulnHigh.setVulnId("Vuln-2");
+        vulnHigh.setSource(Vulnerability.Source.NVD);
+        vulnHigh.setSeverity(Severity.CRITICAL);
+        vulnHigh.setTitle("Title B");
+        vulnHigh.setCwes(List.of(80, 666));
+        vulnHigh.setCvssV2BaseScore(new BigDecimal("9.1"));
+        vulnHigh.setCvssV3BaseScore(new BigDecimal("9.2"));
+        vulnHigh.setCvssV4Score(new BigDecimal("9.3"));
+        vulnHigh.setPublished(Date.from(Instant.parse("2024-01-01T00:00:00Z")));
+
+        qm.addVulnerability(qm.createVulnerability(vulnLow), low, "none");
+        qm.addVulnerability(qm.createVulnerability(vulnHigh), high, "none");
+
+        useJdbiHandle(handle -> handle.attach(EpssDao.class).createOrUpdateAll(List.of(
+                new Epss("Vuln-1", new BigDecimal("0.10"), new BigDecimal("0.11")),
+                new Epss("Vuln-2", new BigDecimal("0.90"), new BigDecimal("0.91")))));
     }
 
 }


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Optimizes portfolio-wide findings queries.

The queries tend to not perform well, which is partly due to how the interface was designed in v4 (way too many columns are sortable, impossible to ensure full index coverage, offset-based pagination, etc.), and partly due to how the data model works (normalized EPSS table, alias resolution, etc.).

This change applies a few query-level optimizations to make the existing interface run better without introducing any breaking changes.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Applies the following optimizations:

* Disables JIT, as it accounts for a considerable amount of query planning time (sometimes multiple seconds) for no gain.
* Separates sorting / pagination from enrichment. Allows expensive enrichment like EPSS and alias resoluton to be executed for only the requested rows (100 by default) instead of the whole data set.
* Pushes EPSS filters into a separate `EXISTS` condition in the `WHERE` clause, instead of always depending on a `LEFT JOIN LATERAL`. This gives the query planner more options and enables semi-joins.
* Resolves EPSS per unique vulnerability that affects at least one component, instead of per finding. The assumption being that most vulns will have N findings, so the cost of EPSS resolution only needs to be paid once, not N times. Note that this is also only done when necessary, e.g. when sorting by EPSS was requested.

<details>
<summary>Query plan for getAllFindings BEFORE</summary>

```
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1838653.99..1839234.93 rows=100 width=5715) (actual time=3483.451..3498.110 rows=100.00 loops=1)
   Buffers: shared hit=1307869, temp read=11236 written=11842
   ->  WindowAgg  (cost=1838653.99..2088315.69 rows=42976 width=5715) (actual time=2190.490..2205.134 rows=100.00 loops=1)
         Window: w1 AS ()
         Storage: Disk  Maximum Storage: 94727kB
         Buffers: shared hit=1307869, temp read=11236 written=11842
         ->  Nested Loop  (cost=1034.37..1838159.56 rows=42976 width=6434) (actual time=642.694..1878.620 rows=67800.00 loops=1)
               Buffers: shared hit=1307421
               ->  Nested Loop  (cost=1034.09..1825223.96 rows=42976 width=6348) (actual time=642.665..1789.060 rows=67800.00 loops=1)
                     Buffers: shared hit=1104021
                     ->  Nested Loop Left Join  (cost=1033.68..1461647.00 rows=42976 width=5783) (actual time=642.616..1612.750 rows=79092.00 loops=1)
                           Buffers: shared hit=798945
                           ->  Gather Merge  (cost=1001.44..75417.80 rows=42976 width=5771) (actual time=642.486..768.702 rows=79092.00 loops=1)
                                 Workers Planned: 2
                                 Workers Launched: 2
                                 Buffers: shared hit=135502
                                 ->  Merge Left Join  (cost=1.42..69457.28 rows=17907 width=5771) (actual time=408.702..508.478 rows=26364.00 loops=3)
                                       Merge Cond: (c."ID" = a."COMPONENT_ID")
                                       Join Filter: ((v."ID" = a."VULNERABILITY_ID") AND (c."PROJECT_ID" = a."PROJECT_ID"))
                                       Filter: (a."SUPPRESSED" IS DISTINCT FROM true)
                                       Buffers: shared hit=135502
                                       ->  Nested Loop  (cost=1.28..69323.18 rows=35814 width=3058) (actual time=408.678..504.548 rows=26364.00 loops=3)
                                             Buffers: shared hit=135499
                                             ->  Nested Loop  (cost=0.85..38682.35 rows=35814 width=662) (actual time=408.519..459.334 rows=26364.00 loops=3)
                                                   Buffers: shared hit=81153
                                                   ->  Parallel Index Only Scan using "COMPONENTS_VULNERABILITIES_COMPOSITE_IDX" on "COMPONENTS_VULNERABILITIES" cv  (cost=0.42..2897.92 rows=35814 width=16) (actual time=0.032..6.942 rows=26364.00 loops=3)
                                                         Heap Fetches: 20632
                                                         Index Searches: 1
                                                         Buffers: shared hit=7619
                                                   ->  Memoize  (cost=0.43..1.91 rows=1 width=654) (actual time=0.017..0.017 rows=1.00 loops=79092)
                                                         Cache Key: cv."COMPONENT_ID"
                                                         Cache Mode: logical
                                                         Hits: 19114  Misses: 5680  Evictions: 0  Overflows: 0  Memory Usage: 1326kB
                                                         Buffers: shared hit=73534
                                                         Worker 0:  Hits: 20896  Misses: 6449  Evictions: 0  Overflows: 0  Memory Usage: 1498kB
                                                         Worker 1:  Hits: 20699  Misses: 6254  Evictions: 0  Overflows: 0  Memory Usage: 1453kB
                                                         ->  Index Scan using "COMPONENT_PK" on "COMPONENT" c  (cost=0.42..1.90 rows=1 width=654) (actual time=0.004..0.004 rows=1.00 loops=18383)
                                                               Index Cond: ("ID" = cv."COMPONENT_ID")
                                                               Index Searches: 18383
                                                               Buffers: shared hit=73534
                                             ->  Memoize  (cost=0.43..3.46 rows=1 width=2404) (actual time=0.001..0.001 rows=1.00 loops=79092)
                                                   Cache Key: cv."VULNERABILITY_ID"
                                                   Cache Mode: logical
                                                   Hits: 20269  Misses: 4525  Evictions: 0  Overflows: 0  Memory Usage: 4931kB
                                                   Buffers: shared hit=54346
                                                   Worker 0:  Hits: 22893  Misses: 4452  Evictions: 0  Overflows: 0  Memory Usage: 4946kB
                                                   Worker 1:  Hits: 22344  Misses: 4609  Evictions: 0  Overflows: 0  Memory Usage: 5157kB
                                                   ->  Index Scan using "VULNERABILITY_PK" on "VULNERABILITY" v  (cost=0.42..3.45 rows=1 width=2404) (actual time=0.005..0.005 rows=1.00 loops=13586)
                                                         Index Cond: ("ID" = cv."VULNERABILITY_ID")
                                                         Index Searches: 13586
                                                         Buffers: shared hit=54346
                                       ->  Index Scan using "ANALYSIS_COMPONENT_ID_IDX" on "ANALYSIS" a  (cost=0.14..44.44 rows=20 width=2737) (actual time=0.015..0.015 rows=0.00 loops=3)
                                             Index Searches: 3
                                             Buffers: shared hit=3
                           ->  Limit  (cost=32.23..32.24 rows=1 width=26) (actual time=0.010..0.010 rows=0.69 loops=79092)
                                 Buffers: shared hit=663443
                                 ->  Sort  (cost=32.23..32.24 rows=2 width=26) (actual time=0.010..0.010 rows=0.69 loops=79092)
                                       Sort Key: "*SELECT* 1"."SCORE" DESC NULLS LAST, "*SELECT* 1"."PERCENTILE" DESC NULLS LAST, "*SELECT* 1"."CVE"
                                       Sort Method: quicksort  Memory: 25kB
                                       Buffers: shared hit=663443
                                       ->  Append  (cost=0.42..32.22 rows=2 width=26) (actual time=0.008..0.009 rows=0.69 loops=79092)
                                             Buffers: shared hit=663437
                                             ->  Subquery Scan on "*SELECT* 1"  (cost=0.42..8.45 rows=1 width=26) (actual time=0.001..0.001 rows=0.12 loops=79092)
                                                   Buffers: shared hit=36518
                                                   ->  Result  (cost=0.42..8.44 rows=1 width=26) (actual time=0.001..0.001 rows=0.12 loops=79092)
                                                         One-Time Filter: ((v."SOURCE")::text = 'NVD'::text)
                                                         Buffers: shared hit=36518
                                                         ->  Index Scan using "EPSS_CVE_IDX" on "EPSS" ee  (cost=0.42..8.44 rows=1 width=26) (actual time=0.003..0.003 rows=1.00 loops=9132)
                                                               Index Cond: ("CVE" = (v."VULNID")::text)
                                                               Index Searches: 9132
                                                               Buffers: shared hit=36518
                                             ->  Subquery Scan on "*SELECT* 2"  (cost=5.28..23.76 rows=1 width=26) (actual time=0.007..0.008 rows=0.58 loops=79092)
                                                   Buffers: shared hit=626919
                                                   ->  Result  (cost=5.28..23.75 rows=1 width=26) (actual time=0.007..0.007 rows=0.58 loops=79092)
                                                         One-Time Filter: ((v."SOURCE")::text <> 'NVD'::text)
                                                         Buffers: shared hit=626919
                                                         ->  Nested Loop  (cost=5.28..23.75 rows=1 width=26) (actual time=0.008..0.008 rows=0.65 loops=69960)
                                                               Buffers: shared hit=626919
                                                               ->  Nested Loop  (cost=4.85..20.64 rows=1 width=17) (actual time=0.006..0.006 rows=0.66 loops=69960)
                                                                     Buffers: shared hit=443271
                                                                     ->  Index Scan using "VULNERABILITY_ALIAS_PK" on "VULNERABILITY_ALIAS" va  (cost=0.42..8.44 rows=1 width=16) (actual time=0.003..0.003 rows=0.66 loops=69960)
                                                                           Index Cond: (("SOURCE" = (v."SOURCE")::text) AND ("VULN_ID" = (v."VULNID")::text))
                                                                           Index Searches: 69960
                                                                           Buffers: shared hit=255907
                                                                     ->  Bitmap Heap Scan on "VULNERABILITY_ALIAS" cve_a  (cost=4.43..12.19 rows=1 width=33) (actual time=0.002..0.003 rows=1.00 loops=46027)
                                                                           Recheck Cond: (va."GROUP_ID" = "GROUP_ID")
                                                                           Filter: ("SOURCE" = 'NVD'::text)
                                                                           Rows Removed by Filter: 1
                                                                           Heap Blocks: exact=49283
                                                                           Buffers: shared hit=187364
                                                                           ->  Bitmap Index Scan on "VULNERABILITY_ALIAS_GROUP_IDX"  (cost=0.00..4.43 rows=2 width=0) (actual time=0.002..0.002 rows=2.14 loops=46027)
                                                                                 Index Cond: ("GROUP_ID" = va."GROUP_ID")
                                                                                 Index Searches: 46027
                                                                                 Buffers: shared hit=138081
                                                               ->  Index Scan using "EPSS_CVE_IDX" on "EPSS" ee_1  (cost=0.42..3.10 rows=1 width=26) (actual time=0.003..0.003 rows=0.99 loops=46034)
                                                                     Index Cond: ("CVE" = cve_a."VULN_ID")
                                                                     Index Searches: 46034
                                                                     Buffers: shared hit=183648
                     ->  Limit  (cost=0.42..8.44 rows=1 width=607) (actual time=0.002..0.002 rows=0.86 loops=79092)
                           Buffers: shared hit=305076
                           ->  Index Scan using "FINDINGATTRIBUTION_COMPONENT_VULN_IDX" on "FINDINGATTRIBUTION" fa  (cost=0.42..8.44 rows=1 width=607) (actual time=0.002..0.002 rows=0.86 loops=79092)
                                 Index Cond: (("COMPONENT_ID" = c."ID") AND ("VULNERABILITY_ID" = v."ID") AND ("DELETED_AT" IS NULL))
                                 Index Searches: 79092
                                 Buffers: shared hit=305076
               ->  Index Scan using "PROJECT_PK" on "PROJECT" p  (cost=0.28..0.30 rows=1 width=102) (actual time=0.001..0.001 rows=1.00 loops=67800)
                     Index Cond: ("ID" = c."PROJECT_ID")
                     Filter: ("INACTIVE_SINCE" IS NULL)
                     Index Searches: 67800
                     Buffers: shared hit=203400
         SubPlan 2
           ->  Seq Scan on "COMPONENT_OCCURRENCE"  (cost=0.00..16.10 rows=610 width=8) (actual time=0.009..0.009 rows=0.00 loops=1)
 Planning:
   Buffers: shared hit=1919
 Planning Time: 30.088 ms
 JIT:
   Functions: 154
   Options: Inlining true, Optimization true, Expressions true, Deforming true
   Timing: Generation 14.523 ms (Deform 8.630 ms), Inlining 176.201 ms, Optimization 1354.705 ms, Emission 995.843 ms, Total 2541.271 ms
 Execution Time: 3543.054 ms
(119 rows)
```

</details>

<details>
<summary>Query plan for getAllFindings AFTER</summary>

```
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop Left Join  (cost=408938.35..415260.79 rows=100 width=5715) (actual time=331.234..340.820 rows=100.00 loops=1)
   Buffers: shared hit=378741
   ->  Nested Loop  (cost=408906.11..411454.36 rows=100 width=6430) (actual time=330.278..331.507 rows=100.00 loops=1)
         Buffers: shared hit=377942
         ->  Merge Left Join  (cost=408905.70..410608.36 rows=100 width=5865) (actual time=330.263..331.207 rows=100.00 loops=1)
               Merge Cond: ((c."ID" = a."COMPONENT_ID") AND (v."ID" = a."VULNERABILITY_ID"))
               Join Filter: (c."PROJECT_ID" = a."PROJECT_ID")
               Buffers: shared hit=377542
               ->  Nested Loop  (cost=408895.06..410597.07 rows=100 width=3160) (actual time=330.235..331.146 rows=100.00 loops=1)
                     Buffers: shared hit=377542
                     ->  Nested Loop  (cost=408894.79..410566.97 rows=100 width=3066) (actual time=330.224..330.981 rows=100.00 loops=1)
                           Buffers: shared hit=377242
                           ->  Nested Loop  (cost=408894.36..409726.72 rows=100 width=670) (actual time=330.207..330.544 rows=100.00 loops=1)
                                 Buffers: shared hit=376842
                                 ->  Limit  (cost=408893.94..408893.97 rows=100 width=124) (actual time=330.185..330.252 rows=100.00 loops=1)
                                       Buffers: shared hit=376442
                                       ->  WindowAgg  (cost=408893.94..408903.46 rows=42976 width=124) (actual time=330.184..330.241 rows=100.00 loops=1)
                                             Window: w1 AS ()
                                             Storage: Memory  Maximum Storage: 3489kB
                                             Buffers: shared hit=376442
                                             ->  Nested Loop  (cost=2.12..408366.26 rows=42976 width=16) (actual time=0.885..315.292 rows=67800.00 loops=1)
                                                   Buffers: shared hit=376442
                                                   ->  Nested Loop  (cost=1.84..407035.76 rows=42976 width=24) (actual time=0.837..292.260 rows=67800.00 loops=1)
                                                         Buffers: shared hit=374033
                                                         ->  Merge Left Join  (cost=1.42..43458.80 rows=42976 width=24) (actual time=0.764..154.638 rows=79092.00 loops=1)
                                                               Merge Cond: (c_1."ID" = a_1."COMPONENT_ID")
                                                               Join Filter: ((v_1."ID" = a_1."VULNERABILITY_ID") AND (c_1."PROJECT_ID" = a_1."PROJECT_ID"))
                                                               Filter: (a_1."SUPPRESSED" IS DISTINCT FROM true)
                                                               Buffers: shared hit=101535
                                                               ->  Nested Loop  (cost=1.28..43199.24 rows=85953 width=24) (actual time=0.751..146.233 rows=79092.00 loops=1)
                                                                     Buffers: shared hit=101534
                                                                     ->  Nested Loop  (cost=0.85..35470.32 rows=85953 width=24) (actual time=0.575..102.368 rows=79092.00 loops=1)
                                                                           Buffers: shared hit=80938
                                                                           ->  Index Only Scan using "COMPONENTS_VULNERABILITIES_COMPOSITE_IDX" on "COMPONENTS_VULNERABILITIES" cv  (cost=0.42..3399.31 rows=85953 width=16) (actual time=0.032..13.624 rows=79092.00 loops=1)
                                                                                 Heap Fetches: 20632
                                                                                 Index Searches: 1
                                                                                 Buffers: shared hit=7594
                                                                           ->  Memoize  (cost=0.43..1.91 rows=1 width=16) (actual time=0.001..0.001 rows=1.00 loops=79092)
                                                                                 Cache Key: cv."COMPONENT_ID"
                                                                                 Cache Mode: logical
                                                                                 Hits: 60756  Misses: 18336  Evictions: 0  Overflows: 0  Memory Usage: 2149kB
                                                                                 Buffers: shared hit=73344
                                                                                 ->  Index Scan using "COMPONENT_PK" on "COMPONENT" c_1  (cost=0.42..1.90 rows=1 width=16) (actual time=0.003..0.003 rows=1.00 loops=18336)
                                                                                       Index Cond: ("ID" = cv."COMPONENT_ID")
                                                                                       Index Searches: 18336
                                                                                       Buffers: shared hit=73344
                                                                     ->  Memoize  (cost=0.43..1.19 rows=1 width=8) (actual time=0.000..0.000 rows=1.00 loops=79092)
                                                                           Cache Key: cv."VULNERABILITY_ID"
                                                                           Cache Mode: logical
                                                                           Hits: 73608  Misses: 5484  Evictions: 0  Overflows: 0  Memory Usage: 600kB
                                                                           Buffers: shared hit=20596
                                                                           ->  Index Only Scan using "VULNERABILITY_PK" on "VULNERABILITY" v_1  (cost=0.42..1.18 rows=1 width=8) (actual time=0.003..0.003 rows=1.00 loops=5484)
                                                                                 Index Cond: ("ID" = cv."VULNERABILITY_ID")
                                                                                 Heap Fetches: 1650
                                                                                 Index Searches: 5484
                                                                                 Buffers: shared hit=20596
                                                               ->  Index Scan using "ANALYSIS_COMPONENT_ID_IDX" on "ANALYSIS" a_1  (cost=0.14..44.44 rows=20 width=25) (actual time=0.011..0.011 rows=0.00 loops=1)
                                                                     Index Searches: 1
                                                                     Buffers: shared hit=1
                                                         ->  Limit  (cost=0.42..8.44 rows=1 width=1114) (actual time=0.001..0.002 rows=0.86 loops=79092)
                                                               Buffers: shared hit=272498
                                                               ->  Index Only Scan using "FINDINGATTRIBUTION_COMPONENT_VULN_IDX" on "FINDINGATTRIBUTION" fa  (cost=0.42..8.44 rows=1 width=1114) (actual time=0.001..0.001 rows=0.86 loops=79092)
                                                                     Index Cond: (("COMPONENT_ID" = c_1."ID") AND ("VULNERABILITY_ID" = v_1."ID") AND ("DELETED_AT" IS NULL))
                                                                     Heap Fetches: 35221
                                                                     Index Searches: 79092
                                                                     Buffers: shared hit=272498
                                                   ->  Memoize  (cost=0.29..0.31 rows=1 width=8) (actual time=0.000..0.000 rows=1.00 loops=67800)
                                                         Cache Key: c_1."PROJECT_ID"
                                                         Cache Mode: logical
                                                         Hits: 66997  Misses: 803  Evictions: 0  Overflows: 0  Memory Usage: 88kB
                                                         Buffers: shared hit=2409
                                                         ->  Index Scan using "PROJECT_PK" on "PROJECT" p_1  (cost=0.28..0.30 rows=1 width=8) (actual time=0.002..0.002 rows=1.00 loops=803)
                                                               Index Cond: ("ID" = c_1."PROJECT_ID")
                                                               Filter: ("INACTIVE_SINCE" IS NULL)
                                                               Index Searches: 803
                                                               Buffers: shared hit=2409
                                 ->  Index Scan using "COMPONENT_PK" on "COMPONENT" c  (cost=0.42..8.32 rows=1 width=654) (actual time=0.002..0.002 rows=1.00 loops=100)
                                       Index Cond: ("ID" = c_1."ID")
                                       Index Searches: 100
                                       Buffers: shared hit=400
                           ->  Index Scan using "VULNERABILITY_PK" on "VULNERABILITY" v  (cost=0.42..8.40 rows=1 width=2404) (actual time=0.004..0.004 rows=1.00 loops=100)
                                 Index Cond: ("ID" = v_1."ID")
                                 Index Searches: 100
                                 Buffers: shared hit=400
                     ->  Index Scan using "PROJECT_PK" on "PROJECT" p  (cost=0.28..0.30 rows=1 width=102) (actual time=0.001..0.001 rows=1.00 loops=100)
                           Index Cond: ("ID" = c."PROJECT_ID")
                           Index Searches: 100
                           Buffers: shared hit=300
               ->  Sort  (cost=10.63..10.68 rows=20 width=2737) (actual time=0.025..0.025 rows=0.00 loops=1)
                     Sort Key: a."COMPONENT_ID", a."VULNERABILITY_ID"
                     Sort Method: quicksort  Memory: 25kB
                     ->  Seq Scan on "ANALYSIS" a  (cost=0.00..10.20 rows=20 width=2737) (actual time=0.007..0.007 rows=0.00 loops=1)
         ->  Limit  (cost=0.42..8.44 rows=1 width=607) (actual time=0.002..0.002 rows=1.00 loops=100)
               Buffers: shared hit=400
               ->  Index Scan using "FINDINGATTRIBUTION_COMPONENT_VULN_IDX" on "FINDINGATTRIBUTION" fa_1  (cost=0.42..8.44 rows=1 width=607) (actual time=0.002..0.002 rows=1.00 loops=100)
                     Index Cond: (("COMPONENT_ID" = c."ID") AND ("VULNERABILITY_ID" = v."ID") AND ("DELETED_AT" IS NULL))
                     Index Searches: 100
                     Buffers: shared hit=400
   ->  Limit  (cost=32.23..32.24 rows=1 width=26) (actual time=0.013..0.013 rows=0.05 loops=100)
         Buffers: shared hit=351
         ->  Sort  (cost=32.23..32.24 rows=2 width=26) (actual time=0.011..0.011 rows=0.05 loops=100)
               Sort Key: "*SELECT* 1"."SCORE" DESC NULLS LAST, "*SELECT* 1"."PERCENTILE" DESC NULLS LAST, "*SELECT* 1"."CVE"
               Sort Method: quicksort  Memory: 25kB
               Buffers: shared hit=351
               ->  Append  (cost=0.42..32.22 rows=2 width=26) (actual time=0.005..0.006 rows=0.05 loops=100)
                     Buffers: shared hit=345
                     ->  Subquery Scan on "*SELECT* 1"  (cost=0.42..8.45 rows=1 width=26) (actual time=0.000..0.000 rows=0.00 loops=100)
                           ->  Result  (cost=0.42..8.44 rows=1 width=26) (actual time=0.000..0.000 rows=0.00 loops=100)
                                 One-Time Filter: ((v."SOURCE")::text = 'NVD'::text)
                                 ->  Index Scan using "EPSS_CVE_IDX" on "EPSS" ee  (cost=0.42..8.44 rows=1 width=26) (never executed)
                                       Index Cond: ("CVE" = (v."VULNID")::text)
                                       Index Searches: 0
                     ->  Subquery Scan on "*SELECT* 2"  (cost=5.28..23.76 rows=1 width=26) (actual time=0.005..0.005 rows=0.05 loops=100)
                           Buffers: shared hit=345
                           ->  Result  (cost=5.28..23.75 rows=1 width=26) (actual time=0.005..0.005 rows=0.05 loops=100)
                                 One-Time Filter: ((v."SOURCE")::text <> 'NVD'::text)
                                 Buffers: shared hit=345
                                 ->  Nested Loop  (cost=5.28..23.75 rows=1 width=26) (actual time=0.004..0.004 rows=0.05 loops=100)
                                       Buffers: shared hit=345
                                       ->  Nested Loop  (cost=4.85..20.64 rows=1 width=17) (actual time=0.004..0.004 rows=0.05 loops=100)
                                             Buffers: shared hit=325
                                             ->  Index Scan using "VULNERABILITY_ALIAS_PK" on "VULNERABILITY_ALIAS" va  (cost=0.42..8.44 rows=1 width=16) (actual time=0.003..0.003 rows=0.05 loops=100)
                                                   Index Cond: (("SOURCE" = (v."SOURCE")::text) AND ("VULN_ID" = (v."VULNID")::text))
                                                   Index Searches: 100
                                                   Buffers: shared hit=305
                                             ->  Bitmap Heap Scan on "VULNERABILITY_ALIAS" cve_a  (cost=4.43..12.19 rows=1 width=33) (actual time=0.007..0.008 rows=1.00 loops=5)
                                                   Recheck Cond: (va."GROUP_ID" = "GROUP_ID")
                                                   Filter: ("SOURCE" = 'NVD'::text)
                                                   Rows Removed by Filter: 1
                                                   Heap Blocks: exact=5
                                                   Buffers: shared hit=20
                                                   ->  Bitmap Index Scan on "VULNERABILITY_ALIAS_GROUP_IDX"  (cost=0.00..4.43 rows=2 width=0) (actual time=0.003..0.003 rows=2.00 loops=5)
                                                         Index Cond: ("GROUP_ID" = va."GROUP_ID")
                                                         Index Searches: 5
                                                         Buffers: shared hit=15
                                       ->  Index Scan using "EPSS_CVE_IDX" on "EPSS" ee_1  (cost=0.42..3.10 rows=1 width=26) (actual time=0.010..0.010 rows=1.00 loops=5)
                                             Index Cond: ("CVE" = cve_a."VULN_ID")
                                             Index Searches: 5
                                             Buffers: shared hit=20
   SubPlan 2
     ->  Seq Scan on "COMPONENT_OCCURRENCE"  (cost=0.00..16.10 rows=610 width=8) (actual time=0.005..0.005 rows=0.00 loops=1)
 Planning:
   Buffers: shared hit=1961
 Planning Time: 31.297 ms
 Execution Time: 341.969 ms
(145 rows)
```

</details>

That's roughly a 10x improvement.

<details>
<summary>Query plan for getGroupedFindings BEFORE</summary>

```
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=791805.64..791811.40 rows=100 width=271) (actual time=1423.225..1423.357 rows=100.00 loops=1)
   Buffers: shared hit=453231
   ->  WindowAgg  (cost=791805.64..796757.15 rows=85953 width=271) (actual time=509.288..509.407 rows=100.00 loops=1)
         Window: w1 AS ()
         Storage: Memory  Maximum Storage: 662kB
         Buffers: shared hit=453231
         ->  GroupAggregate  (cost=191.94..790740.44 rows=85953 width=231) (actual time=45.827..507.442 rows=4223.00 loops=1)
               Group Key: v."ID", (COALESCE(a."SEVERITY", v."SEVERITY")), (CASE WHEN ((a."CVSSV2SCORE" IS NOT NULL) OR (a."CVSSV2VECTOR" IS NOT NULL)) THEN a."CVSSV2SCORE" ELSE v."CVSSV2BASESCORE" END), (CASE WHEN ((a."CVSSV3SCORE" IS NOT NULL) OR (a."CVSSV3VECTOR" IS NOT NULL)) THEN a."CVSSV3SCORE" ELSE v."CVSSV3BASESCORE" END), (CASE WHEN ((a."CVSSV4SCORE" IS NOT NULL) OR (a."CVSSV4VECTOR" IS NOT NULL)) THEN a."CVSSV4SCORE" ELSE v."CVSSV4SCORE" END), e."SCORE", e."PERCENTILE", fa."ANALYZERIDENTITY"
               Buffers: shared hit=453231
               ->  Incremental Sort  (cost=191.94..787946.97 rows=85953 width=231) (actual time=45.534..494.017 rows=67800.00 loops=1)
                     Sort Key: v."ID", (COALESCE(a."SEVERITY", v."SEVERITY")), (CASE WHEN ((a."CVSSV2SCORE" IS NOT NULL) OR (a."CVSSV2VECTOR" IS NOT NULL)) THEN a."CVSSV2SCORE" ELSE v."CVSSV2BASESCORE" END), (CASE WHEN ((a."CVSSV3SCORE" IS NOT NULL) OR (a."CVSSV3VECTOR" IS NOT NULL)) THEN a."CVSSV3SCORE" ELSE v."CVSSV3BASESCORE" END), (CASE WHEN ((a."CVSSV4SCORE" IS NOT NULL) OR (a."CVSSV4VECTOR" IS NOT NULL)) THEN a."CVSSV4SCORE" ELSE v."CVSSV4SCORE" END), e."SCORE", e."PERCENTILE", fa."ANALYZERIDENTITY", p."ID"
                     Presorted Key: v."ID"
                     Full-sort Groups: 1020  Sort Method: quicksort  Average Memory: 38kB  Peak Memory: 38kB
                     Pre-sorted Groups: 521  Sort Method: quicksort  Average Memory: 236kB  Peak Memory: 272kB
                     Buffers: shared hit=453231
                     ->  Nested Loop Left Join  (cost=25.01..784978.08 rows=85953 width=231) (actual time=44.089..370.839 rows=67800.00 loops=1)
                           Buffers: shared hit=453220
                           ->  Nested Loop  (cost=2.00..783880.64 rows=85953 width=1789) (actual time=44.047..358.121 rows=67800.00 loops=1)
                                 Buffers: shared hit=453217
                                 ->  Merge Left Join  (cost=1.71..781476.36 rows=85953 width=1789) (actual time=43.999..332.892 rows=67800.00 loops=1)
                                       Merge Cond: (v."ID" = a."VULNERABILITY_ID")
                                       Join Filter: ((c."ID" = a."COMPONENT_ID") AND (c."PROJECT_ID" = a."PROJECT_ID"))
                                       Buffers: shared hit=450808
                                       ->  Nested Loop  (cost=1.57..781216.96 rows=85953 width=149) (actual time=43.978..325.588 rows=67800.00 loops=1)
                                             Buffers: shared hit=450807
                                             ->  Nested Loop  (cost=1.16..54054.58 rows=85953 width=140) (actual time=0.563..169.234 rows=79092.00 loops=1)
                                                   Buffers: shared hit=145731
                                                   ->  Nested Loop  (cost=0.72..35652.51 rows=85953 width=24) (actual time=0.436..119.484 rows=79092.00 loops=1)
                                                         Buffers: shared hit=123795
                                                         ->  Index Scan using "COMPONENTS_VULNERABILITIES_VULNERABILITY_ID_IDX" on "COMPONENTS_VULNERABILITIES" cv  (cost=0.29..3581.49 rows=85953 width=16) (actual time=0.017..23.963 rows=79092.00 loops=1)
                                                               Index Searches: 1
                                                               Buffers: shared hit=50451
                                                         ->  Memoize  (cost=0.43..1.91 rows=1 width=16) (actual time=0.001..0.001 rows=1.00 loops=79092)
                                                               Cache Key: cv."COMPONENT_ID"
                                                               Cache Mode: logical
                                                               Hits: 60756  Misses: 18336  Evictions: 0  Overflows: 0  Memory Usage: 2149kB
                                                               Buffers: shared hit=73344
                                                               ->  Index Scan using "COMPONENT_PK" on "COMPONENT" c  (cost=0.42..1.90 rows=1 width=16) (actual time=0.003..0.003 rows=1.00 loops=18336)
                                                                     Index Cond: ("ID" = cv."COMPONENT_ID")
                                                                     Index Searches: 18336
                                                                     Buffers: shared hit=73344
                                                   ->  Memoize  (cost=0.43..3.46 rows=1 width=124) (actual time=0.000..0.000 rows=1.00 loops=79092)
                                                         Cache Key: cv."VULNERABILITY_ID"
                                                         Cache Mode: logical
                                                         Hits: 73608  Misses: 5484  Evictions: 0  Overflows: 0  Memory Usage: 1056kB
                                                         Buffers: shared hit=21936
                                                         ->  Index Scan using "VULNERABILITY_PK" on "VULNERABILITY" v  (cost=0.42..3.45 rows=1 width=124) (actual time=0.004..0.004 rows=1.00 loops=5484)
                                                               Index Cond: ("ID" = cv."VULNERABILITY_ID")
                                                               Index Searches: 5484
                                                               Buffers: shared hit=21936
                                             ->  Limit  (cost=0.42..8.44 rows=1 width=607) (actual time=0.002..0.002 rows=0.86 loops=79092)
                                                   Buffers: shared hit=305076
                                                   ->  Index Scan using "FINDINGATTRIBUTION_COMPONENT_VULN_IDX" on "FINDINGATTRIBUTION" fa  (cost=0.42..8.44 rows=1 width=607) (actual time=0.002..0.002 rows=0.86 loops=79092)
                                                         Index Cond: (("COMPONENT_ID" = c."ID") AND ("VULNERABILITY_ID" = v."ID") AND ("DELETED_AT" IS NULL))
                                                         Index Searches: 79092
                                                         Buffers: shared hit=305076
                                       ->  Index Scan using "ANALYSIS_VULNERABILITY_ID_IDX" on "ANALYSIS" a  (cost=0.14..44.44 rows=20 width=1672) (actual time=0.013..0.013 rows=0.00 loops=1)
                                             Index Searches: 1
                                             Buffers: shared hit=1
                                 ->  Memoize  (cost=0.29..0.31 rows=1 width=8) (actual time=0.000..0.000 rows=1.00 loops=67800)
                                       Cache Key: c."PROJECT_ID"
                                       Cache Mode: logical
                                       Hits: 66997  Misses: 803  Evictions: 0  Overflows: 0  Memory Usage: 88kB
                                       Buffers: shared hit=2409
                                       ->  Index Scan using "PROJECT_PK" on "PROJECT" p  (cost=0.28..0.30 rows=1 width=8) (actual time=0.002..0.002 rows=1.00 loops=803)
                                             Index Cond: ("ID" = c."PROJECT_ID")
                                             Filter: ("INACTIVE_SINCE" IS NULL)
                                             Index Searches: 803
                                             Buffers: shared hit=2409
                           ->  Materialize  (cost=23.01..23.03 rows=1 width=12) (actual time=0.000..0.000 rows=0.00 loops=67800)
                                 Storage: Memory  Maximum Storage: 17kB
                                 Buffers: shared hit=3
                                 ->  Subquery Scan on e  (cost=23.01..23.02 rows=1 width=12) (actual time=0.036..0.039 rows=0.00 loops=1)
                                       Buffers: shared hit=3
                                       ->  Limit  (cost=23.01..23.01 rows=1 width=26) (actual time=0.036..0.038 rows=0.00 loops=1)
                                             Buffers: shared hit=3
                                             ->  Sort  (cost=23.01..23.01 rows=1 width=26) (actual time=0.033..0.035 rows=0.00 loops=1)
                                                   Sort Key: "*SELECT* 2"."SCORE" DESC NULLS LAST, "*SELECT* 2"."PERCENTILE" DESC NULLS LAST, "*SELECT* 2"."CVE"
                                                   Sort Method: quicksort  Memory: 25kB
                                                   Buffers: shared hit=3
                                                   ->  Subquery Scan on "*SELECT* 2"  (cost=5.27..23.00 rows=1 width=26) (actual time=0.021..0.023 rows=0.00 loops=1)
                                                         Buffers: shared hit=3
                                                         ->  Nested Loop  (cost=5.27..22.99 rows=1 width=26) (actual time=0.020..0.022 rows=0.00 loops=1)
                                                               Buffers: shared hit=3
                                                               ->  Nested Loop  (cost=4.85..19.89 rows=1 width=17) (actual time=0.020..0.021 rows=0.00 loops=1)
                                                                     Buffers: shared hit=3
                                                                     ->  Index Scan using "VULNERABILITY_ALIAS_PK" on "VULNERABILITY_ALIAS" va  (cost=0.42..7.69 rows=1 width=16) (actual time=0.020..0.020 rows=0.00 loops=1)
                                                                           Index Cond: (("SOURCE" = 'v."SOURCE"'::text) AND ("VULN_ID" = 'v."VULNID"'::text))
                                                                           Index Searches: 1
                                                                           Buffers: shared hit=3
                                                                     ->  Bitmap Heap Scan on "VULNERABILITY_ALIAS" cve_a  (cost=4.43..12.19 rows=1 width=33) (never executed)
                                                                           Recheck Cond: (va."GROUP_ID" = "GROUP_ID")
                                                                           Filter: ("SOURCE" = 'NVD'::text)
                                                                           ->  Bitmap Index Scan on "VULNERABILITY_ALIAS_GROUP_IDX"  (cost=0.00..4.43 rows=2 width=0) (never executed)
                                                                                 Index Cond: ("GROUP_ID" = va."GROUP_ID")
                                                                                 Index Searches: 0
                                                               ->  Index Scan using "EPSS_CVE_IDX" on "EPSS" ee  (cost=0.42..3.10 rows=1 width=26) (never executed)
                                                                     Index Cond: ("CVE" = cve_a."VULN_ID")
                                                                     Index Searches: 0
 Planning:
   Buffers: shared hit=1638
 Planning Time: 26.133 ms
 JIT:
   Functions: 78
   Options: Inlining true, Optimization true, Expressions true, Deforming true
   Timing: Generation 5.582 ms (Deform 3.173 ms), Inlining 67.668 ms, Optimization 486.911 ms, Emission 359.446 ms, Total 919.607 ms
 Execution Time: 1450.415 ms
(107 rows)
```

</details>

<details>
<summary>Query plan for getGroupedFindings AFTER</summary>

```
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=828028.42..828034.18 rows=100 width=271) (actual time=534.502..534.560 rows=100.00 loops=1)
   Buffers: shared hit=475650
   ->  WindowAgg  (cost=828028.42..832979.96 rows=85953 width=271) (actual time=534.501..534.554 rows=100.00 loops=1)
         Window: w1 AS ()
         Storage: Memory  Maximum Storage: 662kB
         Buffers: shared hit=475650
         ->  GroupAggregate  (cost=33750.08..826963.25 rows=85953 width=231) (actual time=94.785..532.591 rows=4223.00 loops=1)
               Group Key: v."ID", (COALESCE(a."SEVERITY", v."SEVERITY")), (CASE WHEN ((a."CVSSV2SCORE" IS NOT NULL) OR (a."CVSSV2VECTOR" IS NOT NULL)) THEN a."CVSSV2SCORE" ELSE v."CVSSV2BASESCORE" END), (CASE WHEN ((a."CVSSV3SCORE" IS NOT NULL) OR (a."CVSSV3VECTOR" IS NOT NULL)) THEN a."CVSSV3SCORE" ELSE v."CVSSV3BASESCORE" END), (CASE WHEN ((a."CVSSV4SCORE" IS NOT NULL) OR (a."CVSSV4VECTOR" IS NOT NULL)) THEN a."CVSSV4SCORE" ELSE v."CVSSV4SCORE" END), ep."SCORE", ep."PERCENTILE", fa."ANALYZERIDENTITY"
               Buffers: shared hit=475650
               ->  Incremental Sort  (cost=33750.08..824169.78 rows=85953 width=231) (actual time=94.388..515.918 rows=67800.00 loops=1)
                     Sort Key: v."ID", (COALESCE(a."SEVERITY", v."SEVERITY")), (CASE WHEN ((a."CVSSV2SCORE" IS NOT NULL) OR (a."CVSSV2VECTOR" IS NOT NULL)) THEN a."CVSSV2SCORE" ELSE v."CVSSV2BASESCORE" END), (CASE WHEN ((a."CVSSV3SCORE" IS NOT NULL) OR (a."CVSSV3VECTOR" IS NOT NULL)) THEN a."CVSSV3SCORE" ELSE v."CVSSV3BASESCORE" END), (CASE WHEN ((a."CVSSV4SCORE" IS NOT NULL) OR (a."CVSSV4VECTOR" IS NOT NULL)) THEN a."CVSSV4SCORE" ELSE v."CVSSV4SCORE" END), ep."SCORE", ep."PERCENTILE", fa."ANALYZERIDENTITY", p."ID"
                     Presorted Key: v."ID"
                     Full-sort Groups: 1020  Sort Method: quicksort  Average Memory: 38kB  Peak Memory: 38kB
                     Pre-sorted Groups: 521  Sort Method: quicksort  Average Memory: 236kB  Peak Memory: 272kB
                     Buffers: shared hit=475650
                     ->  Nested Loop  (cost=33582.58..821200.89 rows=85953 width=231) (actual time=93.341..474.530 rows=67800.00 loops=1)
                           Buffers: shared hit=475639
                           ->  Nested Loop  (cost=33582.30..818796.61 rows=85953 width=1801) (actual time=93.308..443.417 rows=67800.00 loops=1)
                                 Buffers: shared hit=473230
                                 ->  Merge Left Join  (cost=33581.88..91634.23 rows=85953 width=1800) (actual time=43.366..287.586 rows=79092.00 loops=1)
                                       Merge Cond: ((v."ID" = a."VULNERABILITY_ID") AND (c."PROJECT_ID" = a."PROJECT_ID") AND (c."ID" = a."COMPONENT_ID"))
                                       Buffers: shared hit=168154
                                       ->  Incremental Sort  (cost=33571.25..90978.74 rows=85953 width=152) (actual time=43.342..273.124 rows=79092.00 loops=1)
                                             Sort Key: v."ID", c."PROJECT_ID", c."ID"
                                             Presorted Key: v."ID"
                                             Full-sort Groups: 1279  Sort Method: quicksort  Average Memory: 31kB  Peak Memory: 31kB
                                             Pre-sorted Groups: 614  Sort Method: quicksort  Average Memory: 229kB  Peak Memory: 272kB
                                             Buffers: shared hit=168154
                                             ->  Nested Loop  (cost=33559.31..88009.86 rows=85953 width=152) (actual time=42.659..221.233 rows=79092.00 loops=1)
                                                   Buffers: shared hit=168154
                                                   ->  Merge Left Join  (cost=33558.88..55938.84 rows=85953 width=144) (actual time=42.239..130.687 rows=79092.00 loops=1)
                                                         Merge Cond: (v."ID" = v_1."ID")
                                                         Buffers: shared hit=94810
                                                         ->  Nested Loop  (cost=0.73..21983.57 rows=85953 width=132) (actual time=0.147..64.880 rows=79092.00 loops=1)
                                                               Buffers: shared hit=72387
                                                               ->  Index Scan using "COMPONENTS_VULNERABILITIES_VULNERABILITY_ID_IDX" on "COMPONENTS_VULNERABILITIES" cv  (cost=0.29..3581.49 rows=85953 width=16) (actual time=0.015..22.833 rows=79092.00 loops=1)
                                                                     Index Searches: 1
                                                                     Buffers: shared hit=50451
                                                               ->  Memoize  (cost=0.43..3.46 rows=1 width=124) (actual time=0.000..0.000 rows=1.00 loops=79092)
                                                                     Cache Key: cv."VULNERABILITY_ID"
                                                                     Cache Mode: logical
                                                                     Hits: 73608  Misses: 5484  Evictions: 0  Overflows: 0  Memory Usage: 1056kB
                                                                     Buffers: shared hit=21936
                                                                     ->  Index Scan using "VULNERABILITY_PK" on "VULNERABILITY" v  (cost=0.42..3.45 rows=1 width=124) (actual time=0.002..0.002 rows=1.00 loops=5484)
                                                                           Index Cond: ("ID" = cv."VULNERABILITY_ID")
                                                                           Index Searches: 5484
                                                                           Buffers: shared hit=21936
                                                         ->  Materialize  (cost=33558.16..33723.13 rows=4713 width=20) (actual time=42.089..49.267 rows=79037.00 loops=1)
                                                               Storage: Memory  Maximum Storage: 17kB
                                                               Buffers: shared hit=22423
                                                               ->  Nested Loop Left Join  (cost=33558.16..33711.35 rows=4713 width=20) (actual time=42.082..45.132 rows=5484.00 loops=1)
                                                                     Buffers: shared hit=22423
                                                                     ->  Unique  (cost=33535.15..33582.28 rows=4713 width=27) (actual time=42.018..43.984 rows=5484.00 loops=1)
                                                                           Buffers: shared hit=22420
                                                                           ->  Sort  (cost=33535.15..33546.93 rows=4713 width=27) (actual time=42.017..42.754 rows=5484.00 loops=1)
                                                                                 Sort Key: v_1."ID", v_1."SOURCE", v_1."VULNID"
                                                                                 Sort Method: quicksort  Memory: 477kB
                                                                                 Buffers: shared hit=22420
                                                                                 ->  Nested Loop  (cost=1558.84..33247.60 rows=4713 width=27) (actual time=13.514..40.572 rows=5484.00 loops=1)
                                                                                       Buffers: shared hit=22420
                                                                                       ->  HashAggregate  (cost=1558.41..1605.54 rows=4713 width=8) (actual time=13.484..14.053 rows=5484.00 loops=1)
                                                                                             Group Key: "COMPONENTS_VULNERABILITIES"."VULNERABILITY_ID"
                                                                                             Batches: 1  Memory Usage: 409kB
                                                                                             Buffers: shared hit=484
                                                                                             ->  Seq Scan on "COMPONENTS_VULNERABILITIES"  (cost=0.00..1343.53 rows=85953 width=8) (actual time=0.015..4.354 rows=79092.00 loops=1)
                                                                                                   Buffers: shared hit=484
                                                                                       ->  Index Scan using "VULNERABILITY_PK" on "VULNERABILITY" v_1  (cost=0.42..6.75 rows=1 width=27) (actual time=0.005..0.005 rows=1.00 loops=5484)
                                                                                             Index Cond: ("ID" = "COMPONENTS_VULNERABILITIES"."VULNERABILITY_ID")
                                                                                             Index Searches: 5484
                                                                                             Buffers: shared hit=21936
                                                                     ->  Materialize  (cost=23.01..23.03 rows=1 width=12) (actual time=0.000..0.000 rows=0.00 loops=5484)
                                                                           Storage: Memory  Maximum Storage: 17kB
                                                                           Buffers: shared hit=3
                                                                           ->  Subquery Scan on ep  (cost=23.01..23.02 rows=1 width=12) (actual time=0.050..0.052 rows=0.00 loops=1)
                                                                                 Buffers: shared hit=3
                                                                                 ->  Limit  (cost=23.01..23.01 rows=1 width=26) (actual time=0.049..0.051 rows=0.00 loops=1)
                                                                                       Buffers: shared hit=3
                                                                                       ->  Sort  (cost=23.01..23.01 rows=1 width=26) (actual time=0.048..0.050 rows=0.00 loops=1)
                                                                                             Sort Key: "*SELECT* 2"."SCORE" DESC NULLS LAST, "*SELECT* 2"."PERCENTILE" DESC NULLS LAST, "*SELECT* 2"."CVE"
                                                                                             Sort Method: quicksort  Memory: 25kB
                                                                                             Buffers: shared hit=3
                                                                                             ->  Subquery Scan on "*SELECT* 2"  (cost=5.27..23.00 rows=1 width=26) (actual time=0.019..0.020 rows=0.00 loops=1)
                                                                                                   Buffers: shared hit=3
                                                                                                   ->  Nested Loop  (cost=5.27..22.99 rows=1 width=26) (actual time=0.018..0.020 rows=0.00 loops=1)
                                                                                                         Buffers: shared hit=3
                                                                                                         ->  Nested Loop  (cost=4.85..19.89 rows=1 width=17) (actual time=0.018..0.019 rows=0.00 loops=1)
                                                                                                               Buffers: shared hit=3
                                                                                                               ->  Index Scan using "VULNERABILITY_ALIAS_PK" on "VULNERABILITY_ALIAS" va  (cost=0.42..7.69 rows=1 width=16) (actual time=0.018..0.018 rows=0.00 loops=1)
                                                                                                                     Index Cond: (("SOURCE" = 'dv."SOURCE"'::text) AND ("VULN_ID" = 'dv."VULNID"'::text))
                                                                                                                     Index Searches: 1
                                                                                                                     Buffers: shared hit=3
                                                                                                               ->  Bitmap Heap Scan on "VULNERABILITY_ALIAS" cve_a  (cost=4.43..12.19 rows=1 width=33) (never executed)
                                                                                                                     Recheck Cond: (va."GROUP_ID" = "GROUP_ID")
                                                                                                                     Filter: ("SOURCE" = 'NVD'::text)
                                                                                                                     ->  Bitmap Index Scan on "VULNERABILITY_ALIAS_GROUP_IDX"  (cost=0.00..4.43 rows=2 width=0) (never executed)
                                                                                                                           Index Cond: ("GROUP_ID" = va."GROUP_ID")
                                                                                                                           Index Searches: 0
                                                                                                         ->  Index Scan using "EPSS_CVE_IDX" on "EPSS" ee  (cost=0.42..3.10 rows=1 width=26) (never executed)
                                                                                                               Index Cond: ("CVE" = cve_a."VULN_ID")
                                                                                                               Index Searches: 0
                                                   ->  Memoize  (cost=0.43..1.91 rows=1 width=16) (actual time=0.001..0.001 rows=1.00 loops=79092)
                                                         Cache Key: cv."COMPONENT_ID"
                                                         Cache Mode: logical
                                                         Hits: 60756  Misses: 18336  Evictions: 0  Overflows: 0  Memory Usage: 2149kB
                                                         Buffers: shared hit=73344
                                                         ->  Index Scan using "COMPONENT_PK" on "COMPONENT" c  (cost=0.42..1.90 rows=1 width=16) (actual time=0.003..0.003 rows=1.00 loops=18336)
                                                               Index Cond: ("ID" = cv."COMPONENT_ID")
                                                               Index Searches: 18336
                                                               Buffers: shared hit=73344
                                       ->  Sort  (cost=10.63..10.68 rows=20 width=1672) (actual time=0.022..0.022 rows=0.00 loops=1)
                                             Sort Key: a."VULNERABILITY_ID", a."PROJECT_ID", a."COMPONENT_ID"
                                             Sort Method: quicksort  Memory: 25kB
                                             ->  Seq Scan on "ANALYSIS" a  (cost=0.00..10.20 rows=20 width=1672) (actual time=0.007..0.007 rows=0.00 loops=1)
                                 ->  Limit  (cost=0.42..8.44 rows=1 width=607) (actual time=0.002..0.002 rows=0.86 loops=79092)
                                       Buffers: shared hit=305076
                                       ->  Index Scan using "FINDINGATTRIBUTION_COMPONENT_VULN_IDX" on "FINDINGATTRIBUTION" fa  (cost=0.42..8.44 rows=1 width=607) (actual time=0.002..0.002 rows=0.86 loops=79092)
                                             Index Cond: (("COMPONENT_ID" = c."ID") AND ("VULNERABILITY_ID" = v."ID") AND ("DELETED_AT" IS NULL))
                                             Index Searches: 79092
                                             Buffers: shared hit=305076
                           ->  Memoize  (cost=0.29..0.31 rows=1 width=8) (actual time=0.000..0.000 rows=1.00 loops=67800)
                                 Cache Key: c."PROJECT_ID"
                                 Cache Mode: logical
                                 Hits: 66997  Misses: 803  Evictions: 0  Overflows: 0  Memory Usage: 88kB
                                 Buffers: shared hit=2409
                                 ->  Index Scan using "PROJECT_PK" on "PROJECT" p  (cost=0.28..0.30 rows=1 width=8) (actual time=0.002..0.002 rows=1.00 loops=803)
                                       Index Cond: ("ID" = c."PROJECT_ID")
                                       Filter: ("INACTIVE_SINCE" IS NULL)
                                       Index Searches: 803
                                       Buffers: shared hit=2409
 Planning:
   Buffers: shared hit=1655
 Planning Time: 14.551 ms
 Execution Time: 535.628 ms
(133 rows)
```

</details>

Roughly a 3x improvement.

Note that more optimization techniques are possible once we migrate the endpoints to API v2 (i.e. keyset pagination, partial counts). Counting accounts by far for the most work to be done by the DB, so the API v1 contract promising exact counts is what hurts the most currently.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
