### PR TITLE
Bump cyclonedx-core-java and json-schema-validtor libs

### DIFF
--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -20,7 +20,6 @@
         <!-- Dependency Versions -->
         <lib.cloud-sql-postgres-socket-factory.version>1.28.4</lib.cloud-sql-postgres-socket-factory.version>
         <lib.owasp-rr-calculator.version>1.0.1</lib.owasp-rr-calculator.version>
-        <lib.cyclonedx-java.version>12.1.0</lib.cyclonedx-java.version>
         <lib.micrometer-jvm-extras.version>0.3.0</lib.micrometer-jvm-extras.version>
         <lib.swagger-parser.version>2.1.44</lib.swagger-parser.version>
         <lib.system-rules.version>1.19.0</lib.system-rules.version>
@@ -317,7 +316,6 @@
         <dependency>
             <groupId>org.cyclonedx</groupId>
             <artifactId>cyclonedx-core-java</artifactId>
-            <version>${lib.cyclonedx-java.version}</version>
         </dependency>
 
         <dependency>

--- a/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidator.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidator.java
@@ -20,25 +20,31 @@ package org.dependencytrack.parser.cyclonedx;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.Version;
-import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.parsers.JsonParser;
-import org.cyclonedx.parsers.Parser;
-import org.cyclonedx.parsers.XmlParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 import javax.xml.XMLConstants;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.events.XMLEvent;
+import javax.xml.transform.stax.StAXSource;
+import javax.xml.validation.Validator;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.cyclonedx.CycloneDxSchema.NS_BOM_10;
 import static org.cyclonedx.CycloneDxSchema.NS_BOM_11;
