### PR TITLE
Extend distro-aware version matching with Red Hat support

### DIFF
--- a/support/os-distro-metadata/pom.xml
+++ b/support/os-distro-metadata/pom.xml
@@ -37,8 +37,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.package-url</groupId>
-            <artifactId>packageurl-java</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>us.springett</groupId>
+            <artifactId>cpe-parser</artifactId>
         </dependency>
 
         <dependency>
@@ -47,15 +53,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
+            <groupId>com.github.package-url</groupId>
+            <artifactId>packageurl-java</artifactId>
         </dependency>
     </dependencies>
 

--- a/support/os-distro-metadata/src/main/java/module-info.java
+++ b/support/os-distro-metadata/src/main/java/module-info.java
@@ -23,6 +23,7 @@ import org.jspecify.annotations.NullMarked;
 module org.dependencytrack.support.distrometadata {
     exports org.dependencytrack.support.distrometadata;
 
-    requires transitive packageurl.java;
+    requires cpe.parser;
     requires transitive org.jspecify;
+    requires transitive packageurl.java;
 }

--- a/support/os-distro-metadata/src/main/java/org/dependencytrack/support/distrometadata/OsDistribution.java
+++ b/support/os-distro-metadata/src/main/java/org/dependencytrack/support/distrometadata/OsDistribution.java
@@ -26,7 +26,11 @@ import java.util.Map;
 /**
  * @since 4.14.0
  */
