### PR TITLE
Fix prepare-vuln-analysis activity failing when components have properties without value

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/vulnanalysis/PrepareVulnAnalysisActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulnanalysis/PrepareVulnAnalysisActivity.java
@@ -123,7 +123,7 @@ public final class PrepareVulnAnalysisActivity implements Activity<PrepareVulnAn
                 if (vulnAnalyzerFactory.isEnabled()) {
                     LOGGER.debug("Analyzer is enabled");
                     requirementsByAnalyzer
-                            .computeIfAbsent(analyzerName, k -> new HashSet<>())
+                            .computeIfAbsent(analyzerName, _ -> new HashSet<>())
                             .addAll(vulnAnalyzerFactory.analyzerRequirements());
                 } else {
                     LOGGER.debug("Analyzer is disabled");
@@ -159,13 +159,18 @@ public final class PrepareVulnAnalysisActivity implements Activity<PrepareVulnAn
                                 final String propertyName = rowView.getColumn("propertyname", String.class);
                                 final String propertyValue = rowView.getColumn("propertyvalue", String.class);
 
-                                map.computeIfAbsent(componentId, k -> new ArrayList<>())
-                                        .add(Property.newBuilder()
+                                final var propertyBuilder =
+                                        Property.newBuilder()
                                                 .setName(groupName != null
                                                         ? "%s:%s".formatted(groupName, propertyName)
-                                                        : propertyName)
-                                                .setValue(propertyValue)
-                                                .build());
+                                                        : propertyName);
+                                if (propertyValue != null) {
+                                    propertyBuilder.setValue(propertyValue);
+                                }
+
+                                map
+                                        .computeIfAbsent(componentId, _ -> new ArrayList<>())
+                                        .add(propertyBuilder.build());
                                 return map;
                             }));
         } else {
@@ -195,7 +200,7 @@ public final class PrepareVulnAnalysisActivity implements Activity<PrepareVulnAn
             return query
                     .bind("projectUuid", projectUuid)
                     .define("requirements", requirements)
-                    .map((rs, stmtCtx) -> {
+                    .map((rs, _) -> {
                         final long componentId = rs.getLong("id");
 
                         final var componentBuilder = Component.newBuilder()

--- a/apiserver/src/test/java/org/dependencytrack/vulnanalysis/PrepareVulnAnalysisActivityTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/vulnanalysis/PrepareVulnAnalysisActivityTest.java
@@ -147,6 +147,16 @@ class PrepareVulnAnalysisActivityTest extends PersistenceCapableTest {
                 IConfigProperty.PropertyType.STRING,
                 null);
 
+        // Property values can be null, make sure that's handled properly.
+        // https://github.com/DependencyTrack/dependency-track/issues/6572
+        qm.createComponentProperty(
+                component,
+                "syft",
+                "package:metadataType",
+                null,
+                IConfigProperty.PropertyType.STRING,
+                null);
+
         final PrepareVulnAnalysisRes res = activity.execute(
                 mockActivityContext(),
                 PrepareVulnAnalysisArg.newBuilder()
@@ -167,6 +177,10 @@ class PrepareVulnAnalysisActivityTest extends PersistenceCapableTest {
                     property -> {
                         assertThat(property.getName()).isEqualTo("aquasecurity:trivy:SrcVersion");
                         assertThat(property.getValue()).isEqualTo("2.35");
+                    },
+                    property -> {
+                        assertThat(property.getName()).isEqualTo("syft:package:metadataType");
+                        assertThat(property.hasValue()).isFalse();
                     });
         });
     }


### PR DESCRIPTION

### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes `prepare-vuln-analysis` activity failing when components have properties without value.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6572 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