@@ -64,6 +70,10 @@ public class CycloneDxValidator {
     private static final CycloneDxValidator INSTANCE = new CycloneDxValidator();
 
     private final JsonMapper jsonMapper = new JsonMapper();
+    private final XMLInputFactory xmlInputFactory = createXmlInputFactory();
+    private final CycloneDxSchema schemaSource = new JsonParser();
+    private final Map<Version, com.networknt.schema.Schema> jsonSchemaCache = new ConcurrentHashMap<>();
+    private final Map<Version, javax.xml.validation.Schema> xmlSchemaCache = new ConcurrentHashMap<>();
 
     CycloneDxValidator() {
     }
@@ -72,26 +82,94 @@ public class CycloneDxValidator {
         return INSTANCE;
     }
 
-    public void validate(final byte[] bomBytes) {
+    public void validate(byte[] bomBytes) {
         final FormatAndVersion formatAndVersion = detectFormatAndSchemaVersion(bomBytes);
-        final Parser bomParser = switch (formatAndVersion.format()) {
-            case JSON -> new JsonParser();
-            case XML -> new XmlParser();
+        final List<String> validationErrors = switch (formatAndVersion.format()) {
+            case JSON -> validateJson(bomBytes, formatAndVersion.version());
+            case XML -> validateXml(bomBytes, formatAndVersion.version());
         };
-        final List<ParseException> validationErrors;
-        try {
-            validationErrors = bomParser.validate(bomBytes, formatAndVersion.version());
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to validate BOM", e);
-        }
         if (!validationErrors.isEmpty()) {
-            throw new InvalidBomException("Schema validation failed", validationErrors.stream()
-                    .map(ParseException::getMessage)
-                    .toList());
+            throw new InvalidBomException("Schema validation failed", validationErrors);
         }
     }
 
-    private FormatAndVersion detectFormatAndSchemaVersion(final byte[] bomBytes) {
+    private List<String> validateJson(byte[] bomBytes, Version version) {
+        final com.networknt.schema.Schema schema =
+                jsonSchemaCache.computeIfAbsent(version, this::loadJsonSchema);
+
+        final JsonNode bomNode;
+        try {
+            bomNode = jsonMapper.readTree(bomBytes);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to parse BOM", e);
+        }
+
+        return schema.validate(bomNode).stream()
+                .map(error -> error.getInstanceLocation() != null && error.getInstanceLocation().getNameCount() > 0
+                        ? "%s: %s".formatted(error.getInstanceLocation(), error.getMessage())
+                        : error.getMessage())
+                .toList();
+    }
+
+    private List<String> validateXml(byte[] bomBytes, Version version) {
+        final javax.xml.validation.Schema schema =
+                xmlSchemaCache.computeIfAbsent(version, this::loadXmlSchema);
+
+        // NB: Validator is not thread-safe.
+        final Validator validator = schema.newValidator();
+        try {
+            validator.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            validator.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        } catch (SAXException e) {
+            throw new IllegalStateException("Failed to harden XML validator", e);
+        }
+
+        final var validationErrors = new ArrayList<String>();
+        validator.setErrorHandler(new ErrorHandler() {
+            @Override
+            public void warning(final SAXParseException e) {
+                validationErrors.add(e.getMessage());
+            }
+
+            @Override
+            public void error(final SAXParseException e) {
+                validationErrors.add(e.getMessage());
+            }
+
+            @Override
+            public void fatalError(final SAXParseException e) {
+                validationErrors.add(e.getMessage());
+            }
+        });
+
+        try {
+            final XMLStreamReader streamReader =
+                    xmlInputFactory.createXMLStreamReader(new ByteArrayInputStream(bomBytes));
+            validator.validate(new StAXSource(streamReader));
+        } catch (SAXException | XMLStreamException | IOException e) {
+            throw new IllegalStateException("Failed to validate BOM", e);
+        }
+
+        return validationErrors;
+    }
+
+    private com.networknt.schema.Schema loadJsonSchema(Version version) {
+        try {
+            return schemaSource.getJsonSchema(version, jsonMapper);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load CycloneDX JSON schema for " + version, e);
+        }
+    }
+
+    private javax.xml.validation.Schema loadXmlSchema(Version version) {
+        try {
+            return schemaSource.getXmlSchema(version);
+        } catch (SAXException e) {
+            throw new IllegalStateException("Failed to load CycloneDX XML schema for " + version, e);
+        }
+    }
+
+    private FormatAndVersion detectFormatAndSchemaVersion(byte[] bomBytes) {
         final var suppressedExceptions = new ArrayList<Exception>(2);
 
         try {
@@ -121,7 +199,7 @@ public class CycloneDxValidator {
         throw exception;
     }
 
-    private Version detectSchemaVersionFromJson(final byte[] bomBytes) throws IOException {
+    private Version detectSchemaVersionFromJson(byte[] bomBytes) throws IOException {
         try (final com.fasterxml.jackson.core.JsonParser jsonParser = jsonMapper.createParser(bomBytes)) {
             JsonToken currentToken = jsonParser.nextToken();
             if (currentToken != JsonToken.START_OBJECT) {
@@ -160,14 +238,7 @@ public class CycloneDxValidator {
         }
     }
 
-    private Version detectSchemaVersionFromXml(final byte[] bomBytes) throws XMLStreamException {
-        final XMLInputFactory xmlInputFactory = XMLInputFactory.newFactory();
-        xmlInputFactory.setProperty(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        // NB: Setting XMLConstants.ACCESS_EXTERNAL_DTD to empty string is recommended by SAST tools,
-        // but Woodstox does not support it: https://github.com/FasterXML/woodstox/issues/51
-        // Setting IS_SUPPORTING_EXTERNAL_ENTITIES to false achieves the same:
-        // https://github.com/FasterXML/woodstox/issues/50#issuecomment-388842419
-        xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+    private Version detectSchemaVersionFromXml(byte[] bomBytes) throws XMLStreamException {
         final var bomBytesStream = new ByteArrayInputStream(bomBytes);
         final XMLStreamReader xmlStreamReader = xmlInputFactory.createXMLStreamReader(bomBytesStream);
 
@@ -220,6 +291,14 @@ public class CycloneDxValidator {
     }
 
     private record FormatAndVersion(Format format, Version version) {
+    }
+
+    private static XMLInputFactory createXmlInputFactory() {
+        final var factory = XMLInputFactory.newFactory();
+        factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setProperty(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        return factory;
     }
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/policy/vulnerability/SyncVulnPolicyBundleActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/vulnerability/SyncVulnPolicyBundleActivity.java
@@ -24,11 +24,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
-import com.networknt.schema.SpecVersion;
-import com.networknt.schema.ValidationMessage;
-import com.networknt.schema.serialization.DefaultJsonNodeReader;
+import com.networknt.schema.Error;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.dialect.Dialects;
+import com.networknt.schema.serialization.DefaultNodeReader;
 import dev.cel.common.CelValidationException;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.dependencytrack.common.ConfigKeys;
@@ -99,7 +99,7 @@ public final class SyncVulnPolicyBundleActivity implements Activity<SyncVulnPoli
     private final Config config;
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
-    private final JsonSchema schema;
+    private final Schema schema;
 
     public SyncVulnPolicyBundleActivity(Config config, HttpClient httpClient) {
         this.config = config;
@@ -108,12 +108,13 @@ public final class SyncVulnPolicyBundleActivity implements Activity<SyncVulnPoli
                 .registerModule(new JavaTimeModule())
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
-        this.schema = JsonSchemaFactory
-                .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012))
-                .jsonNodeReader(DefaultJsonNodeReader.builder()
-                        .yamlMapper(objectMapper)
-                        .build())
-                .build()
+        this.schema = SchemaRegistry
+                .withDialect(
+                        Dialects.getDraft202012(),
+                        builder -> builder
+                                .nodeReader(DefaultNodeReader.builder()
+                                        .yamlMapper(objectMapper)
+                                        .build()))
                 .getSchema(getClass().getResourceAsStream("/schema/vulnerability-policy-v1.schema.json"));
     }
 
@@ -295,13 +296,13 @@ public final class SyncVulnPolicyBundleActivity implements Activity<SyncVulnPoli
 
                 numTotalPolicies++;
 
-                final Set<ValidationMessage> validationMessages = schema.validate(policyNode);
-                if (!validationMessages.isEmpty()) {
+                final List<Error> validationErrors = schema.validate(policyNode);
+                if (!validationErrors.isEmpty()) {
                     LOGGER.warn(
                             "Schema validation of '{}' failed: {}",
                             zipEntry.getName(),
-                            validationMessages.stream()
-                                    .map(ValidationMessage::getMessage)
+                            validationErrors.stream()
+                                    .map(error -> "%s: %s".formatted(error.getInstanceLocation(), error.getMessage()))
                                     .collect(Collectors.joining(", ")));
                     numFailures++;
                     continue;

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/exception/RuntimeConfigSchemaValidationExceptionMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/exception/RuntimeConfigSchemaValidationExceptionMapper.java
@@ -18,7 +18,7 @@
  */
 package org.dependencytrack.resources.v2.exception;
 
-import com.networknt.schema.ValidationMessage;
+import com.networknt.schema.Error;
 import jakarta.ws.rs.ext.Provider;
 import org.dependencytrack.api.v2.model.JsonSchemaValidationError;
 import org.dependencytrack.api.v2.model.JsonSchemaValidationProblemDetails;
@@ -35,23 +35,24 @@ public final class RuntimeConfigSchemaValidationExceptionMapper
 
     @Override
     public JsonSchemaValidationProblemDetails map(final RuntimeConfigSchemaValidationException exception) {
-        final var errors = new ArrayList<JsonSchemaValidationError>(exception.getValidationMessages().size());
+        final var errors = new ArrayList<JsonSchemaValidationError>(exception.getValidationErrors().size());
 
-        for (final ValidationMessage validationMessage : exception.getValidationMessages()) {
-            final var errorBuilder = JsonSchemaValidationError.builder()
-                    .message(validationMessage.getMessage());
+        for (final Error validationError : exception.getValidationErrors()) {
+            final var errorBuilder =
+                    JsonSchemaValidationError.builder()
+                            .message(validationError.getMessage());
 
-            if (validationMessage.getInstanceLocation() != null) {
-                errorBuilder.instanceLocation(validationMessage.getInstanceLocation().toString());
+            if (validationError.getInstanceLocation() != null) {
+                errorBuilder.instanceLocation(validationError.getInstanceLocation().toString());
             }
-            if (validationMessage.getEvaluationPath() != null) {
-                errorBuilder.evaluationPath(validationMessage.getEvaluationPath().toString());
+            if (validationError.getEvaluationPath() != null) {
+                errorBuilder.evaluationPath(validationError.getEvaluationPath().toString());
             }
-            if (validationMessage.getSchemaLocation() != null) {
-                errorBuilder.schemaLocation(validationMessage.getSchemaLocation().toString());
+            if (validationError.getSchemaLocation() != null) {
+                errorBuilder.schemaLocation(validationError.getSchemaLocation().toString());
             }
-            if (validationMessage.getType() != null) {
-                errorBuilder.keyword(validationMessage.getType());
+            if (validationError.getKeyword() != null) {
+                errorBuilder.keyword(validationError.getKeyword());
             }
 
             errors.add(errorBuilder.build());

--- a/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidatorTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidatorTest.java
@@ -151,7 +151,7 @@ public class CycloneDxValidatorTest {
                 .withMessage("Schema validation failed")
                 .extracting(InvalidBomException::getValidationErrors).asInstanceOf(list(String.class))
                 .containsExactly("""
-                        $.components[0].type: does not have a value in the enumeration \
+                        /components/0/type: does not have a value in the enumeration \
                         ["application", "framework", "library", "container", "operating-system", "device", "firmware", "file"]\
                         """);
     }

--- a/apiserver/src/test/java/org/dependencytrack/policy/validation/PolicySchemaValidationTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/validation/PolicySchemaValidationTest.java
@@ -21,54 +21,61 @@ package org.dependencytrack.policy.validation;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
-import com.networknt.schema.SpecVersion;
-import com.networknt.schema.ValidationMessage;
-import com.networknt.schema.serialization.DefaultJsonNodeReader;
+import com.networknt.schema.Error;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.dialect.Dialects;
+import com.networknt.schema.serialization.DefaultNodeReader;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Set;
+import java.util.List;
 
 import static org.apache.commons.io.IOUtils.resourceToString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class PolicySchemaValidationTest {
+class PolicySchemaValidationTest {
 
-    @Test
-    public void testValidPolicyYamlWithSchema() throws IOException {
-        ObjectMapper objMapper = new ObjectMapper(new YAMLFactory());
-        final String jsonSchemaContent = resourceToString("/schema/vulnerability-policy-v1.schema.json", StandardCharsets.UTF_8);
-        final String policyContent = resourceToString("/unit/policy/vulnerability-policy-v1-valid.yaml", StandardCharsets.UTF_8);
-        JsonSchemaFactory factory = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012))
-                .jsonNodeReader(DefaultJsonNodeReader.builder().jsonMapper(objMapper).build())
-                .build();
-        JsonSchema schema = factory.getSchema(jsonSchemaContent);
-        JsonNode jsonNode = objMapper.readTree(policyContent);
-        Set<ValidationMessage> validateMsg = schema.validate(jsonNode);
-        assertTrue(validateMsg.isEmpty());
+    private static ObjectMapper yamlMapper;
+    private static Schema schema;
+
+    @BeforeAll
+    static void beforeAll() {
+        yamlMapper = new ObjectMapper(new YAMLFactory());
+        schema = SchemaRegistry
+                .withDialect(
+                        Dialects.getDraft202012(),
+                        builder -> builder
+                                .nodeReader(DefaultNodeReader.builder()
+                                        .yamlMapper(yamlMapper)
+                                        .build()))
+                .getSchema(PolicySchemaValidationTest.class.getResourceAsStream("/schema/vulnerability-policy-v1.schema.json"));
     }
 
     @Test
-    public void testInvalidPolicyYamlWithSchema() throws IOException {
-        ObjectMapper objMapper = new ObjectMapper(new YAMLFactory());
-        final String jsonSchemaContent = resourceToString("/schema/vulnerability-policy-v1.schema.json", StandardCharsets.UTF_8);
+    void testValidPolicyYamlWithSchema() throws IOException {
+        final String policyContent = resourceToString("/unit/policy/vulnerability-policy-v1-valid.yaml", StandardCharsets.UTF_8);
+        JsonNode jsonNode = yamlMapper.readTree(policyContent);
+        List<Error> errors = schema.validate(jsonNode);
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void testInvalidPolicyYamlWithSchema() throws IOException {
         final String policyContent = resourceToString("/unit/policy/vulnerability-policy-v1-invalid.yaml", StandardCharsets.UTF_8);
-        JsonSchemaFactory factory = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012))
-                .jsonNodeReader(DefaultJsonNodeReader.builder().jsonMapper(objMapper).build())
-                .build();
-        JsonSchema schema = factory.getSchema(jsonSchemaContent);
-        JsonNode jsonNode = objMapper.readTree(policyContent);
-        Set<ValidationMessage> validateMsg = schema.validate(jsonNode);
-        assertThat(validateMsg).satisfiesExactlyInAnyOrder(
-                error -> assertThat(error.getMessage()).isEqualTo("$.conditions: must have at most 1 items but found 2"),
-                error -> assertThat(error.getMessage()).isEqualTo("$.analysis.justification: does not have a value in the enumeration [\"CODE_NOT_PRESENT\", \"CODE_NOT_REACHABLE\", \"REQUIRES_CONFIGURATION\", \"REQUIRES_DEPENDENCY\", \"REQUIRES_ENVIRONMENT\", \"PROTECTED_BY_COMPILER\", \"PROTECTED_AT_RUNTIME\", \"PROTECTED_AT_PERIMETER\", \"PROTECTED_BY_MITIGATING_CONTROL\"]"),
-                error -> assertThat(error.getMessage()).isEqualTo("$.ratings[0].severity: does not have a value in the enumeration [\"CRITICAL\", \"HIGH\", \"MEDIUM\", \"LOW\", \"INFO\", \"UNASSIGNED\"]"),
-                error -> assertThat(error.getMessage()).contains("$.ratings[0].vector: does not match the regex pattern (SL:\\d/M:\\d/O:\\d/S:\\d/ED:\\d/EE:\\d/A:\\d/ID:\\d/LC:\\d/LI:\\d/LAV:\\d/LAC:\\d/FD:\\d/RD:\\d/NC:\\d/PV:\\d)|(AV:(N|A|L)\\/AC:(L|M|H)\\/A[Uu]:(N|S|M)\\/C:(N|P|C)\\/I:(N|P|C)\\/A:(N|P|C)|AV:(N|A|L|P)\\/AC:(L|H)\\/PR:(N|L|H)\\/UI:(N|R)\\/S:(U|C)\\/C:(N|L|H)\\/I:(N|L|H)\\/A:(N|L|H))|(AV:(N|A|L|P)\\/AC:(L|H)\\/PR:(N|L|H)\\/UI:(N|R)\\/S:(U|C)\\/C:(N|L|H)\\/I:(N|L|H)\\/A:(N|L|H)\\/E:(F|H|U|P|X)\\/RL:(W|U|T|O|X)\\/RC:(C|R|U|X)\\/CR:(X|L|M|H)\\/IR:(X|L|M|H)\\/AR:(X|L|M|H)\\/MAV:(X|N|A|L|P)\\/MAC:(X|L|H)\\/MPR:(X|N|L|H)\\/MUI:(X|N|R)\\/MS:(X|U|C)\\/MC:(X|N|L|H)\\/MI:(X|N|L|H)\\/MA:(X|N|L|H)"),
-                error -> assertThat(error.getMessage()).isEqualTo("$.ratings[0].score: string found, number expected")
-        );
+        JsonNode jsonNode = yamlMapper.readTree(policyContent);
+        List<Error> errors = schema.validate(jsonNode);
+        assertThat(errors)
+                .extracting(error -> "%s: %s".formatted(error.getInstanceLocation(), error.getMessage()))
+                .containsExactlyInAnyOrder(
+                        "/conditions: must have at most 1 items but found 2",
+                        "/analysis/justification: does not have a value in the enumeration [\"CODE_NOT_PRESENT\", \"CODE_NOT_REACHABLE\", \"REQUIRES_CONFIGURATION\", \"REQUIRES_DEPENDENCY\", \"REQUIRES_ENVIRONMENT\", \"PROTECTED_BY_COMPILER\", \"PROTECTED_AT_RUNTIME\", \"PROTECTED_AT_PERIMETER\", \"PROTECTED_BY_MITIGATING_CONTROL\"]",
+                        "/ratings/0/severity: does not have a value in the enumeration [\"CRITICAL\", \"HIGH\", \"MEDIUM\", \"LOW\", \"INFO\", \"UNASSIGNED\"]",
+                        "/ratings/0/vector: does not match the regex pattern (SL:\\d/M:\\d/O:\\d/S:\\d/ED:\\d/EE:\\d/A:\\d/ID:\\d/LC:\\d/LI:\\d/LAV:\\d/LAC:\\d/FD:\\d/RD:\\d/NC:\\d/PV:\\d)|(AV:(N|A|L)\\/AC:(L|M|H)\\/A[Uu]:(N|S|M)\\/C:(N|P|C)\\/I:(N|P|C)\\/A:(N|P|C)|AV:(N|A|L|P)\\/AC:(L|H)\\/PR:(N|L|H)\\/UI:(N|R)\\/S:(U|C)\\/C:(N|L|H)\\/I:(N|L|H)\\/A:(N|L|H))|(AV:(N|A|L|P)\\/AC:(L|H)\\/PR:(N|L|H)\\/UI:(N|R)\\/S:(U|C)\\/C:(N|L|H)\\/I:(N|L|H)\\/A:(N|L|H)\\/E:(F|H|U|P|X)\\/RL:(W|U|T|O|X)\\/RC:(C|R|U|X)\\/CR:(X|L|M|H)\\/IR:(X|L|M|H)\\/AR:(X|L|M|H)\\/MAV:(X|N|A|L|P)\\/MAC:(X|L|H)\\/MPR:(X|N|L|H)\\/MUI:(X|N|R)\\/MS:(X|U|C)\\/MC:(X|N|L|H)\\/MI:(X|N|L|H)\\/MA:(X|N|L|H))",
+                        "/ratings/0/score: string found, number expected"
+                );
     }
 }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -1248,9 +1248,9 @@ class BomResourceTest extends ResourceTest {
                           "title": "The uploaded BOM is invalid",
                           "detail": "Schema validation failed",
                           "errors": [
-                            "$: required property 'version' not found",
-                            "$.components[0]: required property 'type' not found",
-                            "$.components[0]: required property 'name' not found"
+                            "required property 'version' not found",
+                            "/components/0: required property 'type' not found",
+                            "/components/0: required property 'name' not found"
                           ]
                         }
                         """);
@@ -1578,7 +1578,7 @@ class BomResourceTest extends ResourceTest {
                   "title": "The uploaded BOM is invalid",
                   "detail": "Schema validation failed",
                   "errors": [
-                    "$.components[0].type: does not have a value in the enumeration [\\"application\\", \\"framework\\", \\"library\\", \\"container\\", \\"operating-system\\", \\"device\\", \\"firmware\\", \\"file\\"]"
+                    "/components/0/type: does not have a value in the enumeration [\\"application\\", \\"framework\\", \\"library\\", \\"container\\", \\"operating-system\\", \\"device\\", \\"firmware\\", \\"file\\"]"
                   ]
                 }
                 """);
@@ -1596,7 +1596,7 @@ class BomResourceTest extends ResourceTest {
             assertThat(subject.getBom().getSpecVersion()).isEmpty();
             assertThat(subject.getBom().getContent()).isEqualTo("(Omitted)");
             assertThat(subject.getErrorsList()).containsOnly("""
-                    $.components[0].type: does not have a value in the enumeration \
+                    /components/0/type: does not have a value in the enumeration \
                     ["application", "framework", "library", "container", "operating-system", \
                     "device", "firmware", "file"]""");
         });

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
@@ -380,7 +380,7 @@ public class VexResourceTest extends ResourceTest {
                   "title": "The uploaded BOM is invalid",
                   "detail": "Schema validation failed",
                   "errors": [
-                    "$.components[0].type: does not have a value in the enumeration [\\"application\\", \\"framework\\", \\"library\\", \\"container\\", \\"operating-system\\", \\"device\\", \\"firmware\\", \\"file\\"]"
+                    "/components/0/type: does not have a value in the enumeration [\\"application\\", \\"framework\\", \\"library\\", \\"container\\", \\"operating-system\\", \\"device\\", \\"firmware\\", \\"file\\"]"
                   ]
                 }
                 """);

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/ExtensionsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/ExtensionsResourceTest.java
@@ -331,11 +331,11 @@ class ExtensionsResourceTest extends ResourceTest {
                   "detail": "The provided configuration failed JSON schema validation.",
                   "errors": [
                     {
-                      "evaluation_path": "$.properties.requiredString.type",
+                      "evaluation_path": "/properties/requiredString/type",
                       "schema_location": "https://example.com/schema/test#/properties/requiredString/type",
-                      "instance_location": "$.requiredString",
+                      "instance_location": "/requiredString",
                       "keyword": "type",
-                      "message": "$.requiredString: null found, string expected"
+                      "message": "null found, string expected"
                     }
                   ]
                 }
@@ -541,10 +541,10 @@ class ExtensionsResourceTest extends ResourceTest {
                   "detail": "The provided configuration failed JSON schema validation.",
                   "errors": [
                     {
-                      "evaluation_path": "$.properties.outcome.enum",
-                      "instance_location": "$.outcome",
+                      "evaluation_path": "/properties/outcome/enum",
+                      "instance_location": "/outcome",
                       "keyword": "enum",
-                      "message": "$.outcome: does not have a value in the enumeration [\\"PASSED\\", \\"FAILED\\"]",
+                      "message": "does not have a value in the enumeration [\\"PASSED\\", \\"FAILED\\"]",
                       "schema_location": "https://example.com/schema/test#/properties/outcome/enum"
                     }
                   ]

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/OpenApiValidationClientResponseFilter.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/OpenApiValidationClientResponseFilter.java
@@ -19,14 +19,13 @@
 package org.dependencytrack.resources.v2;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.Error;
 import com.networknt.schema.InputFormat;
-import com.networknt.schema.JsonMetaSchema;
-import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
-import com.networknt.schema.NonValidationKeyword;
-import com.networknt.schema.SpecVersion;
-import com.networknt.schema.ValidationMessage;
-import com.networknt.schema.oas.OpenApi30;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.dialect.Dialect;
+import com.networknt.schema.dialect.Dialects;
+import com.networknt.schema.keyword.NonValidationKeyword;
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -43,7 +42,7 @@ import org.junit.jupiter.api.Assertions;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Set;
+import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,16 +54,13 @@ public class OpenApiValidationClientResponseFilter implements ClientResponseFilt
 
     public static final String DISABLE_OPENAPI_VALIDATION = "disable-openapi-validation";
 
-    private static final JsonSchemaFactory SCHEMA_FACTORY =
-            JsonSchemaFactory.getInstance(
-                    SpecVersion.VersionFlag.V4,
-                    builder -> builder
-                            .metaSchema(JsonMetaSchema.builder(OpenApi30.getInstance())
-                                    .keyword(new NonValidationKeyword("exampleSetFlag"))
-                                    .keyword(new NonValidationKeyword("extensions"))
-                                    .keyword(new NonValidationKeyword("types"))
-                                    .build())
-                            .defaultMetaSchemaIri(OpenApi30.getInstance().getIri()));
+    private static final SchemaRegistry SCHEMA_REGISTRY =
+            SchemaRegistry.withDialect(
+                    Dialect.builder(Dialects.getOpenApi30())
+                            .keyword(new NonValidationKeyword("exampleSetFlag"))
+                            .keyword(new NonValidationKeyword("extensions"))
+                            .keyword(new NonValidationKeyword("types"))
+                            .build());
 
     private final OpenAPI openApiSpec;
     private final ObjectMapper objectMapper;
@@ -139,10 +135,10 @@ public class OpenApiValidationClientResponseFilter implements ClientResponseFilt
         // Serialize the response schema to JSON so it can be used for validation.
         // NB: The schema already has all $refs resolved so can be handled "standalone".
         final String schemaJson = objectMapper.writeValueAsString(mediaType.getSchema());
-        final JsonSchema schema = SCHEMA_FACTORY.getSchema(schemaJson);
+        final Schema schema = SCHEMA_REGISTRY.getSchema(schemaJson);
 
-        final Set<ValidationMessage> messages = schema.validate(responseText, InputFormat.JSON);
-        assertThat(messages)
+        final List<Error> errors = schema.validate(responseText, InputFormat.JSON);
+        assertThat(errors)
                 .as("""
                                 Got response content that failed to validate against the \
                                 OpenAPI spec of %s %s -> %s (%s): %s""",

--- a/plugin/config/src/main/java/org/dependencytrack/plugin/config/RuntimeConfigMapper.java
+++ b/plugin/config/src/main/java/org/dependencytrack/plugin/config/RuntimeConfigMapper.java
@@ -25,13 +25,13 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import com.networknt.schema.JsonMetaSchema;
-import com.networknt.schema.JsonSchema;
-import com.networknt.schema.JsonSchemaFactory;
-import com.networknt.schema.NonValidationKeyword;
-import com.networknt.schema.SpecVersion;
-import com.networknt.schema.ValidationMessage;
-import com.networknt.schema.serialization.DefaultJsonNodeReader;
+import com.networknt.schema.Error;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.dialect.Dialect;
+import com.networknt.schema.dialect.Dialects;
+import com.networknt.schema.keyword.NonValidationKeyword;
+import com.networknt.schema.serialization.DefaultNodeReader;
 import org.dependencytrack.plugin.api.config.RuntimeConfig;
 import org.dependencytrack.plugin.api.config.RuntimeConfigSpec;
 import org.jspecify.annotations.Nullable;
@@ -75,15 +75,13 @@ public final class RuntimeConfigMapper {
     private static final RuntimeConfigMapper INSTANCE = new RuntimeConfigMapper();
 
     private final ObjectMapper jsonMapper;
-    private final JsonSchemaFactory schemaFactory;
+    private final SchemaRegistry schemaRegistry;
     private final Map<RuntimeConfigSpec, RuntimeConfigSchema> schemaCache;
 
     RuntimeConfigMapper() {
         this.jsonMapper = new ObjectMapper()
                 .setDefaultPropertyInclusion(JsonInclude.Include.NON_EMPTY);
-        final JsonMetaSchema jsonMetaSchema = JsonMetaSchema.builder(
-                        JsonMetaSchema.getV202012().getIri(),
-                        JsonMetaSchema.getV202012())
+        final Dialect schemaDialect = Dialect.builder(Dialects.getDraft202012())
                 // Don't emit warnings when encountering jsonschema2pojo extensions.
                 // https://github.com/joelittlejohn/jsonschema2pojo/wiki/Reference#extensions
                 .keywords(List.of(
@@ -100,15 +98,13 @@ public final class RuntimeConfigMapper {
                         new NonValidationKeyword(CustomAnnotations.SECRET_REF),
                         new NonValidationKeyword(CustomAnnotations.UI_HINT)))
                 .build();
-        this.schemaFactory = JsonSchemaFactory
-                .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012))
-                .jsonNodeReader(
-                        DefaultJsonNodeReader.builder()
-                                .jsonMapper(this.jsonMapper)
-                                .build())
-                .defaultMetaSchemaIri(jsonMetaSchema.getIri())
-                .metaSchema(jsonMetaSchema)
-                .build();
+        this.schemaRegistry = SchemaRegistry
+                .withDialect(
+                        schemaDialect,
+                        builder -> builder
+                                .nodeReader(DefaultNodeReader.builder()
+                                        .jsonMapper(this.jsonMapper)
+                                        .build()));
         this.schemaCache = new ConcurrentHashMap<>();
     }
 
@@ -146,8 +142,8 @@ public final class RuntimeConfigMapper {
      *
      * @param config            The config to validate.
      * @param runtimeConfigSpec The applicable config spec.
-     * @throws NullPointerException             When either {@code config} or {@code configSchemaJson} are {@code null}.
-     * @throws UncheckedIOException             When parsing the config JSON failed.
+     * @throws NullPointerException                   When either {@code config} or {@code configSchemaJson} are {@code null}.
+     * @throws UncheckedIOException                   When parsing the config JSON failed.
      * @throws RuntimeConfigSchemaValidationException When the config failed validation.
      */
     public <T extends RuntimeConfig> JsonNode validate(T config, RuntimeConfigSpec runtimeConfigSpec) {
@@ -157,9 +153,9 @@ public final class RuntimeConfigMapper {
         final RuntimeConfigSchema schema = getSchema(runtimeConfigSpec);
         final JsonNode configNode = jsonMapper.convertValue(config, JsonNode.class);
 
-        final Set<ValidationMessage> validationMessages = schema.jsonSchema().validate(configNode);
-        if (!validationMessages.isEmpty()) {
-            throw new RuntimeConfigSchemaValidationException(validationMessages);
+        final List<Error> validationErrors = schema.jsonSchema().validate(configNode);
+        if (!validationErrors.isEmpty()) {
+            throw new RuntimeConfigSchemaValidationException(validationErrors);
         }
 
         if (runtimeConfigSpec.validator() != null) {
@@ -174,8 +170,8 @@ public final class RuntimeConfigMapper {
      *
      * @param configJson        The config to validate in JSON format.
      * @param runtimeConfigSpec The applicable config spec.
-     * @throws NullPointerException             When either {@code configJson} or {@code configSchemaJson} are {@code null}.
-     * @throws UncheckedIOException             When parsing the config JSON failed.
+     * @throws NullPointerException                   When either {@code configJson} or {@code configSchemaJson} are {@code null}.
+     * @throws UncheckedIOException                   When parsing the config JSON failed.
      * @throws RuntimeConfigSchemaValidationException When the config failed validation.
      */
     public JsonNode validateJson(String configJson, RuntimeConfigSpec runtimeConfigSpec) {
@@ -191,9 +187,9 @@ public final class RuntimeConfigMapper {
             throw new UncheckedIOException(e);
         }
 
-        final Set<ValidationMessage> validationMessages = schema.jsonSchema().validate(configNode);
-        if (!validationMessages.isEmpty()) {
-            throw new RuntimeConfigSchemaValidationException(validationMessages);
+        final List<Error> validationErrors = schema.jsonSchema().validate(configNode);
+        if (!validationErrors.isEmpty()) {
+            throw new RuntimeConfigSchemaValidationException(validationErrors);
         }
 
         return configNode;
@@ -228,7 +224,7 @@ public final class RuntimeConfigMapper {
     private RuntimeConfigSchema getSchema(RuntimeConfigSpec runtimeConfigSpec) {
         return schemaCache.computeIfAbsent(
                 runtimeConfigSpec,
-                clazz -> {
+                _ -> {
                     final JsonNode schemaNode;
                     try {
                         schemaNode = jsonMapper.readValue(runtimeConfigSpec.schema(), JsonNode.class);
@@ -236,7 +232,7 @@ public final class RuntimeConfigMapper {
                         throw new UncheckedIOException(e);
                     }
 
-                    final JsonSchema jsonSchema = schemaFactory.getSchema(schemaNode);
+                    final Schema jsonSchema = schemaRegistry.getSchema(schemaNode);
                     if (jsonSchema.getId() == null || jsonSchema.getId().isBlank()) {
                         throw new IllegalStateException("Schema does not define an ID");
                     }

--- a/plugin/config/src/main/java/org/dependencytrack/plugin/config/RuntimeConfigSchema.java
+++ b/plugin/config/src/main/java/org/dependencytrack/plugin/config/RuntimeConfigSchema.java
@@ -18,7 +18,7 @@
  */
 package org.dependencytrack.plugin.config;
 
-import com.networknt.schema.JsonSchema;
+import com.networknt.schema.Schema;
 
 import java.util.Set;
 
@@ -26,6 +26,6 @@ import java.util.Set;
  * @since 5.0.0
  */
 record RuntimeConfigSchema(
-        JsonSchema jsonSchema,
+        Schema jsonSchema,
         Set<String> secretRefPaths) {
 }

--- a/plugin/config/src/main/java/org/dependencytrack/plugin/config/RuntimeConfigSchemaValidationException.java
+++ b/plugin/config/src/main/java/org/dependencytrack/plugin/config/RuntimeConfigSchemaValidationException.java
@@ -18,7 +18,7 @@
  */
 package org.dependencytrack.plugin.config;
 
-import com.networknt.schema.ValidationMessage;
+import com.networknt.schema.Error;
 import org.dependencytrack.plugin.api.config.InvalidRuntimeConfigException;
 
 import java.util.Collection;
@@ -29,18 +29,18 @@ import java.util.stream.Collectors;
  */
 public final class RuntimeConfigSchemaValidationException extends InvalidRuntimeConfigException {
 
-    private final Collection<ValidationMessage> validationMessages;
+    private final Collection<Error> validationErrors;
 
-    public RuntimeConfigSchemaValidationException(Collection<ValidationMessage> validationMessages) {
+    public RuntimeConfigSchemaValidationException(Collection<Error> validationErrors) {
         super("Runtime config is invalid: [%s]".formatted(
-                validationMessages.stream()
-                        .map(ValidationMessage::getMessage)
+                validationErrors.stream()
+                        .map(error -> "%s: %s".formatted(error.getInstanceLocation(), error.getMessage()))
                         .collect(Collectors.joining(", "))));
-        this.validationMessages = validationMessages;
+        this.validationErrors = validationErrors;
     }
 
-    public Collection<ValidationMessage> getValidationMessages() {
-        return validationMessages;
+    public Collection<Error> getValidationErrors() {
+        return validationErrors;
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
         <lib.cel-extensions.version>0.4.1</lib.cel-extensions.version>
         <lib.commons-lang3.version>3.20.0</lib.commons-lang3.version>
         <lib.cpe-parser.version>3.0.1</lib.cpe-parser.version>
+        <lib.cyclonedx-java.version>12.2.0</lib.cyclonedx-java.version>
         <lib.datanucleus-api-jdo.version>6.0.5</lib.datanucleus-api-jdo.version>
         <lib.datanucleus-core.version>6.0.11</lib.datanucleus-core.version>
         <lib.datanucleus-javax-jdo.version>3.2.1</lib.datanucleus-javax-jdo.version>
@@ -144,7 +145,7 @@
         <lib.jdbi.version>3.53.0</lib.jdbi.version>
         <lib.jersey.version>4.0.2</lib.jersey.version>
         <lib.jetty.version>12.1.10</lib.jetty.version>
-        <lib.json-schema-validator.version>1.5.9</lib.json-schema-validator.version>
+        <lib.json-schema-validator.version>2.0.3</lib.json-schema-validator.version>
         <lib.json-unit.version>5.1.2</lib.json-unit.version>
         <lib.jspecify.version>1.0.0</lib.jspecify.version>
         <lib.junit-jupiter.version>6.1.0</lib.junit-jupiter.version>
@@ -217,6 +218,12 @@
                 <groupId>com.github.ben-manes.caffeine</groupId>
                 <artifactId>caffeine</artifactId>
                 <version>${lib.caffeine.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-core-java</artifactId>
+                <version>${lib.cyclonedx-java.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Bumps cyclonedx-core-java to 12.2.0 and json-schema-validator to 2.0.3 (the latter was blocking the former).

Addresses a variety of breaking changes in json-schema-validator, among them:

* Renaming and relocation of classes
* Changes in default error message content

Additionally, moves the schema validation logic entirely into our own `CycloneDxValidator` instead of delegating to cyclonedx-core-java. The reason for this is that I noticed during testing that cyclonedx-core-java does not cache schemas after first use, so every validation call would reload schemas from disk, and recompile them, which is just wasted work.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Supersedes 

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
