### PR TITLE
Fix project-scoped affects and duplicate bom-refs in VEX/VDR export

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXExporter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXExporter.java
@@ -48,10 +48,53 @@ public class CycloneDXExporter {
     }
 
     public enum Variant {
-        INVENTORY,
-        INVENTORY_WITH_VULNERABILITIES,
-        VDR,
-        VEX
+        INVENTORY                      (false, false, false, true,  true),
+        INVENTORY_WITH_VULNERABILITIES (false, false, true,  true,  true),
+        VDR                            (true,  true,  true,  true,  true),
+        VEX                            (true,  true,  true,  false, false);
+
+        private final boolean filtersToVulnerableComponents;
+        private final boolean includesAnalysis;
+        private final boolean emitsFindings;
+        private final boolean includesDependencyGraph;
+        private final boolean includesServices;
+
+        Variant(final boolean filtersToVulnerableComponents,
+                final boolean includesAnalysis,
+                final boolean emitsFindings,
+                final boolean includesDependencyGraph,
+                final boolean includesServices) {
+            this.filtersToVulnerableComponents = filtersToVulnerableComponents;
+            this.includesAnalysis = includesAnalysis;
+            this.emitsFindings = emitsFindings;
+            this.includesDependencyGraph = includesDependencyGraph;
+            this.includesServices = includesServices;
+        }
+
+        /** Whether {@code components[]} is restricted to components that have findings. */
+        public boolean filtersToVulnerableComponents() {
+            return filtersToVulnerableComponents;
+        }
+
+        /** Whether per-component VEX analysis is emitted on vulnerability entries. */
+        public boolean includesAnalysis() {
+            return includesAnalysis;
+        }
+
+        /** Whether findings are loaded and emitted as {@code vulnerabilities[]}. */
+        public boolean emitsFindings() {
+            return emitsFindings;
+        }
+
+        /** Whether the dependency graph is emitted. */
+        public boolean includesDependencyGraph() {
+            return includesDependencyGraph;
+        }
+
+        /** Whether services are emitted. */
+        public boolean includesServices() {
+            return includesServices;
+        }
     }
 
     private final QueryManager qm;
@@ -70,11 +113,9 @@ public class CycloneDXExporter {
             components = qm.getAllComponents(project);
             services = qm.getAllServiceComponents(project);
         }
-        final List<Finding> findings = switch (variant) {
-            case INVENTORY_WITH_VULNERABILITIES, VDR, VEX -> withJdbiHandle(handle ->
-                    handle.attach(FindingDao.class).getFindings(project.getId(), true));
-            default -> null;
-        };
+        final List<Finding> findings = variant.emitsFindings()
+                ? withJdbiHandle(handle -> handle.attach(FindingDao.class).getFindings(project.getId(), true))
+                : null;
         return create(components, services, findings, project);
     }
 
@@ -84,8 +125,8 @@ public class CycloneDXExporter {
         return create(components, null, null, null);
     }
 
