### PR TITLE
Add JVN (Japan Vulnerability Notes) vulnerability data source

### DIFF
--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -224,6 +224,11 @@
         </dependency>
         <dependency>
             <groupId>org.dependencytrack</groupId>
+            <artifactId>vuln-data-source-jvn</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
             <artifactId>vuln-data-source-nvd</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -229,6 +229,11 @@
         </dependency>
         <dependency>
             <groupId>org.dependencytrack</groupId>
+            <artifactId>vuln-data-source-jvn</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
             <artifactId>vuln-data-source-nvd</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/apiserver/src/main/java/org/dependencytrack/model/Vulnerability.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/Vulnerability.java
@@ -133,6 +133,7 @@ public class Vulnerability implements Serializable {
         INTERNAL, // Internally-managed (and manually entered) vulnerability
         OSV,      // Google OSV Advisories
         SNYK,     // Snyk Purl Vulnerability
+        JVN,      // Japan Vulnerability Notes (JVN iPedia)
         UNKNOWN;  // Unknown vulnerability sources
 
         public static boolean isKnownSource(String source) {

--- a/apiserver/src/main/java/org/dependencytrack/model/Vulnerability.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/Vulnerability.java
@@ -134,6 +134,7 @@ public class Vulnerability implements Serializable {
         OSV,      // Google OSV Advisories
         SNYK,     // Snyk Purl Vulnerability
         CX,       // Checkmarx
+        JVN,      // Japan Vulnerability Notes (JVN iPedia)
         UNKNOWN;  // Unknown vulnerability sources
 
         public static boolean isKnownSource(String source) {

--- a/apiserver/src/test/java/org/dependencytrack/plugin/PluginInitializerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/plugin/PluginInitializerTest.java
@@ -36,6 +36,7 @@ import org.dependencytrack.vulnanalysis.snyk.SnykVulnAnalyzerPlugin;
 import org.dependencytrack.vulnanalysis.trivy.TrivyVulnAnalyzerPlugin;
 import org.dependencytrack.vulnanalysis.vulndb.VulnDbVulnAnalyzerPlugin;
 import org.dependencytrack.vulndatasource.github.GitHubVulnDataSourcePlugin;
+import org.dependencytrack.vulndatasource.jvn.JvnVulnDataSourcePlugin;
 import org.dependencytrack.vulndatasource.nvd.NvdVulnDataSourcePlugin;
 import org.dependencytrack.vulndatasource.osv.OsvVulnDataSourcePlugin;
 import org.eclipse.microprofile.config.Config;
@@ -103,6 +104,7 @@ class PluginInitializerTest extends PersistenceCapableTest {
                 plugin -> assertThat(plugin).isInstanceOf(DefaultPackageMetadataResolutionPlugin.class),
                 plugin -> assertThat(plugin).isInstanceOf(GitHubVulnDataSourcePlugin.class),
                 plugin -> assertThat(plugin).isInstanceOf(InternalVulnAnalyzerPlugin.class),
+                plugin -> assertThat(plugin).isInstanceOf(JvnVulnDataSourcePlugin.class),
                 plugin -> assertThat(plugin).isInstanceOf(NvdVulnDataSourcePlugin.class),
                 plugin -> assertThat(plugin).isInstanceOf(OssIndexVulnAnalyzerPlugin.class),
                 plugin -> assertThat(plugin).isInstanceOf(OsvVulnDataSourcePlugin.class),

--- a/apiserver/src/test/java/org/dependencytrack/plugin/PluginInitializerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/plugin/PluginInitializerTest.java
@@ -37,6 +37,7 @@ import org.dependencytrack.vulnanalysis.snyk.SnykVulnAnalyzerPlugin;
 import org.dependencytrack.vulnanalysis.trivy.TrivyVulnAnalyzerPlugin;
 import org.dependencytrack.vulnanalysis.vulndb.VulnDbVulnAnalyzerPlugin;
 import org.dependencytrack.vulndatasource.github.GitHubVulnDataSourcePlugin;
+import org.dependencytrack.vulndatasource.jvn.JvnVulnDataSourcePlugin;
 import org.dependencytrack.vulndatasource.nvd.NvdVulnDataSourcePlugin;
 import org.dependencytrack.vulndatasource.osv.OsvVulnDataSourcePlugin;
 import org.eclipse.microprofile.config.Config;
@@ -105,6 +106,7 @@ class PluginInitializerTest extends PersistenceCapableTest {
                 plugin -> assertThat(plugin).isInstanceOf(DefaultPackageMetadataResolutionPlugin.class),
                 plugin -> assertThat(plugin).isInstanceOf(GitHubVulnDataSourcePlugin.class),
                 plugin -> assertThat(plugin).isInstanceOf(InternalVulnAnalyzerPlugin.class),
+                plugin -> assertThat(plugin).isInstanceOf(JvnVulnDataSourcePlugin.class),
                 plugin -> assertThat(plugin).isInstanceOf(NvdVulnDataSourcePlugin.class),
                 plugin -> assertThat(plugin).isInstanceOf(OssIndexVulnAnalyzerPlugin.class),
                 plugin -> assertThat(plugin).isInstanceOf(OsvVulnDataSourcePlugin.class),

--- a/docs/adr/031-jvn-vulnerability-data-source.md
+++ b/docs/adr/031-jvn-vulnerability-data-source.md
@@ -1,0 +1,120 @@
+| Status   | Date       | Author(s)                                                      |
+|:---------|:-----------|:---------------------------------------------------------------|
+| Proposed | 2026-07-08 | [@mitsukado-shinagawa](https://github.com/mitsukado-shinagawa) |
+
+## Context
+
+Dependency-Track mirrors vulnerability intelligence from the NVD, GitHub Advisories, and OSV
+(see [ADR-010](./010-vulnerability-datasource-extension-point.md)). None of these cover the
+[Japan Vulnerability Notes (JVN) / JVN iPedia](https://jvndb.jvn.jp/) database operated by
+JPCERT/CC and IPA.
+
+Organizations operating in Japan run software — both domestic-vendor products (e.g. Hitachi
+Cosminexus) and internationally-distributed products (e.g. Cisco) — for which JVN publishes
+vulnerability information, sometimes ahead of, or in addition to, the NVD. Users have asked
+whether JVN data can be mirrored into Dependency-Track the same way the NVD is, so that
+CPE-based matching (`InternalVulnAnalyzer`) can flag affected components.
+
+Before committing to an implementation, a PoC measured the machine-readability of the JVN data
+over the **50 most recently published JVNDB entries** (2026-07-07):
+
+| Metric                              | Result       | Interpretation                                   |
+|:------------------------------------|:-------------|:--------------------------------------------------|
+| Entries carrying a CPE              | 100% (50/50) | Matching substrate is essentially always present  |
+| CPE encoding                        | 100% CPE 2.2 | Must be converted to CPE 2.3 for storage          |
+| CPE + resolvable version            | 94% (47/50)  | Upper bound on precise (range) CPE matching        |
+| Entries carrying a CVE ID           | 96% (48/50)  | Heavy overlap with the NVD                         |
+| JVN-only (no CVE ID)                | 4% (2/50)    | The genuinely additive coverage                   |
+
+Three findings dominate the design:
+
+1. **Versions are not in the CPE.** Every sampled CPE was product-level
+   (`cpe:/a:suse:rancher_fleet`), with the affected version carried in a *separate*,
+   free-text Japanese field (`VersionNumber`, e.g. `"0.15.0 以上 0.15.2 未満"` or `"25.3.3.1"`).
+   Storing the CPE alone yields all-versions (product-level) matches — false positives.
+   Precise matching requires **parsing the Japanese version expressions**
+   (`以上`→`>=`, `以下`→`<=`, `未満`→`<`, `より前`→`<`, exact → `=`) into `vers` ranges,
+   which `BovModelConverter` already turns into `versionStart/End{Including,Excluding}`.
+
+2. **96% of entries duplicate the NVD.** For CVE-carrying entries the NVD is the authoritative
+   source with better-structured version ranges. Per
+   [`VulnerabilityUpdatePolicy`](../../apiserver/src/main/java/org/dependencytrack/vulnanalysis/VulnerabilityUpdatePolicy.java),
+   a non-authoritative data source cannot overwrite a vulnerability owned by an enabled
+   authoritative source, so a JVN source cannot "enrich" an NVD-owned CVE through the standard
+   mirror path. The unique, durable value of JVN is the **~4% JVN-only advisories**
+   (domestic-vendor products, `JVN#`/`JVNVU` without a CVE) plus Japanese-language descriptions
+   and publication timeliness — **not** blanket coverage of already-CVE'd products.
+
+3. **The MyJVN query API cannot backfill history.** MyJVN's `getVulnOverviewList` caps at the
+   ~747 most-recently-published advisories regardless of the requested date range (measured
+   2026-07-08: `datePublicStart=2026-06-01`→731, `=2020-01-01`→747, `=2010-01-01`→747), and
+   bounded historical windows return `totalRes=0`. JVN however publishes **yearly detail feeds**
+   (`.../ja/feed/detail/jvndb_detail_YYYY.rdf`, full history 1988–present) alongside a
+   `checksum.txt` manifest with a `sha256` per feed file. The feeds use the same VULDEF schema
+   as the API's detail responses, and are the acquisition channel used by
+   [vulsio/go-cve-dictionary](https://github.com/vulsio/go-cve-dictionary) (Vuls).
+
+## Decision
+
+Add a `jvn` module under `vuln-data-source/`, implementing the `VulnDataSource` extension point
+of [ADR-010](./010-vulnerability-datasource-extension-point.md), disabled by default. It
+exchanges data as CycloneDX BOVs, reusing the existing mirror pipeline
+(`MirrorVulnDataSourceWorkflow` → `BovModelConverter` → `VulnerableSoftware`), so no changes to
+ingestion, storage, or matching are required.
+
+Scope and behavior:
+
+* **Fetch.** Download the yearly detail feeds `jvndb_detail_YYYY.rdf` for
+  `startYear..currentYear`, skipping years whose `sha256` in `checksum.txt` is unchanged since
+  the last successful run (feed-digest checkpoint in the plugin KV store, mirroring the NVD
+  data source's checkpointing). A failed year is not checkpointed and is retried on the next run.
+* **CPE normalization.** Convert CPE 2.2 URIs to CPE 2.3 formatted strings before emitting them
+  on BOV `affects` components.
+* **Version parsing.** Translate the `VersionNumber` free-text field into `vers` ranges. When no
+  version expression can be parsed for a product, fall back to an all-versions (wildcard) range —
+  the product *is* declared affected by JVN, and this matches how product-level CPEs from the NVD
+  behave — rather than silently dropping the product.
+* **Source identity.** Emit **every** advisory under a new `JVN` source with its
+  `JVNDB-YYYY-NNNNNN` identifier — no CVE→NVD routing and no NVD duplicate check. JVN is stored
+  as-is, like the NVD source; JVN and NVD records for the same CVE coexist.
+
+  *Considered alternative:* emit CVE-carrying advisories under the CVE / NVD identity and reserve
+  the `JVN` source for CVE-less entries, avoiding duplicate records. Rejected because the NVD
+  remains authoritative for those CVEs anyway (`VulnerabilityUpdatePolicy` prevents JVN from
+  updating them once NVD publishes), so the JVN detail — Japanese descriptions, JVN's own version
+  ranges, JVN references — would be unreachable; and because "the JVN record you see is exactly
+  what JVN published" is easier to reason about operationally. The cost is accepted, documented
+  duplication (see Consequences).
+* **Configuration.** `enabled` (default `false`), `feedBaseUrl`
+  (default `https://jvndb.jvn.jp/ja/feed`), `startYear` (default `1998`, the beginning of
+  JVN iPedia data).
+* **`Vulnerability.Source` registration.** A data source that emits its own source identity must
+  be registered in the `org.dependencytrack.model.Vulnerability.Source` enum: the mirror derives
+  the source name from the data source name (`VulnDataSourceMirrorService` upper-cases it, `jvn`
+  → `JVN`) and validates it via `Source.ofName(...)` in `MirrorVulnDataSourceActivity`; an
+  unregistered name fails the whole mirror run. `BovModelConverter` likewise resolves the BOV's
+  source via `Source.ofName`. Adding `JVN` to the enum is therefore part of this change.
+
+## Consequences
+
+* Users can detect JVN advisories (notably for domestic-vendor products and JVN-only entries)
+  via the same CPE matching they already use, by registering the affected product as a component
+  with its CPE.
+* No new persistence, ingestion, or matching code — apart from the one-line `Source` enum entry,
+  the change is isolated to one new module.
+* **Full-history storage and intentional duplication.** Mirroring all years stores tens of
+  thousands of `JVN`-sourced vulnerabilities, and CVE-carrying advisories produce a `JVN` record
+  alongside the NVD's `CVE-*` record — a component may be flagged by both. This duplication is
+  an accepted trade-off for complete, self-contained JVN coverage. The first full backfill
+  downloads all yearly feeds; subsequent runs only re-fetch years whose `checksum.txt` `sha256`
+  changed.
+* A **Japanese version-expression parser** becomes a maintained component; its coverage caps
+  matching precision, and un-parseable expressions degrade to all-versions matches. This parser
+  is the primary implementation and maintenance risk.
+* CPE string alignment between JVN and the NVD/user-registered components is assumed; entries
+  with non-concrete CPEs (e.g. `cpe:/a:misc:multiple_vendors`) will not match and are dropped.
+* For internationally-covered products (e.g. Cisco), this adds little over the existing NVD
+  source; the value is realized on domestic-vendor and JVN-only entries.
+* Prior art exists for the *architecture* (fetch JVN feeds → local DB → CPE match) in
+  [vulsio/go-cve-dictionary](https://github.com/vulsio/go-cve-dictionary), but not within
+  Dependency-Track; this would be the first such integration.

--- a/docs/adr/036-jvn-vulnerability-data-source.md
+++ b/docs/adr/036-jvn-vulnerability-data-source.md
@@ -68,6 +68,8 @@ Scope and behavior:
   `startYear..currentYear`, skipping years whose `sha256` in `checksum.txt` is unchanged since
   the last successful run (feed-digest checkpoint in the plugin KV store, mirroring the NVD
   data source's checkpointing). A failed year is not checkpointed and is retried on the next run.
+  Each feed is downloaded to a temporary file and parsed as a stream, one `<Vulinfo>` at a time —
+  again mirroring the NVD data source — so memory usage is independent of feed size.
 * **CPE normalization.** Convert CPE 2.2 URIs to CPE 2.3 formatted strings before emitting them
   on BOV `affects` components.
 * **Version parsing.** Translate the `VersionNumber` free-text field into `vers` ranges. When no

--- a/vuln-data-source/jvn/pom.xml
+++ b/vuln-data-source/jvn/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This file is part of Dependency-Track.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright (c) OWASP Foundation. All Rights Reserved.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.dependencytrack</groupId>
+        <artifactId>vuln-data-source-parent</artifactId>
+        <version>5.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>vuln-data-source-jvn</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Vulnerability Data Source :: JVN</name>
+
+    <properties>
+        <project.parentBaseDir>${project.basedir}/../..</project.parentBaseDir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
+            <artifactId>vuln-data-source-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
+            <artifactId>plugin-testing</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>us.springett</groupId>
+            <artifactId>cpe-parser</artifactId>
+        </dependency>
+
+        <!-- Required at compile time by the jsonschema2pojo-generated config class. -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <!-- Parses the JVN feed checksum.txt manifest; provided at runtime by Dependency-Track. -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.nscuro</groupId>
+            <artifactId>versatile-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jsonschema2pojo</groupId>
+                <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sourceDirectory>${basedir}/src/main/resources/org/dependencytrack/vulndatasource/jvn</sourceDirectory>
+                    <targetPackage>org.dependencytrack.vulndatasource.jvn</targetPackage>
+                    <generateBuilders>true</generateBuilders>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnAdvisory.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnAdvisory.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource.jvn;
+
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * A parsed JVN advisory, as returned by the MyJVN {@code getVulnDetailInfo} API.
+ *
+ * @since 5.1.0
+ */
+record JvnAdvisory(
+        String jvnDbId,
+        @Nullable String title,
+        @Nullable String overview,
+        @Nullable String detail,
+        @Nullable String recommendation,
+        List<String> cveIds,
+        List<Integer> cweIds,
+        List<Cvss> cvssList,
+        List<AffectedProduct> affected,
+        List<String> referenceUrls,
+        @Nullable Instant datePublic,
+        @Nullable Instant dateLastUpdated) {
+
+    /** An affected product: a single (product-level) CPE plus its Japanese version expressions. */
+    record AffectedProduct(
+            @Nullable String vendor,
+            @Nullable String productName,
+            String cpe22,
+            List<String> versionTexts) {
+    }
+
+    /** A CVSS rating attached to the advisory. */
+    record Cvss(
+            @Nullable String version,
+            @Nullable String severity,
+            @Nullable Double baseScore,
+            @Nullable String vector) {
+    }
+}

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnAdvisory.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnAdvisory.java
@@ -34,7 +34,6 @@ record JvnAdvisory(
         @Nullable String overview,
         @Nullable String detail,
         @Nullable String recommendation,
-        List<String> cveIds,
         List<Integer> cweIds,
         List<Cvss> cvssList,
         List<AffectedProduct> affected,

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnAdvisorySource.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnAdvisorySource.java
@@ -1,0 +1,152 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource.jvn;
+
+import org.jspecify.annotations.Nullable;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.XMLConstants;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.stax.StAXSource;
+import java.io.BufferedInputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Streams the {@code <Vulinfo>} entries of a VULDEF detail feed, materializing one
+ * {@link JvnAdvisory} at a time to keep the memory footprint independent of the feed size.
+ * <p>
+ * A StAX cursor scans for {@code Vulinfo} start elements; each matched subtree — a few KB —
+ * is copied into a small DOM fragment and handed to {@link JvnDetailParser#parseVulinfo(Element)},
+ * so the per-field extraction logic is shared with no whole-document DOM ever being built.
+ *
+ * @since 5.1.0
+ */
+final class JvnAdvisorySource implements Iterator<JvnAdvisory>, Closeable {
+
+    private final InputStream inputStream;
+    private final XMLStreamReader xmlReader;
+    private final Transformer transformer;
+    private @Nullable JvnAdvisory nextAdvisory;
+
+    JvnAdvisorySource(final InputStream inputStream) throws IOException {
+        this.inputStream = inputStream;
+        try {
+            final XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+            inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+            inputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+            inputFactory.setProperty(XMLInputFactory.IS_COALESCING, true);
+            this.xmlReader = inputFactory.createXMLStreamReader(inputStream);
+
+            final TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+            this.transformer = transformerFactory.newTransformer();
+        } catch (XMLStreamException | TransformerException | RuntimeException e) {
+            try {
+                inputStream.close();
+            } catch (IOException closeException) {
+                e.addSuppressed(closeException);
+            }
+            throw new IOException("Failed to open JVN detail feed", e);
+        }
+    }
+
+    /**
+     * Opens a downloaded feed file for streaming; the file is deleted once the source is closed.
+     */
+    static JvnAdvisorySource open(final Path feedFilePath) throws IOException {
+        return new JvnAdvisorySource(new BufferedInputStream(
+                Files.newInputStream(feedFilePath, StandardOpenOption.DELETE_ON_CLOSE)));
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (nextAdvisory == null) {
+            nextAdvisory = advance();
+        }
+        return nextAdvisory != null;
+    }
+
+    @Override
+    public JvnAdvisory next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        final JvnAdvisory advisory = requireNonNull(nextAdvisory);
+        nextAdvisory = null;
+        return advisory;
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            xmlReader.close();
+        } catch (XMLStreamException e) {
+            throw new IOException("Failed to close JVN detail feed reader", e);
+        } finally {
+            inputStream.close();
+        }
+    }
+
+    private @Nullable JvnAdvisory advance() {
+        try {
+            while (true) {
+                final int event = xmlReader.getEventType();
+                if (event == XMLStreamConstants.START_ELEMENT
+                        && "Vulinfo".equals(xmlReader.getLocalName())) {
+                    // The identity transform consumes the reader through the matching end element
+                    // plus one further event, so the loop must re-examine the current event rather
+                    // than advancing — an immediately following <Vulinfo> would be skipped otherwise.
+                    final var domResult = new DOMResult();
+                    transformer.transform(new StAXSource(xmlReader), domResult);
+                    final Element vulinfo = ((Document) domResult.getNode()).getDocumentElement();
+                    final JvnAdvisory advisory = JvnDetailParser.parseVulinfo(vulinfo);
+                    if (advisory != null) {
+                        return advisory;
+                    }
+                    continue;
+                }
+                if (event == XMLStreamConstants.END_DOCUMENT || !xmlReader.hasNext()) {
+                    return null;
+                }
+                xmlReader.next();
+            }
+        } catch (XMLStreamException | TransformerException e) {
+            throw new IllegalArgumentException("Failed to parse JVN detail XML", e);
+        }
+    }
+}

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnClient.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnClient.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource.jvn;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A thin client for the JVN data feeds published under {@code https://jvndb.jvn.jp/ja/feed}.
+ * <p>
+ * Fetches the per-year detail feeds ({@code detail/jvndb_detail_YYYY.rdf}, full history 1988–present)
+ * and the {@code checksum.txt} manifest used to skip years whose feed has not changed. This is the
+ * same acquisition strategy used by go-cve-dictionary / Vuls, and — unlike the MyJVN
+ * {@code getVulnOverviewList} API — is not capped to the most-recent advisories.
+ *
+ * @since 5.1.0
+ */
+final class JvnClient {
+
+    static final String DEFAULT_FEED_BASE_URL = "https://jvndb.jvn.jp/ja/feed";
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private final HttpClient httpClient;
+    private final String feedBaseUrl;
+
+    JvnClient(final HttpClient httpClient, final String feedBaseUrl) {
+        this.httpClient = httpClient;
+        this.feedBaseUrl = feedBaseUrl.endsWith("/")
+                ? feedBaseUrl.substring(0, feedBaseUrl.length() - 1)
+                : feedBaseUrl;
+    }
+
+    /** Downloads the full detail feed (a VULDEF document) for a single publication year. */
+    byte[] fetchDetailFeed(final int year) throws IOException, InterruptedException {
+        return get(feedBaseUrl + "/detail/" + detailFeedFilename(year));
+    }
+
+    /**
+     * Fetches {@code checksum.txt} and returns a map of feed filename to its {@code sha256} digest,
+     * so callers can skip re-downloading years whose feed is unchanged since the last run.
+     */
+    Map<String, String> fetchChecksums() throws IOException, InterruptedException {
+        final JsonNode array = JSON.readTree(get(feedBaseUrl + "/checksum.txt"));
+        final Map<String, String> digestByFilename = new HashMap<>();
+        if (array.isArray()) {
+            for (final JsonNode entry : array) {
+                final String filename = entry.path("filename").asText(null);
+                final String sha256 = entry.path("sha256").asText(null);
+                if (filename != null && sha256 != null) {
+                    digestByFilename.put(filename, sha256);
+                }
+            }
+        }
+        return digestByFilename;
+    }
+
+    /** The {@code checksum.txt} filename for a year's detail feed (e.g. {@code jvndb_detail_2015.rdf}). */
+    static String detailFeedFilename(final int year) {
+        return "jvndb_detail_" + year + ".rdf";
+    }
+
+    String feedBaseUrl() {
+        return feedBaseUrl;
+    }
+
+    private byte[] get(final String url) throws IOException, InterruptedException {
+        final HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(60))
+                .header("User-Agent", "Dependency-Track JVN data source")
+                .GET()
+                .build();
+        final HttpResponse<byte[]> response = httpClient.send(request, BodyHandlers.ofByteArray());
+        if (response.statusCode() != 200) {
+            throw new IOException("Unexpected response code " + response.statusCode()
+                    + " from JVN feed: " + url);
+        }
+        return response.body();
+    }
+}

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnClient.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnClient.java
@@ -20,6 +20,8 @@ package org.dependencytrack.vulndatasource.jvn;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
@@ -27,6 +29,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,7 +49,10 @@ final class JvnClient {
 
     static final String DEFAULT_FEED_BASE_URL = "https://jvndb.jvn.jp/ja/feed";
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(JvnClient.class);
     private static final ObjectMapper JSON = new ObjectMapper();
+    private static final Duration FEED_REQUEST_TIMEOUT = Duration.ofMinutes(10);
+    private static final Duration CHECKSUM_REQUEST_TIMEOUT = Duration.ofSeconds(60);
 
     private final HttpClient httpClient;
     private final String feedBaseUrl;
@@ -57,9 +64,31 @@ final class JvnClient {
                 : feedBaseUrl;
     }
 
-    /** Downloads the full detail feed (a VULDEF document) for a single publication year. */
-    byte[] fetchDetailFeed(final int year) throws IOException, InterruptedException {
-        return get(feedBaseUrl + "/detail/" + detailFeedFilename(year));
+    /**
+     * Downloads the full detail feed (a VULDEF document) for a single publication year to a
+     * temporary file, so the feed is never buffered on the heap. The caller owns the returned
+     * file and is responsible for deleting it.
+     */
+    Path downloadDetailFeed(final int year) throws IOException, InterruptedException {
+        final String url = feedBaseUrl + "/detail/" + detailFeedFilename(year);
+        final HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(FEED_REQUEST_TIMEOUT)
+                .GET()
+                .build();
+        final Path tempFile = Files.createTempFile(null, null);
+        try {
+            final HttpResponse<Path> response = httpClient.send(request, BodyHandlers.ofFile(tempFile));
+            if (response.statusCode() != 200) {
+                // BodyHandlers.ofFile writes the error body to the file as well.
+                throw new IOException("Unexpected response code " + response.statusCode()
+                        + " from JVN feed: " + url);
+            }
+            return response.body();
+        } catch (IOException | InterruptedException | RuntimeException e) {
+            tryDelete(tempFile);
+            throw e;
+        }
     }
 
     /**
@@ -93,8 +122,7 @@ final class JvnClient {
     private byte[] get(final String url) throws IOException, InterruptedException {
         final HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(url))
-                .timeout(Duration.ofSeconds(60))
-                .header("User-Agent", "Dependency-Track JVN data source")
+                .timeout(CHECKSUM_REQUEST_TIMEOUT)
                 .GET()
                 .build();
         final HttpResponse<byte[]> response = httpClient.send(request, BodyHandlers.ofByteArray());
@@ -103,5 +131,13 @@ final class JvnClient {
                     + " from JVN feed: " + url);
         }
         return response.body();
+    }
+
+    private static void tryDelete(final Path filePath) {
+        try {
+            Files.deleteIfExists(filePath);
+        } catch (IOException e) {
+            LOGGER.warn("Failed to delete temp file {}", filePath, e);
+        }
     }
 }

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnDetailParser.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnDetailParser.java
@@ -1,0 +1,304 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource.jvn;
+
+import org.jspecify.annotations.Nullable;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Parses the XML returned by the MyJVN {@code getVulnDetailInfo} API into a {@link JvnAdvisory}.
+ * <p>
+ * Uses namespace-agnostic local-name matching, since the VULDEF document mixes several XML
+ * namespaces ({@code vuldef}, {@code sec}, {@code marking}, ...).
+ *
+ * @since 5.1.0
+ */
+final class JvnDetailParser {
+
+    private static final Pattern CVE_ID = Pattern.compile("CVE-\\d{4}-\\d{4,}");
+    private static final Pattern CWE_ID = Pattern.compile("CWE-(\\d+)");
+
+    private JvnDetailParser() {
+    }
+
+    static List<JvnAdvisory> parse(final byte[] xml) {
+        return parse(new ByteArrayInputStream(xml));
+    }
+
+    static List<JvnAdvisory> parse(final InputStream xml) {
+        final Document document = parseDocument(xml);
+        final var advisories = new ArrayList<JvnAdvisory>();
+        for (final Element vulinfo : childElementsByLocalName(document.getDocumentElement(), "Vulinfo")) {
+            final JvnAdvisory advisory = parseVulinfo(vulinfo);
+            if (advisory != null) {
+                advisories.add(advisory);
+            }
+        }
+        return advisories;
+    }
+
+    private static @Nullable JvnAdvisory parseVulinfo(final Element vulinfo) {
+        final String jvnDbId = firstText(vulinfo, "VulinfoID");
+        if (jvnDbId == null || jvnDbId.isBlank()) {
+            return null;
+        }
+
+        final Element data = firstElement(vulinfo, "VulinfoData");
+        final String title = data != null ? firstText(data, "Title") : null;
+        // <Overview> is nested inside <VulinfoData><VulinfoDescription>, not a direct child of
+        // VulinfoData, so it must be located via a descendant search (not firstText).
+        final String overview = data != null ? firstDescendantText(data, "Overview") : null;
+        // <Impact><ImpactItem><Description> is the detailed impact text (rendered as the UI's
+        // "Details" field); <Solution><SolutionItem><Description> is the countermeasure (the UI's
+        // "Recommendation"). Navigate the section explicitly so the unrelated <HistoryItem>
+        // <Description> is not picked up.
+        final String detail = data != null ? joinItemDescriptions(data, "Impact", "ImpactItem") : null;
+        final String recommendation =
+                data != null ? joinItemDescriptions(data, "Solution", "SolutionItem") : null;
+
+        final var cveIds = new ArrayList<String>();
+        final var cweIds = new ArrayList<Integer>();
+        final var referenceUrls = new ArrayList<String>();
+        for (final Element related : descendantsByLocalName(vulinfo, "RelatedItem")) {
+            final String id = firstText(related, "VulinfoID");
+            // CWE weaknesses are carried as <RelatedItem type="cwe"> whose VulinfoID is e.g.
+            // "CWE-78". Collect the numeric id, and skip its <URL> — a JVN CWE glossary link, not
+            // an advisory reference.
+            final Integer cwe = parseCweId(id);
+            if ("cwe".equalsIgnoreCase(attr(related, "type")) || cwe != null) {
+                if (cwe != null && !cweIds.contains(cwe)) {
+                    cweIds.add(cwe);
+                }
+                continue;
+            }
+            if (id != null && CVE_ID.matcher(id).matches() && !cveIds.contains(id)) {
+                cveIds.add(id);
+            }
+            final String url = firstText(related, "URL");
+            if (url != null && !url.isBlank() && !referenceUrls.contains(url)) {
+                referenceUrls.add(url);
+            }
+        }
+
+        final var affected = new ArrayList<JvnAdvisory.AffectedProduct>();
+        for (final Element item : descendantsByLocalName(vulinfo, "AffectedItem")) {
+            final String cpe = firstText(item, "Cpe");
+            if (cpe == null || cpe.isBlank()) {
+                continue;
+            }
+            final var versionTexts = new ArrayList<String>();
+            for (final Element vn : childElementsByLocalName(item, "VersionNumber")) {
+                final String text = textOf(vn);
+                if (text != null && !text.isBlank()) {
+                    versionTexts.add(text.trim());
+                }
+            }
+            affected.add(new JvnAdvisory.AffectedProduct(
+                    firstText(item, "Name"),
+                    firstText(item, "ProductName"),
+                    cpe.trim(),
+                    List.copyOf(versionTexts)));
+        }
+
+        final var cvssList = new ArrayList<JvnAdvisory.Cvss>();
+        for (final Element cvss : descendantsByLocalName(vulinfo, "Cvss")) {
+            cvssList.add(new JvnAdvisory.Cvss(
+                    attr(cvss, "version"),
+                    firstText(cvss, "Severity"),
+                    parseDouble(firstText(cvss, "Base")),
+                    firstText(cvss, "Vector")));
+        }
+
+        return new JvnAdvisory(
+                jvnDbId.trim(),
+                title,
+                overview,
+                detail,
+                recommendation,
+                List.copyOf(cveIds),
+                List.copyOf(cweIds),
+                List.copyOf(cvssList),
+                List.copyOf(affected),
+                List.copyOf(referenceUrls),
+                parseInstant(firstDescendantText(vulinfo, "DatePublic")),
+                parseInstant(firstDescendantText(vulinfo, "DateLastUpdated")));
+    }
+
+    // ---- DOM helpers (namespace-agnostic) ----
+
+    private static Document parseDocument(final InputStream xml) {
+        try {
+            final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            final DocumentBuilder builder = factory.newDocumentBuilder();
+            final Document document = builder.parse(new InputSource(xml));
+            document.getDocumentElement().normalize();
+            return document;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to parse JVN detail XML", e);
+        }
+    }
+
+    private static List<Element> childElementsByLocalName(final Element parent, final String localName) {
+        final var result = new ArrayList<Element>();
+        final NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            final Node node = children.item(i);
+            if (node.getNodeType() == Node.ELEMENT_NODE && localName.equals(node.getLocalName())) {
+                result.add((Element) node);
+            }
+        }
+        return result;
+    }
+
+    private static List<Element> descendantsByLocalName(final Element parent, final String localName) {
+        final var result = new ArrayList<Element>();
+        collectDescendants(parent, localName, result);
+        return result;
+    }
+
+    private static void collectDescendants(final Element parent, final String localName, final List<Element> out) {
+        final NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            final Node node = children.item(i);
+            if (node.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            final Element element = (Element) node;
+            if (localName.equals(element.getLocalName())) {
+                out.add(element);
+            }
+            collectDescendants(element, localName, out);
+        }
+    }
+
+    private static @Nullable Element firstElement(final Element parent, final String localName) {
+        final List<Element> elements = childElementsByLocalName(parent, localName);
+        return elements.isEmpty() ? null : elements.getFirst();
+    }
+
+    private static @Nullable String firstText(final Element parent, final String localName) {
+        final List<Element> direct = childElementsByLocalName(parent, localName);
+        if (!direct.isEmpty()) {
+            return textOf(direct.getFirst());
+        }
+        return null;
+    }
+
+    private static @Nullable String firstDescendantText(final Element parent, final String localName) {
+        final List<Element> descendants = descendantsByLocalName(parent, localName);
+        return descendants.isEmpty() ? null : textOf(descendants.getFirst());
+    }
+
+    private static @Nullable String textOf(final @Nullable Element element) {
+        if (element == null) {
+            return null;
+        }
+        final String text = element.getTextContent();
+        return text == null ? null : text.trim();
+    }
+
+    private static @Nullable String attr(final Element element, final String name) {
+        final String value = element.getAttribute(name);
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    /**
+     * Joins the {@code <Description>} texts of every {@code <itemLocalName>} under the
+     * {@code <sectionLocalName>} child of {@code data} (e.g. Impact/ImpactItem or
+     * Solution/SolutionItem), or {@code null} if the section is absent or carries no description.
+     */
+    private static @Nullable String joinItemDescriptions(
+            final Element data, final String sectionLocalName, final String itemLocalName) {
+        final Element section = firstElement(data, sectionLocalName);
+        if (section == null) {
+            return null;
+        }
+        final var parts = new ArrayList<String>();
+        for (final Element item : childElementsByLocalName(section, itemLocalName)) {
+            final String description = firstText(item, "Description");
+            if (description != null && !description.isBlank() && !parts.contains(description)) {
+                parts.add(description);
+            }
+        }
+        return parts.isEmpty() ? null : String.join("\n\n", parts);
+    }
+
+    private static @Nullable Integer parseCweId(final @Nullable String value) {
+        if (value == null) {
+            return null;
+        }
+        final var matcher = CWE_ID.matcher(value.trim());
+        if (!matcher.matches()) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(matcher.group(1));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static @Nullable Double parseDouble(final @Nullable String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Double.parseDouble(value.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static @Nullable Instant parseInstant(final @Nullable String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return OffsetDateTime.parse(value.trim()).toInstant();
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+
+    static byte[] bytes(final String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnDetailParser.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnDetailParser.java
@@ -19,18 +19,12 @@
 package org.dependencytrack.vulndatasource.jvn;
 
 import org.jspecify.annotations.Nullable;
-import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
 
-import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
@@ -39,7 +33,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 /**
- * Parses the XML returned by the MyJVN {@code getVulnDetailInfo} API into a {@link JvnAdvisory}.
+ * Parses a single {@code <Vulinfo>} element of a VULDEF document into a {@link JvnAdvisory}.
  * <p>
  * Uses namespace-agnostic local-name matching, since the VULDEF document mixes several XML
  * namespaces ({@code vuldef}, {@code sec}, {@code marking}, ...).
@@ -48,29 +42,23 @@ import java.util.regex.Pattern;
  */
 final class JvnDetailParser {
 
-    private static final Pattern CVE_ID = Pattern.compile("CVE-\\d{4}-\\d{4,}");
     private static final Pattern CWE_ID = Pattern.compile("CWE-(\\d+)");
 
     private JvnDetailParser() {
     }
 
-    static List<JvnAdvisory> parse(final byte[] xml) {
-        return parse(new ByteArrayInputStream(xml));
-    }
-
+    /** Drains a whole feed into a list; intended for tests — production code streams instead. */
     static List<JvnAdvisory> parse(final InputStream xml) {
-        final Document document = parseDocument(xml);
-        final var advisories = new ArrayList<JvnAdvisory>();
-        for (final Element vulinfo : childElementsByLocalName(document.getDocumentElement(), "Vulinfo")) {
-            final JvnAdvisory advisory = parseVulinfo(vulinfo);
-            if (advisory != null) {
-                advisories.add(advisory);
-            }
+        try (final var source = new JvnAdvisorySource(xml)) {
+            final var advisories = new ArrayList<JvnAdvisory>();
+            source.forEachRemaining(advisories::add);
+            return advisories;
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to parse JVN detail XML", e);
         }
-        return advisories;
     }
 
-    private static @Nullable JvnAdvisory parseVulinfo(final Element vulinfo) {
+    static @Nullable JvnAdvisory parseVulinfo(final Element vulinfo) {
         final String jvnDbId = firstText(vulinfo, "VulinfoID");
         if (jvnDbId == null || jvnDbId.isBlank()) {
             return null;
@@ -89,7 +77,6 @@ final class JvnDetailParser {
         final String recommendation =
                 data != null ? joinItemDescriptions(data, "Solution", "SolutionItem") : null;
 
-        final var cveIds = new ArrayList<String>();
         final var cweIds = new ArrayList<Integer>();
         final var referenceUrls = new ArrayList<String>();
         for (final Element related : descendantsByLocalName(vulinfo, "RelatedItem")) {
@@ -103,9 +90,6 @@ final class JvnDetailParser {
                     cweIds.add(cwe);
                 }
                 continue;
-            }
-            if (id != null && CVE_ID.matcher(id).matches() && !cveIds.contains(id)) {
-                cveIds.add(id);
             }
             final String url = firstText(related, "URL");
             if (url != null && !url.isBlank() && !referenceUrls.contains(url)) {
@@ -148,7 +132,6 @@ final class JvnDetailParser {
                 overview,
                 detail,
                 recommendation,
-                List.copyOf(cveIds),
                 List.copyOf(cweIds),
                 List.copyOf(cvssList),
                 List.copyOf(affected),
@@ -158,23 +141,6 @@ final class JvnDetailParser {
     }
 
     // ---- DOM helpers (namespace-agnostic) ----
-
-    private static Document parseDocument(final InputStream xml) {
-        try {
-            final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            factory.setNamespaceAware(true);
-            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-            final DocumentBuilder builder = factory.newDocumentBuilder();
-            final Document document = builder.parse(new InputSource(xml));
-            document.getDocumentElement().normalize();
-            return document;
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Failed to parse JVN detail XML", e);
-        }
-    }
 
     private static List<Element> childElementsByLocalName(final Element parent, final String localName) {
         final var result = new ArrayList<Element>();
@@ -296,9 +262,5 @@ final class JvnDetailParser {
         } catch (DateTimeParseException e) {
             return null;
         }
-    }
-
-    static byte[] bytes(final String s) {
-        return s.getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnVersionParser.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnVersionParser.java
@@ -1,0 +1,269 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource.jvn;
+
+import io.github.nscuro.versatile.Comparator;
+import io.github.nscuro.versatile.Vers;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses JVN's free-text Japanese affected-version expressions (the {@code <VersionNumber>}
+ * field of a MyJVN {@code AffectedItem}) into a structured result usable for CPE range matching.
+ * <p>
+ * JVN encodes affected versions as natural-language Japanese text separate from the (product-level)
+ * CPE, so a precise range match requires translating that text into a {@code vers} range. This is
+ * the precision differentiator over go-cve-dictionary/Vuls, which leaves JVN matches at product
+ * level.
+ * <p>
+ * Supported forms (observed in real JVN data):
+ * <ul>
+ *   <li>{@code "X 未満"} / {@code "X より前"}          -&gt; &lt; X</li>
+ *   <li>{@code "X 以下"} / {@code "X 以前"}            -&gt; &lt;= X</li>
+ *   <li>{@code "X 以上"} / {@code "X 以降"}            -&gt; &gt;= X</li>
+ *   <li>{@code "X より後"} / {@code "X 超"}           -&gt; &gt; X</li>
+ *   <li>{@code "X 以上 Y 未満"}                        -&gt; &gt;= X, &lt; Y</li>
+ *   <li>{@code "X から Y"} / {@code "X 〜 Y"}          -&gt; &gt;= X, &lt;= Y</li>
+ *   <li>{@code "X およびそれ以前"}                     -&gt; &lt;= X</li>
+ *   <li>{@code "X"} (bare single version)            -&gt; exact</li>
+ *   <li>{@code "すべてのバージョン"}                   -&gt; all-versions range</li>
+ * </ul>
+ * Texts that fail to parse as-is get one salvage attempt with platform/edition qualifiers
+ * stripped ({@code "5.0 (client)"}, {@code "3 (x86-64)"}, {@code "Version 1809 for x64-based
+ * Systems"}, {@code "12.04 LTS"}, {@code "2013 SP1"} …) — NVD carries the same products with
+ * these qualifiers in separate CPE attributes (edition/update/target hardware), so dropping
+ * them from the version value matches NVD's representation. Only known qualifier vocabulary is
+ * stripped, and never from a text that already parsed, so no version value is ever invented.
+ * <p>
+ * Anything else (discrete lists, unrecognised wording) yields {@link Unparseable} so the
+ * caller can degrade to a product-level match rather than guess.
+ *
+ * @since 5.1.0
+ */
+public final class JvnVersionParser {
+
+    /** Outcome of parsing a JVN version expression. */
+    public sealed interface Result permits ExactVersion, VersionRange, Unparseable {
+    }
+
+    /** A single, exact affected version. */
+    public record ExactVersion(String version) implements Result {
+    }
+
+    /** A structured affected-version range. */
+    public record VersionRange(Vers vers) implements Result {
+    }
+
+    /** The expression could not be interpreted; caller should degrade to product-level. */
+    public record Unparseable(String reason) implements Result {
+    }
+
+    // A version token: starts with an alphanumeric, may contain '.', '_', '-' and alphanumerics.
+    // Covers semver (1.2.3), zero-padded (02.004.001.000) and Hitachi-style (11-40, 06-50-a).
+    private static final String V = "[0-9A-Za-z][0-9A-Za-z._-]*";
+
+    private static final Pattern GTE = Pattern.compile("(" + V + ")\\s*(?:以上|以降)");
+    private static final Pattern GT = Pattern.compile("(" + V + ")\\s*(?:より後|を超える|超)");
+    private static final Pattern LT = Pattern.compile("(" + V + ")\\s*(?:未満|より前)");
+    private static final Pattern LTE = Pattern.compile("(" + V + ")\\s*(?:以下|以前)");
+    private static final Pattern AND_BEFORE = Pattern.compile("(" + V + ")\\s*およびそれ以前");
+    private static final Pattern AND_AFTER = Pattern.compile("(" + V + ")\\s*およびそれ以降");
+    // "X から Y (まで)" or "X 〜 Y" (wave dash) — inclusive range.
+    private static final Pattern FROM_TO =
+            Pattern.compile("(" + V + ")\\s*(?:から|[〜～~])\\s*(" + V + ")\\s*(?:まで)?");
+    private static final Pattern SINGLE = Pattern.compile("^\\s*(" + V + ")\\s*$");
+    // Cisco-style version strings ("11.1(15)ca", "12.0(3.4)T1") carry a parenthesized build
+    // number inside the version. NVD stores these verbatim as CPE version values, so they are
+    // taken as exact versions rather than stripped.
+    private static final Pattern PAREN_BUILD_VERSION =
+            Pattern.compile("^\\s*(\\d[\\d.]*\\([0-9A-Za-z.]+\\)[0-9A-Za-z]*)\\s*$");
+
+    // JVN spells "all versions" out in Japanese instead of using a range expression.
+    private static final Pattern ALL_VERSIONS =
+            Pattern.compile("^(?:すべてのバージョン|全てのバージョン|全バージョン)$");
+
+    // Platform/edition/packaging words that JVN appends to version texts but that carry no
+    // version information (NVD encodes them in separate CPE attributes). Only these are
+    // eligible for salvage-stripping; anything else stays unparseable.
+    private static final String QUALIFIER_WORDS =
+            "x86(?:[-_]64)?|x64|amd64|ia64|arm64|itanium|sparc|client|server|desktop|workstation"
+                    + "|es|as|ws|core|editions?|installation|installed";
+    private static final Pattern TRAILING_PAREN_QUALIFIER = Pattern.compile(
+            "\\s*[（(][^（）()]*(?:\\b(?:" + QUALIFIER_WORDS + ")\\b"
+                    + "|ビット|エディション|インストール|販売|版)[^（）()]*[）)]\\s*$",
+            Pattern.CASE_INSENSITIVE);
+    // "… for x64-based Systems", "… for 32-bit systems SP2", "… for 64-bit editions".
+    private static final Pattern TRAILING_PLATFORM_PHRASE = Pattern.compile(
+            "\\s+for\\s+[\\w -]*(?:systems?|editions?)(\\s+SP\\d+)?\\s*$", Pattern.CASE_INSENSITIVE);
+    // Bare trailing qualifier tokens: "12.04 LTS", "11 Express", "2013 SP1", "2013 RT".
+    private static final Pattern TRAILING_QUALIFIER_TOKEN = Pattern.compile(
+            "\\s+(?:LTS|RT|Express|Gold|Editions?|SP\\d+)\\s*$", Pattern.CASE_INSENSITIVE);
+    // Leading qualifier words in front of the version value: "Version 1809" (left over after
+    // stripping "for x64-based Systems"), "- Standard Edition Version 4", "LTSC 2021".
+    private static final Pattern LEADING_QUALIFIER_WORDS = Pattern.compile(
+            "^[-\\s]*(?:(?:Standard|Web|Light|Professional|Enterprise|Datacenter|Core) )*"
+                    + "(?:Edition )?(?:Version |LTSC )",
+            Pattern.CASE_INSENSITIVE);
+
+    private JvnVersionParser() {
+    }
+
+    /**
+     * @param rawText The JVN {@code VersionNumber} text.
+     * @param scheme  The {@code vers} versioning scheme to build the range with
+     *                (typically {@code "generic"} for CPE-identified products).
+     * @return The parsed {@link Result}.
+     */
+    public static Result parse(final String rawText, final String scheme) {
+        if (rawText == null) {
+            return new Unparseable("null");
+        }
+
+        // Normalise full-width spaces and collapse whitespace.
+        final String text = rawText.replace('　', ' ').trim().replaceAll("\\s+", " ");
+        if (text.isEmpty()) {
+            return new Unparseable("empty");
+        }
+
+        if (ALL_VERSIONS.matcher(text).matches()) {
+            try {
+                return new VersionRange(Vers.builder(scheme)
+                        .withConstraint(Comparator.WILDCARD, null)
+                        .build());
+            } catch (RuntimeException e) {
+                return new Unparseable("vers build failed: " + e.getMessage());
+            }
+        }
+
+        final Result result = parseCore(text, scheme);
+        if (!(result instanceof Unparseable)) {
+            return result;
+        }
+
+        final String stripped = stripQualifiers(text);
+        if (!stripped.isEmpty() && !stripped.equals(text)) {
+            final Result salvaged = parseCore(stripped, scheme);
+            if (!(salvaged instanceof Unparseable)) {
+                return salvaged;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Removes trailing platform/edition qualifiers (and a leading {@code "Version "} left over
+     * after stripping) so texts like {@code "5.0 (client)"} or {@code "Version 1809 for
+     * x64-based Systems"} can be retried as plain version expressions. Returns the text
+     * unchanged when no known qualifier matches; may return an empty string when the text was
+     * nothing but qualifiers (e.g. {@code "(Server Core installation)"}).
+     */
+    private static String stripQualifiers(final String text) {
+        String current = text;
+        while (true) {
+            String next = TRAILING_PAREN_QUALIFIER.matcher(current).replaceFirst("");
+            next = TRAILING_PLATFORM_PHRASE.matcher(next).replaceFirst("");
+            next = TRAILING_QUALIFIER_TOKEN.matcher(next).replaceFirst("");
+            if (next.equals(current)) {
+                break;
+            }
+            current = next;
+        }
+        return LEADING_QUALIFIER_WORDS.matcher(current).replaceFirst("").trim();
+    }
+
+    private static Result parseCore(final String text, final String scheme) {
+        final Matcher single = SINGLE.matcher(text);
+        if (single.matches()) {
+            return new ExactVersion(single.group(1));
+        }
+        final Matcher parenBuild = PAREN_BUILD_VERSION.matcher(text);
+        if (parenBuild.matches()) {
+            return new ExactVersion(parenBuild.group(1));
+        }
+
+        String gte = null;
+        String gt = null;
+        String lte = null;
+        String lt = null;
+
+        final Matcher andBefore = AND_BEFORE.matcher(text);
+        if (andBefore.find()) {
+            lte = andBefore.group(1);
+        }
+        final Matcher andAfter = AND_AFTER.matcher(text);
+        if (andAfter.find()) {
+            gte = andAfter.group(1);
+        }
+
+        final Matcher fromTo = FROM_TO.matcher(text);
+        if (fromTo.find()) {
+            gte = fromTo.group(1);
+            lte = fromTo.group(2);
+        }
+
+        if (gte == null) {
+            final Matcher m = GTE.matcher(text);
+            if (m.find()) {
+                gte = m.group(1);
+            }
+        }
+        if (gt == null) {
+            final Matcher m = GT.matcher(text);
+            if (m.find()) {
+                gt = m.group(1);
+            }
+        }
+        if (lt == null) {
+            final Matcher m = LT.matcher(text);
+            if (m.find()) {
+                lt = m.group(1);
+            }
+        }
+        if (lte == null) {
+            final Matcher m = LTE.matcher(text);
+            if (m.find()) {
+                lte = m.group(1);
+            }
+        }
+
+        if (gte == null && gt == null && lte == null && lt == null) {
+            return new Unparseable("no recognised bound: " + text);
+        }
+
+        try {
+            final var builder = Vers.builder(scheme);
+            if (gte != null) {
+                builder.withConstraint(Comparator.GREATER_THAN_OR_EQUAL, gte);
+            }
+            if (gt != null) {
+                builder.withConstraint(Comparator.GREATER_THAN, gt);
+            }
+            if (lte != null) {
+                builder.withConstraint(Comparator.LESS_THAN_OR_EQUAL, lte);
+            }
+            if (lt != null) {
+                builder.withConstraint(Comparator.LESS_THAN, lt);
+            }
+            return new VersionRange(builder.build());
+        } catch (RuntimeException e) {
+            return new Unparseable("vers build failed: " + e.getMessage());
+        }
+    }
+}

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSource.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSource.java
@@ -1,0 +1,161 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource.jvn;
+
+import org.cyclonedx.proto.v1_7.Bom;
+import org.cyclonedx.proto.v1_7.Vulnerability;
+import org.dependencytrack.vulndatasource.api.VulnDataSource;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * A {@link VulnDataSource} for JVN (Japan Vulnerability Notes).
+ * <p>
+ * Mirrors the complete JVN history by downloading the yearly detail feeds
+ * ({@code jvndb_detail_YYYY.rdf}) for {@code startYear..endYear}, parsing every {@code <Vulinfo>}
+ * via {@link JvnDetailParser} and converting it to a CycloneDX BOV. Years whose feed digest
+ * ({@code sha256} from {@code checksum.txt}) is unchanged since the previous run are skipped.
+ *
+ * @since 5.1.0
+ */
+final class JvnVulnDataSource implements VulnDataSource {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JvnVulnDataSource.class);
+
+    private final JvnClient client;
+    private final WatermarkManager watermarkManager;
+    private final Deque<Integer> pendingYears = new ArrayDeque<>();
+    private final Deque<JvnAdvisory> advisoryBuffer = new ArrayDeque<>();
+
+    private @Nullable Map<String, String> feedDigestByFilename;
+    private boolean completedSuccessfully;
+    private @Nullable Bom nextBom;
+
+    JvnVulnDataSource(
+            final JvnClient client,
+            final WatermarkManager watermarkManager,
+            final int startYear,
+            final int endYear) {
+        this.client = client;
+        this.watermarkManager = watermarkManager;
+        for (int year = startYear; year <= endYear; year++) {
+            pendingYears.add(year);
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (nextBom != null) {
+            return true;
+        }
+
+        while (true) {
+            if (!advisoryBuffer.isEmpty()) {
+                nextBom = ModelConverter.convert(advisoryBuffer.poll());
+                return true;
+            }
+            if (pendingYears.isEmpty()) {
+                completedSuccessfully = true;
+                return false;
+            }
+            loadYear(pendingYears.poll());
+        }
+    }
+
+    @Override
+    public Bom next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        final Bom bom = nextBom;
+        nextBom = null;
+        return bom;
+    }
+
+    @Override
+    public void markProcessed(final Bom bov) {
+        if (bov.getVulnerabilitiesCount() == 0) {
+            return;
+        }
+        final Vulnerability vuln = bov.getVulnerabilities(0);
+        if (vuln.hasPublished()) {
+            watermarkManager.maybeAdvance(Instant.ofEpochSecond(
+                    vuln.getPublished().getSeconds(), vuln.getPublished().getNanos()));
+        }
+    }
+
+    @Override
+    public void close() {
+        // Persist the watermark and the digests of the years processed this run, but only on a full
+        // pass — an interrupted run must re-fetch the years it did not finish.
+        if (completedSuccessfully) {
+            watermarkManager.maybeCommit();
+        }
+    }
+
+    /** Fetches, parses and buffers a single year's detail feed, unless its checksum is unchanged. */
+    private void loadYear(final int year) {
+        final String filename = JvnClient.detailFeedFilename(year);
+        final @Nullable String digest = feedDigest(filename);
+        if (digest != null && digest.equals(watermarkManager.getCommittedFeedDigest(filename))) {
+            LOGGER.debug("JVN feed {} unchanged since last run; skipping", filename);
+            return;
+        }
+        try {
+            final List<JvnAdvisory> advisories = JvnDetailParser.parse(client.fetchDetailFeed(year));
+            advisoryBuffer.addAll(advisories);
+            // Record the digest only after a successful fetch+parse, so a failed year is retried.
+            if (digest != null) {
+                watermarkManager.recordFeedDigest(filename, digest);
+            }
+            LOGGER.info("Fetched {} JVN advisories from {}", advisories.size(), filename);
+        } catch (IOException e) {
+            LOGGER.warn("Failed to fetch JVN feed {}; skipping", filename, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (RuntimeException e) {
+            LOGGER.warn("Failed to parse JVN feed {}; skipping", filename, e);
+        }
+    }
+
+    /** The {@code checksum.txt} digest for {@code filename}, fetching the manifest lazily once per run. */
+    private @Nullable String feedDigest(final String filename) {
+        if (feedDigestByFilename == null) {
+            try {
+                feedDigestByFilename = client.fetchChecksums();
+            } catch (IOException e) {
+                LOGGER.warn("Failed to fetch JVN checksum.txt; feeds will not be skipped this run", e);
+                feedDigestByFilename = Map.of();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                feedDigestByFilename = Map.of();
+            }
+        }
+        return feedDigestByFilename.get(filename);
+    }
+}

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSource.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSource.java
@@ -26,20 +26,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A {@link VulnDataSource} for JVN (Japan Vulnerability Notes).
  * <p>
  * Mirrors the complete JVN history by downloading the yearly detail feeds
- * ({@code jvndb_detail_YYYY.rdf}) for {@code startYear..endYear}, parsing every {@code <Vulinfo>}
- * via {@link JvnDetailParser} and converting it to a CycloneDX BOV. Years whose feed digest
- * ({@code sha256} from {@code checksum.txt}) is unchanged since the previous run are skipped.
+ * ({@code jvndb_detail_YYYY.rdf}) for {@code startYear..endYear} to a temporary file and streaming
+ * one {@code <Vulinfo>} at a time via {@link JvnAdvisorySource}, converting each to a CycloneDX
+ * BOV. Years whose feed digest ({@code sha256} from {@code checksum.txt}) is unchanged since the
+ * previous run are skipped.
  *
  * @since 5.1.0
  */
@@ -50,11 +53,15 @@ final class JvnVulnDataSource implements VulnDataSource {
     private final JvnClient client;
     private final WatermarkManager watermarkManager;
     private final Deque<Integer> pendingYears = new ArrayDeque<>();
-    private final Deque<JvnAdvisory> advisoryBuffer = new ArrayDeque<>();
 
     private @Nullable Map<String, String> feedDigestByFilename;
     private boolean completedSuccessfully;
     private @Nullable Bom nextBom;
+
+    private @Nullable JvnAdvisorySource currentSource;
+    private @Nullable String currentFeedFilename;
+    private @Nullable String currentFeedDigest;
+    private int currentFeedAdvisoryCount;
 
     JvnVulnDataSource(
             final JvnClient client,
@@ -75,15 +82,20 @@ final class JvnVulnDataSource implements VulnDataSource {
         }
 
         while (true) {
-            if (!advisoryBuffer.isEmpty()) {
-                nextBom = ModelConverter.convert(advisoryBuffer.poll());
-                return true;
+            final JvnAdvisorySource source = currentSource;
+            if (source != null) {
+                final JvnAdvisory advisory = readAdvisory(source);
+                if (advisory != null) {
+                    nextBom = ModelConverter.convert(advisory);
+                    return true;
+                }
+                continue;
             }
             if (pendingYears.isEmpty()) {
                 completedSuccessfully = true;
                 return false;
             }
-            loadYear(pendingYears.poll());
+            openYear(pendingYears.poll());
         }
     }
 
@@ -92,7 +104,7 @@ final class JvnVulnDataSource implements VulnDataSource {
         if (!hasNext()) {
             throw new NoSuchElementException();
         }
-        final Bom bom = nextBom;
+        final Bom bom = requireNonNull(nextBom);
         nextBom = null;
         return bom;
     }
@@ -116,10 +128,33 @@ final class JvnVulnDataSource implements VulnDataSource {
         if (completedSuccessfully) {
             watermarkManager.maybeCommit();
         }
+        closeCurrentFeed();
     }
 
-    /** Fetches, parses and buffers a single year's detail feed, unless its checksum is unchanged. */
-    private void loadYear(final int year) {
+    /**
+     * Returns the next advisory of the current feed, or {@code null} after closing it — either
+     * because it was fully drained (only then is its digest recorded, so a partially parsed year
+     * is retried next run) or because parsing failed.
+     */
+    private @Nullable JvnAdvisory readAdvisory(final JvnAdvisorySource source) {
+        try {
+            if (source.hasNext()) {
+                currentFeedAdvisoryCount++;
+                return source.next();
+            }
+            if (currentFeedFilename != null && currentFeedDigest != null) {
+                watermarkManager.recordFeedDigest(currentFeedFilename, currentFeedDigest);
+            }
+            LOGGER.info("Fetched {} JVN advisories from {}", currentFeedAdvisoryCount, currentFeedFilename);
+        } catch (RuntimeException e) {
+            LOGGER.warn("Failed to parse JVN feed {}; skipping", currentFeedFilename, e);
+        }
+        closeCurrentFeed();
+        return null;
+    }
+
+    /** Downloads a single year's detail feed and opens it for streaming, unless its checksum is unchanged. */
+    private void openYear(final int year) {
         final String filename = JvnClient.detailFeedFilename(year);
         final @Nullable String digest = feedDigest(filename);
         if (digest != null && digest.equals(watermarkManager.getCommittedFeedDigest(filename))) {
@@ -127,19 +162,31 @@ final class JvnVulnDataSource implements VulnDataSource {
             return;
         }
         try {
-            final List<JvnAdvisory> advisories = JvnDetailParser.parse(client.fetchDetailFeed(year));
-            advisoryBuffer.addAll(advisories);
-            // Record the digest only after a successful fetch+parse, so a failed year is retried.
-            if (digest != null) {
-                watermarkManager.recordFeedDigest(filename, digest);
-            }
-            LOGGER.info("Fetched {} JVN advisories from {}", advisories.size(), filename);
+            final Path feedFile = client.downloadDetailFeed(year);
+            currentSource = JvnAdvisorySource.open(feedFile);
+            currentFeedFilename = filename;
+            currentFeedDigest = digest;
+            currentFeedAdvisoryCount = 0;
         } catch (IOException e) {
             LOGGER.warn("Failed to fetch JVN feed {}; skipping", filename, e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-        } catch (RuntimeException e) {
-            LOGGER.warn("Failed to parse JVN feed {}; skipping", filename, e);
+        }
+    }
+
+    /** Closes the current feed's source, which also deletes its temporary file. */
+    private void closeCurrentFeed() {
+        final JvnAdvisorySource source = currentSource;
+        currentSource = null;
+        currentFeedFilename = null;
+        currentFeedDigest = null;
+        currentFeedAdvisoryCount = 0;
+        if (source != null) {
+            try {
+                source.close();
+            } catch (IOException e) {
+                LOGGER.warn("Failed to close JVN feed source", e);
+            }
         }
     }
 

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSourceFactory.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSourceFactory.java
@@ -1,0 +1,214 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource.jvn;
+
+import org.dependencytrack.plugin.api.ExtensionTestResult;
+import org.dependencytrack.plugin.api.RuntimeConfigurable;
+import org.dependencytrack.plugin.api.ServiceRegistry;
+import org.dependencytrack.plugin.api.Testable;
+import org.dependencytrack.plugin.api.config.ConfigRegistry;
+import org.dependencytrack.plugin.api.config.InvalidRuntimeConfigException;
+import org.dependencytrack.plugin.api.config.RuntimeConfig;
+import org.dependencytrack.plugin.api.config.RuntimeConfigSpec;
+import org.dependencytrack.plugin.api.storage.KeyValueStore;
+import org.dependencytrack.vulndatasource.api.VulnDataSource;
+import org.dependencytrack.vulndatasource.api.VulnDataSourceFactory;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.time.Year;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @since 5.1.0
+ */
+@NullMarked
+final class JvnVulnDataSourceFactory implements VulnDataSourceFactory, RuntimeConfigurable, Testable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JvnVulnDataSourceFactory.class);
+
+    // JVN iPedia has data reaching back to 1998; this bounds the initial backfill.
+    private static final int DEFAULT_START_YEAR = 1998;
+
+    private @Nullable ConfigRegistry configRegistry;
+    private @Nullable KeyValueStore kvStore;
+    private @Nullable HttpClient httpClient;
+
+    @Override
+    public String extensionName() {
+        return "jvn";
+    }
+
+    @Override
+    public Class<? extends VulnDataSource> extensionClass() {
+        return JvnVulnDataSource.class;
+    }
+
+    @Override
+    public int priority() {
+        return PRIORITY_HIGHEST + 90;
+    }
+
+    @Override
+    public void init(final ServiceRegistry serviceRegistry) {
+        this.configRegistry = serviceRegistry.require(ConfigRegistry.class);
+        this.kvStore = serviceRegistry.require(KeyValueStore.class);
+        this.httpClient = serviceRegistry.require(HttpClient.class);
+    }
+
+    @Override
+    public RuntimeConfigSpec runtimeConfigSpec() {
+        final var defaultConfig = new JvnVulnDataSourceConfigV1()
+                .withEnabled(false)
+                .withFeedBaseUrl(URI.create(JvnClient.DEFAULT_FEED_BASE_URL))
+                .withStartYear(DEFAULT_START_YEAR);
+
+        return RuntimeConfigSpec.of(defaultConfig, config -> {
+            if (!config.isEnabled()) {
+                return;
+            }
+            if (config.getFeedBaseUrl() == null) {
+                throw new InvalidRuntimeConfigException("No JVN data feed base URL provided");
+            }
+            if (config.getStartYear() != null && config.getStartYear() < 1998) {
+                throw new InvalidRuntimeConfigException("startYear must be 1998 or later");
+            }
+        });
+    }
+
+    @Override
+    public boolean isDataSourceEnabled() {
+        requireNonNull(configRegistry, "configRegistry must not be null");
+        return configRegistry.getRuntimeConfig(JvnVulnDataSourceConfigV1.class).isEnabled();
+    }
+
+    @Override
+    public VulnDataSource create() {
+        requireNonNull(configRegistry, "configRegistry must not be null");
+        requireNonNull(kvStore, "kvStore must not be null");
+        requireNonNull(httpClient, "httpClient must not be null");
+
+        final var config = configRegistry.getRuntimeConfig(JvnVulnDataSourceConfigV1.class);
+        if (!config.isEnabled()) {
+            throw new IllegalStateException("Vulnerability data source is disabled and cannot be created");
+        }
+
+        final int startYear = config.getStartYear() != null ? config.getStartYear() : DEFAULT_START_YEAR;
+        final int endYear = Year.now(ZoneOffset.UTC).getValue();
+
+        // Feed-digest keys are the detail-feed filenames, so a run only re-fetches changed years.
+        final List<String> feedNames = new ArrayList<>();
+        for (int year = startYear; year <= endYear; year++) {
+            feedNames.add(JvnClient.detailFeedFilename(year));
+        }
+
+        final var watermarkManager = new WatermarkManager(kvStore, feedNames);
+        final var client = new JvnClient(httpClient, feedBaseUrlOf(config));
+        return new JvnVulnDataSource(client, watermarkManager, startYear, endYear);
+    }
+
+    @Override
+    public ExtensionTestResult test(final @Nullable RuntimeConfig runtimeConfig) {
+        requireNonNull(configRegistry, "configRegistry has not been initialized");
+        requireNonNull(httpClient, "httpClient has not been initialized");
+        requireNonNull(runtimeConfig, "runtimeConfig must not be null");
+
+        final var jvnConfig = (JvnVulnDataSourceConfigV1) runtimeConfig;
+        final var testResult = ExtensionTestResult.ofChecks("connection", "feed_format");
+        if (!jvnConfig.isEnabled()) {
+            return testResult;
+        }
+
+        final String feedBaseUrl = feedBaseUrlOf(jvnConfig);
+        final URI baseUri = URI.create(feedBaseUrl);
+
+        if (!configRegistry
+                .getDeploymentConfig()
+                .getOptionalValue("allow-local-connections", boolean.class)
+                .orElse(false)) {
+            try {
+                final var hostAddress = InetAddress.getByName(baseUri.getHost());
+                if (hostAddress.isLoopbackAddress()
+                        || hostAddress.isLinkLocalAddress()
+                        || hostAddress.isSiteLocalAddress()
+                        || hostAddress.isAnyLocalAddress()) {
+                    return testResult.fail("connection", "Connection to local hosts is not allowed");
+                }
+            } catch (UnknownHostException e) {
+                return testResult.fail("connection", "Unknown host");
+            }
+        }
+
+        final int year = Year.now(ZoneOffset.UTC).getValue();
+        final URI probeUri = URI.create(feedBaseUrl + "/detail/" + JvnClient.detailFeedFilename(year));
+        final HttpRequest request = HttpRequest.newBuilder()
+                .uri(probeUri)
+                .timeout(Duration.ofSeconds(30))
+                .GET()
+                .build();
+
+        final HttpResponse<byte[]> response;
+        try {
+            response = httpClient.send(request, BodyHandlers.ofByteArray());
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            LOGGER.warn("Failed to connect to {}", probeUri, e);
+            return testResult.fail("connection", "Connection failed, check logs for details");
+        }
+
+        if (response.statusCode() != 200) {
+            LOGGER.warn("Unexpected response code {} from {}", response.statusCode(), probeUri);
+            return testResult.fail("connection", "Unexpected response code, check logs for details");
+        }
+        testResult.pass("connection");
+
+        try {
+            var _ = JvnDetailParser.parse(response.body());
+            testResult.pass("feed_format");
+        } catch (RuntimeException e) {
+            LOGGER.warn("Failed to parse detail feed from {}", probeUri, e);
+            testResult.fail("feed_format", "Failed to parse detail feed, check logs for details");
+        }
+
+        return testResult;
+    }
+
+    private static String feedBaseUrlOf(final JvnVulnDataSourceConfigV1 config) {
+        return config.getFeedBaseUrl() != null
+                ? config.getFeedBaseUrl().toString()
+                : JvnClient.DEFAULT_FEED_BASE_URL;
+    }
+}

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSourceFactory.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSourceFactory.java
@@ -29,7 +29,6 @@ import org.dependencytrack.plugin.api.config.RuntimeConfigSpec;
 import org.dependencytrack.plugin.api.storage.KeyValueStore;
 import org.dependencytrack.vulndatasource.api.VulnDataSource;
 import org.dependencytrack.vulndatasource.api.VulnDataSourceFactory;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +41,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Year;
 import java.time.ZoneOffset;
@@ -53,7 +54,6 @@ import static java.util.Objects.requireNonNull;
 /**
  * @since 5.1.0
  */
-@NullMarked
 final class JvnVulnDataSourceFactory implements VulnDataSourceFactory, RuntimeConfigurable, Testable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JvnVulnDataSourceFactory.class);
@@ -178,32 +178,52 @@ final class JvnVulnDataSourceFactory implements VulnDataSourceFactory, RuntimeCo
                 .GET()
                 .build();
 
-        final HttpResponse<byte[]> response;
+        final Path tempFile;
         try {
-            response = httpClient.send(request, BodyHandlers.ofByteArray());
-        } catch (IOException | InterruptedException e) {
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
+            tempFile = Files.createTempFile(null, null);
+        } catch (IOException e) {
+            LOGGER.warn("Failed to create temp file for probe of {}", probeUri, e);
+            return testResult.fail("connection", "Failed to create temporary file, check logs for details");
+        }
+
+        try {
+            final HttpResponse<Path> response;
+            try {
+                response = httpClient.send(request, BodyHandlers.ofFile(tempFile));
+            } catch (IOException | InterruptedException e) {
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+                LOGGER.warn("Failed to connect to {}", probeUri, e);
+                return testResult.fail("connection", "Connection failed, check logs for details");
             }
-            LOGGER.warn("Failed to connect to {}", probeUri, e);
-            return testResult.fail("connection", "Connection failed, check logs for details");
-        }
 
-        if (response.statusCode() != 200) {
-            LOGGER.warn("Unexpected response code {} from {}", response.statusCode(), probeUri);
-            return testResult.fail("connection", "Unexpected response code, check logs for details");
-        }
-        testResult.pass("connection");
+            if (response.statusCode() != 200) {
+                LOGGER.warn("Unexpected response code {} from {}", response.statusCode(), probeUri);
+                return testResult.fail("connection", "Unexpected response code, check logs for details");
+            }
+            testResult.pass("connection");
 
-        try {
-            var _ = JvnDetailParser.parse(response.body());
-            testResult.pass("feed_format");
-        } catch (RuntimeException e) {
-            LOGGER.warn("Failed to parse detail feed from {}", probeUri, e);
-            testResult.fail("feed_format", "Failed to parse detail feed, check logs for details");
-        }
+            // Drain the feed one advisory at a time, so the probe validates the whole document
+            // without ever holding more than a single advisory in memory.
+            try (final var advisorySource = JvnAdvisorySource.open(tempFile)) {
+                while (advisorySource.hasNext()) {
+                    var _ = advisorySource.next();
+                }
+                testResult.pass("feed_format");
+            } catch (IOException | RuntimeException e) {
+                LOGGER.warn("Failed to parse detail feed from {}", probeUri, e);
+                testResult.fail("feed_format", "Failed to parse detail feed, check logs for details");
+            }
 
-        return testResult;
+            return testResult;
+        } finally {
+            try {
+                Files.deleteIfExists(tempFile);
+            } catch (IOException e) {
+                LOGGER.warn("Failed to delete temp file {}", tempFile, e);
+            }
+        }
     }
 
     private static String feedBaseUrlOf(final JvnVulnDataSourceConfigV1 config) {

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSourcePlugin.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSourcePlugin.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource.jvn;
+
+import org.dependencytrack.plugin.api.ExtensionFactory;
+import org.dependencytrack.plugin.api.ExtensionPoint;
+import org.dependencytrack.plugin.api.Plugin;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * @since 5.1.0
+ */
+public final class JvnVulnDataSourcePlugin implements Plugin {
+
+    @Override
+    public Collection<? extends ExtensionFactory<? extends ExtensionPoint>> extensionFactories() {
+        return List.of(new JvnVulnDataSourceFactory());
+    }
+
+}

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/ModelConverter.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/ModelConverter.java
@@ -1,0 +1,265 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource.jvn;
+
+import com.google.protobuf.util.Timestamps;
+import io.github.nscuro.versatile.Comparator;
+import io.github.nscuro.versatile.Vers;
+import org.cyclonedx.proto.v1_7.Bom;
+import org.cyclonedx.proto.v1_7.Classification;
+import org.cyclonedx.proto.v1_7.Component;
+import org.cyclonedx.proto.v1_7.ExternalReference;
+import org.cyclonedx.proto.v1_7.Property;
+import org.cyclonedx.proto.v1_7.ScoreMethod;
+import org.cyclonedx.proto.v1_7.Severity;
+import org.cyclonedx.proto.v1_7.Source;
+import org.cyclonedx.proto.v1_7.Vulnerability;
+import org.cyclonedx.proto.v1_7.VulnerabilityAffectedVersions;
+import org.cyclonedx.proto.v1_7.VulnerabilityAffects;
+import org.cyclonedx.proto.v1_7.VulnerabilityRating;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import us.springett.parsers.cpe.Cpe;
+import us.springett.parsers.cpe.CpeParser;
+import us.springett.parsers.cpe.exceptions.CpeParsingException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Converts a parsed {@link JvnAdvisory} into a CycloneDX Bill of Vulnerabilities (BOV).
+ * <p>
+ * Reuses the {@code Component} + {@code VulnerabilityAffects} emission shape of the NVD data source.
+ * The JVN-specific parts are: CPE 2.2 to 2.3 normalisation, and translation of the free-text
+ * Japanese {@code VersionNumber} into {@code vers} ranges via {@link JvnVersionParser}.
+ *
+ * @since 5.1.0
+ */
+final class ModelConverter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ModelConverter.class);
+    private static final Source SOURCE_JVN = Source.newBuilder().setName("JVN").build();
+    private static final String TITLE_PROPERTY = "dependency-track:vuln:title";
+    private static final String VERS_SCHEME = "generic";
+
+    private ModelConverter() {
+    }
+
+    static Bom convert(final JvnAdvisory advisory) {
+        // Store every JVN advisory as-is under the JVN source, keyed by its JVNDB id. No CVE->NVD
+        // routing and no NVD duplicate check: a JVN record and the NVD's CVE record may coexist.
+        final Vulnerability.Builder vulnBuilder = Vulnerability.newBuilder()
+                .setSource(SOURCE_JVN)
+                .setId(advisory.jvnDbId())
+                .addAllRatings(parseRatings(advisory.cvssList()));
+
+        if (advisory.overview() != null && !advisory.overview().isBlank()) {
+            vulnBuilder.setDescription(advisory.overview());
+        }
+        if (advisory.detail() != null && !advisory.detail().isBlank()) {
+            vulnBuilder.setDetail(advisory.detail());
+        }
+        if (advisory.recommendation() != null && !advisory.recommendation().isBlank()) {
+            vulnBuilder.setRecommendation(advisory.recommendation());
+        }
+        if (advisory.title() != null && !advisory.title().isBlank()) {
+            vulnBuilder.addProperties(Property.newBuilder()
+                    .setName(TITLE_PROPERTY)
+                    .setValue(advisory.title()));
+        }
+        if (!advisory.cweIds().isEmpty()) {
+            vulnBuilder.addAllCwes(advisory.cweIds());
+        }
+        if (advisory.datePublic() != null) {
+            vulnBuilder.setPublished(Timestamps.fromMillis(advisory.datePublic().toEpochMilli()));
+        }
+        if (advisory.dateLastUpdated() != null) {
+            vulnBuilder.setUpdated(Timestamps.fromMillis(advisory.dateLastUpdated().toEpochMilli()));
+        }
+
+        final var componentByCpe = new HashMap<String, Component>();
+        final var affectsBuilderByBomRef = new HashMap<String, VulnerabilityAffects.Builder>();
+
+        for (final JvnAdvisory.AffectedProduct product : advisory.affected()) {
+            final Cpe cpe;
+            final String cpe23;
+            try {
+                cpe = CpeParser.parse(product.cpe22());
+                cpe23 = cpe.toCpe23FS();
+            } catch (CpeParsingException e) {
+                LOGGER.debug("Skipping unparseable CPE '{}' of {}", product.cpe22(), advisory.jvnDbId());
+                continue;
+            }
+
+            // Skip non-concrete products (e.g. cpe:/a:misc:multiple_vendors would never map to a
+            // concrete component anyway; "*"/"-" would match everything from a vendor).
+            final String productName = cpe.getProduct();
+            if ("*".equals(productName) || "-".equals(productName)) {
+                continue;
+            }
+
+            final Component component = componentByCpe.computeIfAbsent(cpe23, ref -> Component.newBuilder()
+                    .setBomRef(UUID.nameUUIDFromBytes(ref.getBytes()).toString())
+                    .setType(determineComponentType(cpe))
+                    .setPublisher(cpe.getVendor())
+                    .setName(cpe.getProduct())
+                    .setCpe(ref)
+                    .build());
+
+            final VulnerabilityAffects.Builder affectsBuilder = affectsBuilderByBomRef.computeIfAbsent(
+                    component.getBomRef(),
+                    bomRef -> VulnerabilityAffects.newBuilder().setRef(bomRef));
+
+            addAffectedVersions(advisory, product, affectsBuilder);
+        }
+
+        final List<Component> components = componentByCpe.values().stream()
+                .sorted(java.util.Comparator.comparing(Component::getBomRef))
+                .toList();
+        final List<VulnerabilityAffects> affects = affectsBuilderByBomRef.values().stream()
+                .map(VulnerabilityAffects.Builder::build)
+                .sorted(java.util.Comparator.comparing(VulnerabilityAffects::getRef))
+                .toList();
+
+        final Bom.Builder bomBuilder = Bom.newBuilder()
+                .addAllComponents(components)
+                .addVulnerabilities(vulnBuilder.addAllAffects(affects).build());
+        for (final String url : advisory.referenceUrls()) {
+            bomBuilder.addExternalReferences(ExternalReference.newBuilder().setUrl(url).build());
+        }
+        return bomBuilder.build();
+    }
+
+    private static void addAffectedVersions(
+            final JvnAdvisory advisory,
+            final JvnAdvisory.AffectedProduct product,
+            final VulnerabilityAffects.Builder affectsBuilder) {
+        boolean anyStructured = false;
+
+        for (final String versionText : product.versionTexts()) {
+            final JvnVersionParser.Result result = JvnVersionParser.parse(versionText, VERS_SCHEME);
+            switch (result) {
+                case JvnVersionParser.ExactVersion exact -> {
+                    if (!hasVersion(affectsBuilder, exact.version())) {
+                        affectsBuilder.addVersions(VulnerabilityAffectedVersions.newBuilder()
+                                .setVersion(exact.version()));
+                    }
+                    anyStructured = true;
+                }
+                case JvnVersionParser.VersionRange range -> {
+                    final String vers = range.vers().toString();
+                    if (!hasRange(affectsBuilder, vers)) {
+                        affectsBuilder.addVersions(VulnerabilityAffectedVersions.newBuilder()
+                                .setRange(vers));
+                    }
+                    anyStructured = true;
+                }
+                case JvnVersionParser.Unparseable unparseable ->
+                        LOGGER.debug("Unparseable version '{}' for {} ({}): {}",
+                                versionText, product.cpe22(), advisory.jvnDbId(), unparseable.reason());
+            }
+        }
+
+        // No structured version could be derived (empty, "all versions", or all unparseable).
+        // The product is nonetheless declared affected by JVN, so emit an all-versions (wildcard)
+        // range to preserve recall. This matches how NVD treats product-level CPEs.
+        if (!anyStructured) {
+            final String wildcard = Vers.builder(VERS_SCHEME)
+                    .withConstraint(Comparator.WILDCARD, null)
+                    .build()
+                    .toString();
+            if (!hasRange(affectsBuilder, wildcard)) {
+                affectsBuilder.addVersions(VulnerabilityAffectedVersions.newBuilder().setRange(wildcard));
+            }
+        }
+    }
+
+    private static boolean hasVersion(final VulnerabilityAffects.Builder builder, final String version) {
+        return builder.getVersionsList().stream()
+                .filter(VulnerabilityAffectedVersions::hasVersion)
+                .anyMatch(v -> v.getVersion().equals(version));
+    }
+
+    private static boolean hasRange(final VulnerabilityAffects.Builder builder, final String range) {
+        return builder.getVersionsList().stream()
+                .filter(VulnerabilityAffectedVersions::hasRange)
+                .anyMatch(v -> v.getRange().equals(range));
+    }
+
+    private static Classification determineComponentType(final Cpe cpe) {
+        return switch (cpe.getPart()) {
+            case APPLICATION -> Classification.CLASSIFICATION_APPLICATION;
+            case HARDWARE_DEVICE -> Classification.CLASSIFICATION_DEVICE;
+            case OPERATING_SYSTEM -> Classification.CLASSIFICATION_OPERATING_SYSTEM;
+            default -> Classification.CLASSIFICATION_NULL;
+        };
+    }
+
+    private static List<VulnerabilityRating> parseRatings(final List<JvnAdvisory.Cvss> cvssList) {
+        final var ratings = new ArrayList<VulnerabilityRating>();
+        for (final JvnAdvisory.Cvss cvss : cvssList) {
+            final VulnerabilityRating.Builder builder = VulnerabilityRating.newBuilder()
+                    .setMethod(mapMethod(cvss.version()))
+                    .setSeverity(mapSeverity(cvss.severity()));
+            if (cvss.baseScore() != null) {
+                builder.setScore(cvss.baseScore());
+            }
+            if (cvss.vector() != null) {
+                builder.setVector(cvss.vector());
+            }
+            ratings.add(builder.build());
+        }
+        return ratings;
+    }
+
+    private static ScoreMethod mapMethod(final String version) {
+        if (version == null) {
+            return ScoreMethod.SCORE_METHOD_OTHER;
+        }
+        if (version.startsWith("2")) {
+            return ScoreMethod.SCORE_METHOD_CVSSV2;
+        }
+        if (version.startsWith("3.1")) {
+            return ScoreMethod.SCORE_METHOD_CVSSV31;
+        }
+        if (version.startsWith("3")) {
+            return ScoreMethod.SCORE_METHOD_CVSSV3;
+        }
+        if (version.startsWith("4")) {
+            return ScoreMethod.SCORE_METHOD_CVSSV4;
+        }
+        return ScoreMethod.SCORE_METHOD_OTHER;
+    }
+
+    private static Severity mapSeverity(final String severity) {
+        if (severity == null) {
+            return Severity.SEVERITY_UNKNOWN;
+        }
+        return switch (severity.toUpperCase(java.util.Locale.ROOT)) {
+            case "CRITICAL" -> Severity.SEVERITY_CRITICAL;
+            case "HIGH" -> Severity.SEVERITY_HIGH;
+            case "MEDIUM", "MODERATE" -> Severity.SEVERITY_MEDIUM;
+            case "LOW" -> Severity.SEVERITY_LOW;
+            case "NONE" -> Severity.SEVERITY_NONE;
+            default -> Severity.SEVERITY_UNKNOWN;
+        };
+    }
+}

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/ModelConverter.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/ModelConverter.java
@@ -33,6 +33,7 @@ import org.cyclonedx.proto.v1_7.Vulnerability;
 import org.cyclonedx.proto.v1_7.VulnerabilityAffectedVersions;
 import org.cyclonedx.proto.v1_7.VulnerabilityAffects;
 import org.cyclonedx.proto.v1_7.VulnerabilityRating;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import us.springett.parsers.cpe.Cpe;
@@ -230,7 +231,7 @@ final class ModelConverter {
         return ratings;
     }
 
-    private static ScoreMethod mapMethod(final String version) {
+    private static ScoreMethod mapMethod(final @Nullable String version) {
         if (version == null) {
             return ScoreMethod.SCORE_METHOD_OTHER;
         }
@@ -249,7 +250,7 @@ final class ModelConverter {
         return ScoreMethod.SCORE_METHOD_OTHER;
     }
 
-    private static Severity mapSeverity(final String severity) {
+    private static Severity mapSeverity(final @Nullable String severity) {
         if (severity == null) {
             return Severity.SEVERITY_UNKNOWN;
         }

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/WatermarkManager.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/WatermarkManager.java
@@ -1,0 +1,173 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource.jvn;
+
+import org.dependencytrack.plugin.api.storage.CompareAndPutResult;
+import org.dependencytrack.plugin.api.storage.KeyValueStore;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Persists mirror-run checkpoints via the plugin {@link KeyValueStore}: the sha256 digest of each
+ * yearly detail feed (from {@code checksum.txt}), so subsequent runs skip unchanged years, and the
+ * highest {@code datePublic} processed, as a progress indicator.
+ * <p>
+ * Adapted from the NVD data source's {@code WatermarkManager}.
+ *
+ * @since 5.1.0
+ */
+final class WatermarkManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WatermarkManager.class);
+    private static final String FEED_DIGEST_KEY_PREFIX = "feed-digest:";
+
+    private final KeyValueStore kvStore;
+    private Instant committedWatermark;
+    private Instant pendingWatermark;
+    private Long committedWatermarkVersion;
+    private final Map<String, String> committedFeedDigests;
+    private final Map<String, Long> committedFeedDigestVersions;
+    private final Map<String, String> pendingFeedDigests;
+
+    WatermarkManager(final KeyValueStore kvStore, final Collection<String> feedNames) {
+        Instant committedWatermark = null;
+        Long committedWatermarkVersion = null;
+
+        final KeyValueStore.Entry watermarkEntry = kvStore.get("watermark");
+        if (watermarkEntry != null) {
+            try {
+                committedWatermark = Instant.ofEpochMilli(
+                        Long.parseLong(watermarkEntry.value()));
+                committedWatermarkVersion = watermarkEntry.version();
+            } catch (NumberFormatException ex) {
+                LOGGER.warn("Encountered invalid watermark: {}; Ignoring", watermarkEntry, ex);
+            }
+        }
+
+        final var committedFeedDigests = new HashMap<String, String>();
+        final var committedFeedDigestVersions = new HashMap<String, Long>();
+
+        if (!feedNames.isEmpty()) {
+            final Map<String, String> feedNameByKey = feedNames.stream()
+                    .collect(Collectors.toMap(
+                            name -> FEED_DIGEST_KEY_PREFIX + name,
+                            name -> name));
+
+            final Map<String, KeyValueStore.Entry> entries = kvStore.getMany(feedNameByKey.keySet());
+            for (final Map.Entry<String, KeyValueStore.Entry> entry : entries.entrySet()) {
+                final String feedName = feedNameByKey.get(entry.getKey());
+                committedFeedDigests.put(feedName, entry.getValue().value());
+                committedFeedDigestVersions.put(feedName, entry.getValue().version());
+            }
+        }
+
+        this.kvStore = kvStore;
+        this.committedWatermark = committedWatermark;
+        this.committedWatermarkVersion = committedWatermarkVersion;
+        this.committedFeedDigests = committedFeedDigests;
+        this.committedFeedDigestVersions = committedFeedDigestVersions;
+        this.pendingFeedDigests = new HashMap<>();
+    }
+
+    @Nullable Instant getWatermark() {
+        return committedWatermark;
+    }
+
+    void maybeAdvance(final Instant watermark) {
+        if (watermark == null) {
+            return;
+        }
+        if (pendingWatermark == null || pendingWatermark.isBefore(watermark)) {
+            LOGGER.debug("Advancing watermark from {} to {}", pendingWatermark, watermark);
+            pendingWatermark = watermark;
+        }
+    }
+
+    /** The digest committed for a feed on a previous run, or {@code null} if it was never seen. */
+    @Nullable String getCommittedFeedDigest(final String feedName) {
+        return committedFeedDigests.get(feedName);
+    }
+
+    /** Records the digest of a feed processed this run; persisted by {@link #maybeCommit()}. */
+    void recordFeedDigest(final String feedName, final String digest) {
+        pendingFeedDigests.put(feedName, digest);
+    }
+
+    void maybeCommit() {
+        commitWatermark();
+        commitFeedDigests();
+    }
+
+    private void commitWatermark() {
+        if (pendingWatermark == null
+                || (committedWatermark != null && committedWatermark.equals(pendingWatermark))) {
+            return;
+        }
+
+        LOGGER.debug("Committing watermark {} to KV store", pendingWatermark);
+        final CompareAndPutResult capResult = kvStore.compareAndPut(
+                "watermark",
+                String.valueOf(pendingWatermark.toEpochMilli()),
+                committedWatermarkVersion);
+        switch (capResult) {
+            case CompareAndPutResult.Success(long newVersion) -> {
+                committedWatermark = pendingWatermark;
+                committedWatermarkVersion = newVersion;
+                pendingWatermark = null;
+            }
+            case CompareAndPutResult.Failure(CompareAndPutResult.Failure.Reason reason) ->
+                    throw new IllegalStateException(
+                            "Failed to commit watermark %s to KV store: %s".formatted(
+                                    pendingWatermark, reason));
+        }
+    }
+
+    private void commitFeedDigests() {
+        for (final Map.Entry<String, String> pending : pendingFeedDigests.entrySet()) {
+            final String feedName = pending.getKey();
+            final String digest = pending.getValue();
+            if (digest.equals(committedFeedDigests.get(feedName))) {
+                continue;
+            }
+            final CompareAndPutResult capResult = kvStore.compareAndPut(
+                    FEED_DIGEST_KEY_PREFIX + feedName,
+                    digest,
+                    committedFeedDigestVersions.get(feedName));
+            switch (capResult) {
+                case CompareAndPutResult.Success(long newVersion) -> {
+                    committedFeedDigests.put(feedName, digest);
+                    committedFeedDigestVersions.put(feedName, newVersion);
+                }
+                case CompareAndPutResult.Failure(CompareAndPutResult.Failure.Reason reason) ->
+                        throw new IllegalStateException(
+                                "Failed to commit feed digest for %s to KV store: %s".formatted(
+                                        feedName, reason));
+            }
+        }
+        pendingFeedDigests.clear();
+    }
+
+}

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/WatermarkManager.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/WatermarkManager.java
@@ -45,9 +45,9 @@ final class WatermarkManager {
     private static final String FEED_DIGEST_KEY_PREFIX = "feed-digest:";
 
     private final KeyValueStore kvStore;
-    private Instant committedWatermark;
-    private Instant pendingWatermark;
-    private Long committedWatermarkVersion;
+    private @Nullable Instant committedWatermark;
+    private @Nullable Instant pendingWatermark;
+    private @Nullable Long committedWatermarkVersion;
     private final Map<String, String> committedFeedDigests;
     private final Map<String, Long> committedFeedDigestVersions;
     private final Map<String, String> pendingFeedDigests;

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/package-info.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+@NullMarked
+package org.dependencytrack.vulndatasource.jvn;
+
+import org.jspecify.annotations.NullMarked;

--- a/vuln-data-source/jvn/src/main/resources/META-INF/services/org.dependencytrack.plugin.api.Plugin
+++ b/vuln-data-source/jvn/src/main/resources/META-INF/services/org.dependencytrack.plugin.api.Plugin
@@ -1,0 +1,1 @@
+org.dependencytrack.vulndatasource.jvn.JvnVulnDataSourcePlugin

--- a/vuln-data-source/jvn/src/main/resources/org/dependencytrack/vulndatasource/jvn/jvn-vuln-data-source-config-v1.schema.json
+++ b/vuln-data-source/jvn/src/main/resources/org/dependencytrack/vulndatasource/jvn/jvn-vuln-data-source-config-v1.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dependencytrack.org/schemas/jvn-vuln-data-source-config-v1.schema.json",
+  "type": "object",
+  "javaInterfaces": [
+    "org.dependencytrack.plugin.api.config.RuntimeConfig"
+  ],
+  "properties": {
+    "enabled": {
+      "type": "boolean",
+      "title": "Enabled",
+      "description": "Whether the JVN (Japan Vulnerability Notes) data source should be enabled.",
+      "existingJavaType": "boolean"
+    },
+    "feedBaseUrl": {
+      "type": "string",
+      "title": "JVN data feed base URL",
+      "description": "Base URL of the JVN data feeds (the `.../ja/feed` directory). The yearly detail feeds (`detail/jvndb_detail_YYYY.rdf`) and `checksum.txt` are read from here. Defaults to `https://jvndb.jvn.jp/ja/feed`.",
+      "format": "uri",
+      "minLength": 1
+    },
+    "startYear": {
+      "type": "integer",
+      "title": "Backfill start year",
+      "description": "First publication year to mirror from the yearly detail feeds (JVN iPedia data reaches back to 1998). Defaults to 1998."
+    }
+  },
+  "required": [
+    "enabled"
+  ]
+}

--- a/vuln-data-source/jvn/src/test/java/org/dependencytrack/vulndatasource/jvn/JvnAdvisorySourceTest.java
+++ b/vuln-data-source/jvn/src/test/java/org/dependencytrack/vulndatasource/jvn/JvnAdvisorySourceTest.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource.jvn;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JvnAdvisorySourceTest {
+
+    @Test
+    void streamsMultipleVulinfosInDocumentOrder() throws Exception {
+        // Duplicate the fixture's single <Vulinfo> under a second id, within the same root.
+        final String fixtureXml = fixture();
+        final int start = fixtureXml.indexOf("<Vulinfo>");
+        final int end = fixtureXml.indexOf("</Vulinfo>") + "</Vulinfo>".length();
+        final String vulinfo = fixtureXml.substring(start, end);
+        final String secondVulinfo = vulinfo.replace("JVNDB-2026-022538", "JVNDB-2026-999999");
+        final String doubledXml = fixtureXml.substring(0, end)
+                + secondVulinfo
+                + fixtureXml.substring(end);
+
+        try (final var source = new JvnAdvisorySource(inputStream(doubledXml))) {
+            assertTrue(source.hasNext());
+            assertEquals("JVNDB-2026-022538", source.next().jvnDbId());
+            assertTrue(source.hasNext());
+            assertEquals("JVNDB-2026-999999", source.next().jvnDbId());
+            assertFalse(source.hasNext());
+        }
+    }
+
+    @Test
+    void rejectsDoctypeDeclarations() throws Exception {
+        final String xml = "<?xml version=\"1.0\"?><!DOCTYPE foo [<!ENTITY xxe \"boom\">]>"
+                + "<VULDEF-Document><Vulinfo><VulinfoID>&xxe;</VulinfoID></Vulinfo></VULDEF-Document>";
+
+        try (final var source = new JvnAdvisorySource(inputStream(xml))) {
+            assertThrows(IllegalArgumentException.class, source::hasNext);
+        }
+    }
+
+    @Test
+    void throwsOnTruncatedDocument() throws Exception {
+        final String truncatedXml = fixture().substring(0, fixture().indexOf("</Vulinfo>"));
+
+        try (final var source = new JvnAdvisorySource(inputStream(truncatedXml))) {
+            assertThrows(IllegalArgumentException.class, () -> {
+                while (source.hasNext()) {
+                    source.next();
+                }
+            });
+        }
+    }
+
+    private String fixture() throws Exception {
+        try (InputStream in = getClass().getResourceAsStream("/jvn-detail-with-range.xml")) {
+            assertNotNull(in, "fixture jvn-detail-with-range.xml must be present");
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static InputStream inputStream(final String xml) {
+        return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/vuln-data-source/jvn/src/test/java/org/dependencytrack/vulndatasource/jvn/JvnDetailParserTest.java
+++ b/vuln-data-source/jvn/src/test/java/org/dependencytrack/vulndatasource/jvn/JvnDetailParserTest.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource.jvn;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JvnDetailParserTest {
+
+    @Test
+    void parsesRealDetailWithMultipleVersionRanges() throws Exception {
+        final List<JvnAdvisory> advisories;
+        try (InputStream in = getClass().getResourceAsStream("/jvn-detail-with-range.xml")) {
+            assertNotNull(in, "fixture jvn-detail-with-range.xml must be present");
+            advisories = JvnDetailParser.parse(in);
+        }
+
+        assertEquals(1, advisories.size());
+        final JvnAdvisory advisory = advisories.getFirst();
+        assertEquals("JVNDB-2026-022538", advisory.jvnDbId());
+        assertNotNull(advisory.title());
+
+        // <Overview> is nested in <VulinfoDescription>; ensure it is extracted.
+        assertNotNull(advisory.overview(), "expected the overview/description to be parsed");
+        assertTrue(advisory.overview().contains("valuesFrom"));
+
+        // <Impact><ImpactItem><Description> -> detail; <Solution><SolutionItem><Description> ->
+        // recommendation. The unrelated <HistoryItem><Description> must not leak into either.
+        assertNotNull(advisory.detail(), "expected the impact detail to be parsed");
+        assertTrue(advisory.detail().contains("外部に漏れる"));
+        assertFalse(advisory.detail().contains("掲載"), "history text must not leak into detail");
+        assertNotNull(advisory.recommendation(), "expected the solution/recommendation to be parsed");
+        assertTrue(advisory.recommendation().contains("ベンダ情報を参照"));
+
+        assertFalse(advisory.cveIds().isEmpty(), "expected at least one CVE id");
+        assertTrue(advisory.cveIds().stream().allMatch(id -> id.startsWith("CVE-")));
+
+        // The fixture carries a <RelatedItem type="cwe"> of CWE-1287; its numeric id is collected,
+        // and its glossary URL must NOT leak into the reference list.
+        assertEquals(List.of(1287), advisory.cweIds());
+        assertTrue(advisory.referenceUrls().stream().noneMatch(url -> url.contains("/cwe/")),
+                "CWE glossary URLs must not be filed as references");
+
+        assertEquals(1, advisory.affected().size());
+        final JvnAdvisory.AffectedProduct product = advisory.affected().getFirst();
+        assertEquals("cpe:/a:suse:rancher_fleet", product.cpe22());
+        // The fixture lists four affected version ranges for this product.
+        assertEquals(4, product.versionTexts().size());
+        assertTrue(product.versionTexts().contains("0.15.0 以上 0.15.2 未満"));
+
+        assertNotNull(advisory.datePublic());
+    }
+}

--- a/vuln-data-source/jvn/src/test/java/org/dependencytrack/vulndatasource/jvn/JvnDetailParserTest.java
+++ b/vuln-data-source/jvn/src/test/java/org/dependencytrack/vulndatasource/jvn/JvnDetailParserTest.java
@@ -55,9 +55,6 @@ class JvnDetailParserTest {
         assertNotNull(advisory.recommendation(), "expected the solution/recommendation to be parsed");
         assertTrue(advisory.recommendation().contains("ベンダ情報を参照"));
 
-        assertFalse(advisory.cveIds().isEmpty(), "expected at least one CVE id");
-        assertTrue(advisory.cveIds().stream().allMatch(id -> id.startsWith("CVE-")));
-
         // The fixture carries a <RelatedItem type="cwe"> of CWE-1287; its numeric id is collected,
         // and its glossary URL must NOT leak into the reference list.
         assertEquals(List.of(1287), advisory.cweIds());

--- a/vuln-data-source/jvn/src/test/java/org/dependencytrack/vulndatasource/jvn/JvnVersionParserTest.java
+++ b/vuln-data-source/jvn/src/test/java/org/dependencytrack/vulndatasource/jvn/JvnVersionParserTest.java
@@ -1,0 +1,143 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource.jvn;
+
+import org.dependencytrack.vulndatasource.jvn.JvnVersionParser.ExactVersion;
+import org.dependencytrack.vulndatasource.jvn.JvnVersionParser.Result;
+import org.dependencytrack.vulndatasource.jvn.JvnVersionParser.Unparseable;
+import org.dependencytrack.vulndatasource.jvn.JvnVersionParser.VersionRange;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Cases are drawn from real JVN {@code VersionNumber} strings observed in the last month of data.
+ */
+class JvnVersionParserTest {
+
+    @ParameterizedTest
+    @CsvSource(delimiter = ';', value = {
+            "0.15.0 以上 0.15.2 未満 ; vers:generic/>=0.15.0|<0.15.2",
+            "0.2.2 以上 3.19.0 未満   ; vers:generic/>=0.2.2|<3.19.0",
+            "0.32.0 未満             ; vers:generic/<0.32.0",
+            "1.0 から 3.1.1          ; vers:generic/>=1.0|<=3.1.1",
+            "0.9.5 およびそれ以前      ; vers:generic/<=0.9.5",
+            "5.0 以前                ; vers:generic/<=5.0",
+            "1.2.3 以上              ; vers:generic/>=1.2.3",
+    })
+    void parsesRanges(final String input, final String expectedVers) {
+        final Result result = JvnVersionParser.parse(input, "generic");
+        final VersionRange range = assertInstanceOf(VersionRange.class, result);
+        assertEquals(expectedVers, range.vers().toString());
+    }
+
+    @Test
+    void parsesExactVersion() {
+        final Result result = JvnVersionParser.parse("25.3.3.1", "generic");
+        final ExactVersion exact = assertInstanceOf(ExactVersion.class, result);
+        assertEquals("25.3.3.1", exact.version());
+    }
+
+    @Test
+    void parsesWaveDashRange() {
+        final Result result = JvnVersionParser.parse("1.000A〜1.014Q", "generic");
+        final VersionRange range = assertInstanceOf(VersionRange.class, result);
+        assertEquals("vers:generic/>=1.000A|<=1.014Q", range.vers().toString());
+    }
+
+    @Test
+    void parsesAllVersionsAsWildcardRange() {
+        final Result result = JvnVersionParser.parse("すべてのバージョン", "generic");
+        final VersionRange range = assertInstanceOf(VersionRange.class, result);
+        assertEquals("vers:generic/*", range.vers().toString());
+    }
+
+    @ParameterizedTest
+    @CsvSource(delimiter = ';', value = {
+            // Platform/edition qualifiers carry no version information; NVD encodes them in
+            // separate CPE attributes, so stripping them yields the NVD-equivalent version value.
+            "5.0 (client)                        ; 5.0",
+            "3 (x86-64)                          ; 3",
+            "4.0 (x86-64)                        ; 4.0",
+            "Version 1809 for x64-based Systems  ; 1809",
+            "Version 22H2 for ARM64-based Systems; 22H2",
+            "2019 for 64-bit editions            ; 2019",
+            "12.04 LTS                           ; 12.04",
+            "11 Express                          ; 11",
+            "2013 SP1                            ; 2013",
+            "2000 Gold                           ; 2000",
+            "R2 for x64-based Systems SP1        ; R2",
+            "2016 (32 ビット版)                   ; 2016",
+            "2013 SP1 (32-bit editions)          ; 2013",
+            "2013 RT SP1                         ; 2013",
+            "LTSC 2021 for 32-bit editions       ; 2021",
+            "Standard Version 6                  ; 6",
+            "- Web Edition Version 4             ; 4",
+            "2.5.1 (sparc)                       ; 2.5.1",
+    })
+    void salvagesQualifiedVersions(final String input, final String expectedVersion) {
+        final Result result = JvnVersionParser.parse(input, "generic");
+        final ExactVersion exact = assertInstanceOf(ExactVersion.class, result);
+        assertEquals(expectedVersion, exact.version());
+    }
+
+    @Test
+    void salvagesQualifiedRange() {
+        final Result result = JvnVersionParser.parse("10.5.x から 10.5.8 まで (32 ビット版)", "generic");
+        final VersionRange range = assertInstanceOf(VersionRange.class, result);
+        assertEquals("vers:generic/>=10.5.x|<=10.5.8", range.vers().toString());
+    }
+
+    @ParameterizedTest
+    @CsvSource(delimiter = ';', value = {
+            // Cisco-style parenthesized build numbers are exact version values in NVD's CPEs
+            // and must be kept verbatim, not stripped down to "11.0".
+            "11.0(20.3)   ; 11.0(20.3)",
+            "11.1(15)ca   ; 11.1(15)ca",
+            "12.0(3.4)T1  ; 12.0(3.4)T1",
+    })
+    void parsesParenthesizedBuildVersions(final String input, final String expectedVersion) {
+        final Result result = JvnVersionParser.parse(input, "generic");
+        final ExactVersion exact = assertInstanceOf(ExactVersion.class, result);
+        assertEquals(expectedVersion, exact.version());
+    }
+
+    @ParameterizedTest
+    @CsvSource(delimiter = ';', value = {
+            // Qualifier-only texts must not be salvaged into an invented version value.
+            "(Server Core installation)",
+            "for x64-based Systems",
+            "(x64) SP2",
+            // Parenthesized content that is neither qualifier vocabulary nor a build number
+            // must stay untouched rather than be guessed at.
+            "2017 version 15.9 (includes 15.0 - 15.8)",
+            "10.01 (SD-UX version B.10.10)",
+    })
+    void degradesOnQualifierOnlyOrNonQualifierParens(final String input) {
+        assertInstanceOf(Unparseable.class, JvnVersionParser.parse(input, "generic"));
+    }
+
+    @Test
+    void degradesOnNull() {
+        assertInstanceOf(Unparseable.class, JvnVersionParser.parse(null, "generic"));
+    }
+}

--- a/vuln-data-source/jvn/src/test/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSourceTest.java
+++ b/vuln-data-source/jvn/src/test/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSourceTest.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource.jvn;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.cyclonedx.proto.v1_7.Bom;
+import org.dependencytrack.plugin.testing.MockKeyValueStore;
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@WireMockTest
+class JvnVulnDataSourceTest {
+
+    private static final int YEAR = 2026;
+    private static final String FEED_FILENAME = "jvndb_detail_" + YEAR + ".rdf";
+
+    @Test
+    void iteratesYearlyFeedToBov(final WireMockRuntimeInfo wm) throws Exception {
+        final String detailXml = new String(
+                getClass().getResourceAsStream("/jvn-detail-with-range.xml").readAllBytes(),
+                StandardCharsets.UTF_8);
+        final String checksumJson = """
+                [{"url":"x","filename":"%s","sha256":"deadbeef","size":1,"lastModified":"2026/01/01 00:00:00"}]
+                """.formatted(FEED_FILENAME);
+
+        stubFor(get(urlPathEqualTo("/checksum.txt"))
+                .willReturn(aResponse().withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(checksumJson)));
+        stubFor(get(urlPathEqualTo("/detail/" + FEED_FILENAME))
+                .willReturn(aResponse().withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody(detailXml)));
+
+        final var client = new JvnClient(HttpClient.newHttpClient(), wm.getHttpBaseUrl());
+        final var watermark = new WatermarkManager(new MockKeyValueStore(), List.of(FEED_FILENAME));
+
+        final var boms = new ArrayList<Bom>();
+        try (final var dataSource = new JvnVulnDataSource(client, watermark, YEAR, YEAR)) {
+            while (dataSource.hasNext()) {
+                final Bom bom = dataSource.next();
+                dataSource.markProcessed(bom);
+                boms.add(bom);
+            }
+        }
+
+        assertEquals(1, boms.size());
+        final Bom bom = boms.getFirst();
+        assertEquals(1, bom.getComponentsCount());
+        assertEquals("cpe:2.3:a:suse:rancher_fleet:*:*:*:*:*:*:*:*", bom.getComponents(0).getCpe());
+        assertEquals(1, bom.getVulnerabilitiesCount());
+        // Every JVN advisory is stored as-is under the JVN source, keyed by its JVNDB id
+        // (no CVE->NVD routing), even when it carries a CVE.
+        assertEquals("JVN", bom.getVulnerabilities(0).getSource().getName());
+        assertTrue(bom.getVulnerabilities(0).getId().startsWith("JVNDB-"));
+        assertEquals(4, bom.getVulnerabilities(0).getAffects(0).getVersionsCount());
+    }
+}

--- a/vuln-data-source/jvn/src/test/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSourceTest.java
+++ b/vuln-data-source/jvn/src/test/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSourceTest.java
@@ -34,6 +34,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @WireMockTest
@@ -82,5 +83,43 @@ class JvnVulnDataSourceTest {
         assertEquals("JVN", bom.getVulnerabilities(0).getSource().getName());
         assertTrue(bom.getVulnerabilities(0).getId().startsWith("JVNDB-"));
         assertEquals(4, bom.getVulnerabilities(0).getAffects(0).getVersionsCount());
+    }
+
+    @Test
+    void skipsTruncatedFeedWithoutCommittingItsDigest(final WireMockRuntimeInfo wm) throws Exception {
+        final String detailXml = new String(
+                getClass().getResourceAsStream("/jvn-detail-with-range.xml").readAllBytes(),
+                StandardCharsets.UTF_8);
+        // Cut the feed off in the middle of its <Vulinfo>, after the JVNDB id.
+        final String truncatedXml = detailXml.substring(0, detailXml.indexOf("</Vulinfo>"));
+        final String checksumJson = """
+                [{"url":"x","filename":"%s","sha256":"deadbeef","size":1,"lastModified":"2026/01/01 00:00:00"}]
+                """.formatted(FEED_FILENAME);
+
+        stubFor(get(urlPathEqualTo("/checksum.txt"))
+                .willReturn(aResponse().withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(checksumJson)));
+        stubFor(get(urlPathEqualTo("/detail/" + FEED_FILENAME))
+                .willReturn(aResponse().withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody(truncatedXml)));
+
+        final var client = new JvnClient(HttpClient.newHttpClient(), wm.getHttpBaseUrl());
+        final var kvStore = new MockKeyValueStore();
+
+        final var boms = new ArrayList<Bom>();
+        final var watermark = new WatermarkManager(kvStore, List.of(FEED_FILENAME));
+        try (final var dataSource = new JvnVulnDataSource(client, watermark, YEAR, YEAR)) {
+            while (dataSource.hasNext()) {
+                boms.add(dataSource.next());
+            }
+        }
+
+        // The advisory parsed before the truncation point may or may not surface; what must hold
+        // is that no exception escaped, and the digest was not committed, so a subsequent run
+        // re-fetches the failed year rather than skipping it as unchanged.
+        final var secondWatermark = new WatermarkManager(kvStore, List.of(FEED_FILENAME));
+        assertNull(secondWatermark.getCommittedFeedDigest(FEED_FILENAME));
     }
 }

--- a/vuln-data-source/jvn/src/test/java/org/dependencytrack/vulndatasource/jvn/ModelConverterTest.java
+++ b/vuln-data-source/jvn/src/test/java/org/dependencytrack/vulndatasource/jvn/ModelConverterTest.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource.jvn;
+
+import org.cyclonedx.proto.v1_7.Bom;
+import org.cyclonedx.proto.v1_7.Component;
+import org.cyclonedx.proto.v1_7.Vulnerability;
+import org.cyclonedx.proto.v1_7.VulnerabilityAffects;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ModelConverterTest {
+
+    @Test
+    void convertsRealAdvisoryToBov() throws Exception {
+        final List<JvnAdvisory> advisories;
+        try (InputStream in = getClass().getResourceAsStream("/jvn-detail-with-range.xml")) {
+            assertNotNull(in);
+            advisories = JvnDetailParser.parse(in);
+        }
+        final Bom bom = ModelConverter.convert(advisories.getFirst());
+
+        assertEquals(1, bom.getComponentsCount());
+        final Component component = bom.getComponents(0);
+        assertEquals("cpe:2.3:a:suse:rancher_fleet:*:*:*:*:*:*:*:*", component.getCpe());
+        assertEquals("rancher_fleet", component.getName());
+
+        assertEquals(1, bom.getVulnerabilitiesCount());
+        final Vulnerability vuln = bom.getVulnerabilities(0);
+        // Every advisory is stored as-is under the JVN source, keyed by its JVNDB id, even when
+        // it carries a CVE (no CVE->NVD routing / dedup).
+        assertEquals("JVNDB-2026-022538", vuln.getId());
+        assertEquals("JVN", vuln.getSource().getName());
+
+        assertEquals(1, vuln.getAffectsCount());
+        final VulnerabilityAffects affects = vuln.getAffects(0);
+        assertEquals(component.getBomRef(), affects.getRef());
+        // Four affected version ranges in the fixture, all parseable to vers ranges.
+        assertEquals(4, affects.getVersionsCount());
+        assertTrue(affects.getVersionsList().stream()
+                .anyMatch(v -> v.getRange().equals("vers:generic/>=0.15.0|<0.15.2")));
+    }
+}

--- a/vuln-data-source/jvn/src/test/resources/jvn-detail-with-range.xml
+++ b/vuln-data-source/jvn/src/test/resources/jvn-detail-with-range.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" ?>   
+<VULDEF-Document 
+version="3.2" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xmlns="http://jvn.jp/vuldef/" 
+xmlns:vuldef="http://jvn.jp/vuldef/" 
+xmlns:status="http://jvndb.jvn.jp/myjvn/Status" 
+xmlns:sec="http://jvn.jp/rss/mod_sec/3.0/" 
+xmlns:marking="http://data-marking.mitre.org/Marking-1" 
+xmlns:tlpMarking="http://data-marking.mitre.org/extensions/MarkingStructure#TLP-1" 
+xsi:schemaLocation="http://jvn.jp/vuldef/ https://jvndb.jvn.jp/schema/vuldef_3.2.xsd http://jvn.jp/rss/mod_sec/3.0/ https://jvndb.jvn.jp/schema/mod_sec_3.0.xsd http://data-marking.mitre.org/extensions/MarkingStructure#TLP-1 https://jvndb.jvn.jp/schema/tlp_marking.xsd http://jvndb.jvn.jp/myjvn/Status https://jvndb.jvn.jp/schema/status_3.3.xsd" 
+xml:lang="ja">
+    <Vulinfo>
+      <VulinfoID>JVNDB-2026-022538</VulinfoID>
+      <VulinfoData>
+        <Title>SUSEのRancher Fleetにおける指定されたタイプの入力に対する不適切な検証に関する脆弱性</Title>
+        <VulinfoDescription>
+          <Overview>SUSE Rancher FleetのHelm Deployer（バージョン0.15の0.15.2未満、0.14の0.14.6未満、0.13の0.13.11未満、及び0.12の0.12.15未満）において、「valuesFrom」の参照の検証が欠如しているため、あるテナントの所有者が他のテナントのFleet認証情報にアクセスできる可能性があります。 </Overview>
+        </VulinfoDescription>
+        <Affected>
+          <AffectedItem>
+            <Name>SUSE</Name>
+            <ProductName>Rancher Fleet</ProductName>
+            <Cpe version="2.2">cpe:/a:suse:rancher_fleet</Cpe>
+            <VersionNumber>0.12.0 以上 0.12.15 未満</VersionNumber>
+            <VersionNumber>0.13.0 以上 0.13.11 未満</VersionNumber>
+            <VersionNumber>0.14.0 以上 0.14.6 未満</VersionNumber>
+            <VersionNumber>0.15.0 以上 0.15.2 未満</VersionNumber>
+          </AffectedItem>
+        </Affected>
+        <Impact>
+          <Cvss version="3.0">
+            <Severity type="Base">Critical</Severity>
+            <Base>9.9</Base>
+            <Vector>CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H</Vector>
+          </Cvss>
+          <ImpactItem>
+            <Description>・当該ソフトウェアが扱う全ての情報が外部に漏れる可能性があります。 ・当該ソフトウェアが扱う全ての情報が書き換えられる可能性があります。 ・当該ソフトウェアが完全に停止する可能性があります。 </Description>
+          </ImpactItem>
+        </Impact>
+        <Solution>
+          <SolutionItem>
+            <Description>ベンダ情報を参照して適切な対策を実施してください。 </Description>
+          </SolutionItem>
+        </Solution>
+        <Related>
+          <RelatedItem type="vendor">
+            <Name>GitHub</Name>
+            <VulinfoID>Cross namespace secret disclosure via unvalidated `valuesFrom` references in Helm Deployer  Advisory  rancher/fleet  GitHub</VulinfoID>
+            <URL>https://github.com/rancher/fleet/security/advisories/GHSA-xr65-5cpm-g36x</URL>
+          </RelatedItem>
+          <RelatedItem type="advisory">
+            <Name>Common Vulnerabilities and Exposures (CVE)</Name>
+            <VulinfoID>CVE-2026-44935</VulinfoID>
+            <URL>https://www.cve.org/CVERecord?id=CVE-2026-44935</URL>
+          </RelatedItem>
+          <RelatedItem type="advisory">
+            <Name>National Vulnerability Database (NVD)</Name>
+            <VulinfoID>CVE-2026-44935</VulinfoID>
+            <URL>https://nvd.nist.gov/vuln/detail/CVE-2026-44935</URL>
+          </RelatedItem>
+          <RelatedItem type="cwe">
+            <Name>JVNDB</Name>
+            <VulinfoID>CWE-1287</VulinfoID>
+            <Title>指定されたタイプの入力に対する不適切な検証</Title>
+            <URL>https://cwe.mitre.org/data/definitions/1287.html</URL>
+          </RelatedItem>
+        </Related>
+        <History>
+          <HistoryItem>
+            <HistoryNo>1</HistoryNo>
+            <DateTime>2026-07-07T10:44:46+09:00</DateTime>
+            <Description>[2026年07月07日]\n  掲載</Description>
+          </HistoryItem>
+        </History>
+        <DateFirstPublished>2026-07-07T10:44:46+09:00</DateFirstPublished>
+        <DateLastUpdated>2026-07-07T10:44:46+09:00</DateLastUpdated>
+        <DatePublic>2026-07-02T00:00:00+09:00</DatePublic>
+      </VulinfoData>
+    </Vulinfo>
+    <sec:handling>
+      <marking:Marking>
+        <marking:Marking_Structure xsi:type="tlpMarking:TLPMarkingStructureType" marking_model_name="TLP" marking_model_ref="http://www.us-cert.gov/tlp/" color="WHITE"/>
+      </marking:Marking>
+    </sec:handling>
+    <status:Status version="3.3" method="getVulnDetailInfo" lang="ja" retCd="0" retMax="10" errCd="" errMsg="" totalRes="1" totalResRet="1" firstRes="1" feed="hnd" vulnId="JVNDB-2026-022538"/>
+  </VULDEF-Document>
+

--- a/vuln-data-source/pom.xml
+++ b/vuln-data-source/pom.xml
@@ -33,6 +33,7 @@
     <modules>
         <module>api</module>
         <module>github</module>
+        <module>jvn</module>
         <module>nvd</module>
         <module>osv</module>
     </modules>


### PR DESCRIPTION
### Description

Adds a new vulnerability data source module for [JVN / JVN iPedia](https://jvndb.jvn.jp/) (Japan Vulnerability Notes, operated by JPCERT/CC and IPA), implementing the `VulnDataSource` extension point of ADR-010. Disabled by default.

The module mirrors the complete JVN history from the yearly detail feeds (`jvndb_detail_YYYY.rdf`, 1998–present), skipping years whose `sha256` in `checksum.txt` is unchanged since the last successful run (feed-digest checkpoint in the plugin KV store, mirroring the NVD module's checkpointing). Advisories are converted to CycloneDX BOVs and flow through the existing mirror pipeline — no changes to ingestion, storage, or matching.

JVN-specific handling:

* **CPE 2.2 → 2.3 normalisation.** JVN publishes CPE 2.2 URIs; they are converted to CPE 2.3 formatted strings before being emitted on BOV `affects` components.
* **Japanese version-expression parsing.** JVN CPEs are product-level; affected versions are carried in a free-text Japanese field (e.g. `"0.15.0 以上 0.15.2 未満"`). These are parsed into `vers` ranges (`以上`→`>=`, `未満`→`<`, …) so CPE matching is version-precise. Products with no parseable version fall back to an all-versions range.
* **Source identity.** Every advisory is stored as-is under a new `JVN` source, keyed by its `JVNDB-*` id (no CVE→NVD routing; rationale and the considered alternative are in the ADR). This requires registering `JVN` in `Vulnerability.Source`, since the mirror validates source names via `Source.ofName`.

### Addressed Issue

Closes #6626

### Additional Details

* ADR: `docs/adr/031-jvn-vulnerability-data-source.md` (first commit of this PR, status *Proposed*) documents the PoC measurements that drove the design — notably that the MyJVN query API caps at the ~747 most recent advisories and cannot backfill history (hence the yearly feeds, the same channel vulsio/go-cve-dictionary uses), and that ~96% of JVN entries overlap the NVD, making the JVN-only ~4% (mostly Japanese domestic-vendor products), Japanese descriptions, and timeliness the durable value.
* Verified end-to-end against live JVN data: 709 advisories ingested through the mirror pipeline; `InternalVulnAnalyzer` produced findings for in-range CPE components and correctly did not match out-of-range versions.
* Unit tests cover the feed client/iterator (WireMock), the VULDEF detail parser, the Japanese version-expression parser, and BOV conversion.
* As noted in #6187, this is contributed in-tree for now. Once external plugin loading matures, I'd be happy to use this module as a real-world test case for migrating a vulnerability data source out-of-tree.

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [x] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
