### PR TITLE
Fix local file storage not anticipating Windows-style paths

### DIFF
--- a/file-storage/provider-local/pom.xml
+++ b/file-storage/provider-local/pom.xml
@@ -49,6 +49,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/file-storage/provider-local/src/main/java/org/dependencytrack/filestorage/local/LocalFileStorage.java
+++ b/file-storage/provider-local/src/main/java/org/dependencytrack/filestorage/local/LocalFileStorage.java
@@ -77,7 +77,10 @@ final class LocalFileStorage implements FileStorage {
         }
 
         final Path relativeFilePath = baseDirPath.relativize(filePath);
-        final URI locationUri = URI.create("%s:///%s".formatted(LocalFileStorageProvider.NAME, relativeFilePath));
+        final URI locationUri = URI.create(
+                "%s:///%s".formatted(
+                        LocalFileStorageProvider.NAME,
+                        relativeFilePath.toString().replace(relativeFilePath.getFileSystem().getSeparator(), "/")));
 
         final MessageDigest messageDigest;
         try {

--- a/file-storage/provider-local/src/test/java/org/dependencytrack/filestorage/local/LocalFileStorageTest.java
+++ b/file-storage/provider-local/src/test/java/org/dependencytrack/filestorage/local/LocalFileStorageTest.java
@@ -18,6 +18,8 @@
  */
 package org.dependencytrack.filestorage.local;
 
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import org.dependencytrack.filestorage.api.FileStorage;
 import org.dependencytrack.filestorage.proto.v1.FileMetadata;
@@ -28,6 +30,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.ProxySelector;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -248,6 +252,24 @@ class LocalFileStorageTest {
         }
 
         assertThat(tempDirPath).exists();
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    void shouldUseForwardSlashesInLocationOnWindowsFilesystem() throws Exception {
+        try (final FileSystem fileSystem = Jimfs.newFileSystem(Configuration.windows())) {
+            final Path baseDirPath = fileSystem.getPath("C:\\storage");
+            Files.createDirectories(baseDirPath);
+            final FileStorage storage = new LocalFileStorage(baseDirPath, 5);
+
+            final FileMetadata fileMetadata = storage.store("foo/bar", new ByteArrayInputStream("baz".getBytes()));
+            assertThat(fileMetadata.getLocation()).isEqualTo("local:///foo/bar");
+
+            final InputStream fileStream = storage.get(fileMetadata);
+            assertThat(fileStream.readAllBytes()).asString().isEqualTo("baz");
+
+            assertThat(storage.delete(fileMetadata)).isTrue();
+        }
     }
 
     private FileStorage createStorage() {

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
         <lib.jdbi.version>3.53.0</lib.jdbi.version>
         <lib.jersey.version>4.0.2</lib.jersey.version>
         <lib.jetty.version>12.1.10</lib.jetty.version>
+        <lib.jimfs.version>1.3.1</lib.jimfs.version>
         <lib.json-schema-validator.version>2.0.3</lib.json-schema-validator.version>
         <lib.json-unit.version>5.1.2</lib.json-unit.version>
         <lib.jspecify.version>1.0.0</lib.jspecify.version>
@@ -347,6 +348,12 @@
                 <version>${lib.jdbi.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.jimfs</groupId>
+                <artifactId>jimfs</artifactId>
+                <version>${lib.jimfs.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes local file storage not anticipating Windows-style paths.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6627 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

On Windows, `Path#toString` produces file paths with backslashes.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
