### PR TITLE
feat(policy): support wildcard and regex matching for Vulnerability ID policy conditions

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/compat/VulnerabilityIdCelPolicyScriptSourceBuilder.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/compat/VulnerabilityIdCelPolicyScriptSourceBuilder.java
@@ -23,19 +23,45 @@ import org.dependencytrack.model.PolicyCondition;
 import static org.dependencytrack.policy.cel.compat.CelPolicyScriptSourceBuilder.escapeQuotes;
 
 public class VulnerabilityIdCelPolicyScriptSourceBuilder implements CelPolicyScriptSourceBuilder {
+
     @Override
     public String apply(final PolicyCondition policyCondition) {
-        final String scriptSrc = """
-                vulns.exists(v, v.id == "%s")
-                """.formatted(escapeQuotes(policyCondition.getValue()));
+        final String value = policyCondition.getValue();
 
-        if (policyCondition.getOperator() == PolicyCondition.Operator.IS) {
-            return scriptSrc;
-        } else if (policyCondition.getOperator() == PolicyCondition.Operator.IS_NOT) {
-            return "!" + scriptSrc;
+        return switch (policyCondition.getOperator()) {
+            case IS -> """
+                    vulns.exists(v, v.id == "%s")
+                    """.formatted(escapeQuotes(value));
+            case IS_NOT -> """
+                    !vulns.exists(v, v.id == "%s")
+                    """.formatted(escapeQuotes(value));
+            case MATCHES -> """
+                    vulns.exists(v, v.id.matches("%s"))
+                    """.formatted(escapeQuotes(toRegex(value)));
+            case NO_MATCH -> """
+                    !vulns.exists(v, v.id.matches("%s"))
+                    """.formatted(escapeQuotes(toRegex(value)));
+            default -> null;
+        };
+    }
+
+    /**
+     * Normalizes a condition value into a regular expression, mirroring the behavior of
+     * {@code org.dependencytrack.policy.Matcher} in Dependency-Track v4. A bare {@code *}
+     * is treated as a wildcard ({@code .*}), and the pattern is anchored with {@code .*} on
+     * either end when it is not already anchored, so the match behaves as a substring match.
+     * This preserves the semantics the {@code MATCHES} / {@code NO_MATCH} operators had for
+     * vulnerability-id conditions in v4.
+     */
+    static String toRegex(final String conditionString) {
+        String regex = conditionString.replace("*", ".*").replace("..*", ".*");
+        if (!regex.startsWith("^") && !regex.startsWith(".*")) {
+            regex = ".*" + regex;
         }
-
-        return null;
+        if (!regex.endsWith("$") && !regex.endsWith(".*")) {
+            regex = regex + ".*";
+        }
+        return regex;
     }
 
 }

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/VulnerabilityIdConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/VulnerabilityIdConditionTest.java
@@ -45,7 +45,19 @@ public class VulnerabilityIdConditionTest extends PersistenceCapableTest {
                 // IS_NOT with exact match
                 new Object[]{PolicyCondition.Operator.IS_NOT, "CVE-123", "CVE-123", false},
                 // IS with quotes
-                new Object[]{PolicyCondition.Operator.IS, "\"CVE-123", "\"CVE-123", true}
+                new Object[]{PolicyCondition.Operator.IS, "\"CVE-123", "\"CVE-123", true},
+                // MATCHES with wildcard catches malware advisories (MAL-*)
+                new Object[]{PolicyCondition.Operator.MATCHES, "MAL-*", "MAL-2026-3463", true},
+                // MATCHES wildcard with no match
+                new Object[]{PolicyCondition.Operator.MATCHES, "MAL-*", "CVE-2026-1234", false},
+                // MATCHES with a plain regex (CVE-2024-*)
+                new Object[]{PolicyCondition.Operator.MATCHES, "CVE-2024-*", "CVE-2024-9999", true},
+                // MATCHES with a regular expression using alternation and char classes
+                new Object[]{PolicyCondition.Operator.MATCHES, "^CVE-202[34]-", "CVE-2023-1", true},
+                // NO_MATCH excludes allowlisted advisories via regex alternation
+                new Object[]{PolicyCondition.Operator.NO_MATCH, "(MAL-2026-(3463|3432)|MAL-2025-(5870|5869))", "MAL-2026-9999", true},
+                // NO_MATCH: allowlisted advisory produces no violation
+                new Object[]{PolicyCondition.Operator.NO_MATCH, "(MAL-2026-(3463|3432)|MAL-2025-(5870|5869))", "MAL-2026-3463", false}
         };
     }
 


### PR DESCRIPTION
### Description

The `VULNERABILITY_ID` policy condition currently supports only the `IS` and `IS_NOT` operators, which perform exact string equality against a vulnerability identifier. This change adds support for the `MATCHES` and `NO_MATCH` operators to the same condition, allowing a single condition to match a family of vulnerability IDs.

The condition value is normalized into a regular expression that mirrors the semantics already used by other regex-capable conditions (a bare `*` is treated as a wildcard, and the pattern is anchored with `.*` so it behaves as a substring match), then evaluated via CEL's `matches()` function. `IS` / `IS_NOT` are unchanged and retain exact-match behavior.

This enables policies such as "Vulnerability ID matches `MAL-*`" to flag every malware advisory, optionally paired with a `NO_MATCH` condition to allowlist specific identifiers.

The corresponding frontend change (operator options + syntax tooltip) is [submitted](https://github.com/DependencyTrack/frontend/pull/1653) separately against DependencyTrack/frontend.

<img width="1697" height="672" alt="image" src="https://github.com/user-attachments/assets/d0db319e-b3e1-47db-852b-65ada5f5148b" />


### Addressed Issue
N/A

### Additional Details

The change is isolated to `VulnerabilityIdCelPolicyScriptSourceBuilder`. The glob-to-regex normalization is intentionally kept identical to the historic `Matcher` behavior so operators that relied on it in prior versions produce the same results. No database model, enum, or API surface changes are required — `MATCHES` / `NO_MATCH` already exist in `PolicyCondition.Operator`.

Note: This was originally implemented by Ankit for internal use

### Checklist

- [x] I have read and understand the [contributing guidelines]
- ~[ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~[ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- ~[ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~
