### PR TITLE
Remove unnecessary enrichment when querying for individual projects

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -118,16 +118,9 @@ final class ProjectQueryManager extends QueryManager {
         }
 
         preprocessACLs(query, queryFilter, params);
+        query.setNamedParameters(params);
         query.setRange(0, 1);
-        final Project project = singleResult(query.executeWithMap(params));
-        if (project != null) {
-            // set Metrics to prevent extra round trip
-            project.setMetrics(withJdbiHandle(handle ->
-                    handle.attach(MetricsDao.class).getMostRecentProjectMetrics(project.getId())));
-            // set ProjectVersions to prevent extra round trip
-            project.setVersions(getProjectVersions(project));
-        }
-        return project;
+        return executeAndCloseUnique(query);
     }
 
     /**
@@ -145,17 +138,10 @@ final class ProjectQueryManager extends QueryManager {
         final String queryFilter = "(name == :name) && (isLatest == true)";
 
         preprocessACLs(query, queryFilter, params);
+        query.setNamedParameters(params);
         query.setRange(0, 1);
 
-        final Project project = singleResult(query.executeWithMap(params));
-        if (project != null) {
-            // set Metrics to prevent extra round trip
-            project.setMetrics(withJdbiHandle(handle ->
-                    handle.attach(MetricsDao.class).getMostRecentProjectMetrics(project.getId())));
-            // set ProjectVersions to prevent extra round trip
-            project.setVersions(getProjectVersions(project));
-        }
-        return project;
+        return executeAndCloseUnique(query);
     }
 
     @Override
@@ -645,7 +631,7 @@ final class ProjectQueryManager extends QueryManager {
         }
     }
 
-    private List<ProjectVersion> getProjectVersions(Project project) {
+    public List<ProjectVersion> getProjectVersions(Project project) {
         final Query<Project> query = pm.newQuery(Project.class);
         query.setResult("uuid, version, isLatest, inactiveSince");
         query.setOrdering("id asc"); // Ensure consistent ordering

--- a/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -54,6 +54,7 @@ import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
 import org.dependencytrack.model.PolicyViolation;
 import org.dependencytrack.model.Project;
+import org.dependencytrack.model.ProjectVersion;
 import org.dependencytrack.model.ProjectProperty;
 import org.dependencytrack.model.Repository;
 import org.dependencytrack.model.RepositoryType;
@@ -411,6 +412,10 @@ public class QueryManager extends AlpineQueryManager {
 
     public Project getLatestProjectVersion(final String name) {
         return getProjectQueryManager().getLatestProjectVersion(name);
+    }
+
+    public List<ProjectVersion> getProjectVersions(final Project project) {
+        return getProjectQueryManager().getProjectVersions(project);
     }
 
     public boolean hasAccess(final Principal principal, final Project project) {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -349,6 +349,11 @@ public class ProjectResource extends AbstractApiResource {
             final Project project = ProjectAccess.unrestricted(() -> qm.getLatestProjectVersion(name));
             if (project != null) {
                 requireAccess(qm, project);
+                project.setMetrics(
+                        withJdbiHandle(handle -> handle
+                                .attach(MetricsDao.class)
+                                .getMostRecentProjectMetrics(project.getId())));
+                project.setVersions(qm.getProjectVersions(project));
                 return Response.ok(project).build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();
@@ -387,6 +392,11 @@ public class ProjectResource extends AbstractApiResource {
             final Project project = ProjectAccess.unrestricted(() -> qm.getProject(name, version));
             if (project != null) {
                 requireAccess(qm, project);
+                project.setMetrics(
+                        withJdbiHandle(handle -> handle
+                                .attach(MetricsDao.class)
+                                .getMostRecentProjectMetrics(project.getId())));
+                project.setVersions(qm.getProjectVersions(project));
                 return Response.ok(project).build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Removes metrics and versions enrichment from `ProjectQueryManager#getLatestProjectVersion(name)` and `#getProject(name, version)`. That data is only needed by one call site, but all others (e.g. BOM and VEX upload endpoints) paid the cost for it despite not needing it.

Enrichment is now done directly at the call site where it's needed.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
