### PR TITLE
Use WireMock for NVD vuln data source tests

### DIFF
--- a/vuln-data-source/nvd/src/test/java/org/dependencytrack/vulndatasource/nvd/NvdVulnDataSourceTest.java
+++ b/vuln-data-source/nvd/src/test/java/org/dependencytrack/vulndatasource/nvd/NvdVulnDataSourceTest.java
@@ -18,77 +18,103 @@
  */
 package org.dependencytrack.vulndatasource.nvd;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.google.protobuf.util.Timestamps;
 import org.cyclonedx.proto.v1_7.Bom;
 import org.cyclonedx.proto.v1_7.Vulnerability;
-import org.dependencytrack.plugin.api.MutableServiceRegistry;
-import org.dependencytrack.plugin.api.config.ConfigRegistry;
-import org.dependencytrack.plugin.api.storage.KeyValueStore;
-import org.dependencytrack.plugin.testing.MockConfigRegistry;
 import org.dependencytrack.plugin.testing.MockKeyValueStore;
-import org.dependencytrack.vulndatasource.api.VulnDataSource;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.net.URI;
+import java.io.ByteArrayOutputStream;
 import java.net.http.HttpClient;
+import java.time.Instant;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+@WireMockTest
 class NvdVulnDataSourceTest {
 
-    private NvdVulnDataSourceFactory dataSourceFactory;
-    private VulnDataSource dataSource;
-
-    @BeforeEach
-    void beforeEach() {
-        final var config = new NvdVulnDataSourceConfigV1();
-        config.setEnabled(true);
-        config.setCveFeedsUrl(URI.create("https://nvd.nist.gov/feeds"));
-
-        dataSourceFactory = new NvdVulnDataSourceFactory();
-
-        final var configRegistry = new MockConfigRegistry(dataSourceFactory.runtimeConfigSpec(), config);
-
-        dataSourceFactory.init(
-                new MutableServiceRegistry()
-                        .register(ConfigRegistry.class, configRegistry)
-                        .register(HttpClient.class, HttpClient.newHttpClient())
-                        .register(KeyValueStore.class, new MockKeyValueStore()));
-        dataSource = dataSourceFactory.create();
-    }
+    private NvdVulnDataSource dataSource;
+    private MockKeyValueStore kvStore;
 
     @AfterEach
     void afterEach() {
         if (dataSource != null) {
             dataSource.close();
         }
-        if (dataSourceFactory != null) {
-            dataSourceFactory.close();
-        }
     }
 
     @Test
-    void test() {
-        for (int i = 0; i < 5; i++) {
-            assertThat(dataSource.hasNext()).isTrue();
+    void shouldIterateCvesFromModifiedFeed(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlEqualTo("/json/cve/2.0/nvdcve-2.0-modified.meta"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("""
+                                lastModifiedDate:2024-01-01T00:00:00.000Z
+                                sha256:0000000000000000000000000000000000000000000000000000000000000000
+                                """)));
 
-            final Bom bov = dataSource.next();
-            assertThat(bov).isNotNull();
-            assertThat(bov.getVulnerabilitiesCount()).isEqualTo(1);
+        stubFor(get(urlEqualTo("/json/cve/2.0/nvdcve-2.0-modified.json.gz"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/gzip")
+                        .withBody(gzip(/* language=JSON */ """
+                                {
+                                  "vulnerabilities": [
+                                    {
+                                      "cve": {
+                                        "id": "CVE-2024-0001",
+                                        "lastModified": "2024-01-01T00:00:00.000",
+                                        "descriptions": [
+                                          {
+                                            "lang": "en",
+                                            "value": "Test vulnerability"
+                                          }
+                                        ],
+                                        "metrics": {}
+                                      }
+                                    }
+                                  ]
+                                }
+                                """))));
 
-            final Vulnerability vuln = bov.getVulnerabilities(0);
-            assertThat(vuln.getId()).startsWith("CVE-");
-            assertThat(vuln.getSource().getName()).isEqualTo("NVD");
-            assertThat(vuln.getDescription()).isNotEmpty();
+        dataSource = createDataSource(wmRuntimeInfo.getHttpBaseUrl());
 
-            dataSource.markProcessed(bov);
-        }
+        assertThat(dataSource.hasNext()).isTrue();
+
+        final Bom bov = dataSource.next();
+        assertThat(bov).isNotNull();
+        assertThat(bov.getVulnerabilitiesCount()).isEqualTo(1);
+
+        final Vulnerability vuln = bov.getVulnerabilities(0);
+        assertThat(vuln.getId()).isEqualTo("CVE-2024-0001");
+        assertThat(vuln.getSource().getName()).isEqualTo("NVD");
+        assertThat(vuln.getDescription()).isEqualTo("Test vulnerability");
+
+        dataSource.markProcessed(bov);
+
+        assertThat(dataSource.hasNext()).isFalse();
     }
 
     @Test
-    void markProcessedShouldThrowWhenBovHasUnexpectedVulnCount() {
+    void markProcessedShouldThrowWhenBovHasUnexpectedVulnCount(WireMockRuntimeInfo wmRuntimeInfo) {
+        dataSource = createDataSource(wmRuntimeInfo.getHttpBaseUrl());
+
         final var bov = Bom.newBuilder()
                 .addVulnerabilities(Vulnerability.newBuilder().setId("CVE-123"))
                 .addVulnerabilities(Vulnerability.newBuilder().setId("CVE-456"))
@@ -97,6 +123,264 @@ class NvdVulnDataSourceTest {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> dataSource.markProcessed(bov))
                 .withMessage("BOV must have exactly one vulnerability, but has 2");
+    }
+
+    @Test
+    void shouldSkipCvesBelowWatermark(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        kvStore = new MockKeyValueStore();
+        kvStore.put("watermark", String.valueOf(Instant.parse("2024-06-01T00:00:00Z").toEpochMilli()));
+
+        stubFor(get(urlEqualTo("/json/cve/2.0/nvdcve-2.0-modified.meta"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("""
+                                lastModifiedDate:2025-01-01T00:00:00.000Z
+                                sha256:0000000000000000000000000000000000000000000000000000000000000000
+                                """)));
+
+        stubFor(get(urlEqualTo("/json/cve/2.0/nvdcve-2.0-modified.json.gz"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/gzip")
+                        .withBody(gzip(/* language=JSON */ """
+                                {
+                                  "vulnerabilities": [
+                                    {
+                                      "cve": {
+                                        "id": "CVE-2024-0001",
+                                        "lastModified": "2024-01-01T00:00:00.000",
+                                        "descriptions": [{"lang": "en", "value": "Below watermark"}],
+                                        "metrics": {}
+                                      }
+                                    },
+                                    {
+                                      "cve": {
+                                        "id": "CVE-2024-0002",
+                                        "lastModified": "2024-12-01T00:00:00.000",
+                                        "descriptions": [{"lang": "en", "value": "Above watermark"}],
+                                        "metrics": {}
+                                      }
+                                    }
+                                  ]
+                                }
+                                """))));
+
+        dataSource = createDataSource(
+                wmRuntimeInfo.getHttpBaseUrl(),
+                kvStore,
+                List.of(new NvdDataFeed.ModifiedDataFeed()));
+
+        assertThat(dataSource.hasNext()).isTrue();
+        assertThat(dataSource.next().getVulnerabilities(0).getId()).isEqualTo("CVE-2024-0002");
+        assertThat(dataSource.hasNext()).isFalse();
+    }
+
+    @Test
+    void shouldSkipFeedWhenDigestUnchanged(WireMockRuntimeInfo wmRuntimeInfo) {
+        kvStore = new MockKeyValueStore();
+        kvStore.put(
+                "feed-digest:modified",
+                "0000000000000000000000000000000000000000000000000000000000000000");
+
+        stubFor(get(urlEqualTo("/json/cve/2.0/nvdcve-2.0-modified.meta"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("""
+                                lastModifiedDate:2024-01-01T00:00:00.000Z
+                                sha256:0000000000000000000000000000000000000000000000000000000000000000
+                                """)));
+
+        dataSource = createDataSource(
+                wmRuntimeInfo.getHttpBaseUrl(),
+                kvStore,
+                List.of(new NvdDataFeed.ModifiedDataFeed()));
+
+        assertThat(dataSource.hasNext()).isFalse();
+        verify(0, getRequestedFor(urlEqualTo("/json/cve/2.0/nvdcve-2.0-modified.json.gz")));
+    }
+
+    @Test
+    void shouldSkipFeedWhenBelowWatermark(WireMockRuntimeInfo wmRuntimeInfo) {
+        kvStore = new MockKeyValueStore();
+        kvStore.put("watermark", String.valueOf(Instant.parse("2024-06-01T00:00:00Z").toEpochMilli()));
+
+        stubFor(get(urlEqualTo("/json/cve/2.0/nvdcve-2.0-modified.meta"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("""
+                                lastModifiedDate:2024-01-01T00:00:00.000Z
+                                sha256:0000000000000000000000000000000000000000000000000000000000000000
+                                """)));
+
+        dataSource = createDataSource(
+                wmRuntimeInfo.getHttpBaseUrl(),
+                kvStore,
+                List.of(new NvdDataFeed.ModifiedDataFeed()));
+
+        assertThat(dataSource.hasNext()).isFalse();
+        verify(0, getRequestedFor(urlEqualTo("/json/cve/2.0/nvdcve-2.0-modified.json.gz")));
+    }
+
+    @Test
+    void shouldCommitWatermarkOnClose(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        kvStore = new MockKeyValueStore();
+
+        stubFor(get(urlEqualTo("/json/cve/2.0/nvdcve-2.0-modified.meta"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("""
+                                lastModifiedDate:2024-01-01T00:00:00.000Z
+                                sha256:0000000000000000000000000000000000000000000000000000000000000000
+                                """)));
+
+        stubFor(get(urlEqualTo("/json/cve/2.0/nvdcve-2.0-modified.json.gz"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/gzip")
+                        .withBody(gzip(/* language=JSON */ """
+                                {
+                                  "vulnerabilities": [
+                                    {
+                                      "cve": {
+                                        "id": "CVE-2024-0001",
+                                        "lastModified": "2024-01-01T00:00:00.000",
+                                        "descriptions": [{"lang": "en", "value": "Test vulnerability"}],
+                                        "metrics": {}
+                                      }
+                                    }
+                                  ]
+                                }
+                                """))));
+
+        dataSource = createDataSource(
+                wmRuntimeInfo.getHttpBaseUrl(),
+                kvStore,
+                List.of(new NvdDataFeed.ModifiedDataFeed()));
+
+        final Bom bov = dataSource.next();
+        dataSource.markProcessed(bov);
+        assertThat(dataSource.hasNext()).isFalse();
+
+        dataSource.close();
+        dataSource = null;
+
+        final long expectedMillis = Timestamps.toMillis(bov.getVulnerabilities(0).getUpdated());
+        assertThat(kvStore.get("watermark").value()).isEqualTo(String.valueOf(expectedMillis));
+    }
+
+    @Test
+    void shouldCommitFeedDigestOnClose(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        kvStore = new MockKeyValueStore();
+
+        stubFor(get(urlEqualTo("/json/cve/2.0/nvdcve-2.0-modified.meta"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("""
+                                lastModifiedDate:2024-01-01T00:00:00.000Z
+                                sha256:0000000000000000000000000000000000000000000000000000000000000000
+                                """)));
+
+        stubFor(get(urlEqualTo("/json/cve/2.0/nvdcve-2.0-modified.json.gz"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/gzip")
+                        .withBody(gzip(/* language=JSON */ """
+                                {
+                                  "vulnerabilities": [
+                                    {
+                                      "cve": {
+                                        "id": "CVE-2024-0001",
+                                        "lastModified": "2024-01-01T00:00:00.000",
+                                        "descriptions": [{"lang": "en", "value": "Test vulnerability"}],
+                                        "metrics": {}
+                                      }
+                                    }
+                                  ]
+                                }
+                                """))));
+
+        dataSource = createDataSource(
+                wmRuntimeInfo.getHttpBaseUrl(),
+                kvStore,
+                List.of(new NvdDataFeed.ModifiedDataFeed()));
+
+        while (dataSource.hasNext()) {
+            dataSource.next();
+        }
+
+        dataSource.close();
+        dataSource = null;
+
+        assertThat(kvStore.get("feed-digest:modified").value())
+                .isEqualTo("0000000000000000000000000000000000000000000000000000000000000000");
+    }
+
+    @Test
+    void shouldThrowWhenMetadataResponseNotOk(WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(get(urlEqualTo("/json/cve/2.0/nvdcve-2.0-modified.meta"))
+                .willReturn(aResponse().withStatus(500)));
+
+        dataSource = createDataSource(wmRuntimeInfo.getHttpBaseUrl());
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> dataSource.hasNext())
+                .withMessage("Unexpected response code: 500");
+    }
+
+    @Test
+    void shouldThrowWhenFeedDownloadNotOk(WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(get(urlEqualTo("/json/cve/2.0/nvdcve-2.0-modified.meta"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("""
+                                lastModifiedDate:2024-01-01T00:00:00.000Z
+                                sha256:0000000000000000000000000000000000000000000000000000000000000000
+                                """)));
+        stubFor(get(urlEqualTo("/json/cve/2.0/nvdcve-2.0-modified.json.gz"))
+                .willReturn(aResponse().withStatus(500)));
+
+        dataSource = createDataSource(wmRuntimeInfo.getHttpBaseUrl());
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> dataSource.hasNext())
+                .withMessage("Unexpected response code: 500");
+    }
+
+    private NvdVulnDataSource createDataSource(String feedsUrl) {
+        return createDataSource(
+                feedsUrl,
+                new MockKeyValueStore(),
+                List.of(new NvdDataFeed.ModifiedDataFeed()));
+    }
+
+    private NvdVulnDataSource createDataSource(
+            String feedsUrl,
+            MockKeyValueStore kvStore,
+            List<NvdDataFeed> feeds) {
+        this.kvStore = kvStore;
+        final var watermarkManager = new WatermarkManager(
+                kvStore,
+                feeds.stream().map(NvdDataFeed::name).toList());
+        final ObjectMapper objectMapper = new ObjectMapper()
+                .configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, true)
+                .configure(JsonReadFeature.ALLOW_TRAILING_COMMA.mappedFeature(), true)
+                .registerModule(new JavaTimeModule());
+
+        return new NvdVulnDataSource(
+                watermarkManager,
+                objectMapper,
+                HttpClient.newHttpClient(),
+                feedsUrl,
+                feeds);
+    }
+
+    private static byte[] gzip(String content) throws Exception {
+        final var out = new ByteArrayOutputStream();
+        try (final var gzipOut = new GZIPOutputStream(out)) {
+            gzipOut.write(content.getBytes());
+        }
+
+        return out.toByteArray();
     }
 
 }


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Switches from calling the NVD directly to emulating NVD responses using WireMock. Also adds more test coverage for the NVD vuln data source in general, in particular around watermarking and digest behavior.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
