### PR TITLE
Include KEV flag in notifications

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/notification/NotificationModelConverter.java
+++ b/apiserver/src/main/java/org/dependencytrack/notification/NotificationModelConverter.java
@@ -250,7 +250,8 @@ public final class NotificationModelConverter {
         final Vulnerability.Builder builder = Vulnerability.newBuilder()
                 .setUuid(vuln.getUuid().toString())
                 .setVulnId(vuln.getVulnId())
-                .setSource(vuln.getSource());
+                .setSource(vuln.getSource())
+                .setIsKev(vuln.isKev());
 
         if (vuln.getAliases() != null) {
             getUniqueAliases(vuln).stream()

--- a/apiserver/src/main/java/org/dependencytrack/persistence/AnalysisQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/AnalysisQueryManager.java
@@ -28,6 +28,7 @@ import org.dependencytrack.model.AnalysisResponse;
 import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.VulnerabilityKey;
 import org.dependencytrack.notification.JdoNotificationEmitter;
 import org.dependencytrack.notification.NotificationModelConverter;
 import org.dependencytrack.persistence.command.MakeAnalysisCommand;
@@ -148,6 +149,12 @@ public class AnalysisQueryManager extends QueryManager {
 
             if (!command.options().contains(MakeAnalysisCommand.Option.OMIT_NOTIFICATION)
                     && (stateChanged || suppressionChanged)) {
+                // NB: KEV is a transient field and must be computed ad-hoc.
+                final boolean isKev = !super.getKev(
+                        List.of(VulnerabilityKey.of(
+                                analysis.getVulnerability()))).isEmpty();
+                analysis.getVulnerability().setKev(isKev);
+
                 new JdoNotificationEmitter(this).emit(
                         createVulnerabilityAnalysisDecisionChangeNotification(
                                 NotificationModelConverter.convert(analysis.getProject()),

--- a/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -809,6 +809,10 @@ public class QueryManager extends AlpineQueryManager {
         return getVulnerabilityQueryManager().getVulnerabilityAliases(vulnerability);
     }
 
+    public Set<VulnerabilityKey> getKev(Collection<VulnerabilityKey> keys) {
+        return getVulnerabilityQueryManager().getKev(keys);
+    }
+
     public Analysis getAnalysis(Component component, Vulnerability vulnerability) {
         return getAnalysisQueryManager().getAnalysis(component, vulnerability);
     }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -339,6 +339,7 @@ final class VulnerabilityQueryManager extends QueryManager {
         return result;
     }
 
+    @Override
     public Set<VulnerabilityKey> getKev(Collection<VulnerabilityKey> keys) {
         if (keys.isEmpty()) {
             return Set.of();

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -145,6 +145,7 @@ public interface NotificationSubjectDao extends SqlObject {
                  , COALESCE(a."SEVERITY", v."SEVERITY") AS "vulnSeverity"
                  , STRING_TO_ARRAY(v."CWES", ',') AS "vulnCwes"
                  , JSONB_VULN_ALIASES(v."SOURCE", v."VULNID") AS "vulnAliasesJson"
+                 , <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "vulnIsKev"
               FROM UNNEST(:componentIds, :vulnerabilityIds)
                 AS req(component_id, vulnerability_id)
              INNER JOIN "COMPONENTS_VULNERABILITIES" AS cv
@@ -259,6 +260,7 @@ public interface NotificationSubjectDao extends SqlObject {
                              , COALESCE(a."SEVERITY", v."SEVERITY") AS "vulnSeverity"
                              , STRING_TO_ARRAY(v."CWES", ',') AS "vulnCwes"
                              , JSONB_VULN_ALIASES(v."SOURCE", v."VULNID") AS "vulnAliasesJson"
+                             , <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "vulnIsKev"
                           FROM "COMPONENT" AS c
                          INNER JOIN "PROJECT" AS p
                             ON p."ID" = c."PROJECT_ID"
@@ -405,6 +407,7 @@ public interface NotificationSubjectDao extends SqlObject {
                              , COALESCE(a."SEVERITY", v."SEVERITY") AS "vulnSeverity"
                              , STRING_TO_ARRAY(v."CWES", ',') AS "vulnCwes"
                              , JSONB_VULN_ALIASES(v."SOURCE", v."VULNID") AS "vulnAliasesJson"
+                             , <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "vulnIsKev"
                              , req.analysis_state AS "vulnAnalysisState"
                              , req.suppressed AS "isVulnAnalysisSuppressed"
                              , format('/api/v1/vulnerability/source/%s/vuln/%s/projects', v."SOURCE", v."VULNID") AS "affectedProjectsApiUrl"
@@ -595,6 +598,7 @@ public interface NotificationSubjectDao extends SqlObject {
                              , COALESCE(a."SEVERITY", v."SEVERITY") AS "vulnSeverity"
                              , STRING_TO_ARRAY(v."CWES", ',') AS "vulnCwes"
                              , JSONB_VULN_ALIASES(v."SOURCE", v."VULNID") AS "vulnAliasesJson"
+                             , <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "vulnIsKev"
                           FROM UNNEST(:componentIds, :vulnDbIds)
                             AS t(component_id, vuln_db_id)
                          INNER JOIN "VULNERABILITY" AS v

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationVulnerabilityRowMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationVulnerabilityRowMapper.java
@@ -63,6 +63,7 @@ public class NotificationVulnerabilityRowMapper implements RowMapper<Vulnerabili
         maybeSet(rs, "vulnSeverity", ResultSet::getString, builder::setSeverity);
         maybeSet(rs, "vulnCwes", NotificationVulnerabilityRowMapper::maybeConvertCwes, builder::addAllCwes);
         maybeSet(rs, "vulnAliasesJson", NotificationVulnerabilityRowMapper::maybeConvertAliases, builder::addAllAliases);
+        maybeSet(rs, "vulnIsKev", ResultSet::getBoolean, builder::setIsKev);
         return builder.build();
     }
 

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
@@ -20,6 +20,7 @@ package org.dependencytrack.persistence.jdbi;
 
 import com.google.protobuf.util.JsonFormat;
 import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.kevdatasource.api.KevAssertion;
 import org.dependencytrack.model.Analysis;
 import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.Component;
@@ -103,9 +104,24 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
         vulnB.setSource(Vulnerability.Source.NVD);
         qm.persist(vulnB);
 
-        useJdbiTransaction(handle -> new VulnerabilityAliasDao(handle)
-                .syncAssertions("TEST", new VulnerabilityKey("CVE-100", Vulnerability.Source.NVD),
-                        Set.of(new VulnerabilityKey("GHSA-100", Vulnerability.Source.GITHUB))));
+        useJdbiTransaction(handle -> {
+            new VulnerabilityAliasDao(handle)
+                    .syncAssertions(
+                            "TEST",
+                            new VulnerabilityKey("CVE-100", Vulnerability.Source.NVD),
+                            Set.of(new VulnerabilityKey("GHSA-100", Vulnerability.Source.GITHUB)));
+            handle
+                    .attach(KevDao.class)
+                    .upsertBatch("cisa", List.of(
+                            new KevAssertion(
+                                    "NVD",
+                                    "CVE-100",
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null)));
+        });
 
         qm.addVulnerability(vulnA, component, "internal");
         qm.addVulnerability(vulnB, component, "internal");
@@ -125,7 +141,7 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                         .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
                         .withMatcher("componentUuid", equalTo(component.getUuid().toString()))
                         .withMatcher("vulnUuid", equalTo(vulnA.getUuid().toString()))
-                        .isEqualTo("""
+                        .isEqualTo(/* language=JSON */ """
                                 {
                                   "affectedProjects": [
                                     {
@@ -193,7 +209,8 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                                     "vulnId": "CVE-100",
                                     "cvssV2Vector": "(AV:N/AC:M/Au:S/C:P/I:P/A:P)",
                                     "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-                                    "owaspRRVector": "(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)"
+                                    "owaspRRVector": "(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)",
+                                    "isKev": true
                                   }
                                 }
                                 """));
@@ -247,7 +264,7 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                 .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
                 .withMatcher("componentUuid", equalTo(component.getUuid().toString()))
                 .withMatcher("vulnUuid", equalTo(vuln.getUuid().toString()))
-                .isEqualTo("""
+                .isEqualTo(/* language=JSON */ """
                         {
                           "component": {
                             "uuid": "${json-unit.matches:componentUuid}",
@@ -270,7 +287,8 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                             "severity": "CRITICAL",
                             "cvssV2Vector": "",
                             "cvssV3Vector": "cvssV3VectorOverwrite",
-                            "owaspRRVector": "owaspRrVector"
+                            "owaspRRVector": "owaspRrVector",
+                            "isKev": false
                           },
                           "affectedProjects": [
                             {
@@ -332,11 +350,25 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
         vulnB.setSource(Vulnerability.Source.NVD);
         qm.persist(vulnB);
 
-        useJdbiTransaction(handle -> new VulnerabilityAliasDao(handle)
-                .syncAssertions(
-                        "TEST",
-                        new VulnerabilityKey("CVE-100", Vulnerability.Source.NVD),
-                        Set.of(new VulnerabilityKey("GHSA-100", Vulnerability.Source.GITHUB))));
+        useJdbiTransaction(handle -> {
+            new VulnerabilityAliasDao(handle)
+                    .syncAssertions(
+                            "TEST",
+                            new VulnerabilityKey("CVE-100", Vulnerability.Source.NVD),
+                            Set.of(new VulnerabilityKey("GHSA-100", Vulnerability.Source.GITHUB)));
+
+            handle
+                    .attach(KevDao.class)
+                    .upsertBatch("cisa", List.of(
+                            new KevAssertion(
+                                    "NVD",
+                                    "CVE-100",
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null)));
+        });
 
         qm.addVulnerability(vulnA, component, "internal");
         qm.addVulnerability(vulnB, component, "internal");
@@ -355,7 +387,7 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                 .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
                 .withMatcher("componentUuid", equalTo(component.getUuid().toString()))
                 .withMatcher("vulnUuid", equalTo(vulnA.getUuid().toString()))
-                .isEqualTo("""
+                .isEqualTo(/* language=JSON */ """
                         {
                           "component": {
                             "uuid": "${json-unit.matches:componentUuid}",
@@ -410,7 +442,8 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                               "owaspRRVector": "(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)",
                               "aliases": [
                                 {"vulnId": "GHSA-100", "source": "GITHUB"}
-                              ]
+                              ],
+                              "isKev": true
                             }
                           ]
                         }
@@ -465,7 +498,7 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                 .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
                 .withMatcher("componentUuid", equalTo(component.getUuid().toString()))
                 .withMatcher("vulnUuid", equalTo(vuln.getUuid().toString()))
-                .isEqualTo("""
+                .isEqualTo(/* language=JSON */ """
                         {
                           "component": {
                             "uuid": "${json-unit.matches:componentUuid}",
@@ -489,7 +522,8 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                               "severity": "CRITICAL",
                               "cvssV2Vector": "",
                               "cvssV3Vector": "cvssV3VectorOverwrite",
-                              "owaspRRVector": "owaspRrVector"
+                              "owaspRRVector": "owaspRrVector",
+                              "isKev": false
                             }
                           ]
                         }
@@ -540,9 +574,25 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
         vulnA.setCwes(List.of(666, 777));
         qm.persist(vulnA);
 
-        useJdbiTransaction(handle -> new VulnerabilityAliasDao(handle)
-                .syncAssertions("TEST", new VulnerabilityKey("CVE-100", Vulnerability.Source.NVD),
-                        Set.of(new VulnerabilityKey("GHSA-100", Vulnerability.Source.GITHUB))));
+        useJdbiTransaction(handle -> {
+            new VulnerabilityAliasDao(handle)
+                    .syncAssertions(
+                            "TEST",
+                            new VulnerabilityKey("CVE-100", Vulnerability.Source.NVD),
+                            Set.of(new VulnerabilityKey("GHSA-100", Vulnerability.Source.GITHUB)));
+
+            handle
+                    .attach(KevDao.class)
+                    .upsertBatch("cisa", List.of(
+                            new KevAssertion(
+                                    "NVD",
+                                    "CVE-100",
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null)));
+        });
 
         qm.addVulnerability(vulnA, component, "internal");
 
@@ -565,7 +615,7 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                         .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
                         .withMatcher("componentUuid", equalTo(component.getUuid().toString()))
                         .withMatcher("vulnUuid", equalTo(vulnA.getUuid().toString()))
-                        .isEqualTo("""
+                        .isEqualTo(/* language=JSON */ """
                                 {
                                      "component": {
                                          "uuid": "${json-unit.matches:componentUuid}",
@@ -622,7 +672,8 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                                          ],
                                          "cvssV2Vector": "(AV:N/AC:M/Au:S/C:P/I:P/A:P)",
                                          "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-                                         "owaspRRVector": "(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)"
+                                         "owaspRRVector": "(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)",
+                                         "isKev": true
                                      },
                                      "analysis": {
                                          "component": {
@@ -680,7 +731,8 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                                              ],
                                          "cvssV2Vector": "(AV:N/AC:M/Au:S/C:P/I:P/A:P)",
                                          "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-                                         "owaspRRVector": "(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)"
+                                         "owaspRRVector": "(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)",
+                                         "isKev": true
                                          },
                                          "state": "NOT_AFFECTED",
                                          "suppressed": false

--- a/e2e/src/test/java/org/dependencytrack/e2e/BomUploadProcessingE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/BomUploadProcessingE2ET.java
@@ -239,7 +239,8 @@ class BomUploadProcessingE2ET extends AbstractE2ET {
                                 "source": "INTERNAL",
                                 "cvssv3" : "${json-unit.any-number}",
                                 "severity": "CRITICAL",
-                                "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+                                "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+                                "isKev": false
                               },
                               "affectedProjectsReference": {
                                 "apiUri": "/api/v1/vulnerability/source/INTERNAL/vuln/INT-123/projects",

--- a/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
@@ -454,7 +454,8 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
                                   "source": "INTERNAL",
                                   "cvssv3": 7.1,
                                   "severity": "HIGH",
-                                  "cvssV3Vector" : "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H"
+                                  "cvssV3Vector" : "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
+                                  "isKev": false
                                 },
                                 {
                                   "uuid": "${json-unit.any-string}",
@@ -463,7 +464,8 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
                                   "cvssv2": 2.6,
                                   "cvssv3": 9.8,
                                   "severity": "LOW",
-                                  "cvssV3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                  "cvssV3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                                  "isKev": false
                                 }
                               ]
                             }
@@ -512,7 +514,8 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
                                 "source": "INTERNAL",
                                 "cvssv3": 7.1,
                                 "severity": "HIGH",
-                                "cvssV3Vector" : "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H"
+                                "cvssV3Vector" : "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
+                                "isKev": false
                               },
                               "analysisTrigger" : "ANALYSIS_TRIGGER_BOM_UPLOAD",
                               "vulnerabilityAnalysisLevel": "BOM_UPLOAD_ANALYSIS",
@@ -574,7 +577,8 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
                                 "cvssv2": 2.6,
                                 "cvssv3": 9.8,
                                 "severity": "LOW",
-                                "cvssV3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                "cvssV3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                                "isKev": false
                               },
                               "analysisTrigger" : "ANALYSIS_TRIGGER_BOM_UPLOAD",
                               "vulnerabilityAnalysisLevel": "BOM_UPLOAD_ANALYSIS",

--- a/notification/api/src/main/java/org/dependencytrack/notification/api/TestNotificationFactory.java
+++ b/notification/api/src/main/java/org/dependencytrack/notification/api/TestNotificationFactory.java
@@ -446,6 +446,7 @@ public final class TestNotificationFactory {
                 .addCwes(Vulnerability.Cwe.newBuilder()
                         .setCweId(777)
                         .setName("Regular Expression without Anchors"))
+                .setIsKev(false)
                 .build();
     }
 

--- a/notification/api/src/main/proto/org/dependencytrack/notification/v1/notification.proto
+++ b/notification/api/src/main/proto/org/dependencytrack/notification/v1/notification.proto
@@ -224,6 +224,9 @@ message Vulnerability {
   optional double cvss_v4 = 19 [json_name = "cvssv4"];
   optional string cvss_v4_vector = 20 [json_name = "cvssV4Vector"];
 
+  // Whether the vulnerability is known to be exploited.
+  optional bool is_kev = 21 [json_name = "isKev"];
+
   message Alias {
     string id = 1 [json_name = "vulnId"];
     string source = 2;

--- a/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/webhook/WebhookNotificationPublisherTest.java
+++ b/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/webhook/WebhookNotificationPublisherTest.java
@@ -271,7 +271,8 @@ class WebhookNotificationPublisherTest extends AbstractNotificationPublisherTest
                                     "cweId": 777,
                                     "name": "Regular Expression without Anchors"
                                   }
-                                ]
+                                ],
+                                "isKev": false
                               },
                               "affectedProjectsReference": {
                                 "apiUri": "/api/v1/vulnerability/source/INTERNAL/vuln/INT-001/projects",
@@ -361,7 +362,8 @@ class WebhookNotificationPublisherTest extends AbstractNotificationPublisherTest
                                       "cweId": 777,
                                       "name": "Regular Expression without Anchors"
                                     }
-                                  ]
+                                  ],
+                                  "isKev": false
                                 }
                               ]
                             }


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds an `is_kev` flag to vulnerability messages in notifications. 

Besides the information being useful to receivers, it also allows users to leverage notification filter expressions to, for example, only receive notifications for KEV vulns.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #2267 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
