### PR TITLE
Fix getAffectedProjects endpoint not accounting for suppressed findings

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
@@ -208,6 +208,14 @@ public interface VulnerabilityDao {
                       AND fa."VULNERABILITY_ID" = "VULNERABILITY"."ID"
                       AND fa."DELETED_AT" IS NULL
                  )
+                 AND NOT EXISTS (
+                   SELECT 1
+                     FROM "ANALYSIS" AS a
+                    WHERE a."PROJECT_ID" = "PROJECT"."ID"
+                      AND a."COMPONENT_ID" = "COMPONENT"."ID"
+                      AND a."VULNERABILITY_ID" = "VULNERABILITY"."ID"
+                      AND a."SUPPRESSED" IS TRUE
+                 )
             )
             SELECT "UUID" AS "uuid"
                  , "NAME" AS "name"
@@ -222,7 +230,8 @@ public interface VulnerabilityDao {
              WHERE EXISTS(
                  SELECT 1
                    FROM "CTE_AFFECTED_COMPONENTS"
-                  WHERE "PROJECT_ID" = "PROJECT"."ID")
+                  WHERE "PROJECT_ID" = "PROJECT"."ID"
+             )
             <#if searchText>
               AND (
                 LOWER("PROJECT"."NAME") LIKE ('%' || LOWER(:searchText) || '%')

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -645,6 +645,29 @@ public class VulnerabilityResourceTest extends ResourceTest {
     }
 
     @Test
+    public void getAffectedProjectsShouldNotIncludeProjectWhenAllFindingsSuppressed() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+
+        final SampleData sampleData = new SampleData();
+        qm.makeAnalysis(
+                new MakeAnalysisCommand(sampleData.c1, sampleData.v1)
+                        .withState(AnalysisState.FALSE_POSITIVE)
+                        .withSuppress(true));
+
+        final Response response = jersey
+                .target(V1_VULNERABILITY
+                        + "/source/" + sampleData.v1.getSource()
+                        + "/vuln/" + sampleData.v1.getVulnId()
+                        + "/projects")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("0");
+        assertThatJson(getPlainTextBody(response)).isEqualTo("[]");
+    }
+
+    @Test
     public void getAffectedProjectWithSearchTextTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
         final var sampleData = new SampleData();


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes a regression from v4 behavior where the endpoint previously only considered a project as being affected if at least one non-suppressed finding existed for it.

In v5, the query was migrated from JDO / N+1 pattern to proper SQL, but the suppression consideration was erroneously dropped. This change restores v4 behavior.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->
N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
