### PR TITLE
Add project `isActive` parameter for BOM upload API

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -188,6 +188,7 @@ final class ProjectQueryManager extends QueryManager {
         project.setParent(parent);
         project.setPurl(purl);
         project.setInactiveSince(inactiveSince);
+        project.setActive(inactiveSince == null);
         project.setIsLatest(isLatest);
         return createProject(project, tags, commitIndex);
     }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -188,7 +188,6 @@ final class ProjectQueryManager extends QueryManager {
         project.setParent(parent);
         project.setPurl(purl);
         project.setInactiveSince(inactiveSince);
-        project.setActive(inactiveSince == null);
         project.setIsLatest(isLatest);
         return createProject(project, tags, commitIndex);
     }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -334,10 +334,7 @@ public class BomResource extends AbstractApiResource {
                       the response's content type will be <code>application/problem+json</code>.
                     </p>
                     <p>
-                      The upload can target an existing project directly with <code>project</code>, or use
-                      <code>projectName</code> and <code>projectVersion</code> to look up the project and,
-                      with <code>autoCreate</code>, create it when it does not already exist. When creating
-                      projects, <code>parentUUID</code> or <code>parentName</code> and
+                      When creating projects, <code>parentUUID</code> or <code>parentName</code> and
                       <code>parentVersion</code> can place the new project under a parent,
                       <code>projectTags</code> can apply tags, and <code>isLatest</code> can mark it as
                       the latest version. The <code>isActive</code> parameter sets the project's active
@@ -538,10 +535,7 @@ public class BomResource extends AbstractApiResource {
                       the response's content type will be <code>application/problem+json</code>.
                     </p>
                     <p>
-                      The upload can target an existing project directly with <code>project</code>, or use
-                      <code>projectName</code> and <code>projectVersion</code> to look up the project and,
-                      with <code>autoCreate</code>, create it when it does not already exist. When creating
-                      projects, <code>parentUUID</code> or <code>parentName</code> and
+                      When creating projects, <code>parentUUID</code> or <code>parentName</code> and
                       <code>parentVersion</code> can place the new project under a parent,
                       <code>projectTags</code> can apply tags, and <code>isLatest</code> can mark it as
                       the latest version. The <code>isActive</code> parameter sets the project's active

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -334,6 +334,17 @@ public class BomResource extends AbstractApiResource {
                       the response's content type will be <code>application/problem+json</code>.
                     </p>
                     <p>
+                      The upload can target an existing project directly with <code>project</code>, or use
+                      <code>projectName</code> and <code>projectVersion</code> to look up the project and,
+                      with <code>autoCreate</code>, create it when it does not already exist. When creating
+                      projects, <code>parentUUID</code> or <code>parentName</code> and
+                      <code>parentVersion</code> can place the new project under a parent,
+                      <code>projectTags</code> can apply tags, and <code>isLatest</code> can mark it as
+                      the latest version. The <code>isActive</code> parameter sets the project's active
+                      state whenever it is provided, including when the target project already exists, so
+                      clients should send it only when they intend to change that state.
+                    </p>
+                    <p>
                       The maximum allowed length of the <code>bom</code> value is 20'000'000 characters.
                       When uploading large BOMs, the <code>POST</code> endpoint is preferred,
                       as it does not have this limit.
@@ -389,7 +400,9 @@ public class BomResource extends AbstractApiResource {
                                 .build());
                     }
                     maybeBindTags(qm, project, request.getProjectTags());
-                    maybeSetProjectActive(qm, project, request.isActive());
+                    if (request.isActive() != null) {
+                        project.setActive(request.isActive());
+                    }
                     return ProjectInfo.of(project);
                 });
             }
@@ -483,7 +496,9 @@ public class BomResource extends AbstractApiResource {
                                 .build());
                     }
                     maybeBindTags(qm, project, request.getProjectTags());
