### PR TITLE
Mark project as not required and only validate when specified.

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
@@ -147,7 +147,6 @@ public class AnalysisResource extends AlpineResource {
     public Response updateAnalysis(AnalysisRequest request) {
         final Validator validator = getValidator();
         failOnValidationError(
-                validator.validateProperty(request, "project"),
                 validator.validateProperty(request, "component"),
                 validator.validateProperty(request, "vulnerability"),
                 validator.validateProperty(request, "analysisState"),
@@ -158,13 +157,16 @@ public class AnalysisResource extends AlpineResource {
         );
         try (QueryManager qm = new QueryManager()) {
             final Project project = qm.getObjectByUuid(Project.class, request.getProject());
-            if (project == null) {
-                return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();
-            }
+
             final Component component = qm.getObjectByUuid(Component.class, request.getComponent());
             if (component == null) {
                 return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();
             }
+
+            if (project != null && component.getProject().getId() != project.getId()){
+                return Response.status(Response.Status.CONFLICT).entity("The component has a different project than the one specified via the project param.").build();
+            }
+
             final Vulnerability vulnerability = qm.getObjectByUuid(Vulnerability.class, request.getVulnerability());
             if (vulnerability == null) {
                 return Response.status(Response.Status.NOT_FOUND).entity("The vulnerability could not be found.").build();


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

"Hey, so after our little chat, I thought I'd just quickly add it myself. My thinking behind it was that I'd simply check whether the component's project and the (optional) project match. That way we can resolve the 500 and also get users used to the idea that the project field will go away entirely. With the conflict, we can then prevent someone (like me) from wondering why what they expected isn't happening :)

### Addressed Issue

https://github.com/DependencyTrack/dependency-track/issues/6561

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [ ] I have read and understand the [contributing guidelines] (No 404 not found)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective (no)
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended (no)
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly (no)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly (cant find any docs)
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/` (no)

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
