### PR TITLE
Reuse testcontainers for dev mode

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -155,7 +155,8 @@ make test-e2e
 ## Dev Mode
 
 Dev mode launches the API server with auto-provisioned containers for PostgreSQL
-and the frontend. Containers are created on startup and disposed of on shutdown.
+and the frontend. Containers are created on startup and, unless reuse is enabled
+(see [Container Reuse](#container-reuse)), disposed of on shutdown.
 
 ```shell
 make apiserver-dev
@@ -165,6 +166,21 @@ The API server will be available at `http://localhost:8080`.
 Frontend and PostgreSQL ports are logged during startup.
 
 Dev mode specific configuration can be made in [`application-dev.properties`](apiserver/src/main/resources/application-dev.properties).
+
+### Container Reuse
+
+Dev mode is configured to reuse its containers across restarts, so PostgreSQL
+state (schema and data) is preserved and startup is faster. Reuse only takes
+effect once it has been opted into globally, by setting either `testcontainers.reuse.enable=true`
+in `~/.testcontainers.properties`, or the `TESTCONTAINERS_REUSE_ENABLE=true` environment variable.
+Without it, containers are disposed on shutdown as usual.
+See the [Testcontainers reuse docs](https://java.testcontainers.org/features/reuse/#how-to-use-it).
+
+To remove reused (or otherwise stale) dev services containers, e.g. to start from a clean slate, run:
+
+```shell
+make apiserver-dev-remove-containers
+```
 
 ## DataNucleus Bytecode Enhancement
 

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,15 @@ apiserver-dev:
 	$(MVN) $(MVN_FLAGS) -q -Pquick,dev-services -pl apiserver -am verify
 .PHONY: apiserver-dev
 
+apiserver-dev-remove-containers:
+	@ids=$$(docker ps -aq --filter label=org.dependencytrack.dev-services); \
+	if [ -n "$$ids" ]; then \
+		docker rm -f $$ids; \
+	else \
+		echo "No dev services containers to remove"; \
+	fi
+.PHONY: apiserver-dev-remove-containers
+
 test-e2e: build-image
 	$(MVND) $(MVN_FLAGS) -pl e2e -DskipE2E=false verify
 .PHONY: test-e2e

--- a/apiserver/src/main/java/org/dependencytrack/common/ConfigKeys.java
+++ b/apiserver/src/main/java/org/dependencytrack/common/ConfigKeys.java
@@ -24,6 +24,7 @@ package org.dependencytrack.common;
 public final class ConfigKeys {
 
     public static final String DEV_SERVICES_ENABLED = "dt.dev-services.enabled";
+    public static final String DEV_SERVICES_CONTAINER_REUSE_ENABLED = "dt.dev-services.container-reuse.enabled";
     public static final String DEV_SERVICES_FRONTEND_IMAGE = "dt.dev-services.frontend-image";
     public static final String DEV_SERVICES_POSTGRES_IMAGE = "dt.dev-services.postgres-image";
     public static final String DEV_SERVICES_FRONTEND_PORT = "dt.dev-services.frontend-port";

--- a/apiserver/src/main/java/org/dependencytrack/dev/DevServices.java
+++ b/apiserver/src/main/java/org/dependencytrack/dev/DevServices.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import static org.dependencytrack.common.ConfigKeys.DEV_SERVICES_CONTAINER_REUSE_ENABLED;
 import static org.dependencytrack.common.ConfigKeys.DEV_SERVICES_ENABLED;
 import static org.dependencytrack.common.ConfigKeys.DEV_SERVICES_FRONTEND_IMAGE;
 import static org.dependencytrack.common.ConfigKeys.DEV_SERVICES_FRONTEND_PORT;
@@ -42,14 +43,19 @@ public class DevServices implements AutoCloseable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DevServices.class);
 
+    private static final String DEV_SERVICES_LABEL = "org.dependencytrack.dev-services";
+
     private final Config config = ConfigProvider.getConfig();
     private AutoCloseable postgresContainer;
     private AutoCloseable frontendContainer;
+    private boolean isContainerReuseActive;
 
     public void start() {
         if (!config.getValue(DEV_SERVICES_ENABLED, boolean.class)) {
             return;
         }
+
+        final boolean shouldReuseContainers = config.getValue(DEV_SERVICES_CONTAINER_REUSE_ENABLED, boolean.class);
 
         try {
             // Testcontainers will not be available outside the test scope,
@@ -80,6 +86,14 @@ public class DevServices implements AutoCloseable {
 
             final Method addFixedExposedPortMethod = genericContainerClass.getDeclaredMethod("addFixedExposedPort", int.class, int.class);
             addFixedExposedPortMethod.setAccessible(true);
+            final Method withReuseMethod = genericContainerClass.getMethod("withReuse", boolean.class);
+            final Method withLabelMethod = genericContainerClass.getMethod("withLabel", String.class, String.class);
+
+            // Reuse only takes effect when it has been opted into globally.
+            final Class<?> testcontainersConfigClass = Class.forName("org.testcontainers.utility.TestcontainersConfiguration");
+            final Object testcontainersConfig = testcontainersConfigClass.getMethod("getInstance").invoke(null);
+            final var envSupportsReuse = (boolean) testcontainersConfigClass.getMethod("environmentSupportsReuse").invoke(testcontainersConfig);
+            isContainerReuseActive = shouldReuseContainers && envSupportsReuse;
 
             final Class<?> postgresContainerClass = Class.forName("org.testcontainers.postgresql.PostgreSQLContainer");
             final Constructor<?> postgresContainerConstructor = postgresContainerClass.getDeclaredConstructor(String.class);
@@ -88,14 +102,19 @@ public class DevServices implements AutoCloseable {
             postgresContainerClass.getMethod("withPassword", String.class).invoke(postgresContainer, postgresPassword);
             postgresContainerClass.getMethod("withDatabaseName", String.class).invoke(postgresContainer, postgresDatabase);
             postgresContainerClass.getMethod("withUrlParam", String.class, String.class).invoke(postgresContainer, "reWriteBatchedInserts", "true");
+            withReuseMethod.invoke(postgresContainer, shouldReuseContainers);
+            withLabelMethod.invoke(postgresContainer, DEV_SERVICES_LABEL, "true");
             addFixedExposedPortMethod.invoke(postgresContainer, /* hostPort */ postgresPort, /* containerPort */  5432);
 
+            final String frontendImage = config.getValue(DEV_SERVICES_FRONTEND_IMAGE, String.class);
             final Constructor<?> genericContainerConstructor = genericContainerClass.getDeclaredConstructor(String.class);
-            frontendContainer = (AutoCloseable) genericContainerConstructor.newInstance(config.getValue(DEV_SERVICES_FRONTEND_IMAGE, String.class));
+            frontendContainer = (AutoCloseable) genericContainerConstructor.newInstance(frontendImage);
             genericContainerClass.getMethod("withEnv", String.class, String.class).invoke(frontendContainer, "API_BASE_URL", "http://localhost:8080");
             genericContainerClass.getMethod("withExposedPorts", Integer[].class).invoke(frontendContainer, (Object) new Integer[]{8080});
+            withReuseMethod.invoke(frontendContainer, shouldReuseContainers);
+            withLabelMethod.invoke(frontendContainer, DEV_SERVICES_LABEL, "true");
             addFixedExposedPortMethod.invoke(frontendContainer, /* hostPort */ frontendPort, /* containerPort */ 8080);
-            if (config.getValue(DEV_SERVICES_FRONTEND_IMAGE, String.class).endsWith(":snapshot")) {
+            if (frontendImage.matches(".*:\\d*-?snapshot")) {
                 genericContainerClass.getMethod("withImagePullPolicy", imagePullPolicyClass).invoke(frontendContainer, alwaysPullPolicy);
             }
 
@@ -106,12 +125,17 @@ public class DevServices implements AutoCloseable {
             throw new RuntimeException("Failed to launch containers", e);
         }
 
-        LOGGER.info("PostgreSQL is listening at localhost:%d".formatted(postgresPort));
-        LOGGER.info("Frontend is listening at http://localhost:%d".formatted(frontendPort));
+        LOGGER.info("PostgreSQL is listening at localhost:{}", postgresPort);
+        LOGGER.info("Frontend is listening at http://localhost:{}", frontendPort);
     }
 
     @Override
     public void close() {
+        if (isContainerReuseActive) {
+            LOGGER.info("Testcontainers reuse is active; leaving containers running");
+            return;
+        }
+
         if (postgresContainer != null) {
             LOGGER.info("Stopping postgres container");
             try {

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -977,6 +977,23 @@ dt.init-tasks.exit-after-completion=false
 # @type:     boolean
 dt.dev-services.enabled=false
 
+# Whether dev services containers shall be reused across restarts.
+# <br/><br/>
+# When enabled, containers are kept running when Dependency-Track stops, and
+# re-attached to on the next start. This preserves PostgreSQL state (schema and data)
+# across restarts and avoids the cost of re-provisioning on every run.
+# <br/><br/>
+# This additionally requires Testcontainers reuse to be opted into on the
+# developer's machine, either via testcontainers.reuse.enable=true in the
+# `~/.testcontainers.properties` file, or the `TESTCONTAINERS_REUSE_ENABLE=true`
+# environment variable. Without it, this option has no effect and containers
+# are disposed on shutdown as usual.
+# See <https://java.testcontainers.org/features/reuse/#how-to-use-it>.
+#
+# @category: Development
+# @type:     boolean
+dt.dev-services.container-reuse.enabled=true
+
 # The image to use for the frontend dev services container.
 #
 # @category: Development


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Reuses testcontainers for dev mode.

Removes friction from dev workflows by retaining database state across restarts, so you don't have to login and populate data from scratch each time.


### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
