### PR TITLE
fix: fall back to recent NVD feed when modified exceeds size threshold

### DIFF
--- a/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdDataFeed.java
+++ b/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdDataFeed.java
@@ -29,6 +29,14 @@ sealed interface NvdDataFeed {
 
         @Override
         public String name() {
+            return "modified";
+        }
+    }
+
+    record RecentDataFeed() implements NvdDataFeed {
+
+        @Override
+        public String name() {
             return "recent";
         }
     }

--- a/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdDataFeed.java
+++ b/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdDataFeed.java
@@ -29,7 +29,7 @@ sealed interface NvdDataFeed {
 
         @Override
         public String name() {
-            return "modified";
+            return "recent";
         }
     }
 

--- a/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdDataFeedMetadata.java
+++ b/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdDataFeedMetadata.java
@@ -26,17 +26,23 @@ import java.util.Locale;
 /**
  * @since 5.0.0
  */
-record NvdDataFeedMetadata(Instant lastModifiedAt, @Nullable String sha256) {
+record NvdDataFeedMetadata(Instant lastModifiedAt, @Nullable String sha256, long gzSize) {
 
     static NvdDataFeedMetadata of(final String metadataString) {
         Instant lastModifiedAt = null;
         String sha256 = null;
+        long gzSize = -1;
 
         for (final String line : metadataString.lines().toList()) {
             if (line.startsWith("lastModifiedDate:")) {
                 lastModifiedAt = Instant.parse(line.substring("lastModifiedDate:".length()));
             } else if (line.startsWith("sha256:")) {
                 sha256 = line.substring("sha256:".length()).strip().toLowerCase(Locale.ROOT);
+            } else if (line.startsWith("gzSize:")) {
+                try {
+                    gzSize = Long.parseLong(line.substring("gzSize:".length()).strip());
+                } catch (NumberFormatException ignored) {
+                }
             }
         }
 
@@ -44,7 +50,7 @@ record NvdDataFeedMetadata(Instant lastModifiedAt, @Nullable String sha256) {
             throw new IllegalArgumentException("Missing lastModifiedDate in metadata");
         }
 
-        return new NvdDataFeedMetadata(lastModifiedAt, sha256);
+        return new NvdDataFeedMetadata(lastModifiedAt, sha256, gzSize);
     }
 
 }

--- a/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdVulnDataSourceFactory.java
+++ b/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdVulnDataSourceFactory.java
@@ -132,12 +132,43 @@ final class NvdVulnDataSourceFactory implements VulnDataSourceFactory, RuntimeCo
                 .sorted(Comparator.reverseOrder())
                 .map(NvdDataFeed.YearDataFeed::new)
                 .collect(Collectors.toList());
-        feeds.add(new NvdDataFeed.ModifiedDataFeed());
+        feeds.add(resolveIncrementalFeed(config.getCveFeedsUrl().toString()));
 
         final List<String> feedNames = feeds.stream().map(NvdDataFeed::name).toList();
         final var watermarkManager = new WatermarkManager(kvStore, feedNames);
 
         return new NvdVulnDataSource(watermarkManager, objectMapper, httpClient, config.getCveFeedsUrl().toString(), feeds);
+    }
+
+    private NvdDataFeed resolveIncrementalFeed(final String feedsUrl) {
+        requireNonNull(httpClient, "httpClient must not be null");
+
+        final var modifiedMetaUri = URI.create(
+                "%s/json/cve/2.0/nvdcve-2.0-modified.meta".formatted(feedsUrl));
+
+        final HttpRequest request = HttpRequest.newBuilder()
+                .uri(modifiedMetaUri)
+                .timeout(Duration.ofSeconds(10))
+                .GET()
+                .build();
+
+        try {
+            final HttpResponse<String> response = httpClient.send(request, BodyHandlers.ofString());
+            if (response.statusCode() == 200 && !response.body().isBlank()) {
+                LOGGER.debug("NVD modified feed is available (HTTP {}), using ModifiedDataFeed", response.statusCode());
+                return new NvdDataFeed.ModifiedDataFeed();
+            }
+            LOGGER.warn(
+                    "NVD modified feed probe returned HTTP {} — falling back to RecentDataFeed",
+                    response.statusCode());
+        } catch (IOException e) {
+            LOGGER.warn("NVD modified feed probe failed ({}), falling back to RecentDataFeed", e.getMessage());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.warn("NVD modified feed probe interrupted, falling back to RecentDataFeed");
+        }
+
+        return new NvdDataFeed.RecentDataFeed();
     }
 
     @Override