-                    maybeSetProjectActive(qm, project, request.isActive());
+                    if (request.isActive() != null) {
+                        project.setActive(request.isActive());
+                    }
                     return ProjectInfo.of(project);
                 });
             }
@@ -500,15 +515,6 @@ public class BomResource extends AbstractApiResource {
         }
 
         return processUpload(projectInfo, bomBytes);
-    }
-
-    private void maybeSetProjectActive(QueryManager qm, Project project, Boolean isActive) {
-        if (isActive == null) {
-            return;
-        }
-
-        project.setActive(isActive);
-        qm.persist(project);
     }
 
     @POST
@@ -530,6 +536,17 @@ public class BomResource extends AbstractApiResource {
                       The BOM will be validated against the CycloneDX schema. If schema validation fails,
                       a response with problem details in RFC 9457 format will be returned. In this case,
                       the response's content type will be <code>application/problem+json</code>.
+                    </p>
+                    <p>
+                      The upload can target an existing project directly with <code>project</code>, or use
+                      <code>projectName</code> and <code>projectVersion</code> to look up the project and,
+                      with <code>autoCreate</code>, create it when it does not already exist. When creating
+                      projects, <code>parentUUID</code> or <code>parentName</code> and
+                      <code>parentVersion</code> can place the new project under a parent,
+                      <code>projectTags</code> can apply tags, and <code>isLatest</code> can mark it as
+                      the latest version. The <code>isActive</code> parameter sets the project's active
+                      state whenever it is provided, including when the target project already exists, so
+                      clients should send it only when they intend to change that state.
                     </p>
                     <p>Requires permission <strong>BOM_UPLOAD</strong></p>""",
             operationId = "UploadBom"
@@ -600,7 +617,9 @@ public class BomResource extends AbstractApiResource {
                                 .build());
                     }
                     maybeBindTags(qm, project, requestTags);
-                    maybeSetProjectActive(qm, project, isActive);
+                    if (isActive != null) {
+                        project.setActive(isActive);
+                    }
                     return ProjectInfo.of(project);
                 });
             }
@@ -682,7 +701,9 @@ public class BomResource extends AbstractApiResource {
                                 .build());
                     }
                     maybeBindTags(qm, project, requestTags);
-                    maybeSetProjectActive(qm, project, isActive);
+                    if (isActive != null) {
+                        project.setActive(isActive);
+                    }
                     return ProjectInfo.of(project);
                 });
             }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -97,9 +97,11 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -442,7 +444,7 @@ public class BomResource extends AbstractApiResource {
                             try {
                                 project = qm.createProject(trimmedProjectName, null,
                                         trimmedProjectVersion, request.getProjectTags(), parent,
-                                        null, null, request.isLatest(), true);
+                                        null, request.isActive() ? null : Date.from(Instant.now()), request.isLatest(), true);
                             } catch (RuntimeException e) {
                                 if (isUniqueConstraintViolation(e)) {
                                     throw new WebApplicationException(Response
@@ -553,6 +555,7 @@ public class BomResource extends AbstractApiResource {
             @FormDataParam("parentVersion") String parentVersion,
             @FormDataParam("parentUUID") String parentUUID,
             @DefaultValue("false") @FormDataParam("isLatest") boolean isLatest,
+            @DefaultValue("true") @FormDataParam("isActive") boolean isActive,
             @Parameter(schema = @Schema(type = "string")) @FormDataParam("bom") final List<FormDataBodyPart> artifactParts
     ) {
         if (artifactParts == null || artifactParts.isEmpty()) {
@@ -628,7 +631,7 @@ public class BomResource extends AbstractApiResource {
                                 }
                             }
                             try {
-                                project = qm.createProject(trimmedProjectName, null, trimmedProjectVersion, requestTags, parent, null, null, isLatest, true);
+                                project = qm.createProject(trimmedProjectName, null, trimmedProjectVersion, requestTags, parent, null, isActive ? null : Date.from(Instant.now()), isLatest, true);
                             } catch (RuntimeException e) {
                                 if (isUniqueConstraintViolation(e)) {
                                     throw new WebApplicationException(Response

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -389,6 +389,7 @@ public class BomResource extends AbstractApiResource {
                                 .build());
                     }
                     maybeBindTags(qm, project, request.getProjectTags());
+                    maybeSetProjectActive(qm, project, request.isActive());
                     return ProjectInfo.of(project);
                 });
             }
@@ -443,8 +444,9 @@ public class BomResource extends AbstractApiResource {
                             }
                             try {
                                 project = qm.createProject(trimmedProjectName, null,
-                                        trimmedProjectVersion, request.getProjectTags(), parent,
-                                        null, request.isActive() ? null : Date.from(Instant.now()), request.isLatest(), true);
+                                        trimmedProjectVersion, request.getProjectTags(), parent, null,
+                                        Boolean.FALSE.equals(request.isActive()) ? Date.from(Instant.now()) : null,
+                                        request.isLatest(), true);
                             } catch (RuntimeException e) {
                                 if (isUniqueConstraintViolation(e)) {
                                     throw new WebApplicationException(Response
@@ -481,6 +483,7 @@ public class BomResource extends AbstractApiResource {
                                 .build());
                     }
                     maybeBindTags(qm, project, request.getProjectTags());
+                    maybeSetProjectActive(qm, project, request.isActive());
                     return ProjectInfo.of(project);
                 });
             }
@@ -497,6 +500,15 @@ public class BomResource extends AbstractApiResource {
         }
 
         return processUpload(projectInfo, bomBytes);
+    }
+
+    private void maybeSetProjectActive(QueryManager qm, Project project, Boolean isActive) {
+        if (isActive == null) {
+            return;
+        }
+
+        project.setActive(isActive);
+        qm.persist(project);
     }
 
     @POST
@@ -555,7 +567,7 @@ public class BomResource extends AbstractApiResource {
             @FormDataParam("parentVersion") String parentVersion,
             @FormDataParam("parentUUID") String parentUUID,
             @DefaultValue("false") @FormDataParam("isLatest") boolean isLatest,
-            @DefaultValue("true") @FormDataParam("isActive") boolean isActive,
+            @FormDataParam("isActive") Boolean isActive,
             @Parameter(schema = @Schema(type = "string")) @FormDataParam("bom") final List<FormDataBodyPart> artifactParts
     ) {
         if (artifactParts == null || artifactParts.isEmpty()) {
@@ -588,6 +600,7 @@ public class BomResource extends AbstractApiResource {
                                 .build());
                     }
                     maybeBindTags(qm, project, requestTags);
+                    maybeSetProjectActive(qm, project, isActive);
                     return ProjectInfo.of(project);
                 });
             }
@@ -631,7 +644,8 @@ public class BomResource extends AbstractApiResource {
                                 }
                             }
                             try {
-                                project = qm.createProject(trimmedProjectName, null, trimmedProjectVersion, requestTags, parent, null, isActive ? null : Date.from(Instant.now()), isLatest, true);
+                                project = qm.createProject(trimmedProjectName, null, trimmedProjectVersion, requestTags, parent,
+                                        null, Boolean.FALSE.equals(isActive) ? Date.from(Instant.now()) : null, isLatest, true);
                             } catch (RuntimeException e) {
                                 if (isUniqueConstraintViolation(e)) {
                                     throw new WebApplicationException(Response
@@ -668,6 +682,7 @@ public class BomResource extends AbstractApiResource {
                                 .build());
                     }
                     maybeBindTags(qm, project, requestTags);
+                    maybeSetProjectActive(qm, project, isActive);
                     return ProjectInfo.of(project);
                 });
             }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/BomSubmitRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/BomSubmitRequest.java
@@ -79,14 +79,17 @@ public final class BomSubmitRequest {
 
     private final boolean isLatest;
 
+    private final boolean isActive;
+
     public BomSubmitRequest(String project,
                             String projectName,
                             String projectVersion,
                             List<Tag> projectTags,
                             boolean autoCreate,
                             boolean isLatest,
+                            boolean isActive,
                             String bom) {
-        this(project, projectName, projectVersion, projectTags, autoCreate, null, null, null, isLatest, bom);
+        this(project, projectName, projectVersion, projectTags, autoCreate, null, null, null, isLatest, isActive, bom);
     }
 
     @JsonCreator
@@ -99,6 +102,7 @@ public final class BomSubmitRequest {
                             @JsonProperty(value = "parentName") String parentName,
                             @JsonProperty(value = "parentVersion") String parentVersion,
                             @JsonProperty(value = "isLatest", defaultValue = "false") @JsonAlias("isLatestProjectVersion") boolean isLatest,
+                            @JsonProperty(value = "isActive", defaultValue = "true") boolean isActive,
                             @JsonProperty(value = "bom", required = true) String bom) {
         this.project = project;
         this.projectName = projectName;
@@ -109,6 +113,7 @@ public final class BomSubmitRequest {
         this.parentName = parentName;
         this.parentVersion = parentVersion;
         this.isLatest = isLatest;
+        this.isActive = isActive;
         this.bom = bom;
     }
 
@@ -153,6 +158,9 @@ public final class BomSubmitRequest {
 
     @JsonProperty("isLatest")
     public boolean isLatest() { return isLatest; }
+
+    @JsonProperty("isActive")
+    public boolean isActive() { return isActive; }
 
     @Schema(
             description = "Base64 encoded BOM",

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/BomSubmitRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/BomSubmitRequest.java
@@ -79,7 +79,7 @@ public final class BomSubmitRequest {
 
     private final boolean isLatest;
 
-    private final boolean isActive;
+    private final Boolean isActive;
 
     public BomSubmitRequest(String project,
                             String projectName,
@@ -102,7 +102,7 @@ public final class BomSubmitRequest {
                             @JsonProperty(value = "parentName") String parentName,
                             @JsonProperty(value = "parentVersion") String parentVersion,
                             @JsonProperty(value = "isLatest", defaultValue = "false") @JsonAlias("isLatestProjectVersion") boolean isLatest,
-                            @JsonProperty(value = "isActive", defaultValue = "true") boolean isActive,
+                            @JsonProperty(value = "isActive") Boolean isActive,
                             @JsonProperty(value = "bom", required = true) String bom) {
         this.project = project;
         this.projectName = projectName;
@@ -160,7 +160,7 @@ public final class BomSubmitRequest {
     public boolean isLatest() { return isLatest; }
 
     @JsonProperty("isActive")
-    public boolean isActive() { return isActive; }
+    public Boolean isActive() { return isActive; }
 
     @Schema(
             description = "Base64 encoded BOM",

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -2529,4 +2529,68 @@ class BomResourceTest extends ResourceTest {
                 """);
     }
 
