### PR TITLE
Make KEV usable in component and vulnerability policies

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyEngine.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyEngine.java
@@ -69,6 +69,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.apache.commons.collections4.MultiMapUtils.emptyMultiValuedMap;
 import static org.dependencytrack.notification.api.NotificationFactory.createPolicyViolationNotification;
@@ -225,18 +226,24 @@ public final class CelPolicyEngine {
         final Map<Long, Vulnerability> protoVulnById;
         final Map<Long, Set<Long>> vulnIdsByComponentId;
         if (requirements.containsKey(TYPE_VULNERABILITY)) {
-            protoVulnById = withJdbiHandle(handle ->
-                    new CelPolicyDao(handle)
-                            .fetchAllVulnerabilities(
-                                    projectId,
-                                    requirements.get(TYPE_VULNERABILITY)));
-
             vulnIdsByComponentId = withJdbiHandle(handle ->
                     new CelPolicyDao(handle)
                             .fetchAllComponentsVulnerabilities(projectId));
+
+            if (!vulnIdsByComponentId.isEmpty()) {
+                protoVulnById = withJdbiHandle(handle ->
+                        new CelPolicyDao(handle)
+                                .fetchAllVulnerabilities(
+                                        vulnIdsByComponentId.values().stream()
+                                                .flatMap(Set::stream)
+                                                .collect(Collectors.toSet()),
+                                        requirements.get(TYPE_VULNERABILITY)));
+            } else {
+                protoVulnById = Map.of();
+            }
         } else {
-            protoVulnById = Collections.emptyMap();
-            vulnIdsByComponentId = Collections.emptyMap();
+            protoVulnById = Map.of();
+            vulnIdsByComponentId = Map.of();
         }
 
         final var violationsByComponentId = new ArrayListValuedHashMap<Long, PolicyViolation>();

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
@@ -204,7 +204,7 @@ public final class CelPolicyDao {
                 .bind("projectId", projectId)
                 .reduceResultSet(
                         new HashMap<>(),
-                        (accumulator, rs, ctx) -> {
+                        (accumulator, rs, _) -> {
                             final long componentId = rs.getLong("component_id");
                             final long vulnerabilityId = rs.getLong("vulnerability_id");
                             accumulator
@@ -299,7 +299,7 @@ public final class CelPolicyDao {
     }
 
     public Map<Long, Vulnerability> fetchAllVulnerabilities(
-            long projectId,
+            Collection<Long> vulnDbIds,
             Collection<String> protoFieldNames) {
         final List<String> fetchColumns = new ArrayList<>();
         fetchColumns.add("v.\"ID\" AS db_id");
@@ -308,18 +308,19 @@ public final class CelPolicyDao {
         final boolean shouldFetchEpss =
                 protoFieldNames.contains("epss_score")
                         || protoFieldNames.contains("epss_percentile");
+        final boolean shouldFetchIsKev = protoFieldNames.contains("is_kev");
 
         final var vulnRowMapper = new CelPolicyVulnerabilityRowMapper();
         return jdbiHandle
                 .createQuery(/* language=InjectedFreeMarker */ """
                         <#-- @ftlvariable name="fetchColumns" type="java.util.Collection<String>" -->
                         <#-- @ftlvariable name="shouldFetchEpss" type="boolean" -->
-                        SELECT DISTINCT ${fetchColumns?join(", ")}
+                        <#-- @ftlvariable name="shouldFetchIsKev" type="boolean" -->
+                        SELECT ${fetchColumns?join(", ")}
+                        <#if shouldFetchIsKev>
+                             , <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS is_kev
+                        </#if>
                           FROM "VULNERABILITY" AS v
-                         INNER JOIN "COMPONENTS_VULNERABILITIES" AS cv
-                            ON cv."VULNERABILITY_ID" = v."ID"
-                         INNER JOIN "COMPONENT" AS c
-                            ON c."ID" = cv."COMPONENT_ID"
                         <#if shouldFetchEpss!false>
                           LEFT JOIN LATERAL (
                             SELECT "CVE"
@@ -352,18 +353,12 @@ public final class CelPolicyDao {
                              LIMIT 1
                           ) AS ep ON TRUE
                         </#if>
-                         WHERE c."PROJECT_ID" = :projectId
-                           AND EXISTS (
-                             SELECT 1
-                               FROM "FINDINGATTRIBUTION" AS fa
-                              WHERE fa."COMPONENT_ID" = c."ID"
-                                AND fa."VULNERABILITY_ID" = v."ID"
-                                AND fa."DELETED_AT" IS NULL
-                           )
+                         WHERE v."ID" = ANY(:vulnDbIds)
                         """)
                 .define("fetchColumns", fetchColumns)
                 .define("shouldFetchEpss", shouldFetchEpss)
-                .bind("projectId", projectId)
+                .define("shouldFetchIsKev", shouldFetchIsKev)
+                .bindArray("vulnDbIds", Long.class, vulnDbIds)
                 .reduceResultSet(
                         new HashMap<>(),
                         (accumulator, rs, ctx) -> {
@@ -736,17 +731,23 @@ public final class CelPolicyDao {
 
         final List<String> fetchColumns = new ArrayList<>(selectColumns(VULNERABILITY_FIELDS, vulnRequirements));
 
-        final boolean needsEpss = vulnRequirements.contains("epss_score")
-                || vulnRequirements.contains("epss_percentile");
+        final boolean needsEpss =
+                vulnRequirements.contains("epss_score")
+                        || vulnRequirements.contains("epss_percentile");
+        final boolean shouldFetchIsKev = vulnRequirements.contains("is_kev");
 
         final var vulnRowMapper = new CelPolicyVulnerabilityRowMapper();
 
         return jdbiHandle.createQuery(/* language=InjectedFreeMarker */ """
                         <#-- @ftlvariable name="fetchColumns" type="java.util.Collection<String>" -->
                         <#-- @ftlvariable name="needsEpss" type="boolean" -->
+                        <#-- @ftlvariable name="shouldFetchIsKev" type="boolean" -->
                         SELECT v."ID" AS db_id
                         <#if fetchColumns?size gt 0>
                              , ${fetchColumns?join(", ")}
+                        </#if>
+                        <#if shouldFetchIsKev>
+                             , <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS is_kev
                         </#if>
                           FROM "VULNERABILITY" AS v
                         <#if needsEpss!false>
@@ -785,6 +786,7 @@ public final class CelPolicyDao {
                         """)
                 .define("fetchColumns", fetchColumns)
                 .define("needsEpss", needsEpss)
+                .define("shouldFetchIsKev", shouldFetchIsKev)
                 .bindArray("ids", Long.class, vulnIds)
                 .reduceResultSet(
                         new HashMap<>(),

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyFieldMappingRegistry.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyFieldMappingRegistry.java
@@ -119,7 +119,8 @@ public final class CelPolicyFieldMappingRegistry {
             new FieldMapping("last_bom_import", "p.\"LAST_BOM_IMPORTED\""),
             new FieldMapping("metadata_tools", "pm.\"TOOLS\""),
             new FieldMapping("bom_generated", "b.\"GENERATED\""),
-            new FieldMapping("inactive_since", "p.\"INACTIVE_SINCE\""));
+            new FieldMapping("inactive_since", "p.\"INACTIVE_SINCE\""),
+            new FieldMapping("is_kev", "is_kev"));
 
     static final List<FieldMapping> PROJECT_PROPERTY_FIELDS = List.of(
             new FieldMapping("group", "pp.\"GROUPNAME\""),

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyVulnerabilityRowMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyVulnerabilityRowMapper.java
@@ -70,6 +70,7 @@ public final class CelPolicyVulnerabilityRowMapper implements RowMapper<Vulnerab
         maybeSet(rs, "epss_percentile", RowMapperUtil::nullableDouble, builder::setEpssPercentile);
         maybeSet(rs, "cwes", CelPolicyVulnerabilityRowMapper::maybeConvertCwes, builder::addAllCwes);
         maybeSet(rs, "aliases", CelPolicyVulnerabilityRowMapper::maybeConvertAliases, builder::addAllAliases);
+        maybeSet(rs, "is_kev", ResultSet::getBoolean, builder::setIsKev);
         builder.setSeverity(computeSeverity(builder).name());
 
         return builder.build();

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
@@ -21,6 +21,7 @@ package org.dependencytrack.policy.cel;
 import alpine.model.IConfigProperty;
 import com.github.packageurl.PackageURL;
 import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.kevdatasource.api.KevAssertion;
 import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.Bom;
 import org.dependencytrack.model.Classifier;
@@ -45,6 +46,7 @@ import org.dependencytrack.model.VulnerabilityKey;
 import org.dependencytrack.persistence.command.MakeAnalysisCommand;
 import org.dependencytrack.persistence.command.MakeViolationAnalysisCommand;
 import org.dependencytrack.persistence.jdbi.EpssDao;
+import org.dependencytrack.persistence.jdbi.KevDao;
 import org.dependencytrack.persistence.jdbi.PackageArtifactMetadataDao;
 import org.dependencytrack.persistence.jdbi.PackageMetadataDao;
 import org.dependencytrack.persistence.jdbi.VulnerabilityAliasDao;
@@ -249,17 +251,31 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
 
         qm.addVulnerability(vuln, component, "internal");
 
-        useJdbiTransaction(handle -> new VulnerabilityAliasDao(handle)
-                .syncAssertions(
-                        "TEST",
-                        new VulnerabilityKey("CVE-001", Vulnerability.Source.NVD),
-                        Set.of(
-                                new VulnerabilityKey("GHSA-001", Vulnerability.Source.GITHUB),
-                                new VulnerabilityKey("INT-001", Vulnerability.Source.INTERNAL),
-                                new VulnerabilityKey("OSV-001", Vulnerability.Source.OSV),
-                                new VulnerabilityKey("SNYK-001", Vulnerability.Source.SNYK),
-                                new VulnerabilityKey("SONATYPE-001", Vulnerability.Source.OSSINDEX),
-                                new VulnerabilityKey("VULNDB-001", Vulnerability.Source.VULNDB))));
+        useJdbiTransaction(handle -> {
+            new VulnerabilityAliasDao(handle)
+                    .syncAssertions(
+                            "TEST",
+                            new VulnerabilityKey("CVE-001", Vulnerability.Source.NVD),
+                            Set.of(
+                                    new VulnerabilityKey("GHSA-001", Vulnerability.Source.GITHUB),
+                                    new VulnerabilityKey("INT-001", Vulnerability.Source.INTERNAL),
+                                    new VulnerabilityKey("OSV-001", Vulnerability.Source.OSV),
+                                    new VulnerabilityKey("SNYK-001", Vulnerability.Source.SNYK),
+                                    new VulnerabilityKey("SONATYPE-001", Vulnerability.Source.OSSINDEX),
+                                    new VulnerabilityKey("VULNDB-001", Vulnerability.Source.VULNDB)));
+            handle
+                    .attach(KevDao.class)
+                    .upsertBatch("cisa", List.of(
+                            new KevAssertion(
+                                    "NVD",
+                                    "CVE-001",
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null
+                            )));
+        });
 
         useJdbiHandle(handle -> handle.attach(EpssDao.class)
                 .createOrUpdateAll(List.of(new Epss(
@@ -392,6 +408,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
                          && vuln.owasp_rr_vector == "(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)"
                          && vuln.epss_score == 0.6
                          && vuln.epss_percentile == 0.2
+                         && vuln.is_kev
                      )
                 """
                 .replace("__COMPONENT_UUID__", component.getUuid().toString())

--- a/proto/src/main/proto/org/dependencytrack/policy/v1/policy.proto
+++ b/proto/src/main/proto/org/dependencytrack/policy/v1/policy.proto
@@ -188,6 +188,9 @@ message Vulnerability {
   optional string cvssv4_vector = 35;
   optional double cvssv4_score = 36;
 
+  // Whether the vulnerability is known to be exploited.
+  bool is_kev = 37;
+
   message Alias {
     string id = 1;
     string source = 2;


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Makes KEV usable in component and vulnerability policies.

Exposes a new `is_kev` boolean field on the `Vulnerability` policy proto message.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #2267 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Frontend PR: https://github.com/DependencyTrack/frontend/pull/1638

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