-    private Bom create(List<Component>components, final List<ServiceComponent> services, final List<Finding> findings, final Project project) {
-        if (Variant.VDR == variant) {
+    private Bom create(List<Component> components, final List<ServiceComponent> services, final List<Finding> findings, final Project project) {
+        if (variant.filtersToVulnerableComponents()) {
             final Set<UUID> vulnerableComponentUuids = findings.stream()
                     .map(finding -> (UUID) finding.getComponent().get("uuid"))
                     .collect(Collectors.toSet());
@@ -93,8 +134,8 @@ public class CycloneDXExporter {
                     .filter(component -> vulnerableComponentUuids.contains(component.getUuid()))
                     .toList();
         }
-        final List<org.cyclonedx.model.Component> cycloneComponents = (Variant.VEX != variant && components != null) ? components.stream().map(component -> ModelConverter.convert(component)).collect(Collectors.toList()) : null;
-        final List<org.cyclonedx.model.Service> cycloneServices = (Variant.VEX != variant && services != null) ? services.stream().map(service -> ModelConverter.convert(qm, service)).collect(Collectors.toList()) : null;
+        final List<org.cyclonedx.model.Component> cycloneComponents = components != null ? components.stream().map(component -> ModelConverter.convert(component)).collect(Collectors.toList()) : null;
+        final List<org.cyclonedx.model.Service> cycloneServices = (variant.includesServices() && services != null) ? services.stream().map(service -> ModelConverter.convert(qm, service)).collect(Collectors.toList()) : null;
         final Bom bom = new Bom();
         bom.setSerialNumber("urn:uuid:" + UUID.randomUUID());
         bom.setVersion(1);
@@ -102,7 +143,7 @@ public class CycloneDXExporter {
         bom.setComponents(cycloneComponents);
         bom.setServices(cycloneServices);
         bom.setVulnerabilities(ModelConverter.generateVulnerabilities(qm, variant, findings));
-        if (cycloneComponents != null) {
+        if (variant.includesDependencyGraph() && cycloneComponents != null) {
             bom.setDependencies(ModelConverter.generateDependencies(project, components));
         }
         return bom;

--- a/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
@@ -76,11 +76,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -96,6 +99,14 @@ import static org.dependencytrack.util.PurlUtil.silentPurlCoordinatesOnly;
 public class ModelConverter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ModelConverter.class);
+
+    /**
+     * U+001F (Unit Separator) field delimiter for composite keys. A reserved control character
+     * with no legitimate occurrence in vulnerability UUIDs or analysis-detail prose, so it cannot
+     * collide with payload data when used to glue group-key fields together. Package-private so
+     * tests pin against the production constant rather than re-declaring the literal byte.
+     */
+    static final char FIELD_SEPARATOR = '\u001F';
 
     /**
      * Private Constructor.
@@ -927,20 +938,104 @@ public class ModelConverter {
         return cycloneService;
     }
 
-    public static org.cyclonedx.model.vulnerability.Vulnerability convert(final QueryManager qm, final CycloneDXExporter.Variant variant,
-                                                                          final Finding finding) {
-        final Component component = qm.getObjectByUuid(Component.class, finding.getComponent().get("uuid").toString());
-        if (component == null) {
-            return null;
+    /**
+     * Stable serialisation of the analysis fields used to distinguish per-component analyses that
+     * share a vulnerability. Null fields serialise to the empty string; non-null enums use
+     * {@link Enum#name()} so the contract does not depend on {@link String#valueOf(Object)}
+     * returning the literal {@code "null"} for absent values.
+     */
+    static String analysisFingerprint(final Analysis analysis) {
+        if (analysis == null) {
+            return "";
         }
-        final Project project = component.getProject();
-        final Vulnerability vulnerability = qm.getObjectByUuid(Vulnerability.class, finding.getVulnerability().get("uuid").toString());
+        return enumName(analysis.getAnalysisState()) + FIELD_SEPARATOR
+                + enumName(analysis.getAnalysisJustification()) + FIELD_SEPARATOR
+                + enumName(analysis.getAnalysisResponse()) + FIELD_SEPARATOR
+                + Objects.toString(trimToNull(analysis.getAnalysisDetails()), "");
+    }
+
+    private static String enumName(final Enum<?> value) {
+        return value == null ? "" : value.name();
+    }
+
+    private static String componentUuid(final Finding finding) {
+        return Objects.requireNonNull(finding.getComponent().get("uuid"), "componentUuid").toString();
+    }
+
+    private static String vulnerabilityUuid(final Finding finding) {
+        return Objects.requireNonNull(finding.getVulnerability().get("uuid"), "vulnerabilityUuid").toString();
+    }
+
+    private static String analysisCacheKey(final Finding finding) {
+        return componentUuid(finding) + FIELD_SEPARATOR + vulnerabilityUuid(finding);
+    }
+
+    /**
+     * Build a stable grouping key for a finding. The key is the vulnerability identifier alone for
+     * variants that do not emit analysis (so every component affected by a vulnerability collapses
+     * into one group), widened with the analysis fingerprint when the variant emits analysis.
+     */
+    private static String buildGroupKey(final CycloneDXExporter.Variant variant, final Finding finding,
+                                        final Map<String, Analysis> analysisCache) {
+        final String vulnUuid = vulnerabilityUuid(finding);
+        if (!variant.includesAnalysis()) {
+            return vulnUuid;
+        }
+        return vulnUuid + FIELD_SEPARATOR + analysisFingerprint(analysisCache.get(analysisCacheKey(finding)));
+    }
+
+    /**
+     * Convert one group of findings (sharing a vulnerability and, when analysis is emitted, an
+     * analysis fingerprint) into a single CycloneDX vulnerability entry whose {@code affects[]}
+     * carries the sorted union of affected component bom-refs.
+     */
+    private static org.cyclonedx.model.vulnerability.Vulnerability convertGroup(
+            final CycloneDXExporter.Variant variant,
+            final List<Finding> groupFindings,
+            final Map<String, Vulnerability> vulnerabilityCache,
+            final Map<String, Analysis> analysisCache) {
+        final Finding first = groupFindings.get(0);
+        final Vulnerability vulnerability = vulnerabilityCache.get(vulnerabilityUuid(first));
         if (vulnerability == null) {
             return null;
         }
 
         final org.cyclonedx.model.vulnerability.Vulnerability cdxVulnerability = new org.cyclonedx.model.vulnerability.Vulnerability();
-        cdxVulnerability.setBomRef(vulnerability.getUuid().toString());
+        populateScalarFields(cdxVulnerability, vulnerability);
+        cdxVulnerability.setAffects(buildAffects(groupFindings));
+
+        if (variant.includesAnalysis()) {
+            final Analysis analysis = analysisCache.get(analysisCacheKey(first));
+            if (analysis != null) {
+                cdxVulnerability.setAnalysis(buildCdxAnalysis(analysis));
+            }
+        }
+        return cdxVulnerability;
+    }
+
+    /**
+     * The sorted, de-duplicated union of the affected component bom-refs in a group. Sorting keeps
+     * the output deterministic regardless of finding order.
+     */
+    private static List<org.cyclonedx.model.vulnerability.Vulnerability.Affect> buildAffects(
+            final List<Finding> groupFindings) {
+        final List<String> componentUuids = groupFindings.stream()
+                .map(ModelConverter::componentUuid)
+                .distinct()
+                .sorted()
+                .toList();
+        final List<org.cyclonedx.model.vulnerability.Vulnerability.Affect> affects = new ArrayList<>(componentUuids.size());
+        for (final String uuid : componentUuids) {
+            final org.cyclonedx.model.vulnerability.Vulnerability.Affect affect = new org.cyclonedx.model.vulnerability.Vulnerability.Affect();
+            affect.setRef(uuid);
+            affects.add(affect);
+        }
+        return affects;
+    }
+
+    private static void populateScalarFields(
+            final org.cyclonedx.model.vulnerability.Vulnerability cdxVulnerability,
+            final Vulnerability vulnerability) {
         cdxVulnerability.setId(vulnerability.getVulnId());
         // Add the vulnerability source
         org.cyclonedx.model.vulnerability.Vulnerability.Source cdxSource = new org.cyclonedx.model.vulnerability.Vulnerability.Source();
@@ -1027,45 +1122,26 @@ public class ModelConverter {
         cdxVulnerability.setCreated(vulnerability.getCreated());
         cdxVulnerability.setPublished(vulnerability.getPublished());
         cdxVulnerability.setUpdated(vulnerability.getUpdated());
+    }
 
-        if (CycloneDXExporter.Variant.INVENTORY_WITH_VULNERABILITIES == variant || CycloneDXExporter.Variant.VDR == variant) {
-            final List<org.cyclonedx.model.vulnerability.Vulnerability.Affect> affects = new ArrayList<>();
-            final org.cyclonedx.model.vulnerability.Vulnerability.Affect affect = new org.cyclonedx.model.vulnerability.Vulnerability.Affect();
-            affect.setRef(component.getUuid().toString());
-            affects.add(affect);
-            cdxVulnerability.setAffects(affects);
-        } else if (CycloneDXExporter.Variant.VEX == variant && project != null) {
-            final List<org.cyclonedx.model.vulnerability.Vulnerability.Affect> affects = new ArrayList<>();
-            final org.cyclonedx.model.vulnerability.Vulnerability.Affect affect = new org.cyclonedx.model.vulnerability.Vulnerability.Affect();
-            affect.setRef(project.getUuid().toString());
-            affects.add(affect);
-            cdxVulnerability.setAffects(affects);
-        }
-
-        if (CycloneDXExporter.Variant.VEX == variant || CycloneDXExporter.Variant.VDR == variant) {
-            final Analysis analysis = qm.getAnalysis(component, vulnerability);
-            if (analysis != null) {
-                final org.cyclonedx.model.vulnerability.Vulnerability.Analysis cdxAnalysis = new org.cyclonedx.model.vulnerability.Vulnerability.Analysis();
-                if (analysis.getAnalysisResponse() != null) {
-                    final org.cyclonedx.model.vulnerability.Vulnerability.Analysis.Response response = convertDtVulnAnalysisResponseToCdxAnalysisResponse(analysis.getAnalysisResponse());
-                    if (response != null) {
-                        List<org.cyclonedx.model.vulnerability.Vulnerability.Analysis.Response> responses = new ArrayList<>();
-                        responses.add(response);
-                        cdxAnalysis.setResponses(responses);
-                    }
-                }
-                if (analysis.getAnalysisState() != null) {
-                    cdxAnalysis.setState(convertDtVulnAnalysisStateToCdxAnalysisState(analysis.getAnalysisState()));
-                }
-                if (analysis.getAnalysisJustification() != null) {
-                    cdxAnalysis.setJustification(convertDtVulnAnalysisJustificationToCdxAnalysisJustification(analysis.getAnalysisJustification()));
-                }
-                cdxAnalysis.setDetail(StringUtils.trimToNull(analysis.getAnalysisDetails()));
-                cdxVulnerability.setAnalysis(cdxAnalysis);
+    private static org.cyclonedx.model.vulnerability.Vulnerability.Analysis buildCdxAnalysis(final Analysis analysis) {
+        final org.cyclonedx.model.vulnerability.Vulnerability.Analysis cdxAnalysis = new org.cyclonedx.model.vulnerability.Vulnerability.Analysis();
+        if (analysis.getAnalysisResponse() != null) {
+            final org.cyclonedx.model.vulnerability.Vulnerability.Analysis.Response response = convertDtVulnAnalysisResponseToCdxAnalysisResponse(analysis.getAnalysisResponse());
+            if (response != null) {
+                List<org.cyclonedx.model.vulnerability.Vulnerability.Analysis.Response> responses = new ArrayList<>();
+                responses.add(response);
+                cdxAnalysis.setResponses(responses);
             }
         }
-
-        return cdxVulnerability;
+        if (analysis.getAnalysisState() != null) {
+            cdxAnalysis.setState(convertDtVulnAnalysisStateToCdxAnalysisState(analysis.getAnalysisState()));
+        }
+        if (analysis.getAnalysisJustification() != null) {
+            cdxAnalysis.setJustification(convertDtVulnAnalysisJustificationToCdxAnalysisJustification(analysis.getAnalysisJustification()));
+        }
+        cdxAnalysis.setDetail(StringUtils.trimToNull(analysis.getAnalysisDetails()));
+        return cdxAnalysis;
     }
 
     /**
@@ -1283,6 +1359,25 @@ public class ModelConverter {
         }
     }
 
+    /**
+     * Group findings by {@code (vulnerability, analysis fingerprint)} and emit one
+     * {@link org.cyclonedx.model.vulnerability.Vulnerability} entry per group with {@code affects[]}
+     * carrying the union of affected component bom-refs — the pattern documented as CycloneDX VEX
+     * Use-Case 13.
+     *
+     * <p>For variants that do not emit analysis (INVENTORY_WITH_VULNERABILITIES) every finding for a
+     * given vulnerability collapses into one group. For variants that do (VDR, VEX) findings sharing
+     * the same per-component analysis for a given vulnerability are grouped together.
+     *
+     * <p>Each emitted entry carries a {@code bom-ref}. Where one vulnerability produces a single
+     * group (the common case) the {@code bom-ref} is the bare Dependency-Track vulnerability UUID —
+     * matching the Hyades reference exports. Where one vulnerability produces multiple groups (the
+     * Use-Case 13 analysis split) entries carry a numeric suffix ({@code <uuid>/0}, {@code <uuid>/1},
+     * …) so the spec rule that every {@code bom-ref} is unique within the BOM still holds.
+     *
+     * <p>Per-finding {@link Analysis} lookups are memoised so the group-key pass and the
+     * group-conversion pass share a single query per {@code (component, vulnerability)} pair.
+     */
     public static List<org.cyclonedx.model.vulnerability.Vulnerability> generateVulnerabilities(
             final QueryManager qm,
             final CycloneDXExporter.Variant variant,
@@ -1291,12 +1386,72 @@ public class ModelConverter {
         if (findings == null) {
             return Collections.emptyList();
         }
-        final var vulnerabilitiesSeen = new HashSet<org.cyclonedx.model.vulnerability.Vulnerability>();
-        return findings.stream()
-                .map(finding -> convert(qm, variant, finding))
-                .filter(Objects::nonNull)
-                .filter(vulnerabilitiesSeen::add)
-                .toList();
+        // Only populated for variants that emit analysis; otherwise it stays empty and the
+        // includesAnalysis() guards short-circuit the reads.
+        final Map<String, Analysis> analysisCache = new HashMap<>(
+                variant.includesAnalysis() ? findings.size() : 0);
+        // Resolve the persistent objects once per unique UUID. Besides avoiding redundant queries,
+        // this retains the newer export behavior of skipping findings whose component or
+        // vulnerability was deleted after the findings query completed.
+        final Map<String, Component> componentCache = new HashMap<>(findings.size());
+        final Map<String, Vulnerability> vulnerabilityCache = new HashMap<>(findings.size());
+        // TreeMap keeps the emitted entries (and their bom-ref suffixes) in deterministic key order.
+        final Map<String, List<Finding>> groups = new TreeMap<>();
+        for (final Finding finding : findings) {
+            final String componentUuid = componentUuid(finding);
+            final String vulnerabilityUuid = vulnerabilityUuid(finding);
+            if (!componentCache.containsKey(componentUuid)) {
+                componentCache.put(componentUuid, qm.getObjectByUuid(Component.class, componentUuid));
+            }
+            if (!vulnerabilityCache.containsKey(vulnerabilityUuid)) {
+                vulnerabilityCache.put(vulnerabilityUuid,
+                        qm.getObjectByUuid(Vulnerability.class, vulnerabilityUuid));
+            }
+            final Component component = componentCache.get(componentUuid);
+            final Vulnerability vulnerability = vulnerabilityCache.get(vulnerabilityUuid);
+            if (component == null || vulnerability == null) {
+                continue;
+            }
+            if (variant.includesAnalysis()) {
+                final String analysisCacheKey = analysisCacheKey(finding);
+                if (!analysisCache.containsKey(analysisCacheKey)) {
+                    analysisCache.put(analysisCacheKey, qm.getAnalysis(component, vulnerability));
+                }
+            }
+            groups.computeIfAbsent(buildGroupKey(variant, finding, analysisCache), k -> new ArrayList<>())
+                    .add(finding);
+        }
+        // Pre-pass: a vulnerability that produced more than one group (the Use-Case 13 analysis
+        // split) needs a disambiguating suffix on each bom-ref; singletons keep the bare UUID.
+        final Map<String, Integer> vulnUuidGroupCount = new HashMap<>();
+        for (final List<Finding> group : groups.values()) {
+            vulnUuidGroupCount.merge(vulnerabilityUuid(group.get(0)), 1, Integer::sum);
+        }
+        final Map<String, Integer> vulnUuidNextIndex = new HashMap<>();
+        final List<org.cyclonedx.model.vulnerability.Vulnerability> result = new ArrayList<>(groups.size());
+        for (final List<Finding> group : groups.values()) {
+            final org.cyclonedx.model.vulnerability.Vulnerability cdxVuln =
+                    convertGroup(variant, group, vulnerabilityCache, analysisCache);
+            if (cdxVuln == null) {
+                continue;
+            }
+            cdxVuln.setBomRef(buildVulnBomRef(group, vulnUuidGroupCount, vulnUuidNextIndex));
+            result.add(cdxVuln);
+        }
+        return result;
+    }
+
+    private static String buildVulnBomRef(final List<Finding> group,
+                                          final Map<String, Integer> vulnUuidGroupCount,
+                                          final Map<String, Integer> vulnUuidNextIndex) {
+        final String vulnUuid = vulnerabilityUuid(group.get(0));
+        if (vulnUuidGroupCount.getOrDefault(vulnUuid, 0) <= 1) {
+            return vulnUuid;
+        }
+        // The slash isolates the suffix from the UUID alphabet, so a singleton's bare UUID can never
+        // be a prefix collision with a multi-group entry. Indices follow TreeMap key order.
+        final int idx = vulnUuidNextIndex.merge(vulnUuid, 0, (old, ignored) -> old + 1);
+        return vulnUuid + "/" + idx;
     }
 
     public static org.cyclonedx.model.Component.Scope mapCdxScope(Scope scope) {

--- a/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporterTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporterTest.java
@@ -20,7 +20,9 @@ package org.dependencytrack.parser.cyclonedx;
 
 import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.Assertions;
+import org.cyclonedx.Version;
 import org.cyclonedx.exception.ParseException;
+import org.cyclonedx.model.Bom;
 import org.cyclonedx.parsers.BomParserFactory;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Analysis;
@@ -32,6 +34,7 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.persistence.command.MakeAnalysisCommand;
 import org.junit.jupiter.api.Test;
 
 import javax.jdo.Query;
@@ -202,6 +205,63 @@ public class CycloneDXVexImporterTest extends PersistenceCapableTest {
         Assertions.assertThat(analysis.getAnalysisComments())
                 .extracting(AnalysisComment::getComment)
                 .containsExactly("Vendor Response: NOT_SET → UPDATE");
+    }
+
+    /**
+     * Round-trip regression for the VEX bom-ref fix: when several components share a vulnerability
+     * but only one is analysed, an exported-then-reimported VEX must apply that analysis to the
+     * analysed component only. Before the fix every {@code affects[].ref} pointed at the project
+     * root, which the importer broadcast to every vulnerable component.
+     */
+    @Test
+    public void shouldApplyExportedVexAnalysisOnlyToAnalyzedComponent() throws Exception {
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final var componentA = new Component();
+        componentA.setProject(project);
+        componentA.setName("acme-lib-a");
+        componentA.setVersion("1.0.0");
+        qm.persist(componentA);
+
+        final var componentB = new Component();
+        componentB.setProject(project);
+        componentB.setName("acme-lib-b");
+        componentB.setVersion("1.0.0");
+        qm.persist(componentB);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("INT-001");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        vuln.setComponents(List.of(componentA, componentB));
+        qm.persist(vuln);
+        qm.addVulnerability(vuln, componentA, "none");
+        qm.addVulnerability(vuln, componentB, "none");
+
+        // Analyse componentA only.
+        qm.makeAnalysis(new MakeAnalysisCommand(componentA, vuln)
+                .withState(AnalysisState.RESOLVED)
+                .withResponse(AnalysisResponse.UPDATE)
+                .withSuppress(true));
+
+        // Export a VEX for the project, then re-import it into the same project.
+        final var exporter = new CycloneDXExporter(CycloneDXExporter.Variant.VEX, qm);
+        final byte[] vexBytes = exporter
+                .export(exporter.create(project), CycloneDXExporter.Format.JSON, Version.VERSION_15)
+                .getBytes(StandardCharsets.UTF_8);
+        final Bom vex = BomParserFactory.createParser(vexBytes).parse(vexBytes);
+        vexImporter.applyVex(qm, vex, project);
+
+        // componentA keeps its analysis; componentB must never receive one.
+        final Analysis analysisA = qm.getAnalysis(componentA, vuln);
+        Assertions.assertThat(analysisA).isNotNull();
+        Assertions.assertThat(analysisA.getAnalysisState()).isEqualTo(AnalysisState.RESOLVED);
+
+        final Analysis analysisB = qm.getAnalysis(componentB, vuln);
+        Assertions.assertThat(analysisB).isNull();
     }
 
     private static final String OWASP_VECTOR =

--- a/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxBomAssertions.java
+++ b/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxBomAssertions.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.parser.cyclonedx;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Test-only assertions that enforce CycloneDX specification rules JSON Schema cannot express.
+ *
+ * <p>The CycloneDX 1.5+ schema description on every {@code bom-ref}-bearing object states that
+ * "Every bom-ref MUST be unique within the BOM" — across {@code metadata.component},
+ * {@code components[]}, {@code services[]}, and {@code vulnerabilities[]}. JSON Schema draft-07
+ * cannot express cross-property uniqueness, so producers must be guarded by separate test-side
+ * assertions like the one below.
+ */
+public final class CycloneDxBomAssertions {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private CycloneDxBomAssertions() {
+    }
+
+    /**
+     * Assert that every {@code bom-ref} value appearing anywhere in the BOM is unique across the
+     * whole document.
+     *
+     * @param json the serialised CycloneDX BOM
+     * @throws AssertionError if any {@code bom-ref} value occurs more than once, or the BOM cannot
+     *                        be parsed
+     */
+    public static void assertBomRefsUnique(final String json) {
+        final JsonNode root;
+        try {
+            root = MAPPER.readTree(json);
+        } catch (Exception e) {
+            throw new AssertionError("Failed to parse BOM JSON for bom-ref uniqueness check", e);
+        }
+        final Map<String, List<String>> refToPaths = new LinkedHashMap<>();
+        collectBomRefs(root, "$", refToPaths);
+
+        final Map<String, List<String>> duplicates = new LinkedHashMap<>();
+        refToPaths.forEach((ref, paths) -> {
+            if (paths.size() > 1) {
+                duplicates.put(ref, paths);
+            }
+        });
+        Assertions.assertThat(duplicates)
+                .as("CycloneDX bom-refs that appear more than once across the document; "
+                        + "value -> JSON paths where the duplicate occurred")
+                .isEmpty();
+    }
+
+    private static void collectBomRefs(final JsonNode node, final String path,
+                                       final Map<String, List<String>> sink) {
+        if (node == null) {
+            return;
+        }
+        if (node.isObject()) {
+            final JsonNode ref = node.get("bom-ref");
+            if (ref != null && ref.isTextual()) {
+                sink.computeIfAbsent(ref.asText(), k -> new ArrayList<>()).add(path);
+            }
+            node.fields().forEachRemaining(entry ->
+                    collectBomRefs(entry.getValue(), path + appendKey(entry.getKey()), sink));
+        } else if (node.isArray()) {
+            int i = 0;
+            for (final JsonNode child : node) {
+                collectBomRefs(child, path + "[" + i + "]", sink);
+                i++;
+            }
+        }
+    }
+
+    /**
+     * Render a JSON object key as a path segment. Plain identifiers use dot-notation
+     * ({@code .foo}); keys with characters that would make the dot form ambiguous —
+     * {@code .}, {@code [}, {@code ]}, {@code "}, or whitespace — fall back to bracket
+     * notation with the key escaped ({@code ["foo.bar"]}).
+     */
+    private static String appendKey(final String key) {
+        for (int i = 0; i < key.length(); i++) {
+            final char c = key.charAt(i);
+            if (c == '.' || c == '[' || c == ']' || c == '"' || Character.isWhitespace(c)) {
+                return "[\"" + key.replace("\\", "\\\\").replace("\"", "\\\"") + "\"]";
+            }
+        }
+        return "." + key;
+    }
+}

--- a/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/util/ModelConverterTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/util/ModelConverterTest.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.parser.cyclonedx.util;
+
+import org.dependencytrack.model.Analysis;
+import org.dependencytrack.model.AnalysisJustification;
+import org.dependencytrack.model.AnalysisResponse;
+import org.dependencytrack.model.AnalysisState;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ModelConverterTest {
+
+    /**
+     * Reference the production constant directly so a future change to the byte used as the
+     * group-key separator forces this test to be re-checked rather than silently passing
+     * against a stale literal.
+     */
+    private static final String SEP = String.valueOf(ModelConverter.FIELD_SEPARATOR);
+
+    @Test
+    void analysisFingerprintReturnsEmptyForNullAnalysis() {
+        assertThat(ModelConverter.analysisFingerprint(null)).isEmpty();
+    }
+
+    @Test
+    void analysisFingerprintEmitsEnumNameNotToString() {
+        final Analysis analysis = new Analysis();
+        analysis.setAnalysisState(AnalysisState.EXPLOITABLE);
+        analysis.setAnalysisJustification(AnalysisJustification.CODE_NOT_REACHABLE);
+        analysis.setAnalysisResponse(AnalysisResponse.UPDATE);
+        analysis.setAnalysisDetails("hand-triaged");
+
+        assertThat(ModelConverter.analysisFingerprint(analysis))
+                .isEqualTo("EXPLOITABLE" + SEP + "CODE_NOT_REACHABLE" + SEP + "UPDATE" + SEP + "hand-triaged");
+    }
+
+    @Test
+    void analysisFingerprintFormatIsStableAcrossNullFields() {
+        final Analysis stateOnly = new Analysis();
+        stateOnly.setAnalysisState(AnalysisState.EXPLOITABLE);
+
+        // The fingerprint contract is positional — null fields collapse to the empty string so a
+        // future "EXPLOITABLE/null/null/null" analysis cannot collide with an analysis whose state
+        // happens to render as "EXPLOITABLEnull" via String.valueOf(Object).
+        assertThat(ModelConverter.analysisFingerprint(stateOnly))
+                .isEqualTo("EXPLOITABLE" + SEP + "" + SEP + "" + SEP + "");
+    }
+
+    @Test
+    void analysisFingerprintTrimsBlankDetailsToEmpty() {
+        final Analysis blankDetails = new Analysis();
+        blankDetails.setAnalysisState(AnalysisState.RESOLVED);
+        blankDetails.setAnalysisDetails("   ");
+
+        assertThat(ModelConverter.analysisFingerprint(blankDetails))
+                .isEqualTo("RESOLVED" + SEP + "" + SEP + "" + SEP + "");
+    }
+
+    @Test
+    void analysisFingerprintDistinguishesByEachField() {
+        final Analysis a = new Analysis();
+        a.setAnalysisState(AnalysisState.EXPLOITABLE);
+        a.setAnalysisResponse(AnalysisResponse.UPDATE);
+
+        final Analysis b = new Analysis();
+        b.setAnalysisState(AnalysisState.EXPLOITABLE);
+        b.setAnalysisResponse(AnalysisResponse.WORKAROUND_AVAILABLE);
+
+        assertThat(ModelConverter.analysisFingerprint(a))
+                .isNotEqualTo(ModelConverter.analysisFingerprint(b));
+    }
+}

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -63,6 +63,7 @@ import org.dependencytrack.model.Tag;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.notification.NotificationScope;
 import org.dependencytrack.notification.proto.v1.BomValidationFailedSubject;
+import org.dependencytrack.parser.cyclonedx.CycloneDxBomAssertions;
 import org.dependencytrack.parser.cyclonedx.CycloneDxValidator;
 import org.dependencytrack.persistence.command.MakeAnalysisCommand;
 import org.dependencytrack.resources.v1.vo.BomSubmitRequest;
@@ -761,25 +762,7 @@ class BomResourceTest extends ResourceTest {
                                     "affects": [
                                         {
                                             "ref": "${json-unit.matches:componentWithVulnUuid}"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "bom-ref": "${json-unit.matches:vulnUuid}",
-                                    "id": "INT-001",
-                                    "source": {
-                                        "name": "INTERNAL"
-                                    },
-                                    "ratings": [
-                                        {
-                                            "source": {
-                                                "name": "INTERNAL"
-                                            },
-                                            "severity": "high",
-                                            "method": "other"
-                                        }
-                                    ],
-                                    "affects": [
+                                        },
                                         {
                                             "ref": "${json-unit.matches:componentWithVulnAndAnalysisUuid}"
                                         }
@@ -788,6 +771,7 @@ class BomResourceTest extends ResourceTest {
                             ]
                         }
                         """));
+        CycloneDxBomAssertions.assertBomRefsUnique(jsonResponse);
 
         // Ensure the dependency graph did not get deleted during export.
         // https://github.com/DependencyTrack/dependency-track/issues/2494
@@ -895,6 +879,11 @@ class BomResourceTest extends ResourceTest {
                 .withMatcher("componentWithoutVulnUuid", equalTo(componentWithoutVuln.getUuid().toString()))
                 .withMatcher("componentWithVulnUuid", equalTo(componentWithVuln.getUuid().toString()))
                 .withMatcher("componentWithVulnAndAnalysisUuid", equalTo(componentWithVulnAndAnalysis.getUuid().toString()))
+                // One CVE affects two components with distinct analysis fingerprints (no analysis vs
+                // RESOLVED), so VDR emits two entries with deterministic suffixed bom-refs. The empty
+                // fingerprint sorts before "RESOLVED", so the un-analysed component is /0.
+                .withMatcher("vulnUuidSuffix0", equalTo(vulnerability.getUuid().toString() + "/0"))
+                .withMatcher("vulnUuidSuffix1", equalTo(vulnerability.getUuid().toString() + "/1"))
                 .isEqualTo(json("""
                         {
                             "bomFormat": "CycloneDX",
@@ -949,7 +938,7 @@ class BomResourceTest extends ResourceTest {
                             ],
                             "vulnerabilities": [
                                 {
-                                    "bom-ref": "${json-unit.matches:vulnUuid}",
+                                    "bom-ref": "${json-unit.matches:vulnUuidSuffix0}",
                                     "id": "INT-001",
                                     "source": {
                                         "name": "INTERNAL"
@@ -970,7 +959,7 @@ class BomResourceTest extends ResourceTest {
                                     ]
                                 },
                                 {
-                                    "bom-ref": "${json-unit.matches:vulnUuid}",
+                                    "bom-ref": "${json-unit.matches:vulnUuidSuffix1}",
                                     "id": "INT-001",
                                     "source": {
                                         "name": "INTERNAL"
@@ -999,6 +988,7 @@ class BomResourceTest extends ResourceTest {
                             ]
                         }
                         """));
+        CycloneDxBomAssertions.assertBomRefsUnique(jsonResponse);
 
         // Ensure the dependency graph did not get deleted during export.
         // https://github.com/DependencyTrack/dependency-track/issues/2494

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
@@ -41,6 +41,7 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectCollectionLogic;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.parser.cyclonedx.CycloneDxBomAssertions;
 import org.dependencytrack.parser.cyclonedx.CycloneDxValidator;
 import org.dependencytrack.persistence.command.MakeAnalysisCommand;
 import org.glassfish.jersey.inject.hk2.AbstractBinder;
@@ -185,6 +186,8 @@ public class VexResourceTest extends ResourceTest {
                 .withMatcher("vulnAUuid", equalTo(vulnA.getUuid().toString()))
                 .withMatcher("vulnBUuid", equalTo(vulnB.getUuid().toString()))
                 .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
+                .withMatcher("componentWithVulnUuid", equalTo(componentWithVuln.getUuid().toString()))
+                .withMatcher("componentWithVulnAndAnalysisUuid", equalTo(componentWithVulnAndAnalysis.getUuid().toString()))
                 .isEqualTo("""
                         {
                           "bomFormat": "CycloneDX",
@@ -207,6 +210,20 @@ public class VexResourceTest extends ResourceTest {
                               }
                             ]
                           },
+                          "components": [
+                            {
+                              "type": "library",
+                              "bom-ref": "${json-unit.matches:componentWithVulnUuid}",
+                              "name": "acme-lib-b",
+                              "version": "1.0.0"
+                            },
+                            {
+                              "type": "library",
+                              "bom-ref": "${json-unit.matches:componentWithVulnAndAnalysisUuid}",
+                              "name": "acme-lib-c",
+                              "version": "1.0.0"
+                            }
+                          ],
                           "vulnerabilities": [
                             {
                               "bom-ref": "${json-unit.matches:vulnAUuid}",
@@ -225,7 +242,7 @@ public class VexResourceTest extends ResourceTest {
                               ],
                               "affects": [
                                 {
-                                  "ref": "${json-unit.matches:projectUuid}"
+                                  "ref": "${json-unit.matches:componentWithVulnUuid}"
                                 }
                               ]
                             },
@@ -252,13 +269,14 @@ public class VexResourceTest extends ResourceTest {
                               },
                               "affects": [
                                 {
-                                  "ref": "${json-unit.matches:projectUuid}"
+                                  "ref": "${json-unit.matches:componentWithVulnAndAnalysisUuid}"
                                 }
                               ]
                             }
                           ]
                         }
                         """);
+        CycloneDxBomAssertions.assertBomRefsUnique(jsonResponse);
     }
 
     @Test
@@ -569,6 +587,8 @@ public class VexResourceTest extends ResourceTest {
                 .withOptions(Option.IGNORING_ARRAY_ORDER)
                 .withMatcher("vulnUuid", equalTo(vuln.getUuid().toString()))
                 .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
+                .withMatcher("componentAUuid", equalTo(componentAWithVuln.getUuid().toString()))
+                .withMatcher("componentBUuid", equalTo(componentBWithVuln.getUuid().toString()))
                 .isEqualTo("""
                         {
                           "bomFormat": "CycloneDX",
@@ -591,6 +611,20 @@ public class VexResourceTest extends ResourceTest {
                               }
                             ]
                           },
+                          "components": [
+                            {
+                              "type": "library",
+                              "bom-ref": "${json-unit.matches:componentAUuid}",
+                              "name": "acme-lib-a",
+                              "version": "1.0.0"
+                            },
+                            {
+                              "type": "library",
+                              "bom-ref": "${json-unit.matches:componentBUuid}",
+                              "name": "acme-lib-b",
+                              "version": "1.0.0"
+                            }
+                          ],
                           "vulnerabilities": [
                             {
                               "bom-ref": "${json-unit.matches:vulnUuid}",
@@ -615,13 +649,17 @@ public class VexResourceTest extends ResourceTest {
                               },
                               "affects": [
                                 {
-                                  "ref": "${json-unit.matches:projectUuid}"
+                                  "ref": "${json-unit.matches:componentAUuid}"
+                                },
+                                {
+                                  "ref": "${json-unit.matches:componentBUuid}"
                                 }
                               ]
                             }
                           ]
                         }
                         """);
+        CycloneDxBomAssertions.assertBomRefsUnique(jsonResponse);
     }
 
     @Test
@@ -676,8 +714,14 @@ public class VexResourceTest extends ResourceTest {
         assertThatNoException().isThrownBy(() -> CycloneDxValidator.getInstance().validate(jsonResponse.getBytes()));
         assertThatJson(jsonResponse)
                 .withOptions(Option.IGNORING_ARRAY_ORDER)
-                .withMatcher("vulnUuid", equalTo(vuln.getUuid().toString()))
                 .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
+                .withMatcher("componentAUuid", equalTo(componentAWithVuln.getUuid().toString()))
+                .withMatcher("componentBUuid", equalTo(componentBWithVuln.getUuid().toString()))
+                // One CVE split across two distinct analysis fingerprints produces two entries; their
+                // bom-refs are disambiguated with a deterministic suffix in fingerprint-sort order
+                // ("EXPLOITABLE" < "IN_TRIAGE"), so the exploitable group is /0 and in_triage is /1.
+                .withMatcher("vulnUuidSuffix0", equalTo(vuln.getUuid().toString() + "/0"))
+                .withMatcher("vulnUuidSuffix1", equalTo(vuln.getUuid().toString() + "/1"))
                 .isEqualTo("""
                         {
                           "bomFormat": "CycloneDX",
@@ -700,9 +744,23 @@ public class VexResourceTest extends ResourceTest {
                               }
                             ]
                           },
+                          "components": [
+                            {
+                              "type": "library",
+                              "bom-ref": "${json-unit.matches:componentAUuid}",
+                              "name": "acme-lib-a",
+                              "version": "1.0.0"
+                            },
+                            {
+                              "type": "library",
+                              "bom-ref": "${json-unit.matches:componentBUuid}",
+                              "name": "acme-lib-b",
+                              "version": "1.0.0"
+                            }
+                          ],
                           "vulnerabilities": [
                             {
-                              "bom-ref": "${json-unit.matches:vulnUuid}",
+                              "bom-ref": "${json-unit.matches:vulnUuidSuffix1}",
                               "id": "INT-001",
                               "source": {
                                 "name": "INTERNAL"
@@ -724,12 +782,12 @@ public class VexResourceTest extends ResourceTest {
                               },
                               "affects": [
                                 {
-                                  "ref": "${json-unit.matches:projectUuid}"
+                                  "ref": "${json-unit.matches:componentAUuid}"
                                 }
                               ]
                             },
                             {
-                              "bom-ref": "${json-unit.matches:vulnUuid}",
+                              "bom-ref": "${json-unit.matches:vulnUuidSuffix0}",
                               "id": "INT-001",
                               "source": {
                                 "name": "INTERNAL"
@@ -751,13 +809,14 @@ public class VexResourceTest extends ResourceTest {
                               },
                               "affects": [
                                 {
-                                  "ref": "${json-unit.matches:projectUuid}"
+                                  "ref": "${json-unit.matches:componentBUuid}"
                                 }
                               ]
                             }
                           ]
                         }
                         """);
+        CycloneDxBomAssertions.assertBomRefsUnique(jsonResponse);
     }
 
     @Test


### PR DESCRIPTION
### Description

CycloneDX VEX and VDR exports were producing documents that violated the  
CycloneDX `bom-ref` uniqueness rule and could not be reliably round-tripped  
back into Dependency-Track:

*   Every `affects[].ref` pointed at the **project** UUID instead of the affected  
    **component(s)**. On re-import, the importer applied one component's analysis  
    to _every_ component sharing the vulnerability.
*   One `vulnerabilities[]` entry was emitted per finding, and all entries for the  
    same vulnerability reused the bare vulnerability UUID as their `bom-ref`. A  
    project with several components affected by the same CVE therefore emitted  
    duplicate `bom-ref` values, which the CycloneDX spec forbids ("Every bom-ref  
    MUST be unique within the BOM").

This PR groups findings by `(vulnerability, analysis fingerprint)` and emits one  
entry per group, with `affects[]` carrying the sorted union of the affected  
component `bom-ref`s — the pattern documented as CycloneDX VEX Use-Case 13. When  
a single vulnerability legitimately splits across distinct analyses, each entry's  
`bom-ref` gets a deterministic numeric suffix (`<uuid>/0`, `<uuid>/1`, …) so  
uniqueness holds; the common single-group case keeps the bare vulnerability UUID,  
matching the existing reference exports.

### Addressed Issue

Fixes #6016  
Fixes #6017

### Additional Details

**Why group by analysis fingerprint.** VDR/VEX emit per-component analysis. Two  
components affected by the same vulnerability may carry _different_ analyses  
(e.g. one `RESOLVED`, one untriaged), so they cannot collapse into a single entry  
without losing analysis fidelity — hence grouping by  
`(vulnerability, analysisFingerprint)`. Variants that do not emit analysis  
(`INVENTORY_WITH_VULNERABILITIES`) collapse all findings for a vulnerability into  
one group.

**Fingerprint contract.** `analysisFingerprint` is a positional,  
`Enum.name()`\-based serialisation of `(state, justification, response, details)`  
joined by U+001F, so absent fields cannot collide with present ones. It is pinned  
by `ModelConverterTest`.

**bom-ref suffixing.** The `<uuid>/N` suffix is applied _only_ when one  
vulnerability produces more than one group; singletons keep the bare UUID for  
backward-compatible output. The `/` separator isolates the suffix from the UUID  
alphabet so a singleton UUID can never prefix-collide with a multi-group entry.

**Variant refactor.** The `Variant` enum was changed from scattered  
`switch`/`==` checks to explicit capability flags (`includesAnalysis()`,  
`emitsFindings()`, `filtersToVulnerableComponents()`, …). This is incidental to  
the fix; happy to split it into a separate commit/PR if you'd prefer to keep the  
fix minimal.

**Performance.** Per-`(component, vulnerability)` analysis lookups are memoised  
across the group-key and group-conversion passes, so this does not add queries  
relative to the previous per-finding path — it reduces them.

**Tests.**

*   `CycloneDXVexImporterTest#shouldApplyExportedVexAnalysisOnlyToAnalyzedComponent`  
    — round-trip regression: exports a VEX and re-imports it, asserting the analysis  
    lands only on the analysed component.
*   `CycloneDxBomAssertions.assertBomRefsUnique` — reusable cross-document  
    `bom-ref` uniqueness assertion, applied to the VEX/VDR/BOM resource tests  
    (JSON Schema cannot express cross-property uniqueness).
*   `ModelConverterTest` — pins the fingerprint serialisation contract.

**ADR.** I don't believe this meets the ADR bar — it's a spec-conformance bug  
fix, not a new API version, auth model, schema change, or cross-cutting  
convention. It does change the shape of an externally-consumed export and its  
re-import semantics, so flagging it explicitly for your judgement.

**Docs.** The previous output was spec-violating, so I don't think the docs  
describe the old `affects`/`bom-ref` behaviour specifically. Happy to open a  
companion PR against `DependencyTrack/docs` if the new behaviour warrants a note.

### Checklist

*   I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
*   This PR fixes a defect, and I have provided tests to verify that the fix is effective
*   ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
*   ~This PR introduces changes to the database model, and I have updated the~ [~migration changelog~](../DEVELOPING.md#database-migrations) ~accordingly~
*   This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/docs) accordingly
*   This PR is a substantial change (per the [ADR criteria](../CONTRIBUTING.md#architecture-decision-records)), and I have added an [ADR](../docs/adr/) under `docs/adr/`