+    @Test
+    void uploadBomIsActiveTest() throws Exception {
+        initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
+        var project = new Project();
+        project.setName("uploadBomIsActive");
+        project.setVersion("1.0.0");
+        project.setActive(true);
+        qm.persist(project);
+
+        String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
+
+        StringBuilder jsonBuilder = new StringBuilder();
+        jsonBuilder.append("{");
+        jsonBuilder.append("\"projectName\": \"uploadBomIsActive\",");
+        jsonBuilder.append("\"projectVersion\": \"1.0.1\",");
+        jsonBuilder.append("\"autoCreate\": true,");
+        jsonBuilder.append("\"bom\": \"").append(bomString).append("\"");
+        jsonBuilder.append(",\"isActive\": false");
+        jsonBuilder.append("}");
+        String jsonRequest = jsonBuilder.toString();
+
+        Response response = jersey.target(V1_BOM).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(jsonRequest, MediaType.APPLICATION_JSON));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        JsonObject json = parseJsonObject(response);
+        Assertions.assertNotNull(json);
+        Assertions.assertNotNull(json.getString("token"));
+        project = qm.getProject("uploadBomIsActive", "1.0.1");
+        Assertions.assertNotNull(project);
+        Assertions.assertFalse(project.isActive());
+    }
+
+    @Test
+    void uploadBomIsActiveWithTagsMultipartTest() throws Exception {
+        initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
+        final var multiPart = new FormDataMultiPart()
+                .field("bom", resourceToString("/unit/bom-1.xml", StandardCharsets.UTF_8), MediaType.APPLICATION_XML_TYPE)
+                .field("projectName", "Acme Example")
+                .field("projectVersion", "1.0")
+                .field("autoCreate", "true")
+                .field("isActive", "false");
+
+        // NB: The GrizzlyConnectorProvider doesn't work with MultiPart requests.
+        // https://github.com/eclipse-ee4j/jersey/issues/5094
+        final var client = ClientBuilder.newClient(new ClientConfig()
+                .register(MultiPartFeature.class)
+                .connectorProvider(new HttpUrlConnectorProvider()));
+
+        final Response response = client.target(jersey.target(V1_BOM).getUri()).request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.entity(multiPart, multiPart.getMediaType()));
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "token": "${json-unit.any-string}",
+                  "projectUuid": "${json-unit.any-string}"
+                }
+                """);
+
+        final Project project = qm.getProject("Acme Example", "1.0");
+        assertThat(project).isNotNull();
+        assertThat(project.isActive()).isFalse();
+    }
 }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -2530,7 +2530,7 @@ class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    void uploadBomIsActiveTest() throws Exception {
+    void uploadBomIsActiveAutoCreateTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
         var project = new Project();
         project.setName("uploadBomIsActive");
@@ -2545,8 +2545,8 @@ class BomResourceTest extends ResourceTest {
         jsonBuilder.append("\"projectName\": \"uploadBomIsActive\",");
         jsonBuilder.append("\"projectVersion\": \"1.0.1\",");
         jsonBuilder.append("\"autoCreate\": true,");
+        jsonBuilder.append("\"isActive\": false,");
         jsonBuilder.append("\"bom\": \"").append(bomString).append("\"");
-        jsonBuilder.append(",\"isActive\": false");
         jsonBuilder.append("}");
         String jsonRequest = jsonBuilder.toString();
 
@@ -2560,10 +2560,45 @@ class BomResourceTest extends ResourceTest {
         project = qm.getProject("uploadBomIsActive", "1.0.1");
         Assertions.assertNotNull(project);
         Assertions.assertFalse(project.isActive());
+        Assertions.assertNotNull(project.getInactiveSince());
     }
 
     @Test
-    void uploadBomIsActiveWithTagsMultipartTest() throws Exception {
+    void uploadBomIsActiveTest() throws Exception {
+        initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
+        var project = new Project();
+        project.setName("uploadBomIsActive");
+        project.setVersion("1.0.0");
+        project.setActive(true);
+        qm.persist(project);
+
+        String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
+
+        StringBuilder jsonBuilder = new StringBuilder();
+        jsonBuilder.append("{");
+        jsonBuilder.append("\"projectName\": \"uploadBomIsActive\",");
+        jsonBuilder.append("\"projectVersion\": \"1.0.0\",");
+        jsonBuilder.append("\"isActive\": false,");
+        jsonBuilder.append("\"bom\": \"").append(bomString).append("\"");
+        jsonBuilder.append("}");
+        String jsonRequest = jsonBuilder.toString();
+
+        Response response = jersey.target(V1_BOM).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(jsonRequest, MediaType.APPLICATION_JSON));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        JsonObject json = parseJsonObject(response);
+        Assertions.assertNotNull(json);
+        Assertions.assertNotNull(json.getString("token"));
+        qm.getPersistenceManager().evictAll();
+        project = qm.getProject("uploadBomIsActive", "1.0.0");
+        Assertions.assertNotNull(project);
+        Assertions.assertFalse(project.isActive());
+        Assertions.assertNotNull(project.getInactiveSince());
+    }
+
+    @Test
+    void uploadBomIsActiveWithAutoCreateMultipartTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
         final var multiPart = new FormDataMultiPart()
                 .field("bom", resourceToString("/unit/bom-1.xml", StandardCharsets.UTF_8), MediaType.APPLICATION_XML_TYPE)
@@ -2592,5 +2627,6 @@ class BomResourceTest extends ResourceTest {
         final Project project = qm.getProject("Acme Example", "1.0");
         assertThat(project).isNotNull();
         assertThat(project.isActive()).isFalse();
+        assertThat(project.getInactiveSince()).isNotNull();
     }
 }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -93,6 +93,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -2530,7 +2531,41 @@ class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    void uploadBomIsActiveAutoCreateTest() throws Exception {
+    void uploadBomIsActiveNullTest() throws Exception {
+        initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
+        var project = new Project();
+        project.setName("uploadBomIsActive");
+        project.setVersion("1.0.0");
+        project.setActive(false);
+        project.setInactiveSince(new Date());
+        qm.persist(project);
+
+        String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
+
+        StringBuilder jsonBuilder = new StringBuilder();
+        jsonBuilder.append("{");
+        jsonBuilder.append("\"projectName\": \"uploadBomIsActive\",");
+        jsonBuilder.append("\"projectVersion\": \"1.0.0\",");
+        jsonBuilder.append("\"bom\": \"").append(bomString).append("\"");
+        jsonBuilder.append("}");
+        String jsonRequest = jsonBuilder.toString();
+
+        Response response = jersey.target(V1_BOM).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(jsonRequest, MediaType.APPLICATION_JSON));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        JsonObject json = parseJsonObject(response);
+        Assertions.assertNotNull(json);
+        Assertions.assertNotNull(json.getString("token"));
+        qm.getPersistenceManager().evictAll();
+        project = qm.getProject("uploadBomIsActive", "1.0.0");
+        Assertions.assertNotNull(project);
+        Assertions.assertFalse(project.isActive());
+        Assertions.assertNotNull(project.getInactiveSince());
+    }
+
+    @Test
+    void uploadBomIsActiveToFalseWithAutoCreateTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
         var project = new Project();
         project.setName("uploadBomIsActive");
@@ -2564,7 +2599,7 @@ class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    void uploadBomIsActiveTest() throws Exception {
+    void uploadBomIsActiveToFalseTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
         var project = new Project();
         project.setName("uploadBomIsActive");
@@ -2598,7 +2633,42 @@ class BomResourceTest extends ResourceTest {
     }
 
     @Test
-    void uploadBomIsActiveWithAutoCreateMultipartTest() throws Exception {
+    void uploadBomIsActiveToTrueTest() throws Exception {
+        initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
+        var project = new Project();
+        project.setName("uploadBomIsActive");
+        project.setVersion("1.0.0");
+        project.setActive(false);
+        project.setInactiveSince(new Date());
+        qm.persist(project);
+
+        String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
+
+        StringBuilder jsonBuilder = new StringBuilder();
+        jsonBuilder.append("{");
+        jsonBuilder.append("\"projectName\": \"uploadBomIsActive\",");
+        jsonBuilder.append("\"projectVersion\": \"1.0.0\",");
+        jsonBuilder.append("\"isActive\": true,");
+        jsonBuilder.append("\"bom\": \"").append(bomString).append("\"");
+        jsonBuilder.append("}");
+        String jsonRequest = jsonBuilder.toString();
+
+        Response response = jersey.target(V1_BOM).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(jsonRequest, MediaType.APPLICATION_JSON));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        JsonObject json = parseJsonObject(response);
+        Assertions.assertNotNull(json);
+        Assertions.assertNotNull(json.getString("token"));
+        qm.getPersistenceManager().evictAll();
+        project = qm.getProject("uploadBomIsActive", "1.0.0");
+        Assertions.assertNotNull(project);
+        Assertions.assertTrue(project.isActive());
+        Assertions.assertNull(project.getInactiveSince());
+    }
+
+    @Test
+    void uploadBomIsActiveToFalseMultipartTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
         final var multiPart = new FormDataMultiPart()
                 .field("bom", resourceToString("/unit/bom-1.xml", StandardCharsets.UTF_8), MediaType.APPLICATION_XML_TYPE)

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -1181,7 +1181,7 @@ class BomResourceTest extends ResourceTest {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
         File file = new File(IOUtils.resourceToURL("/unit/bom-1.xml").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
-        BomSubmitRequest request = new BomSubmitRequest(project.getUuid().toString(), null, null, null, false, false, bomString);
+        BomSubmitRequest request = new BomSubmitRequest(project.getUuid().toString(), null, null, null, false, false, true, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -1205,7 +1205,7 @@ class BomResourceTest extends ResourceTest {
                 SPDXVersion: SPDX-2.2
                 DataLicense: CC0-1.0
                 """.getBytes());
