### PR TITLE
Raise lock timeout for mirror-vuln-data-source activities and set explicit request timeouts for NVD downloads

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/dex/DexEngineInitializer.java
+++ b/apiserver/src/main/java/org/dependencytrack/dex/DexEngineInitializer.java
@@ -267,7 +267,9 @@ public final class DexEngineInitializer implements ServletContextListener {
                 new MirrorVulnDataSourceActivity(pluginManager),
                 protoConverter(MirrorVulnDataSourceArg.class),
                 voidConverter(),
-                Duration.ofMinutes(5));
+                // NB: Account for slow downloads, mainly of sources relying on data dumps.
+                // Activities can't heartbeat while blocked on I/O.
+                Duration.ofMinutes(15));
         engine.registerActivity(
                 new PrepareVulnAnalysisActivity(fileStorage, pluginManager),
                 protoConverter(PrepareVulnAnalysisArg.class),

--- a/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdVulnDataSource.java
+++ b/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdVulnDataSource.java
@@ -41,6 +41,7 @@ import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -54,6 +55,8 @@ import static java.util.Objects.requireNonNull;
 final class NvdVulnDataSource implements VulnDataSource {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NvdVulnDataSource.class);
+    private static final Duration FEED_REQUEST_TIMEOUT = Duration.ofMinutes(10);
+    private static final Duration META_REQUEST_TIMEOUT = Duration.ofSeconds(30);
 
     private final WatermarkManager watermarkManager;
     private final String feedsUrl;
@@ -308,6 +311,7 @@ final class NvdVulnDataSource implements VulnDataSource {
 
         final HttpRequest request = HttpRequest.newBuilder()
                 .uri(feedMetadataUri)
+                .timeout(META_REQUEST_TIMEOUT)
                 .GET()
                 .build();
 
@@ -338,6 +342,7 @@ final class NvdVulnDataSource implements VulnDataSource {
 
         final HttpRequest request = HttpRequest.newBuilder()
                 .uri(feedFileUri)
+                .timeout(FEED_REQUEST_TIMEOUT)
                 .GET()
                 .build();
 
@@ -350,25 +355,37 @@ final class NvdVulnDataSource implements VulnDataSource {
 
         LOGGER.info("Downloading feed {} from {}", feed, feedFileUri);
         LOGGER.debug("Download destination: {}", tempFile);
-        final HttpResponse<Path> response;
         try {
-            response = httpClient.send(
+            final HttpResponse<Path> response = httpClient.send(
                     request, HttpResponse.BodyHandlers.ofFile(tempFile));
+
+            if (response.statusCode() != 200) {
+                throw new IllegalStateException(
+                        "Unexpected response code: " + response.statusCode());
+            }
+
+            return response.body();
         } catch (IOException e) {
+            tryDelete(tempFile);
             throw new IllegalStateException(
                     "Failed to download feed file from " + feedFileUri, e);
         } catch (InterruptedException e) {
+            tryDelete(tempFile);
             Thread.currentThread().interrupt();
             throw new IllegalStateException(
                     "Interrupted while downloading feed file from " + feedFileUri, e);
+        } catch (RuntimeException e) {
+            tryDelete(tempFile);
+            throw e;
         }
+    }
 
-        if (response.statusCode() != 200) {
-            throw new IllegalStateException(
-                    "Unexpected response code: " + response.statusCode());
+    private static void tryDelete(Path filePath) {
+        try {
+            Files.deleteIfExists(filePath);
+        } catch (IOException e) {
+            LOGGER.warn("Failed to delete temp file {}", filePath, e);
         }
-
-        return response.body();
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Raises lock timeout for `mirror-vuln-data-source` activities and set explicit request timeouts for NVD downloads.

Addresses the NVD's current behavior of blocking connections for >5min and then failing them with `RST_STREAM` or similar. The previous task lock timeout caused activities to be re-claimed by worker threads because heartbeats are not emitted when blocked on I/O.

Accounting for users with slower connections, the activity lock timeout is raised from 5min to 15min. Request timeout for NVD `meta` files (tiny) is capped at 30s, and that for feed file download at 10min.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
