### PR TITLE
Fix NPE and redundant queries in VEX/VDR export

### DIFF
--- a/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
@@ -837,8 +837,14 @@ public class ModelConverter {
     public static org.cyclonedx.model.vulnerability.Vulnerability convert(final QueryManager qm, final CycloneDXExporter.Variant variant,
                                                                           final Finding finding) {
         final Component component = qm.getObjectByUuid(Component.class, (String)finding.getComponent().get("uuid"));
+        if (component == null) {
+            return null;
+        }
         final Project project = component.getProject();
         final Vulnerability vulnerability = qm.getObjectByUuid(Vulnerability.class, (String)finding.getVulnerability().get("uuid"));
+        if (vulnerability == null) {
+            return null;
+        }
 
         final org.cyclonedx.model.vulnerability.Vulnerability cdxVulnerability = new org.cyclonedx.model.vulnerability.Vulnerability();
         cdxVulnerability.setBomRef(vulnerability.getUuid().toString());
@@ -928,10 +934,7 @@ public class ModelConverter {
         }
 
         if (CycloneDXExporter.Variant.VEX == variant || CycloneDXExporter.Variant.VDR == variant) {
-            final Analysis analysis = qm.getAnalysis(
-                    qm.getObjectByUuid(Component.class, component.getUuid()),
-                    qm.getObjectByUuid(Vulnerability.class, vulnerability.getUuid())
-            );
+            final Analysis analysis = qm.getAnalysis(component, vulnerability);
             if (analysis != null) {
                 final org.cyclonedx.model.vulnerability.Vulnerability.Analysis cdxAnalysis = new org.cyclonedx.model.vulnerability.Vulnerability.Analysis();
                 if (analysis.getAnalysisResponse() != null) {
@@ -964,6 +967,7 @@ public class ModelConverter {
         final var vulnerabilitiesSeen = new HashSet<org.cyclonedx.model.vulnerability.Vulnerability>();
         return findings.stream()
                 .map(finding -> convert(qm, variant, finding))
+                .filter(Objects::nonNull)
                 .filter(vulnerabilitiesSeen::add)
                 .toList();
     }

--- a/src/test/java/org/dependencytrack/parser/cyclonedx/ModelConverterTest.java
+++ b/src/test/java/org/dependencytrack/parser/cyclonedx/ModelConverterTest.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.parser.cyclonedx;
+
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Finding;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.Severity;
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.parser.cyclonedx.util.ModelConverter;
+import org.dependencytrack.tasks.scanners.AnalyzerIdentity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class ModelConverterTest extends PersistenceCapableTest {
+
+    @Test
+    void generateVulnerabilitiesSkipsFindingWhoseComponentWasDeleted() {
+        final Project project = qm.createProject("acme-app", null, "1.0.0", null, null, null, true, false);
+
+        Vulnerability vulnerability = new Vulnerability();
+        vulnerability.setVulnId("INT-001");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.HIGH);
+        vulnerability = qm.createVulnerability(vulnerability, false);
+
+        Component component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("1.0.0");
+        component = qm.createComponent(component, false);
+        qm.addVulnerability(vulnerability, component, AnalyzerIdentity.INTERNAL_ANALYZER);
+
+        // Resolve the findings up front, mirroring what the exporter does before conversion.
+        final List<Finding> findings = qm.getFindings(project, true);
+        assertThat(findings).hasSize(1);
+
+        // Simulate the component being deleted in the window between the findings query
+        // and the export (e.g. a concurrent re-analysis or manual deletion).
+        qm.recursivelyDelete(component, false);
+
+        // Before the fix this threw a NullPointerException and aborted the whole export.
+        assertThatNoException().isThrownBy(() ->
+                ModelConverter.generateVulnerabilities(qm, CycloneDXExporter.Variant.VEX, findings));
+
+        final List<org.cyclonedx.model.vulnerability.Vulnerability> result =
+                ModelConverter.generateVulnerabilities(qm, CycloneDXExporter.Variant.VEX, findings);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void generateVulnerabilitiesConvertsFindingWithResolvableComponent() {
+        final Project project = qm.createProject("acme-app", null, "1.0.0", null, null, null, true, false);
+
+        Vulnerability vulnerability = new Vulnerability();
+        vulnerability.setVulnId("INT-001");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.HIGH);
+        vulnerability = qm.createVulnerability(vulnerability, false);
+
+        Component component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("1.0.0");
+        component = qm.createComponent(component, false);
+        qm.addVulnerability(vulnerability, component, AnalyzerIdentity.INTERNAL_ANALYZER);
+
+        final List<Finding> findings = qm.getFindings(project, true);
+
+        final List<org.cyclonedx.model.vulnerability.Vulnerability> result =
+                ModelConverter.generateVulnerabilities(qm, CycloneDXExporter.Variant.VEX, findings);
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo("INT-001");
+    }
+}


### PR DESCRIPTION
### Description

Fixes a `NullPointerException` that aborts the entire VEX/VDR CycloneDX export when a
finding references a component or vulnerability that was deleted between the findings
query and the export. `ModelConverter.convert()` resolved the `Component` and
`Vulnerability` by UUID but dereferenced them without null checks, so a concurrent
deletion (e.g. re-analysis or manual removal) caused `component.getProject()` to throw
and the whole export to fail with a 500. Such findings are now skipped via a guard in
`convert()` and a `filter` in `generateVulnerabilities()`, so the export completes with
the remaining vulnerabilities.

Also removes two redundant database queries per finding: for the VEX/VDR variant the
analysis lookup re-fetched the `Component` and `Vulnerability` by UUID even though both
were already resolved earlier in the same method. It now reuses the resolved objects.

### Addressed Issue

fixes #6613

### Additional Details

A regression test (`ModelConverterTest`) was added covering both a finding whose
component was deleted (previously reproduced the NPE, now returns an empty result) and
a normal finding that still converts correctly. The test was verified to fail against
the unpatched code and pass with the fix.

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [ ] ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- [ ] ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations