### PR TITLE
Backport: Fix badges for collection projects showing no metrics

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/BadgeResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/BadgeResource.java
@@ -81,8 +81,12 @@ public class BadgeResource extends AbstractApiResource {
             }
             final Project project = qm.getObjectByUuid(Project.class, uuid);
             if (project != null) {
-                final ProjectMetrics metrics = withJdbiHandle(handle ->
-                        handle.attach(MetricsDao.class).getMostRecentProjectMetrics(project.getId()));
+                final ProjectMetrics metrics = withJdbiHandle(handle -> {
+                    final var dao = handle.attach(MetricsDao.class);
+                    return project.getCollectionLogic() == null
+                            ? dao.getMostRecentProjectMetrics(project.getId())
+                            : dao.getMostRecentCollectionProjectMetrics(project.getId());
+                });
                 final var badger = new Badger();
 
                 String linkToProjectVuln = null;
@@ -124,8 +128,12 @@ public class BadgeResource extends AbstractApiResource {
             }
             final Project project = qm.getProject(name, version);
             if (project != null) {
-                final ProjectMetrics metrics = withJdbiHandle(handle ->
-                        handle.attach(MetricsDao.class).getMostRecentProjectMetrics(project.getId()));
+                final ProjectMetrics metrics = withJdbiHandle(handle -> {
+                    final var dao = handle.attach(MetricsDao.class);
+                    return project.getCollectionLogic() == null
+                            ? dao.getMostRecentProjectMetrics(project.getId())
+                            : dao.getMostRecentCollectionProjectMetrics(project.getId());
+                });
                 final var badger = new Badger();
 
                 String linkToProjectVuln = null;
@@ -165,8 +173,12 @@ public class BadgeResource extends AbstractApiResource {
             }
             final Project project = qm.getObjectByUuid(Project.class, uuid);
             if (project != null) {
-                final ProjectMetrics metrics = withJdbiHandle(handle ->
-                        handle.attach(MetricsDao.class).getMostRecentProjectMetrics(project.getId()));
+                final ProjectMetrics metrics = withJdbiHandle(handle -> {
+                    final var dao = handle.attach(MetricsDao.class);
+                    return project.getCollectionLogic() == null
+                            ? dao.getMostRecentProjectMetrics(project.getId())
+                            : dao.getMostRecentCollectionProjectMetrics(project.getId());
+                });
                 final var badger = new Badger();
 
                 String linkToProjectViolations = null;
@@ -208,8 +220,12 @@ public class BadgeResource extends AbstractApiResource {
             }
             final Project project = qm.getProject(name, version);
             if (project != null) {
-                final ProjectMetrics metrics = withJdbiHandle(handle ->
-                        handle.attach(MetricsDao.class).getMostRecentProjectMetrics(project.getId()));
+                final ProjectMetrics metrics = withJdbiHandle(handle -> {
+                    final var dao = handle.attach(MetricsDao.class);
+                    return project.getCollectionLogic() == null
+                            ? dao.getMostRecentProjectMetrics(project.getId())
+                            : dao.getMostRecentCollectionProjectMetrics(project.getId());
+                });
                 final var badger = new Badger();
 
                 String linkToProjectViolations = null;

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/BadgeResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/BadgeResourceTest.java
@@ -25,6 +25,9 @@ import jakarta.ws.rs.core.Response;
 import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.Project;
+import org.dependencytrack.model.ProjectCollectionLogic;
+import org.dependencytrack.model.ProjectMetrics;
+import org.dependencytrack.persistence.jdbi.MetricsTestDao;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,10 +38,15 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Date;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.model.ConfigPropertyConstants.GENERAL_BADGE_ENABLED;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiHandle;
 
 public class BadgeResourceTest extends ResourceTest {
 
@@ -187,6 +195,136 @@ public class BadgeResourceTest extends ResourceTest {
                 .request()
                 .get(Response.class);
         assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    public void shouldReturnVulnBadgeWithAggregatedMetricsForCollectionProjectByUuid() {
+        final Project collection = createCollectionProjectWithChildMetrics();
+
+        final Response response = jersey
+                .target(V1_BADGE + "/vulns/project/" + collection.getUuid())
+                .request()
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString("Content-Type")).isEqualTo("image/svg+xml");
+        assertThatBodyContainsAggregatedVulnMetrics(getPlainTextBody(response));
+    }
+
+    @Test
+    public void shouldReturnVulnBadgeWithAggregatedMetricsForCollectionProjectByNameAndVersion() {
+        final Project collection = createCollectionProjectWithChildMetrics();
+
+        final Response response = jersey
+                .target(V1_BADGE
+                        + "/vulns/project/"
+                        + collection.getName()
+                        + "/"
+                        + collection.getVersion())
+                .request()
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString("Content-Type")).isEqualTo("image/svg+xml");
+        assertThatBodyContainsAggregatedVulnMetrics(getPlainTextBody(response));
+    }
+
+    @Test
+    public void shouldReturnViolationsBadgeWithAggregatedMetricsForCollectionProjectByUuid() {
+        final Project collection = createCollectionProjectWithChildMetrics();
+
+        final Response response = jersey
+                .target(V1_BADGE + "/violations/project/" + collection.getUuid())
+                .request()
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString("Content-Type")).isEqualTo("image/svg+xml");
+        assertThatBodyContainsAggregatedViolationMetrics(getPlainTextBody(response));
+    }
+
+    @Test
+    public void shouldReturnViolationsBadgeWithAggregatedMetricsForCollectionProjectByNameAndVersion() {
+        final Project collection = createCollectionProjectWithChildMetrics();
+
+        final Response response = jersey
+                .target(V1_BADGE
+                        + "/violations/project/"
+                        + collection.getName()
+                        + "/"
+                        + collection.getVersion())
+                .request()
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString("Content-Type")).isEqualTo("image/svg+xml");
+        assertThatBodyContainsAggregatedViolationMetrics(getPlainTextBody(response));
+    }
+
+    private Project createCollectionProjectWithChildMetrics() {
+        final var parent = new Project();
+        parent.setName("acme-collection");
+        parent.setVersion("1.0.0");
+        parent.setCollectionLogic(ProjectCollectionLogic.AGGREGATE_DIRECT_CHILDREN);
+        qm.persist(parent);
+
+        final var childA = new Project();
+        childA.setName("acme-child-a");
+        childA.setParent(parent);
+        qm.persist(childA);
+
+        final var childB = new Project();
+        childB.setName("acme-child-b");
+        childB.setParent(parent);
+        qm.persist(childB);
+
+        useJdbiHandle(handle -> {
+            final var dao = handle.attach(MetricsTestDao.class);
+            dao.createMetricsPartitionsForDate("PROJECTMETRICS", LocalDate.now(ZoneOffset.UTC));
+            final Date now = Date.from(Instant.now());
+
+            final var metricsA = new ProjectMetrics();
+            metricsA.setProjectId(childA.getId());
+            metricsA.setCritical(2);
+            metricsA.setHigh(3);
+            metricsA.setMedium(1);
+            metricsA.setVulnerabilities(6);
+            metricsA.setPolicyViolationsTotal(6);
+            metricsA.setPolicyViolationsFail(2);
+            metricsA.setPolicyViolationsWarn(3);
+            metricsA.setPolicyViolationsInfo(1);
+            metricsA.setFirstOccurrence(now);
+            metricsA.setLastOccurrence(now);
+            dao.createProjectMetrics(metricsA);
+
+            final var metricsB = new ProjectMetrics();
+            metricsB.setProjectId(childB.getId());
+            metricsB.setCritical(1);
+            metricsB.setHigh(4);
+            metricsB.setMedium(5);
+            metricsB.setVulnerabilities(10);
+            metricsB.setPolicyViolationsTotal(4);
+            metricsB.setPolicyViolationsFail(1);
+            metricsB.setPolicyViolationsWarn(1);
+            metricsB.setPolicyViolationsInfo(2);
+            metricsB.setFirstOccurrence(now);
+            metricsB.setLastOccurrence(now);
+            dao.createProjectMetrics(metricsB);
+        });
+
+        return parent;
+    }
+
+    private void assertThatBodyContainsAggregatedVulnMetrics(String body) {
+        assertThat(isLikelySvg(body)).isTrue();
+        assertThat(body)
+                .contains(">3</text>")
+                .contains(">7</text>")
+                .contains(">6</text>");
+    }
+
+    private void assertThatBodyContainsAggregatedViolationMetrics(String body) {
+        assertThat(isLikelySvg(body)).isTrue();
+        assertThat(body)
+                .contains(">3</text>")
+                .contains(">4</text>")
+                .contains(">3</text>");
     }
 
     private boolean isLikelySvg(String body) {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes badges for collection projects showing no metrics.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6526
Backports #6539 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Collection project metrics are calculated ad-hoc and thus must take a different code path than normal project metrics.


### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
