### PR TITLE
Add project tag filter to component identity endpoint (#6089)

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -28,6 +28,7 @@ import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonValue;
 import org.apache.commons.lang3.tuple.Pair;
+import org.dependencytrack.model.Tag;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentIdentity;
 import org.dependencytrack.model.ComponentOccurrence;
@@ -325,11 +326,12 @@ final class ComponentQueryManager extends QueryManager {
      * @return a list of components
      */
     public PaginatedResult getComponents(
-            ComponentIdentity identity,
-            Project project,
-            boolean includeMetrics,
-            boolean excludeInactiveProjects,
-            boolean onlyLatestProjectVersions) {
+        ComponentIdentity identity,
+        Project project,
+        boolean includeMetrics,
+        boolean excludeInactiveProjects,
+        boolean onlyLatestProjectVersions,
+        String projectTag)  {
         if (identity == null) {
             return null;
         }
@@ -347,6 +349,14 @@ final class ComponentQueryManager extends QueryManager {
         if (onlyLatestProjectVersions) {
             queryFilterElements.add(" project.isLatest == true ");
         }
+        if (projectTag != null && !projectTag.isBlank()) {
+    final Tag tag = getTagByName(projectTag.trim());
+
+    if (tag != null) {
+        queryFilterElements.add(" project.tags.contains(:tag) ");
+        queryParams.put("tag", tag);
+    }
+}
 
         final PaginatedResult result;
         if (identity.getGroup() != null || identity.getName() != null || identity.getVersion() != null) {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -486,16 +486,18 @@ public class QueryManager extends AlpineQueryManager {
 
     public PaginatedResult getComponents(
             ComponentIdentity identity,
-            Project project,
-            boolean includeMetrics,
-            boolean excludeInactiveProjects,
-            boolean onlyLatestProjectVersions) {
+        Project project,
+        boolean includeMetrics,
+        boolean excludeInactiveProjects,
+        boolean onlyLatestProjectVersions,
+        String projectTag) {
         return getComponentQueryManager().getComponents(
-                identity,
-                project,
-                includeMetrics,
-                excludeInactiveProjects,
-                onlyLatestProjectVersions);
+        identity,
+        project,
+        includeMetrics,
+        excludeInactiveProjects,
+        onlyLatestProjectVersions,
+        projectTag);
     }
 
     public Component createComponent(Component component, boolean commitIndex) {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -228,7 +228,10 @@ public class ComponentResource extends AbstractApiResource {
                                            @Parameter(description = "When true, only return components from active projects")
                                            @QueryParam("excludeInactiveProjects") boolean excludeInactiveProjects,
                                            @Parameter(description = "When true, only return components from projects flagged as the latest version")
-                                           @QueryParam("onlyLatestProjectVersions") boolean onlyLatestProjectVersions) {
+                                           @QueryParam("onlyLatestProjectVersions") boolean onlyLatestProjectVersions,
+@Parameter(description = "Only return components belonging to projects with the specified tag")
+@QueryParam("projectTag")
+String projectTag) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             Project project = null;
             if (projectUuid != null) {
@@ -254,11 +257,12 @@ public class ComponentResource extends AbstractApiResource {
                 return Response.ok().header(TOTAL_COUNT_HEADER, 0).build();
             } else {
                 final PaginatedResult result = qm.getComponents(
-                        identity,
-                        project,
-                        /* includeMetrics */ true,
-                        excludeInactiveProjects,
-                        onlyLatestProjectVersions);
+        identity,
+        project,
+        /* includeMetrics */ true,
+        excludeInactiveProjects,
+        onlyLatestProjectVersions,
+        projectTag);
                 return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
             }
         }


### PR DESCRIPTION
## Summary

This PR implements support for filtering components by project tag in the deprecated V1 component identity endpoint.

It adds a new optional query parameter:

* `projectTag`

When provided, only components belonging to projects with the specified tag are returned.

Example:

```http
GET /api/v1/component/identity?name=library&projectTag=backend
```

## Changes

* Added `projectTag` query parameter to `ComponentResource`
* Propagated the parameter through `QueryManager`
* Added project tag filtering logic in `ComponentQueryManager`

Closes #6089.
