### PR TITLE
Backport: Fix excessive churn of vulnerable software associations during mirroring

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/VulnerableSoftware.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/VulnerableSoftware.java
@@ -419,11 +419,10 @@ public class VulnerableSoftware implements ICpe, Serializable {
      * @since 4.10.0
      */
     public boolean equalsIgnoringDatastoreIdentity(final VulnerableSoftware otherVs) {
-        return Objects.equals(otherVs.getPurl(), this.getPurl())
-               && Objects.equals(otherVs.getPurlType(), this.getPurlType())
+        // NB: The full purl string and purlVersion are intentionally excluded.
+        return Objects.equals(otherVs.getPurlType(), this.getPurlType())
                && Objects.equals(otherVs.getPurlNamespace(), this.getPurlNamespace())
                && Objects.equals(otherVs.getPurlName(), this.getPurlName())
-               && Objects.equals(otherVs.getPurlVersion(), this.getPurlVersion())
                && Objects.equals(otherVs.getPurlQualifiers(), this.getPurlQualifiers())
                && Objects.equals(otherVs.getPurlSubpath(), this.getPurlSubpath())
                && Objects.equals(otherVs.getCpe22(), this.getCpe22())
@@ -454,12 +453,11 @@ public class VulnerableSoftware implements ICpe, Serializable {
      * @since 4.10.0
      */
     public int hashCodeWithoutDatastoreIdentity() {
+        // NB: The full purl string and purlVersion are intentionally excluded.
         return Objects.hash(
-                this.getPurl(),
                 this.getPurlType(),
                 this.getPurlNamespace(),
                 this.getPurlName(),
-                this.getPurlVersion(),
                 this.getPurlQualifiers(),
                 this.getPurlSubpath(),
                 this.getCpe22(),

--- a/apiserver/src/test/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivityTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivityTest.java
@@ -24,6 +24,7 @@ import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.cache.api.NoopCacheManager;
 import org.dependencytrack.dex.api.ActivityContext;
 import org.dependencytrack.dex.api.failure.TerminalApplicationFailureException;
+import org.dependencytrack.model.AffectedVersionAttribution;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.persistence.jdbi.JdbiFactory;
@@ -1495,6 +1496,109 @@ class MirrorVulnDataSourceActivityTest extends PersistenceCapableTest {
         assertThat(vuln.getVulnerableVersions()).isNull();
         assertThat(vuln.getPatchedVersions()).isNull();
         assertThat(vuln.getVulnerableSoftware()).isEmpty();
+    }
+
+    @Test
+    void shouldNotChurnAffectedVersionAttributionWhenReMirroringIdenticalData() throws Exception {
+        final var bovJson = /* language=JSON */ """
+                {
+                  "components": [
+                    {
+                      "bomRef": "component",
+                      "purl": "pkg:maven/com.acme/product@1.0.0"
+                    }
+                  ],
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2024-0001",
+                      "source": { "name": "NVD" },
+                      "affects": [
+                        {
+                          "ref": "component",
+                          "versions": [
+                            { "range": "vers:maven/>=0" }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """;
+        final Bom bov = generateBomFromJson(bovJson);
+
+        final var dataSourceMock = mock(VulnDataSource.class);
+        doReturn(true, false).when(dataSourceMock).hasNext();
+        doReturn(bov).when(dataSourceMock).next();
+
+        final var activity = new MirrorVulnDataSourceActivity(createPluginManager("nvd", dataSourceMock));
+        activity.execute(mock(ActivityContext.class), MirrorVulnDataSourceArg.newBuilder().setDataSourceName("nvd").setSourceName("NVD").build());
+
+        Vulnerability vuln = qm.getVulnerabilityByVulnId("NVD", "CVE-2024-0001");
+        List<AffectedVersionAttribution> attributions = qm.getAffectedVersionAttributions(vuln, vuln.getVulnerableSoftware());
+        assertThat(attributions).hasSize(1);
+        final long attributionId = attributions.getFirst().getId();
+
+        activity.execute(mock(ActivityContext.class), MirrorVulnDataSourceArg.newBuilder().setDataSourceName("nvd").setSourceName("NVD").build());
+
+        vuln = qm.getVulnerabilityByVulnId("NVD", "CVE-2024-0001");
+        attributions = qm.getAffectedVersionAttributions(vuln, vuln.getVulnerableSoftware());
+        assertThat(attributions).satisfiesExactly(
+                attribution -> assertThat(attribution.getId()).isEqualTo(attributionId));
+    }
+
+    @Test
+    void shouldNotChurnAffectedVersionAttributionWhenPurlVersionIsDropped() throws Exception {
+        final var bovJson = /* language=JSON */ """
+                {
+                  "components": [
+                    {
+                      "bomRef": "component",
+                      "purl": "pkg:deb/ubuntu/product@1.0.0?distro=jammy"
+                    }
+                  ],
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2024-0001",
+                      "source": { "name": "NVD" },
+                      "affects": [
+                        {
+                          "ref": "component",
+                          "versions": [
+                            { "range": "vers:deb/>=0" }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """;
+
+        final var dataSourceMock = mock(VulnDataSource.class);
+        doReturn(true, false).when(dataSourceMock).hasNext();
+        doReturn(generateBomFromJson(bovJson)).when(dataSourceMock).next();
+
+        var activity = new MirrorVulnDataSourceActivity(createPluginManager("nvd", dataSourceMock));
+        activity.execute(mock(ActivityContext.class), MirrorVulnDataSourceArg.newBuilder().setDataSourceName("nvd").setSourceName("NVD").build());
+
+        Vulnerability vuln = qm.getVulnerabilityByVulnId("NVD", "CVE-2024-0001");
+        List<AffectedVersionAttribution> attributions =
+                qm.getAffectedVersionAttributions(vuln, vuln.getVulnerableSoftware());
+        assertThat(attributions).hasSize(1);
+        final long attributionId = attributions.getFirst().getId();
+
+        final var bovJsonVersionLess = bovJson.replace("product@1.0.0", "product");
+        pluginManager.close();
+        final var dataSourceMockVersionLess = mock(VulnDataSource.class);
+        doReturn(true, false).when(dataSourceMockVersionLess).hasNext();
+        doReturn(generateBomFromJson(bovJsonVersionLess)).when(dataSourceMockVersionLess).next();
+
+        activity = new MirrorVulnDataSourceActivity(createPluginManager("nvd", dataSourceMockVersionLess));
+        activity.execute(mock(ActivityContext.class), MirrorVulnDataSourceArg.newBuilder().setDataSourceName("nvd").setSourceName("NVD").build());
+
+        vuln = qm.getVulnerabilityByVulnId("NVD", "CVE-2024-0001");
+        attributions = qm.getAffectedVersionAttributions(vuln, vuln.getVulnerableSoftware());
+        assertThat(attributions).hasSize(1);
+        assertThat(attributions.getFirst().getId()).isEqualTo(attributionId);
     }
 
     private static class TestVulnDataSourceFactory implements VulnDataSourceFactory {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes excessive churn of vulnerable software associations during mirroring.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #6499 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