-        BomSubmitRequest request = new BomSubmitRequest(project.getUuid().toString(), null, null, null, false, false, bomString);
+        BomSubmitRequest request = new BomSubmitRequest(project.getUuid().toString(), null, null, null, false, false, true, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -1234,7 +1234,7 @@ class BomResourceTest extends ResourceTest {
                   ]
                 }
                 """.getBytes());
-        BomSubmitRequest request = new BomSubmitRequest(project.getUuid().toString(), null, null, null, false, false, bomString);
+        BomSubmitRequest request = new BomSubmitRequest(project.getUuid().toString(), null, null, null, false, false, true, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -1261,7 +1261,7 @@ class BomResourceTest extends ResourceTest {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
         File file = new File(IOUtils.resourceToURL("/unit/bom-invalid.json").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
-        BomSubmitRequest request = new BomSubmitRequest(project.getUuid().toString(), null, null, null, false, false, bomString);
+        BomSubmitRequest request = new BomSubmitRequest(project.getUuid().toString(), null, null, null, false, false, true, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -1280,7 +1280,7 @@ class BomResourceTest extends ResourceTest {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
         File file = new File(IOUtils.resourceToURL("/unit/bom-1.xml").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
-        BomSubmitRequest request = new BomSubmitRequest(UUID.randomUUID().toString(), null, null, null, false, false, bomString);
+        BomSubmitRequest request = new BomSubmitRequest(UUID.randomUUID().toString(), null, null, null, false, false, true, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -1295,7 +1295,7 @@ class BomResourceTest extends ResourceTest {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
         File file = new File(IOUtils.resourceToURL("/unit/bom-1.xml").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
-        BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0", null, true, false, bomString);
+        BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0", null, true, false, true, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -1314,7 +1314,7 @@ class BomResourceTest extends ResourceTest {
 
         File file = new File(IOUtils.resourceToURL("/unit/bom-1.xml").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
-        BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0", null, true, false, bomString);
+        BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0", null, true, false, true, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -1421,7 +1421,7 @@ class BomResourceTest extends ResourceTest {
         File file = new File(IOUtils.resourceToURL("/unit/bom-1.xml").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
         // Upload parent project
-        BomSubmitRequest request = new BomSubmitRequest(null, "Acme Parent", "1.0", null, true, false, bomString);
+        BomSubmitRequest request = new BomSubmitRequest(null, "Acme Parent", "1.0", null, true, false, true, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -1433,7 +1433,7 @@ class BomResourceTest extends ResourceTest {
         String parentUUID = parent.getUuid().toString();
 
         // Upload first child, search parent by UUID
-        request = new BomSubmitRequest(null, "Acme Example", "1.0", null, true, parentUUID, null, null, false, bomString);
+        request = new BomSubmitRequest(null, "Acme Example", "1.0", null, true, parentUUID, null, null, false, true, bomString);
         response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -1448,7 +1448,7 @@ class BomResourceTest extends ResourceTest {
         Assertions.assertEquals(parentUUID, child.getParent().getUuid().toString());
 
         // Upload second child, search parent by name+ver
-        request = new BomSubmitRequest(null, "Acme Example", "2.0", null, true, null, "Acme Parent", "1.0", false, bomString);
+        request = new BomSubmitRequest(null, "Acme Example", "2.0", null, true, null, "Acme Parent", "1.0", false, true, bomString);
         response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -1463,7 +1463,7 @@ class BomResourceTest extends ResourceTest {
         Assertions.assertEquals(parentUUID, child.getParent().getUuid().toString());
 
         // Upload third child, specify parent's UUID, name, ver. Name and ver are ignored when UUID is specified.
-        request = new BomSubmitRequest(null, "Acme Example", "3.0", null, true, parentUUID, "Non-existent parent", "1.0", false, bomString);
+        request = new BomSubmitRequest(null, "Acme Example", "3.0", null, true, parentUUID, "Non-existent parent", "1.0", false, true, bomString);
         response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -1483,7 +1483,7 @@ class BomResourceTest extends ResourceTest {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
         File file = new File(IOUtils.resourceToURL("/unit/bom-1.xml").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
-        BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0", null, true, UUID.randomUUID().toString(), null, null, false, bomString);
+        BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0", null, true, UUID.randomUUID().toString(), null, null, false, true, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -1491,7 +1491,7 @@ class BomResourceTest extends ResourceTest {
         String body = getPlainTextBody(response);
         Assertions.assertEquals("The parent project could not be found.", body);
 
-        request = new BomSubmitRequest(null, "Acme Example", "2.0", null, true, null, "Non-existent parent", null, false, bomString);
+        request = new BomSubmitRequest(null, "Acme Example", "2.0", null, true, null, "Non-existent parent", null, false, true, bomString);
         response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -1526,7 +1526,7 @@ class BomResourceTest extends ResourceTest {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
         File file = filePath.toFile();
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
-        BomSubmitRequest request = new BomSubmitRequest(project.getUuid().toString(), null, null, null, false, false, bomString);
+        BomSubmitRequest request = new BomSubmitRequest(project.getUuid().toString(), null, null, null, false, false, true, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -1740,7 +1740,7 @@ class BomResourceTest extends ResourceTest {
             tag.setName(name);
             return tag;
         }).collect(Collectors.toList());
-        BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0", tags, true, false, bomString);
+        BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0", tags, true, false, true, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -2025,7 +2025,7 @@ class BomResourceTest extends ResourceTest {
 
         String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
         BomSubmitRequest request = new BomSubmitRequest(null, accessLatestProject.getName(),
-                "1.0.1", null, true, true, bomString);
+                "1.0.1", null, true, true, true, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -2048,7 +2048,7 @@ class BomResourceTest extends ResourceTest {
 
         String bomString = Base64.getEncoder().encodeToString(resourceToByteArray("/unit/bom-1.xml"));
         BomSubmitRequest request = new BomSubmitRequest(null, noAccessLatestProject.getName(),
-                "1.0.1", null, true, true, bomString);
+                "1.0.1", null, true, true, true, bomString);
         Response response = jersey.target(V1_BOM).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));


### PR DESCRIPTION
### Description

Introduce an optional `isActive` property for project bom (v1/bom).
```
isActive = null -> no action
isActive = false -> deactivate project with inactiveSince = now
isActive = true -> activate project
```

### Addressed Issue

Closes https://github.com/DependencyTrack/dependency-track/issues/6285

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
