### PR TITLE
Auto-close issues that do not use an issue template

### DIFF
--- a/.github/workflows/ci-issue-template.yml
+++ b/.github/workflows/ci-issue-template.yml
@@ -1,0 +1,70 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+name: Issue Template Check
+
+on:
+  issues:
+    types: [ opened ]
+
+permissions: { }
+
+jobs:
+  validate:
+    name: Validate Issue Template
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Close issues that bypass templates
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const issue = context.payload.issue;
+
+            if (issue.user.type === 'Bot') {
+              core.notice(`Skipping bot author '${issue.user.login}'.`);
+              return;
+            }
+
+            const templateLabels = ['defect', 'in triage', 'enhancement'];
+            if (issue.labels.some(label => templateLabels.includes(label.name))) {
+              core.notice('Issue carries template labels; nothing to do.');
+              return;
+            }
+
+            core.notice(`Closing issue #${issue.number}: opened without an issue template.`);
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: issue.number,
+              body: [
+                'This issue was opened without using an issue template, which is only possible when',
+                'creating issues via the GitHub API. As stated in our',
+                '[contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#filing-issues),',
+                'issues that do not use a template will be closed.',
+                '',
+                'Please recreate this issue via the',
+                '[issue chooser](https://github.com/DependencyTrack/dependency-track/issues/new/choose).',
+              ].join('\n'),
+            });
+
+            await github.rest.issues.update({
+              ...context.repo,
+              issue_number: issue.number,
+              state: 'closed',
+              state_reason: 'not_planned',
+            });

--- a/.github/workflows/ci-issue-template.yml
+++ b/.github/workflows/ci-issue-template.yml
@@ -51,15 +51,9 @@ jobs:
             await github.rest.issues.createComment({
               ...context.repo,
               issue_number: issue.number,
-              body: [
-                'This issue was opened without using an issue template, which is only possible when',
-                'creating issues via the GitHub API. As stated in our',
-                '[contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#filing-issues),',
-                'issues that do not use a template will be closed.',
-                '',
-                'Please recreate this issue via the',
-                '[issue chooser](https://github.com/DependencyTrack/dependency-track/issues/new/choose).',
-              ].join('\n'),
+              body: `This issue was opened without using an issue template, which is only possible when creating issues via the GitHub API. As stated in our [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#filing-issues), issues that do not use a template will be closed.
+
+            Please recreate this issue via the [issue chooser](https://github.com/DependencyTrack/dependency-track/issues/new/choose).`,
             });
 
             await github.rest.issues.update({

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,10 @@ do not work anymore.
 
 ## Filing Issues
 
+> [!IMPORTANT]
+> New issues **must** be filed using one of the provided [issue templates](https://github.com/DependencyTrack/dependency-track/issues/new/choose).
+> **Issues that do not use a template will be closed automatically.**
+
 ### Looking for existing Issues
 
 Before you create a new issue, please do a search in [open issues](https://github.com/DependencyTrack/dependency-track/issues?q=is%3Aissue+is%3Aopen+) 
@@ -26,8 +30,6 @@ If you find your issue already exists, add relevant comments to the existing iss
 Optionally indicate your interest by reacting with *thumbs up* (👍). Issues with higher community attention are more likely to be addressed sooner.
 
 If you cannot find an existing issue for your bug or feature request, create a new issue using the guidelines below.
-
-New issues must be filed using one of the provided issue templates. **Issues that do not use a template will be closed.**
 
 ### Requesting Enhancements
 


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Auto-closes issues that do not use an issue template.

The practice of closing issues in this case is already stated in our CONTRIBUTING.md file, the new workflow just automates it.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->
N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