-public sealed interface OsDistribution permits AlpineDistribution, DebianDistribution, UbuntuDistribution {
+public sealed interface OsDistribution permits
+        AlpineDistribution,
+        DebianDistribution,
+        RedHatDistribution,
+        UbuntuDistribution {
 
     String purlQualifierValue();
 
@@ -38,26 +42,30 @@ public sealed interface OsDistribution permits AlpineDistribution, DebianDistrib
         }
 
         final Map<String, String> qualifiers = purl.getQualifiers();
-        if (qualifiers == null) {
+        final String distroQualifier = qualifiers != null
+                ? qualifiers.get("distro")
+                : null;
+
+        if (distroQualifier != null && !distroQualifier.isEmpty()) {
+            if ("apk".equals(purl.getType())) {
+                return AlpineDistribution.of(distroQualifier);
+            }
+            if ("deb".equals(purl.getType())) {
+                if ("debian".equalsIgnoreCase(purl.getNamespace())) {
+                    return DebianDistribution.of(distroQualifier);
+                }
+                if ("ubuntu".equalsIgnoreCase(purl.getNamespace())) {
+                    return UbuntuDistribution.of(distroQualifier);
+                }
+            }
+            if ("rpm".equals(purl.getType()) && "redhat".equalsIgnoreCase(purl.getNamespace())) {
+                return RedHatDistribution.of(distroQualifier);
+            }
             return null;
         }
 
-        final String distroQualifier = qualifiers.get("distro");
-        if (distroQualifier == null || distroQualifier.isEmpty()) {
-            return null;
-        }
-
-        if ("apk".equals(purl.getType())) {
-            return AlpineDistribution.of(distroQualifier);
-        }
-
-        if ("deb".equals(purl.getType())) {
-            if ("debian".equalsIgnoreCase(purl.getNamespace())) {
-                return DebianDistribution.of(distroQualifier);
-            }
-            if ("ubuntu".equalsIgnoreCase(purl.getNamespace())) {
-                return UbuntuDistribution.of(distroQualifier);
-            }
+        if ("rpm".equals(purl.getType()) && "redhat".equalsIgnoreCase(purl.getNamespace())) {
+            return RedHatDistribution.ofRpmRelease(purl.getVersion());
         }
 
         return null;

--- a/support/os-distro-metadata/src/main/java/org/dependencytrack/support/distrometadata/RedHatDistribution.java
+++ b/support/os-distro-metadata/src/main/java/org/dependencytrack/support/distrometadata/RedHatDistribution.java
@@ -1,0 +1,161 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.distrometadata;
+
+import org.jspecify.annotations.Nullable;
+import us.springett.parsers.cpe.Cpe;
+import us.springett.parsers.cpe.CpeParser;
+import us.springett.parsers.cpe.exceptions.CpeParsingException;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @since 5.1.0
+ */
+public record RedHatDistribution(String majorVersion) implements OsDistribution {
+
+    private static final Pattern VERSION_PATTERN = Pattern.compile("^(\\d+)(?:\\..*)?$");
+
+    /// Finds the `el<N>` Enterprise Linux marker in an RPM release string and
+    /// captures the RHEL major. The common form is the dist tag that Red Hat's
+    /// `%{?dist}` macro sets, such as `.el8` or `.el9`, where N is the major version
+    /// of Enterprise Linux.
+    ///
+    /// We also match the same `el<N>` token in Red Hat build conventions that
+    /// have no formal spec but show up in real RHEL and OSV data:
+    ///
+    /// * EUS and z-stream releases (`.el8_6`)
+    /// * product build suffixes (`.el8sat`)
+    /// * the modular release marker (`+el8.7.0+...`)
+    ///
+    /// Note that only the major version is captured.
+    private static final Pattern EL_MARKER_PATTERN = Pattern.compile("(?:^|[.+])el(\\d+)(?:\\.\\d+)?");
+
+    public RedHatDistribution {
+        requireNonNull(majorVersion, "majorVersion must not be null");
+    }
+
+    @Override
+    public String purlQualifierValue() {
+        return "redhat-" + majorVersion;
+    }
+
+    @Override
+    public boolean matches(OsDistribution other) {
+        return other instanceof RedHatDistribution(final String otherMajorVersion)
+                && this.majorVersion.equals(otherMajorVersion);
+    }
+
+    public static @Nullable RedHatDistribution of(@Nullable String qualifierValue) {
+        if (qualifierValue == null || qualifierValue.isEmpty()) {
+            return null;
+        }
+
+        // NB: Some generators emit "rhel-<version>" (e.g. Syft),
+        // others "redhat-<version>" (e.g. Trivy).
+        final String qualifierValueLower = qualifierValue.toLowerCase();
+        final String version;
+        if (qualifierValueLower.startsWith("rhel-")) {
+            version = qualifierValue.substring("rhel-".length());
+        } else if (qualifierValueLower.startsWith("redhat-")) {
+            version = qualifierValue.substring("redhat-".length());
+        } else {
+            version = qualifierValue;
+        }
+
+        return ofVersion(version);
+    }
+
+    public static @Nullable RedHatDistribution ofVersion(@Nullable String version) {
+        if (version == null || version.isBlank()) {
+            return null;
+        }
+
+        final Matcher matcher = VERSION_PATTERN.matcher(version);
+        if (!matcher.matches()) {
+            return null;
+        }
+
+        return new RedHatDistribution(matcher.group(1));
+    }
+
+    public static @Nullable RedHatDistribution ofCpe(@Nullable String cpeSuffix) {
+        if (cpeSuffix == null || cpeSuffix.isEmpty()) {
+            return null;
+        }
+
+        final Cpe cpe;
+        try {
+            cpe = CpeParser.parse("cpe:/a:redhat:" + cpeSuffix);
+        } catch (CpeParsingException _) {
+            return null;
+        }
+
+        // NB: An explicit "el<N>" OS target in the edition is the same disttag
+        // convention used in RPM release strings, so reuse the extractor.
+        // It takes precedence over the product version field.
+        final RedHatDistribution fromEdition = ofRpmRelease(cpe.getEdition());
+        if (fromEdition != null) {
+            return fromEdition;
+        }
+
+        if (isRhelStreamProduct(cpe.getProduct())) {
+            return ofVersion(cpe.getVersion());
+        }
+
+        return null;
+    }
+
+    public static @Nullable RedHatDistribution ofRpmRelease(@Nullable String version) {
+        if (version == null || version.isEmpty()) {
+            return null;
+        }
+
+        final Matcher matcher = EL_MARKER_PATTERN.matcher(version);
+        if (!matcher.find()) {
+            return null;
+        }
+
+        return new RedHatDistribution(matcher.group(1));
+    }
+
+    /// CPE products whose CPE version field is the RHEL `major(.minor)`. Determined
+    /// by sampling the OSV Red Hat advisory data. Products not in this list
+    /// (e.g. `satellite`, `openshift`, `rhel_software_collections`) put their own product
+    /// version in the version field, so the RHEL major must come from the edition's
+    /// `el<N>` target instead. Hardcoding the list risks going out of date,
+    /// but new streams are released very rarely.
+    private static boolean isRhelStreamProduct(String product) {
+        return product.startsWith("enterprise_linux")
+                || product.equals("rhel_aus")
+                || product.equals("rhel_e4s")
+                || product.equals("rhel_els")
+                || product.equals("rhel_eus")
+                || product.equals("rhel_eus_long_life")
+                || product.equals("rhel_mission_critical")
+                || product.equals("rhel_productivity")
+                || product.equals("rhel_tus")
+                || product.equals("rhel_virtualization")
+                || product.startsWith("rhel_extras");
+    }
+
+}

--- a/support/os-distro-metadata/src/test/java/org/dependencytrack/support/distrometadata/OsDistributionTest.java
+++ b/support/os-distro-metadata/src/test/java/org/dependencytrack/support/distrometadata/OsDistributionTest.java
@@ -55,6 +55,28 @@ class OsDistributionTest {
     }
 
     @Test
+    void shouldReturnNullForRpmPurlWithUnknownNamespace() throws Exception {
+        final var purl = new PackageURL("pkg:rpm/centos/sudo@1.9.5?distro=centos-9");
+        assertThat(OsDistribution.of(purl)).isNull();
+    }
+
+    @Test
+    void shouldFallBackToRpmDisttagWhenRedhatPurlHasNoQualifier() throws Exception {
+        final var purl = new PackageURL("pkg:rpm/redhat/libsolv@0.7.24-3.el9");
+        final OsDistribution distro = OsDistribution.of(purl);
+        assertThat(distro).isInstanceOf(RedHatDistribution.class);
+        assertThat(distro.purlQualifierValue()).isEqualTo("redhat-9");
+    }
+
+    @Test
+    void shouldNotFallBackToRpmDisttagWhenRedhatPurlHasUnparseableQualifier() throws Exception {
+        // Explicit (but bogus) qualifier should NOT be silently overridden by the
+        // version-based heuristic.
+        final var purl = new PackageURL("pkg:rpm/redhat/libsolv@0.7.24-3.el9?distro=garbage");
+        assertThat(OsDistribution.of(purl)).isNull();
+    }
+
+    @Test
     void shouldNotMatchDebianWithUbuntu() throws Exception {
         final OsDistribution debian = OsDistribution.of(new PackageURL("pkg:deb/debian/sudo@1.9.5?distro=debian-11"));
         final OsDistribution ubuntu = OsDistribution.of(new PackageURL("pkg:deb/ubuntu/sudo@1.9.5?distro=ubuntu-22.04"));
@@ -74,6 +96,17 @@ class OsDistributionTest {
         assertThat(debian).isNotNull();
         assertThat(alpine.matches(debian)).isFalse();
         assertThat(debian.matches(alpine)).isFalse();
+    }
+
+    @Test
+    void shouldNotMatchRedHatWithAlpine() throws Exception {
+        final OsDistribution redhat = OsDistribution.of(new PackageURL("pkg:rpm/redhat/curl@8.5.0?distro=rhel-9"));
+        final OsDistribution alpine = OsDistribution.of(new PackageURL("pkg:apk/alpine/curl@8.5.0?distro=3.16"));
+
+        assertThat(redhat).isNotNull();
+        assertThat(alpine).isNotNull();
+        assertThat(redhat.matches(alpine)).isFalse();
+        assertThat(alpine.matches(redhat)).isFalse();
     }
 
 }

--- a/support/os-distro-metadata/src/test/java/org/dependencytrack/support/distrometadata/RedHatDistributionTest.java
+++ b/support/os-distro-metadata/src/test/java/org/dependencytrack/support/distrometadata/RedHatDistributionTest.java
@@ -1,0 +1,220 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.distrometadata;
+
+import com.github.packageurl.PackageURL;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RedHatDistributionTest {
+
+    @Nested
+    class OfQualifierValueTest {
+
+        @ParameterizedTest
+        @CsvSource(value = {
+                "pkg:rpm/redhat/sudo@1.9.5?distro=rhel-9, redhat-9",
+                "pkg:rpm/redhat/sudo@1.9.5?distro=rhel-8.6, redhat-8",
+                "pkg:rpm/redhat/sudo@1.9.5?distro=redhat-9.7, redhat-9",
+                "pkg:rpm/redhat/sudo@1.9.5?distro=9.2, redhat-9",
+                "pkg:rpm/redhat/sudo@1.9.5?distro=RHEL-9, redhat-9",
+        })
+        void shouldParseFromPurl(String purl, String expectedQualifier) throws Exception {
+            final OsDistribution distro = OsDistribution.of(new PackageURL(purl));
+            assertThat(distro).isNotNull();
+            assertThat(distro).isInstanceOf(RedHatDistribution.class);
+            assertThat(distro.purlQualifierValue()).isEqualTo(expectedQualifier);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"foo", "rhel-", "redhat-", "*", "abc-9", "9abc"})
+        void shouldReturnNullForInvalidQualifier(String qualifier) {
+            assertThat(RedHatDistribution.of(qualifier)).isNull();
+        }
+
+    }
+
+    @Nested
+    class OfVersionTest {
+
+        @ParameterizedTest
+        @CsvSource(value = {
+                "9, redhat-9",
+                "8, redhat-8",
+                "8.6, redhat-8",
+                "9.2.0, redhat-9",
+        })
+        void shouldParseFromVersion(String version, String expectedQualifier) {
+            final RedHatDistribution distro = RedHatDistribution.ofVersion(version);
+            assertThat(distro).isNotNull();
+            assertThat(distro.purlQualifierValue()).isEqualTo(expectedQualifier);
+        }
+
+    }
+
+    @Nested
+    class OfCpeTest {
+
+        @ParameterizedTest
+        @CsvSource(value = {
+                "rhel_aus:8.4::appstream, redhat-8",
+                "rhel_eus:9.2::baseos, redhat-9",
+                "rhel_e4s:8.2, redhat-8",
+                "rhel_els:7, redhat-7",
+                "rhel_extras:6, redhat-6",
+                "enterprise_linux:8::baseos, redhat-8",
+                "enterprise_linux:9::appstream, redhat-9",
+                "enterprise_linux_eus:10.0, redhat-10",
+                "openshift:4.18::el8, redhat-8",
+                "openshift_container_platform:4.18::el9, redhat-9",
+                "satellite:6.16::el8, redhat-8",
+                "satellite_capsule:6.16::el8, redhat-8",
+                "jboss_enterprise_application_platform:7.4::el8, redhat-8",
+                "rhel_software_collections:3::el7, redhat-7",
+                "rhel_dotnet:6.0::el7, redhat-7",
+                "satellite:6.16::el8_sat, redhat-8",
+        })
+        void shouldParseFromCpe(String cpe, String expectedQualifier) {
+            final RedHatDistribution distro = RedHatDistribution.ofCpe(cpe);
+            assertThat(distro).isNotNull();
+            assertThat(distro.purlQualifierValue()).isEqualTo(expectedQualifier);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {
+                "rhel_aus",
+                "appstream",
+                "noversion",
+                "openshift:4.18",
+                "satellite:6.16",
+                "openshift:4.12::fastdatapath",
+                "rhel_application_stack:2",
+                "rhel_application_server:1",
+                "rhel_atomic:7",
+        })
+        void shouldReturnNullForCpeWithoutResolvableRhelMajor(String cpe) {
+            assertThat(RedHatDistribution.ofCpe(cpe)).isNull();
+        }
+
+    }
+
+    @Nested
+    class OfRpmReleaseTest {
+
+        @ParameterizedTest
+        @CsvSource(value = {
+                "0.7.24-3.el9, redhat-9",
+                "2.34-125.el9_5.8, redhat-9",
+                "0.7.20-6.el8sat, redhat-8",
+                "1.module+el8.7.0+12345+abcdef1, redhat-8",
+                "1-1.el10, redhat-10",
+                "1.0-3.el8_6.cve_2021_44228, redhat-8",
+                "1:0.7.20-6.el8sat, redhat-8",
+                "el9, redhat-9",
+        })
+        void shouldExtractFromRpmRelease(String version, String expectedQualifier) {
+            final RedHatDistribution distro = RedHatDistribution.ofRpmRelease(version);
+            assertThat(distro).isNotNull();
+            assertThat(distro.purlQualifierValue()).isEqualTo(expectedQualifier);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {
+                "1.0", "1.0-3",
+                "1.0-3.fc35",
+                "1.0-1.amzn2023",
+                "1.0-1.mga9",
+                "model-1.0",
+        })
+        void shouldReturnNullWhenRpmReleaseHasNoDisttag(String version) {
+            assertThat(RedHatDistribution.ofRpmRelease(version)).isNull();
+        }
+
+    }
+
+    @Nested
+    class MatchesTest {
+
+        @Test
+        void shouldMatchOnMajorVersionAcrossMinor() throws Exception {
+            final OsDistribution distroA = OsDistribution.of(new PackageURL("pkg:rpm/redhat/sudo@1.9.5?distro=rhel-8.6"));
+            final OsDistribution distroB = OsDistribution.of(new PackageURL("pkg:rpm/redhat/sudo@1.9.5?distro=rhel-8"));
+
+            assertThat(distroA).isNotNull();
+            assertThat(distroB).isNotNull();
+            assertThat(distroA.matches(distroB)).isTrue();
+            assertThat(distroB.matches(distroA)).isTrue();
+        }
+
+        @Test
+        void shouldMatchRhelAndRedhatPrefixForSameMajor() throws Exception {
+            final OsDistribution distroA = OsDistribution.of(new PackageURL("pkg:rpm/redhat/sudo@1.9.5?distro=rhel-9"));
+            final OsDistribution distroB = OsDistribution.of(new PackageURL("pkg:rpm/redhat/sudo@1.9.5?distro=redhat-9.7"));
+
+            assertThat(distroA).isNotNull();
+            assertThat(distroB).isNotNull();
+            assertThat(distroA.matches(distroB)).isTrue();
+            assertThat(distroB.matches(distroA)).isTrue();
+        }
+
+        @Test
+        void shouldMatchComponentWithRhelPrefixAgainstCpe() throws Exception {
+            final OsDistribution component = OsDistribution.of(new PackageURL("pkg:rpm/redhat/libsolv@0.7.24-3.el8?distro=rhel-8"));
+            final RedHatDistribution advisory = RedHatDistribution.ofCpe("rhel_aus:8.4::appstream");
+
+            assertThat(component).isNotNull();
+            assertThat(advisory).isNotNull();
+            assertThat(component.matches(advisory)).isTrue();
+            assertThat(advisory.matches(component)).isTrue();
+        }
+
+        @Test
+        void shouldNotMatchComponentAgainstCpeOfDifferentMajor() throws Exception {
+            final OsDistribution component = OsDistribution.of(new PackageURL("pkg:rpm/redhat/libsolv@0.7.24-3.el9?distro=redhat-9.7"));
+            final RedHatDistribution advisory = RedHatDistribution.ofCpe("rhel_aus:8.0::baseos");
+
+            assertThat(component).isNotNull();
+            assertThat(advisory).isNotNull();
+            assertThat(component.matches(advisory)).isFalse();
+            assertThat(advisory.matches(component)).isFalse();
+        }
+
+        @Test
+        void shouldNotMatchDifferentMajorVersions() throws Exception {
+            final OsDistribution distroA = OsDistribution.of(new PackageURL("pkg:rpm/redhat/sudo@1.9.5?distro=rhel-8"));
+            final OsDistribution distroB = OsDistribution.of(new PackageURL("pkg:rpm/redhat/sudo@1.9.5?distro=rhel-9"));
+
+            assertThat(distroA).isNotNull();
+            assertThat(distroB).isNotNull();
+            assertThat(distroA.matches(distroB)).isFalse();
+            assertThat(distroB.matches(distroA)).isFalse();
+        }
+
+    }
+
+}

--- a/vuln-analysis/internal/src/main/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzer.java
+++ b/vuln-analysis/internal/src/main/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzer.java
@@ -32,6 +32,7 @@ import org.cyclonedx.proto.v1_7.Source;
 import org.cyclonedx.proto.v1_7.Vulnerability;
 import org.cyclonedx.proto.v1_7.VulnerabilityAffects;
 import org.dependencytrack.support.distrometadata.OsDistribution;
+import org.dependencytrack.support.distrometadata.RedHatDistribution;
 import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
 import org.dependencytrack.vulnanalysis.internal.Coordinate.CpeCoordinate;
 import org.dependencytrack.vulnanalysis.internal.Coordinate.PurlCoordinate;
@@ -608,39 +609,84 @@ final class InternalVulnAnalyzer implements VulnAnalyzer {
     }
 
     private static boolean matchesDistro(PackageURL componentPurl, MatchingCriteria criteria) {
+        final PackageURL criteriaPurl = criteria.purl();
         final String componentDistroQualifier = distroQualifierOf(componentPurl);
-        final String vsDistroQualifier = distroQualifierOf(criteria.purl());
+        final String criteriaDistroQualifier = distroQualifierOf(criteriaPurl);
 
-        // When both the component and the vulnerable software record have a distro
-        // qualifier, they must match *before* we perform the actual version comparison.
-        if (componentDistroQualifier != null && vsDistroQualifier != null) {
-            // Simplest case: the qualifiers just match without special interpretation.
-            if (!componentDistroQualifier.equals(vsDistroQualifier)) {
-                // Could still match, but depends on distro semantics.
-                // e.g. "debian-13" should match "trixie".
-                final OsDistribution componentDistro = OsDistribution.of(componentPurl);
-                final OsDistribution vsDistro = OsDistribution.of(criteria.purl());
+        if (componentDistroQualifier != null
+                && componentDistroQualifier.equals(criteriaDistroQualifier)) {
+            return true;
+        }
 
-                if (componentDistro != null && vsDistro != null) {
-                    if (!componentDistro.matches(vsDistro)) {
-                        // Actual mismatch, e.g. "debian-13" != "sid".
-                        return false;
-                    }
-                } else if (componentDistro != null || vsDistro != null) {
-                    // One side was parsed, the other wasn't. The raw qualifier
-                    // strings already differ, so this is a mismatch.
-                    return false;
-                } else {
-                    // Neither side could be parsed. The raw qualifier strings
-                    // already differ, so treat as mismatch to avoid false positives.
-                    LOGGER.debug("Neither distro qualifier could be parsed for comparison: {} vs {}",
-                            componentDistroQualifier, vsDistroQualifier);
-                    return false;
+        final OsDistribution componentDistro = resolveOsDistro(componentPurl);
+        final OsDistribution criteriaDistro = resolveOsDistro(criteriaPurl, criteria);
+
+        if (componentDistro != null && criteriaDistro != null) {
+            return componentDistro.matches(criteriaDistro);
+        }
+
+        // Both sides carry explicit qualifiers, but they're not equal and at least
+        // one couldn't be parsed. Treat as a mismatch to avoid false positives.
+        if (componentDistroQualifier != null && criteriaDistroQualifier != null) {
+            LOGGER.debug(
+                    "Could not reconcile distro qualifiers: {} vs. {}",
+                    componentDistroQualifier,
+                    criteriaDistroQualifier);
+            return false;
+        }
+
+        // At least one side has no distro qualifier at all.
+        // Treat as match to avoid false negatives, since `distro` qualifiers
+        // are still not widely used across BOM generators and vuln DBs.
+        return true;
+    }
+
+    private static @Nullable OsDistribution resolveOsDistro(
+            @Nullable PackageURL purl,
+            @Nullable MatchingCriteria matchingCriteria) {
+        if (purl == null) {
+            return null;
+        }
+
+        final var fromPurl = OsDistribution.of(purl);
+        if (fromPurl != null) {
+            return fromPurl;
+        }
+
+        // If the producer gave an explicit qualifier we couldn't read,
+        // don't override their intent with the criteria range heuristic below.
+        if (distroQualifierOf(purl) != null) {
+            return null;
+        }
+
+        // Red Hat versions are often verbose enough to be able to infer
+        // the distro version. This captures vuln DB records that do not
+        // explicitly declare distros.
+        if (matchingCriteria != null
+                && "rpm".equals(purl.getType())
+                && "redhat".equalsIgnoreCase(purl.getNamespace())) {
+            for (final String versionRangeBound : new @Nullable String[]{
+                    matchingCriteria.versionEndExcluding(),
+                    matchingCriteria.versionEndIncluding(),
+                    matchingCriteria.version(),
+                    matchingCriteria.versionStartExcluding(),
+                    matchingCriteria.versionStartIncluding()}) {
+                if (versionRangeBound == null) {
+                    continue;
+                }
+
+                final var fromVersionRangeBound = RedHatDistribution.ofRpmRelease(versionRangeBound);
+                if (fromVersionRangeBound != null) {
+                    return fromVersionRangeBound;
                 }
             }
         }
 
-        return true;
+        return null;
+    }
+
+    private static @Nullable OsDistribution resolveOsDistro(@Nullable PackageURL purl) {
+        return resolveOsDistro(purl, null);
     }
 
     private static @Nullable String distroQualifierOf(@Nullable PackageURL purl) {
@@ -652,17 +698,14 @@ final class InternalVulnAnalyzer implements VulnAnalyzer {
         return qualifiers != null ? qualifiers.get("distro") : null;
     }
 
-    /**
-     * Returns the PURL's version with any type-specific transformations applied to make it
-     * suitable for ecosystem-aware comparison. Returns the raw version when no transformation
-     * applies, or {@code null} if no version is set.
-     * <p>
-     * Applied transformations:
-     * <ul>
-     *   <li>{@code deb}/{@code rpm}: fold the {@code epoch} qualifier into the version as
-     *       {@code <epoch>:<version>} when not already encoded inline.</li>
-     * </ul>
-     */
+    /// Returns the PURL's version with any type-specific transformations applied to make it
+    /// suitable for ecosystem-aware comparison. Returns the raw version when no transformation
+    /// applies, or `null` if no version is set.
+    ///
+    /// Applied transformations:
+    ///
+    /// * `deb`/`rpm`: fold the `epoch` qualifier into the version as `<epoch>:<version>`
+    ///   when not already encoded inline.
     private static String effectiveVersionOf(PackageURL purl) {
         requireNonNull(purl, "purl must not be null");
         requireNonNull(purl.getVersion(), "purl version must not be null");

--- a/vuln-analysis/internal/src/test/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzerTest.java
+++ b/vuln-analysis/internal/src/test/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzerTest.java
@@ -608,12 +608,59 @@ class InternalVulnAnalyzerTest {
                     // Scenario: Distro matches but version out of range
                     Arguments.of("pkg:deb/debian/sudo?distro=debian-11", Range.withRange().havingEndExcluding("1.0.0"), DOES_NOT_MATCH, "pkg:deb/debian/sudo@1.9.5?distro=debian-11"),
                     // ---
-                    // Unsupported PURL type with distro qualifiers
+                    // Red Hat
+                    // ---
+                    // Scenario: Same RHEL major version
+                    Arguments.of("pkg:rpm/redhat/sudo?distro=rhel-9", RANGE, MATCHES, "pkg:rpm/redhat/sudo@1.9.5?distro=rhel-9"),
+                    // Scenario: rhel- (Syft) vs redhat- (Trivy) prefix on same major version
+                    Arguments.of("pkg:rpm/redhat/sudo?distro=rhel-9", RANGE, MATCHES, "pkg:rpm/redhat/sudo@1.9.5?distro=redhat-9.7"),
+                    // Scenario: Point release vs major version
+                    Arguments.of("pkg:rpm/redhat/sudo?distro=rhel-8.6", RANGE, MATCHES, "pkg:rpm/redhat/sudo@1.9.5?distro=rhel-8"),
+                    // Scenario: Different RHEL major versions
+                    Arguments.of("pkg:rpm/redhat/sudo?distro=rhel-8", RANGE, DOES_NOT_MATCH, "pkg:rpm/redhat/sudo@1.9.5?distro=rhel-9"),
+                    // Scenario: VS has Red Hat distro, component does not
+                    Arguments.of("pkg:rpm/redhat/sudo?distro=rhel-9", RANGE, MATCHES, "pkg:rpm/redhat/sudo@1.9.5"),
+                    // Scenario: Distro matches but version out of range
+                    Arguments.of("pkg:rpm/redhat/sudo?distro=rhel-9", Range.withRange().havingEndExcluding("1.0.0"), DOES_NOT_MATCH, "pkg:rpm/redhat/sudo@1.9.5?distro=rhel-9"),
+                    // Scenario: Unparseable VS qualifier is not overridden by the `el` marker heuristics
+                    Arguments.of("pkg:rpm/redhat/libsolv?distro=garbage", Range.withRange().havingEndExcluding("0.7.30-2.el9"), MATCHES, "pkg:rpm/redhat/libsolv@0.7.24-3.el8"),
+                    // Scenario: Both sides have a distro qualifier, only the VS one parses
+                    Arguments.of("pkg:rpm/redhat/libsolv?distro=rhel-8", RANGE, DOES_NOT_MATCH, "pkg:rpm/redhat/libsolv@0.7.24-3.el8?distro=garbage"),
+                    // ---
+                    // Red Hat: `el` marker heuristics (no explicit `distro=` qualifier)
+                    // ---
+                    // Scenario: VS `el` marker on the fixed bound, component on its own version, same major
+                    Arguments.of("pkg:rpm/redhat/libsolv", Range.withRange().havingEndExcluding("0.7.30-2.el8"), MATCHES, "pkg:rpm/redhat/libsolv@0.7.24-3.el8"),
+                    // Issue:    https://github.com/DependencyTrack/dependency-track/issues/6156
+                    // Scenario: Satellite el8sat fixed bound vs el9 component
+                    Arguments.of("pkg:rpm/redhat/libsolv", Range.withRange().havingEndExcluding("1:0.7.20-6.el8sat"), DOES_NOT_MATCH, "pkg:rpm/redhat/libsolv@0.7.24-3.el9"),
+                    // Scenario: Component has explicit distro=rhel-8.6, VS only the fixed bound's el8
+                    Arguments.of("pkg:rpm/redhat/libsolv", Range.withRange().havingEndExcluding("0.7.30-2.el8"), MATCHES, "pkg:rpm/redhat/libsolv@0.7.24-3.el8?distro=rhel-8.6"),
+                    // Scenario: VS has explicit distro=rhel-9, component only an el8
+                    Arguments.of("pkg:rpm/redhat/libsolv?distro=rhel-9", RANGE, DOES_NOT_MATCH, "pkg:rpm/redhat/libsolv@0.7.24-3.el8"),
+                    // Scenario: Modular `el` marker on both sides, same major
+                    Arguments.of("pkg:rpm/redhat/php", Range.withRange().havingEndExcluding("8.0.30-3.module+el8.8.0+19602+1de75c93"), MATCHES, "pkg:rpm/redhat/php@8.0.30-2.module+el8.8.0+19602+1de75c93"),
+                    // Scenario: VS has modular el8 vs el9 modular component
+                    Arguments.of("pkg:rpm/redhat/php", Range.withRange().havingEndExcluding("8.0.30-3.module+el8.8.0+19602+1de75c93"), DOES_NOT_MATCH, "pkg:rpm/redhat/php@8.0.30-2.module+el9.2.0+12345+abcdef1"),
+                    // Scenario: Modular build minor differs but RHEL major matches (el8.7 vs el8.8); range decides
+                    Arguments.of("pkg:rpm/redhat/php", Range.withRange().havingEndExcluding("8.0.30-3.module+el8.8.0+19602+1de75c93"), MATCHES, "pkg:rpm/redhat/php@8.0.30-2.module+el8.7.0+12345+abcdef1"),
+                    // Scenario: Neither side carries any `el` marker; permissive "missing distro = match" default
+                    Arguments.of("pkg:rpm/redhat/libsolv", RANGE, MATCHES, "pkg:rpm/redhat/libsolv@1.0.0"),
+                    // Scenario: VS `el` marker carried by the inclusive upper bound, same major
+                    Arguments.of("pkg:rpm/redhat/libsolv", Range.withRange().havingEndIncluding("0.7.30-2.el8"), MATCHES, "pkg:rpm/redhat/libsolv@0.7.24-3.el8"),
+                    // Scenario: Inclusive upper bound el8 vs el9 component, version in range; distro rejects
+                    Arguments.of("pkg:rpm/redhat/libsolv", Range.withRange().havingEndIncluding("0.7.30-2.el8"), DOES_NOT_MATCH, "pkg:rpm/redhat/libsolv@0.7.24-3.el9"),
+                    // Scenario: VS `el` marker carried by the inclusive lower bound only
+                    Arguments.of("pkg:rpm/redhat/libsolv", Range.withRange().havingStartIncluding("0.7.20-1.el8"), MATCHES, "pkg:rpm/redhat/libsolv@0.7.24-3.el8"),
+                    // Scenario: VS `el` marker carried by the exclusive lower bound only
+                    Arguments.of("pkg:rpm/redhat/libsolv", Range.withRange().havingStartExcluding("0.7.20-1.el8"), MATCHES, "pkg:rpm/redhat/libsolv@0.7.24-3.el8"),
+                    // ---
+                    // Unsupported RPM namespace falls back to raw string comparison
                     // ---
                     // Scenario: Both have distro, neither parseable, same string
-                    Arguments.of("pkg:rpm/redhat/sudo?distro=el-9", RANGE, MATCHES, "pkg:rpm/redhat/sudo@1.9.5?distro=el-9"),
-                    // Scenario: Both have distro, neither parseable, different strings (mismatch)
-                    Arguments.of("pkg:rpm/redhat/sudo?distro=rhel-9", RANGE, DOES_NOT_MATCH, "pkg:rpm/redhat/sudo@1.9.5?distro=el-9"));
+                    Arguments.of("pkg:rpm/centos/sudo?distro=centos-9", RANGE, MATCHES, "pkg:rpm/centos/sudo@1.9.5?distro=centos-9"),
+                    // Scenario: Both have distro, neither parseable, different strings
+                    Arguments.of("pkg:rpm/centos/sudo?distro=centos-8", RANGE, DOES_NOT_MATCH, "pkg:rpm/centos/sudo@1.9.5?distro=centos-9"));
         }
 
         @ParameterizedTest(name = "[{index}] expect={2} src={0} target={3}")

--- a/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvEcosystems.java
+++ b/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvEcosystems.java
@@ -21,6 +21,7 @@ package org.dependencytrack.vulndatasource.osv;
 import org.dependencytrack.support.distrometadata.AlpineDistribution;
 import org.dependencytrack.support.distrometadata.DebianDistribution;
 import org.dependencytrack.support.distrometadata.OsDistribution;
+import org.dependencytrack.support.distrometadata.RedHatDistribution;
 import org.dependencytrack.support.distrometadata.UbuntuDistribution;
 import org.jspecify.annotations.Nullable;
 
@@ -54,6 +55,10 @@ final class OsvEcosystems {
                 final String versionOrSeries = suffix.replaceAll(":(LTS|Pro)", "");
                 yield UbuntuDistribution.of(versionOrSeries);
             }
+            // The Red Hat suffix is a CPE 2.2 URI fragment scoping the RPM to a
+            // specific Red Hat product stream, e.g. `rhel_aus:8.4::appstream`.
+            // https://ossf.github.io/osv-schema/#defined-ecosystems
+            case "red hat" -> RedHatDistribution.ofCpe(suffix);
             default -> null;
         };
     }

--- a/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/OsvEcosystemsTest.java
+++ b/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/OsvEcosystemsTest.java
@@ -53,6 +53,34 @@ class OsvEcosystemsTest {
             "Alpine:v3.22, AlpineDistribution, alpine-3.22",
             "alpine:v3.18, AlpineDistribution, alpine-3.18",
             "Alpine:3.16, AlpineDistribution, alpine-3.16",
+            // Red Hat RHEL streams:
+            "Red Hat:enterprise_linux:8::appstream, RedHatDistribution, redhat-8",
+            "Red Hat:enterprise_linux:9::baseos, RedHatDistribution, redhat-9",
+            "Red Hat:enterprise_linux:7::server, RedHatDistribution, redhat-7",
+            "Red Hat:enterprise_linux:5::as, RedHatDistribution, redhat-5",
+            "Red Hat:enterprise_linux_eus:10.0, RedHatDistribution, redhat-10",
+            "Red Hat:rhel_aus:8.4::appstream, RedHatDistribution, redhat-8",
+            "Red Hat:rhel_eus:9.2::baseos, RedHatDistribution, redhat-9",
+            "Red Hat:rhel_e4s:8.2, RedHatDistribution, redhat-8",
+            "Red Hat:rhel_tus:8.6::appstream, RedHatDistribution, redhat-8",
+            "Red Hat:rhel_els:7, RedHatDistribution, redhat-7",
+            "Red Hat:rhel_extras:6, RedHatDistribution, redhat-6",
+            "red hat:enterprise_linux:9, RedHatDistribution, redhat-9",
+            // Red Hat non-RHEL products:
+            "Red Hat:satellite:6.13::el8, RedHatDistribution, redhat-8",
+            "Red Hat:openshift:4.12::el9, RedHatDistribution, redhat-9",
+            "Red Hat:openshift:4.8::el10, RedHatDistribution, redhat-10",
+            "Red Hat:jboss_enterprise_application_platform:7.4::el8, RedHatDistribution, redhat-8",
+            "Red Hat:ceph_storage:6.1::el9, RedHatDistribution, redhat-9",
+            "Red Hat:openstack:17.1::el8, RedHatDistribution, redhat-8",
+            "Red Hat:red_hat_single_sign_on:7::el6, RedHatDistribution, redhat-6",
+            "Red Hat:ansible_automation_platform:2.5::el9, RedHatDistribution, redhat-9",
+            // Red Hat rhel_* products that put their own version in the version field but
+            // expose the RHEL major version via the edition:
+            "Red Hat:rhel_software_collections:3::el7, RedHatDistribution, redhat-7",
+            "Red Hat:rhel_dotnet:6.0::el7, RedHatDistribution, redhat-7",
+            // Red Hat Edition with trailing variant suffix:
+            "Red Hat:satellite:6.16::el8_sat, RedHatDistribution, redhat-8",
     })
     void shouldResolve(String ecosystem, String expectedType, String expectedQualifier) {
         final OsDistribution distro = OsvEcosystems.toOsDistribution(ecosystem);
@@ -71,6 +99,18 @@ class OsvEcosystemsTest {
     @Test
     void shouldReturnNullForUnknownEcosystem() {
         assertThat(OsvEcosystems.toOsDistribution("Fedora:38")).isNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "Red Hat:",
+            "Red Hat:enterprise_linux",
+            "Red Hat:not a cpe",
+            "Red Hat:satellite:6.13",
+            "Red Hat:openshift:4.12::fastdatapath",
+    })
+    void shouldReturnNullForInvalidRedHatEcosystem(String ecosystem) {
+        assertThat(OsvEcosystems.toOsDistribution(ecosystem)).isNull();
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Extends distro-aware version matching with Red Hat support.

Supersedes and expands on #6325

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #6156

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Verified against sampled data from OSV's data dump for the `Red Hat` ecosystem.

Also adds heuristics to the internal vuln analyzer to detect the Red Hat version from existing version ranges in `VULNERABLESOFTWARE`, so a re-ingestion of the OSV `Red Hat` ecosystem is not required, and the matching improvement takes effect immediately.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
