### PR TITLE
Make banner config readable without permissions

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
@@ -26,6 +26,8 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import java.util.Arrays;
 import java.util.UUID;
 
+import static java.util.Objects.requireNonNull;
+
 public enum ConfigPropertyConstants {
 
     INTERNAL_CLUSTER_ID("internal", "cluster.id", UUID.randomUUID().toString(), PropertyType.STRING, "Unique identifier of the cluster", ConfigPropertyAccessMode.READ_ONLY),
@@ -50,26 +52,26 @@ public enum ConfigPropertyConstants {
     BOM_VALIDATION_TAGS_EXCLUSIVE("artifact", "bom.validation.tags.exclusive", "[]", PropertyType.STRING, "JSON array of tags for which BOM validation shall NOT be performed", ConfigPropertyAccessMode.READ_WRITE),
     FORTIFY_SSC_ENABLED("integrations", "fortify.ssc.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable Fortify SSC integration", ConfigPropertyAccessMode.READ_WRITE),
     FORTIFY_SSC_URL("integrations", "fortify.ssc.url", null, PropertyType.URL, "Base URL to Fortify SSC", ConfigPropertyAccessMode.READ_WRITE),
-    FORTIFY_SSC_TOKEN("integrations", "fortify.ssc.token", null, PropertyType.STRING, "Name of the secret containing the Fortify SSC authentication token", ConfigPropertyAccessMode.READ_WRITE, false, true),
+    FORTIFY_SSC_TOKEN("integrations", "fortify.ssc.token", null, PropertyType.STRING, "Name of the secret containing the Fortify SSC authentication token", ConfigPropertyAccessMode.READ_WRITE, ConfigPropertyVisibility.RESTRICTED, true),
     DEFECTDOJO_ENABLED("integrations", "defectdojo.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable DefectDojo integration", ConfigPropertyAccessMode.READ_WRITE),
     DEFECTDOJO_REIMPORT_ENABLED("integrations", "defectdojo.reimport.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable DefectDojo reimport-scan API endpoint", ConfigPropertyAccessMode.READ_WRITE),
     DEFECTDOJO_URL("integrations", "defectdojo.url", null, PropertyType.URL, "Base URL to DefectDojo", ConfigPropertyAccessMode.READ_WRITE),
-    DEFECTDOJO_API_KEY("integrations", "defectdojo.apiKey", null, PropertyType.STRING, "Name of the secret containing the DefectDojo API key", ConfigPropertyAccessMode.READ_WRITE, false, true),
+    DEFECTDOJO_API_KEY("integrations", "defectdojo.apiKey", null, PropertyType.STRING, "Name of the secret containing the DefectDojo API key", ConfigPropertyAccessMode.READ_WRITE, ConfigPropertyVisibility.RESTRICTED, true),
     KENNA_ENABLED("integrations", "kenna.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable Kenna Security integration", ConfigPropertyAccessMode.READ_WRITE),
     KENNA_API_URL("integrations", "kenna.api.url", "https://api.kennasecurity.com", PropertyType.STRING, "Kenna Security API URL", ConfigPropertyAccessMode.READ_WRITE),
-    KENNA_TOKEN("integrations", "kenna.token", null, PropertyType.STRING, "Name of the secret containing the Kenna Security authentication token", ConfigPropertyAccessMode.READ_WRITE, false, true),
+    KENNA_TOKEN("integrations", "kenna.token", null, PropertyType.STRING, "Name of the secret containing the Kenna Security authentication token", ConfigPropertyAccessMode.READ_WRITE, ConfigPropertyVisibility.RESTRICTED, true),
     KENNA_CONNECTOR_ID("integrations", "kenna.connector.id", null, PropertyType.STRING, "The Kenna Security connector identifier to upload to", ConfigPropertyAccessMode.READ_WRITE),
-    ACCESS_MANAGEMENT_ACL_ENABLED("access-management", "acl.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable access control to projects in the portfolio", ConfigPropertyAccessMode.READ_WRITE, true),
+    ACCESS_MANAGEMENT_ACL_ENABLED("access-management", "acl.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable access control to projects in the portfolio", ConfigPropertyAccessMode.READ_WRITE, ConfigPropertyVisibility.PUBLIC),
     CUSTOM_RISK_SCORE_HISTORY_ENABLED("risk-score", "weight.history.enabled", "true", PropertyType.BOOLEAN, "Flag to re-calculate risk score history", ConfigPropertyAccessMode.READ_WRITE),
     CUSTOM_RISK_SCORE_CRITICAL("risk-score", "weight.critical", "10", PropertyType.INTEGER, "Critical severity vulnerability weight (between 1-10)", ConfigPropertyAccessMode.READ_WRITE),
     CUSTOM_RISK_SCORE_HIGH("risk-score", "weight.high", "5", PropertyType.INTEGER, "High severity vulnerability weight (between 1-10)", ConfigPropertyAccessMode.READ_WRITE),
     CUSTOM_RISK_SCORE_MEDIUM("risk-score", "weight.medium", "3", PropertyType.INTEGER, "Medium severity vulnerability weight (between 1-10)", ConfigPropertyAccessMode.READ_WRITE),
     CUSTOM_RISK_SCORE_LOW("risk-score", "weight.low", "1", PropertyType.INTEGER, "Low severity vulnerability weight (between 1-10)", ConfigPropertyAccessMode.READ_WRITE),
     CUSTOM_RISK_SCORE_UNASSIGNED("risk-score", "weight.unassigned", "5", PropertyType.INTEGER, "Unassigned severity vulnerability weight (between 1-10)", ConfigPropertyAccessMode.READ_WRITE),
-    WELCOME_MESSAGE("general", "welcome.message.html", "%3Chtml%3E%3Ch1%3EYour%20Welcome%20Message%3C%2Fh1%3E%3C%2Fhtml%3E", PropertyType.STRING, "Custom HTML Code that is displayed before login", ConfigPropertyAccessMode.READ_WRITE, true),
-    IS_WELCOME_MESSAGE("general", "welcome.message.enabled", "false", PropertyType.BOOLEAN, "Bool that says whether to show the welcome message or not", ConfigPropertyAccessMode.READ_WRITE, true),
-    BANNER_CONFIG("banner", "config", "{}", PropertyType.STRING, "JSON configuration for the application banner", ConfigPropertyAccessMode.READ_WRITE),
-    DEFAULT_LANGUAGE("general", "default.locale", null, PropertyType.STRING, "Determine the default Language to use", ConfigPropertyAccessMode.READ_WRITE, true),
+    WELCOME_MESSAGE("general", "welcome.message.html", "%3Chtml%3E%3Ch1%3EYour%20Welcome%20Message%3C%2Fh1%3E%3C%2Fhtml%3E", PropertyType.STRING, "Custom HTML Code that is displayed before login", ConfigPropertyAccessMode.READ_WRITE, ConfigPropertyVisibility.PUBLIC),
+    IS_WELCOME_MESSAGE("general", "welcome.message.enabled", "false", PropertyType.BOOLEAN, "Bool that says whether to show the welcome message or not", ConfigPropertyAccessMode.READ_WRITE, ConfigPropertyVisibility.PUBLIC),
+    BANNER_CONFIG("banner", "config", "{}", PropertyType.STRING, "JSON configuration for the application banner", ConfigPropertyAccessMode.READ_WRITE, ConfigPropertyVisibility.INTERNAL),
+    DEFAULT_LANGUAGE("general", "default.locale", null, PropertyType.STRING, "Determine the default Language to use", ConfigPropertyAccessMode.READ_WRITE, ConfigPropertyVisibility.PUBLIC),
     TELEMETRY_SUBMISSION_ENABLED("telemetry", "submission.enabled", ConfigProvider.getConfig().getOptionalValue(ConfigKeys.TELEMETRY_SUBMISSION_DEFAULT_ENABLED, boolean.class).map(String::valueOf).orElse("true"), PropertyType.BOOLEAN, "Whether submission of telemetry data is enabled", ConfigPropertyAccessMode.READ_WRITE),
     TELEMETRY_LAST_SUBMISSION_DATA("telemetry", "last.submission.data", null, PropertyType.STRING, "Data of the last telemetry submission", ConfigPropertyAccessMode.READ_ONLY),
     TELEMETRY_LAST_SUBMISSION_EPOCH_SECONDS("telemetry", "last.submission.epoch.seconds", null, PropertyType.INTEGER, "Timestamp of the last telemetry submission in epoch seconds", ConfigPropertyAccessMode.READ_ONLY);
@@ -80,7 +82,7 @@ public enum ConfigPropertyConstants {
     private final PropertyType propertyType;
     private final String description;
     private final ConfigPropertyAccessMode accessMode;
-    private final Boolean isPublic;
+    private final ConfigPropertyVisibility visibility;
     private final boolean isSecretName;
 
     ConfigPropertyConstants(
@@ -90,7 +92,7 @@ public enum ConfigPropertyConstants {
             PropertyType propertyType,
             String description,
             ConfigPropertyAccessMode accessMode) {
-        this(groupName, propertyName, defaultPropertyValue, propertyType, description, accessMode, false, false);
+        this(groupName, propertyName, defaultPropertyValue, propertyType, description, accessMode, ConfigPropertyVisibility.RESTRICTED, false);
     }
 
     ConfigPropertyConstants(
@@ -100,8 +102,8 @@ public enum ConfigPropertyConstants {
             PropertyType propertyType,
             String description,
             ConfigPropertyAccessMode accessMode,
-            Boolean isPublic) {
-        this(groupName, propertyName, defaultPropertyValue, propertyType, description, accessMode, isPublic, false);
+            ConfigPropertyVisibility visibility) {
+        this(groupName, propertyName, defaultPropertyValue, propertyType, description, accessMode, visibility, false);
     }
 
     ConfigPropertyConstants(
@@ -111,7 +113,7 @@ public enum ConfigPropertyConstants {
             PropertyType propertyType,
             String description,
             ConfigPropertyAccessMode accessMode,
-            Boolean isPublic,
+            ConfigPropertyVisibility visibility,
             boolean isSecretName) {
         this.groupName = groupName;
         this.propertyName = propertyName;
@@ -119,7 +121,7 @@ public enum ConfigPropertyConstants {
         this.propertyType = propertyType;
         this.description = description;
         this.accessMode = accessMode;
-        this.isPublic = isPublic;
+        this.visibility = requireNonNull(visibility, "visibility must not be null");
         this.isSecretName = isSecretName;
     }
 
@@ -155,8 +157,8 @@ public enum ConfigPropertyConstants {
         return accessMode;
     }
 
-    public Boolean getIsPublic() {
-        return isPublic;
+    public ConfigPropertyVisibility getVisibility() {
+        return visibility;
     }
 
     public boolean isSecretName() {

--- a/apiserver/src/main/java/org/dependencytrack/model/ConfigPropertyVisibility.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/ConfigPropertyVisibility.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.model;
+
+/// Controls the visibility of a [ConfigPropertyConstants] value.
+///
+/// Does **not** control who can write. Writing config properties *always*
+/// requires `SYSTEM_CONFIGURATION[_UPDATE]` permissions.
+///
+/// @since 5.1.0
+public enum ConfigPropertyVisibility {
+
+    /// Only visible to principals with the `SYSTEM_CONFIGURATION[_READ]` permission.
+    /// Should be the default unless a specific use case requires broader visibility.
+    RESTRICTED,
+
+    /// Visible to any authenticated principal, no permission required.
+    /// Use for values that may contain organization-internal yet non-confidential
+    /// references not meant for unauthenticated parties.
+    INTERNAL,
+
+    /// Visible to anyone, including unauthenticated parties.
+    PUBLIC
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ConfigPropertyResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ConfigPropertyResource.java
@@ -43,13 +43,16 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.ConfigPropertyConstants;
+import org.dependencytrack.model.ConfigPropertyVisibility;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.v1.vo.ConfigPropertyResponse;
 import org.dependencytrack.resources.v1.vo.UpdateConfigPropertyRequest;
 import org.dependencytrack.secret.management.SecretManager;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * JAX-RS resources for processing ConfigProperties
@@ -194,12 +197,55 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
             @PathParam("groupName") String groupName,
             @Parameter(description = "The property name of the value to retrieve", required = true)
             @PathParam("propertyName") String propertyName) {
+        return getClassifiedConfigProperty(
+                groupName,
+                propertyName,
+                EnumSet.of(ConfigPropertyVisibility.PUBLIC));
+    }
+
+    @GET
+    @Path("/internal/{groupName}/{propertyName}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Returns an internal ConfigProperty",
+            description = """
+                    <p>
+                      Requires authentication, but no permission.
+                      Returns both internal and public properties
+                    </p>"""
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "The internal config property",
+                    content = @Content(schema = @Schema(implementation = ConfigPropertyResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Not an internal- or public-readable config property"),
+            @ApiResponse(responseCode = "404", description = "The config property could not be found")
+    })
+    public Response getInternalConfigProperty(
+            @Parameter(description = "The group name of the value to retrieve", required = true)
+            @PathParam("groupName") String groupName,
+            @Parameter(description = "The property name of the value to retrieve", required = true)
+            @PathParam("propertyName") String propertyName) {
+        return getClassifiedConfigProperty(
+                groupName,
+                propertyName,
+                EnumSet.of(
+                        ConfigPropertyVisibility.PUBLIC,
+                        ConfigPropertyVisibility.INTERNAL));
+    }
+
+    private Response getClassifiedConfigProperty(
+            String groupName,
+            String propertyName,
+            Set<ConfigPropertyVisibility> allowedVisibilities) {
         final var lookup = new ConfigProperty();
         lookup.setGroupName(groupName);
         lookup.setPropertyName(propertyName);
 
         final var wellKnownProperty = ConfigPropertyConstants.ofProperty(lookup);
-        if (wellKnownProperty == null || !wellKnownProperty.getIsPublic()) {
+        if (wellKnownProperty == null || !allowedVisibilities.contains(wellKnownProperty.getVisibility())) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
 

--- a/apiserver/src/test/java/org/dependencytrack/model/ConfigPropertyConstantsTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/model/ConfigPropertyConstantsTest.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.model;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+class ConfigPropertyConstantsTest {
+
+    @ParameterizedTest
+    @EnumSource(ConfigPropertyConstants.class)
+    void shouldOnlyAllowSecretNamesOnPropertiesWithRestrictedVisibility(ConfigPropertyConstants property) {
+        assumeThat(property.getVisibility()).isNotEqualTo(ConfigPropertyVisibility.RESTRICTED);
+        assertThat(property.isSecretName()).isFalse();
+    }
+
+}

--- a/apiserver/src/test/java/org/dependencytrack/resources/ResourceAuthorizationArchitectureTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/ResourceAuthorizationArchitectureTest.java
@@ -52,6 +52,7 @@ class ResourceAuthorizationArchitectureTest {
     private static final Set<String> PERMISSION_ANNOTATION_ALLOWLIST = Set.of(
             "CalculatorResource.getCvssScores",
             "CalculatorResource.getOwaspRRScores",
+            "ConfigPropertyResource.getInternalConfigProperty",
             "CweResource.getCwe",
             "CweResource.getCwes",
             "EventResource.isTokenBeingProcessed",

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
@@ -27,6 +27,7 @@ import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.ConfigPropertyConstants;
+import org.dependencytrack.model.ConfigPropertyVisibility;
 import org.dependencytrack.secret.management.SecretManager;
 import org.dependencytrack.secret.management.SecretMetadata;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
@@ -750,7 +751,10 @@ class ConfigPropertyResourceTest extends ResourceTest {
                     .header(X_API_KEY, apiKey)
                     .get();
 
-            final int expectedStatus = configProperty.getIsPublic() ? 200 : 403;
+            final int expectedStatus =
+                    configProperty.getVisibility() == ConfigPropertyVisibility.PUBLIC
+                            ? 200
+                            : 403;
             assertThat(response.getStatus()).isEqualTo(expectedStatus);
         }
     }
@@ -782,6 +786,152 @@ class ConfigPropertyResourceTest extends ResourceTest {
 
         assertThat(response.getStatus()).isEqualTo(404);
         assertThat(getPlainTextBody(response)).isEqualTo("The config property could not be found.");
+    }
+
+    @Test
+    void shouldReturnFullJsonForInternalConfigProperty() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        qm.createConfigProperty(
+                ConfigPropertyConstants.BANNER_CONFIG.getGroupName(),
+                ConfigPropertyConstants.BANNER_CONFIG.getPropertyName(),
+                ConfigPropertyConstants.BANNER_CONFIG.getDefaultPropertyValue(),
+                ConfigPropertyConstants.BANNER_CONFIG.getPropertyType(),
+                ConfigPropertyConstants.BANNER_CONFIG.getDescription());
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY
+                        + "/internal/" + ConfigPropertyConstants.BANNER_CONFIG.getGroupName()
+                        + "/" + ConfigPropertyConstants.BANNER_CONFIG.getPropertyName())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "groupName": "banner",
+                  "propertyName": "config",
+                  "propertyValue": "{}",
+                  "propertyType": "STRING",
+                  "description": "${json-unit.any-string}"
+                }
+                """);
+    }
+
+    @Test
+    void shouldReturn403ForRestrictedConfigPropertyViaInternalEndpoint() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        for (final var configProperty : ConfigPropertyConstants.values()) {
+            qm.createConfigProperty(
+                    configProperty.getGroupName(),
+                    configProperty.getPropertyName(),
+                    configProperty.getDefaultPropertyValue(),
+                    configProperty.getPropertyType(),
+                    configProperty.getDescription());
+
+            final Response response = jersey
+                    .target(V1_CONFIG_PROPERTY
+                            + "/internal/" + configProperty.getGroupName()
+                            + "/" + configProperty.getPropertyName())
+                    .request()
+                    .header(X_API_KEY, apiKey)
+                    .get();
+
+            final int expectedStatus =
+                    configProperty.getVisibility() == ConfigPropertyVisibility.RESTRICTED
+                            ? 403
+                            : 200;
+            assertThat(response.getStatus()).isEqualTo(expectedStatus);
+        }
+    }
+
+    @Test
+    void shouldReadPublicConfigPropertyWithoutAuthentication() {
+        qm.createConfigProperty(
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
+                "true",
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyType(),
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getDescription());
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY
+                        + "/public/" + ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName()
+                        + "/" + ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName())
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void shouldRequireAuthenticationForInternalConfigProperty() {
+        qm.createConfigProperty(
+                ConfigPropertyConstants.BANNER_CONFIG.getGroupName(),
+                ConfigPropertyConstants.BANNER_CONFIG.getPropertyName(),
+                ConfigPropertyConstants.BANNER_CONFIG.getDefaultPropertyValue(),
+                ConfigPropertyConstants.BANNER_CONFIG.getPropertyType(),
+                ConfigPropertyConstants.BANNER_CONFIG.getDescription());
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY
+                        + "/internal/" + ConfigPropertyConstants.BANNER_CONFIG.getGroupName()
+                        + "/" + ConfigPropertyConstants.BANNER_CONFIG.getPropertyName())
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(401);
+    }
+
+    @Test
+    void shouldReadInternalConfigPropertyWithoutPermission() {
+        qm.createConfigProperty(
+                ConfigPropertyConstants.BANNER_CONFIG.getGroupName(),
+                ConfigPropertyConstants.BANNER_CONFIG.getPropertyName(),
+                ConfigPropertyConstants.BANNER_CONFIG.getDefaultPropertyValue(),
+                ConfigPropertyConstants.BANNER_CONFIG.getPropertyType(),
+                ConfigPropertyConstants.BANNER_CONFIG.getDescription());
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY
+                        + "/internal/" + ConfigPropertyConstants.BANNER_CONFIG.getGroupName()
+                        + "/" + ConfigPropertyConstants.BANNER_CONFIG.getPropertyName())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void shouldReturnPublicConfigPropertyViaInternalEndpoint() {
+        qm.createConfigProperty(
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
+                "true",
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyType(),
+                ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getDescription());
+
+        final Response response = jersey
+                .target(V1_CONFIG_PROPERTY
+                        + "/internal/" + ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName()
+                        + "/" + ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "groupName": "access-management",
+                  "propertyName": "acl.enabled",
+                  "propertyValue": "true",
+                  "propertyType": "BOOLEAN",
+                  "description": "${json-unit.any-string}"
+                }
+                """);
     }
 
     private void createRiskScoreProperties() {


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes a mistake I caused in code review, where I recommended the property to be non-public. However, that requires the `SYSTEM_CONFIGURATION` permission, which most users don't have.

Since this is targeted at mostly non-admin users, the property should be readable by all authenticated users.

To achieve this, the previous isPublic=true/false classification is extended to also handle internal visibility. Unauthenticated principals can see public properties, authenticated can see internal and public, and authorized (admins) can see restricted properties.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #6440 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Frontend PR: https://github.com/DependencyTrack/frontend/pull/1635

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