--- a/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdVulnDataSourceFactory.java
+++ b/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdVulnDataSourceFactory.java
@@ -140,6 +140,10 @@ final class NvdVulnDataSourceFactory implements VulnDataSourceFactory, RuntimeCo
         return new NvdVulnDataSource(watermarkManager, objectMapper, httpClient, config.getCveFeedsUrl().toString(), feeds);
     }
 
+    // 50MB threshold — modified should be a small incremental feed; if it exceeds this
+    // NVD has likely broken it (e.g. serving a full dump). recent (~0.6MB) is used instead.
+    private static final long MODIFIED_FEED_MAX_GZ_BYTES = 50L * 1024 * 1024;
+
     private NvdDataFeed resolveIncrementalFeed(final String feedsUrl) {
         requireNonNull(httpClient, "httpClient must not be null");
 
@@ -154,13 +158,24 @@ final class NvdVulnDataSourceFactory implements VulnDataSourceFactory, RuntimeCo
 
         try {
             final HttpResponse<String> response = httpClient.send(request, BodyHandlers.ofString());
-            if (response.statusCode() == 200 && !response.body().isBlank()) {
-                LOGGER.debug("NVD modified feed is available (HTTP {}), using ModifiedDataFeed", response.statusCode());
-                return new NvdDataFeed.ModifiedDataFeed();
+            if (response.statusCode() != 200 || response.body().isBlank()) {
+                LOGGER.warn("NVD modified feed probe returned HTTP {} — falling back to RecentDataFeed",
+                        response.statusCode());
+                return new NvdDataFeed.RecentDataFeed();
             }
-            LOGGER.warn(
-                    "NVD modified feed probe returned HTTP {} — falling back to RecentDataFeed",
-                    response.statusCode());
+
+            final var metadata = NvdDataFeedMetadata.of(response.body());
+            if (metadata.gzSize() > MODIFIED_FEED_MAX_GZ_BYTES) {
+                LOGGER.warn(
+                        "NVD modified feed gzSize ({} bytes) exceeds threshold ({} bytes) — "
+                                + "feed appears to be a full dump rather than incremental; falling back to RecentDataFeed",
+                        metadata.gzSize(), MODIFIED_FEED_MAX_GZ_BYTES);
+                return new NvdDataFeed.RecentDataFeed();
+            }
+
+            LOGGER.debug("NVD modified feed gzSize {} bytes is within threshold, using ModifiedDataFeed",
+                    metadata.gzSize());
+            return new NvdDataFeed.ModifiedDataFeed();
         } catch (IOException e) {
             LOGGER.warn("NVD modified feed probe failed ({}), falling back to RecentDataFeed", e.getMessage());
         } catch (InterruptedException e) {


### PR DESCRIPTION
## Summary

Fixes #6501

The `nvdcve-2.0-modified.json.gz` feed has been unreliable:
- At times returning 0 bytes or HTTP 401
- Currently serving a full dump of all CVEs (~200MB compressed), causing RST_STREAM errors mid-download via Cloudflare

Once the initial year-feed sync is complete, `modified` is the wrong feed for incremental daily updates. The `recent` feed (`nvdcve-2.0-recent.json.gz`, ~0.6MB) is the correct choice.

## Changes

- `NvdDataFeed.java` — added `RecentDataFeed` record returning `"recent"`
- `NvdDataFeedMetadata.java` — parse `gzSize` field from metadata
- `NvdVulnDataSourceFactory.java` — added `resolveIncrementalFeed()`: probes `nvdcve-2.0-modified.meta` before each sync; falls back to `RecentDataFeed` if the probe returns non-200 or the `gzSize` exceeds 50MB

## Behaviour

- If `modified` is healthy and small (≤50MB): used as normal — no change from current behaviour
- If `modified` is oversized or unavailable: logs a warning and uses `recent` instead
- Self-healing: automatically switches back to `modified` if NVD fixes the feed

## Test plan

- [ ] Trigger manual NVD mirror and confirm `recent` feed is selected when `modified` gzSize exceeds threshold
- [ ] Confirm mirror completes successfully with `recent` feed
- [ ] Confirm `modified` is used when gzSize is within threshold