### PR TITLE
Reduce resource footprint of project metrics updates

### DIFF
--- a/apiserver/src/test/java/org/dependencytrack/metrics/UpdateProjectMetricsActivityTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/metrics/UpdateProjectMetricsActivityTest.java
@@ -35,6 +35,7 @@ import org.dependencytrack.persistence.jdbi.MetricsTestDao;
 import org.dependencytrack.proto.internal.workflow.v1.UpdateProjectMetricsArg;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
@@ -93,27 +94,98 @@ class UpdateProjectMetricsActivityTest extends AbstractMetricsUpdateTaskTest {
     }
 
     @Test
-    void shouldUpdateMetricsUnchanged() throws Exception {
+    void shouldNotCreateNewRowsWhenMetricsUnchanged() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         qm.createProject(project, List.of(), false);
 
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib-a");
+        qm.createComponent(component, false);
+
         // Create risk score configproperties
         createTestConfigProperties();
 
-        // Record initial project metrics
+        // Record initial metrics
         executeActivity(project);
-        final ProjectMetrics metrics = withJdbiHandle(handle -> handle.attach(MetricsDao.class).getMostRecentProjectMetrics(project.getId()));
-        assertThat(metrics.getLastOccurrence()).isEqualTo(metrics.getFirstOccurrence());
+
+        final ProjectMetrics initialProjectMetrics = withJdbiHandle(
+                handle -> handle
+                        .attach(MetricsDao.class)
+                        .getMostRecentProjectMetrics(project.getId()));
+        assertThat(initialProjectMetrics.getLastOccurrence())
+                .isEqualTo(initialProjectMetrics.getFirstOccurrence());
 
         // Run the task a second time, without any metric being changed
-        final var beforeSecondRun = new Date();
         executeActivity(project);
 
-        // Two records should be created in today's partition since it's append-only
-        final var recentMetrics = withJdbiHandle(handle -> handle.attach(MetricsDao.class).getMostRecentProjectMetrics(project.getId()));
-        assertThat(recentMetrics.getLastOccurrence()).isNotEqualTo(metrics.getFirstOccurrence());
-        assertThat(recentMetrics.getLastOccurrence()).isAfterOrEqualTo(beforeSecondRun);
+        // No new row must have been created, and the existing row's timestamp must remain untouched
+        final List<ProjectMetrics> projectMetrics = withJdbiHandle(
+                handle -> handle
+                        .attach(MetricsDao.class)
+                        .getProjectMetricsSince(project.getId(), Instant.EPOCH));
+        assertThat(projectMetrics)
+                .hasSize(1)
+                .first()
+                .extracting(ProjectMetrics::getLastOccurrence)
+                .isEqualTo(initialProjectMetrics.getLastOccurrence());
+
+        final List<DependencyMetrics> componentMetrics = withJdbiHandle(
+                handle -> handle
+                        .attach(MetricsDao.class)
+                        .getDependencyMetricsSince(component.getId(), Instant.EPOCH));
+        assertThat(componentMetrics).hasSize(1);
+    }
+
+    @Test
+    void shouldCreateNewRowsWhenMetricsChanged() throws Exception {
+        createTestConfigProperties();
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.createProject(project, List.of(), false);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib-a");
+        qm.createComponent(component, false);
+
+        // Populate initial metrics.
+        executeActivity(project);
+
+        // Make component affected by a vuln so its metrics values
+        // will differ from the initial ones.
+        var vuln = new Vulnerability();
+        vuln.setVulnId("INTERNAL-001");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        vuln = qm.createVulnerability(vuln);
+        qm.addVulnerability(vuln, component, "none");
+
+        // Calculate metrics again.
+        executeActivity(project);
+
+        // New rows must be created despite snapshots existing for the current day.
+        final List<ProjectMetrics> projectMetrics = withJdbiHandle(
+                handle -> handle
+                        .attach(MetricsDao.class)
+                        .getProjectMetricsSince(project.getId(), Instant.EPOCH));
+        assertThat(projectMetrics)
+                .hasSize(2)
+                .last()
+                .extracting(ProjectMetrics::getVulnerabilities)
+                .isEqualTo(1);
+
+        final List<DependencyMetrics> componentMetrics = withJdbiHandle(
+                handle -> handle
+                        .attach(MetricsDao.class)
+                        .getDependencyMetricsSince(component.getId(), Instant.EPOCH));
+        assertThat(componentMetrics)
+                .hasSize(2)
+                .last()
+                .extracting(DependencyMetrics::getVulnerabilities)
+                .isEqualTo(1);
     }
 
     @Test
@@ -334,6 +406,235 @@ class UpdateProjectMetricsActivityTest extends AbstractMetricsUpdateTaskTest {
         assertThat(componentUnaudited.getLastInheritedRiskScore()).isZero();
         assertThat(componentAudited.getLastInheritedRiskScore()).isZero();
         assertThat(componentSuppressed.getLastInheritedRiskScore()).isZero();
+    }
+
+    @Test
+    void shouldComputeSameMetricsAsComponentLevelComputation() throws Exception {
+        // NB: Project metrics calculate metrics of all components within the project
+        // in bulk. The corresponding logic differs from the one used to update metrics
+        // for individual components (they're different stored procs).
+        //
+        // To ensure consistency between the two paths, it's CRITICAL that both compute
+        // the exact same data. This test is meant to assert this to detect unintended
+        // drift later down the road.
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.createProject(project, List.of(), false);
+
+        createTestConfigProperties();
+
+        var vuln = new Vulnerability();
+        vuln.setVulnId("INTERNAL-001");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        vuln = qm.createVulnerability(vuln);
+
+        final var componentClean = new Component();
+        componentClean.setProject(project);
+        componentClean.setName("acme-lib-clean");
+        qm.createComponent(componentClean, false);
+
+        final var componentVulnUnaudited = new Component();
+        componentVulnUnaudited.setProject(project);
+        componentVulnUnaudited.setName("acme-lib-vuln-unaudited");
+        qm.createComponent(componentVulnUnaudited, false);
+        qm.addVulnerability(vuln, componentVulnUnaudited, "none");
+
+        final var componentVulnAudited = new Component();
+        componentVulnAudited.setProject(project);
+        componentVulnAudited.setName("acme-lib-vuln-audited");
+        qm.createComponent(componentVulnAudited, false);
+        qm.addVulnerability(vuln, componentVulnAudited, "none");
+        qm.makeAnalysis(
+                new MakeAnalysisCommand(componentVulnAudited, vuln)
+                        .withState(AnalysisState.NOT_AFFECTED));
+
+        final var componentVulnSuppressed = new Component();
+        componentVulnSuppressed.setProject(project);
+        componentVulnSuppressed.setName("acme-lib-vuln-suppressed");
+        qm.createComponent(componentVulnSuppressed, false);
+        qm.addVulnerability(vuln, componentVulnSuppressed, "none");
+        qm.makeAnalysis(
+                new MakeAnalysisCommand(componentVulnSuppressed, vuln)
+                        .withState(AnalysisState.FALSE_POSITIVE)
+                        .withSuppress(true));
+
+        final var componentViolationUnaudited = new Component();
+        componentViolationUnaudited.setProject(project);
+        componentViolationUnaudited.setName("acme-lib-violation-unaudited");
+        qm.createComponent(componentViolationUnaudited, false);
+        createPolicyViolation(
+                componentViolationUnaudited,
+                Policy.ViolationState.FAIL,
+                PolicyViolation.Type.LICENSE);
+
+        final var componentViolationAudited = new Component();
+        componentViolationAudited.setProject(project);
+        componentViolationAudited.setName("acme-lib-violation-audited");
+        qm.createComponent(componentViolationAudited, false);
+        final var violationAudited = createPolicyViolation(
+                componentViolationAudited,
+                Policy.ViolationState.WARN,
+                PolicyViolation.Type.OPERATIONAL);
+        qm.makeViolationAnalysis(
+                new MakeViolationAnalysisCommand(componentViolationAudited, violationAudited)
+                        .withState(ViolationAnalysisState.APPROVED));
+
+        final var componentViolationSuppressed = new Component();
+        componentViolationSuppressed.setProject(project);
+        componentViolationSuppressed.setName("acme-lib-violation-suppressed");
+        qm.createComponent(componentViolationSuppressed, false);
+        final var violationSuppressed = createPolicyViolation(
+                componentViolationSuppressed,
+                Policy.ViolationState.INFO,
+                PolicyViolation.Type.SECURITY);
+        qm.makeViolationAnalysis(
+                new MakeViolationAnalysisCommand(componentViolationSuppressed, violationSuppressed)
+                        .withState(ViolationAnalysisState.REJECTED)
+                        .withSuppress(true));
+
+        final List<Component> components = List.of(
+                componentClean,
+                componentVulnUnaudited,
+                componentVulnAudited,
+                componentVulnSuppressed,
+                componentViolationUnaudited,
+                componentViolationAudited,
+                componentViolationSuppressed);
+
+        executeActivity(project);
+
+        final List<DependencyMetrics> projectLevelMetrics = components.stream()
+                .map(component -> withJdbiHandle(handle -> handle
+                        .attach(MetricsDao.class)
+                        .getMostRecentDependencyMetrics(component.getId())))
+                .toList();
+
+        // Wipe all component metrics so the single-component procedure's
+        // change detection cannot skip any insert.
+        useJdbiHandle(handle -> handle.execute("DELETE FROM \"DEPENDENCYMETRICS\""));
+
+        useJdbiHandle(handle -> {
+            final var dao = handle.attach(MetricsDao.class);
+            components.forEach(component -> dao.updateComponentMetrics(component.getUuid()));
+        });
+
+        for (int i = 0; i < components.size(); i++) {
+            final long componentId = components.get(i).getId();
+            final DependencyMetrics componentMetrics = withJdbiHandle(
+                    handle -> handle
+                            .attach(MetricsDao.class)
+                            .getMostRecentDependencyMetrics(componentId));
+            assertThat(componentMetrics)
+                    .usingRecursiveComparison()
+                    .ignoringFields("firstOccurrence", "lastOccurrence")
+                    .isEqualTo(projectLevelMetrics.get(i));
+        }
+    }
+
+    @Test
+    void shouldCreateNewRowsOnNewDay() throws Exception {
+        // Daily datapoint queries (portfolio metrics, PORTFOLIOMETRICS_GLOBAL, collection metrics)
+        // rely on at least one PROJECTMETRICS row existing per project per day.
+        // Snapshots of a previous day must never suppress an insert, even when their values are identical.
+
+        createTestConfigProperties();
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.createProject(project, List.of(), false);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib-a");
+        qm.createComponent(component, false);
+
+        // Seed yesterday's rows, with values identical to what the metrics update will compute.
+        final Date yesterday = Date.from(Instant.now().minus(Duration.ofDays(1)));
+        useJdbiHandle(handle -> {
+            final var dao = handle.attach(MetricsTestDao.class);
+            dao.createPartitionForDaysAgo("PROJECTMETRICS", 1);
+            dao.createPartitionForDaysAgo("DEPENDENCYMETRICS", 1);
+
+            final var projectMetrics = new ProjectMetrics();
+            projectMetrics.setProjectId(project.getId());
+            projectMetrics.setComponents(1);
+            projectMetrics.setFirstOccurrence(yesterday);
+            projectMetrics.setLastOccurrence(yesterday);
+            dao.createProjectMetrics(projectMetrics);
+
+            final var dependencyMetrics = new DependencyMetrics();
+            dependencyMetrics.setProjectId(project.getId());
+            dependencyMetrics.setComponentId(component.getId());
+            dependencyMetrics.setFirstOccurrence(yesterday);
+            dependencyMetrics.setLastOccurrence(yesterday);
+            dao.createDependencyMetrics(dependencyMetrics);
+        });
+
+        executeActivity(project);
+
+        final List<ProjectMetrics> projectMetrics = withJdbiHandle(
+                handle -> handle
+                        .attach(MetricsDao.class)
+                        .getProjectMetricsSince(project.getId(), Instant.EPOCH));
+        assertThat(projectMetrics).hasSize(2);
+        assertThat(projectMetrics.getLast().getLastOccurrence()).isAfter(yesterday);
+
+        final List<DependencyMetrics> componentMetrics = withJdbiHandle(
+                handle -> handle
+                        .attach(MetricsDao.class)
+                        .getDependencyMetricsSince(component.getId(), Instant.EPOCH));
+        assertThat(componentMetrics).hasSize(2);
+        assertThat(componentMetrics.getLast().getLastOccurrence()).isAfter(yesterday);
+    }
+
+    @Test
+    void shouldCreateNewRowsWhenLatestRowHasNullColumns() throws Exception {
+        // Some metric columns are nullable and may be NULL in rows migrated
+        // from v4. Change detection must treat NULL as changed and insert a fresh row,
+        // rather than silently skipping.
+
+        createTestConfigProperties();
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.createProject(project, List.of(), false);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib-a");
+        qm.createComponent(component, false);
+
+        // Seed a row for the current day whose values match what the
+        // metrics update will compute, then NULL out its nullable columns.
+        useJdbiHandle(handle -> {
+            final var dependencyMetrics = new DependencyMetrics();
+            dependencyMetrics.setProjectId(project.getId());
+            dependencyMetrics.setComponentId(component.getId());
+            dependencyMetrics.setFirstOccurrence(Date.from(Instant.now().minus(Duration.ofMinutes(1))));
+            dependencyMetrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofMinutes(1))));
+            handle.attach(MetricsTestDao.class).createDependencyMetrics(dependencyMetrics);
+
+            handle.createUpdate("""
+                            UPDATE "DEPENDENCYMETRICS"
+                               SET "FINDINGS_TOTAL" = NULL
+                                 , "FINDINGS_AUDITED" = NULL
+                                 , "FINDINGS_UNAUDITED" = NULL
+                                 , "UNASSIGNED_SEVERITY" = NULL
+                             WHERE "COMPONENT_ID" = :componentId
+                            """)
+                    .bind("componentId", component.getId())
+                    .execute();
+        });
+
+        executeActivity(project);
+
+        final List<DependencyMetrics> componentMetrics = withJdbiHandle(
+                handle -> handle
+                        .attach(MetricsDao.class)
+                        .getDependencyMetricsSince(component.getId(), Instant.EPOCH));
+        assertThat(componentMetrics).hasSize(2);
     }
 
     private void executeActivity(Project project) throws Exception {

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/MetricsTestDao.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/MetricsTestDao.java
@@ -104,10 +104,68 @@ public interface MetricsTestDao extends SqlObject {
 
     @SqlQuery("""
             INSERT INTO "DEPENDENCYMETRICS"(
-                "COMPONENT_ID", "PROJECT_ID", "FIRST_OCCURRENCE", "LAST_OCCURRENCE", "CRITICAL", "HIGH", "MEDIUM", "LOW", "RISKSCORE",
-                "SUPPRESSED", "VULNERABILITIES")
-            VALUES (:componentId, :projectId, :firstOccurrence, :lastOccurrence, :critical, :high, :medium, :low, :inheritedRiskScore,
-                 :suppressed, :vulnerabilities)
+              "COMPONENT_ID"
+            , "PROJECT_ID"
+            , "FIRST_OCCURRENCE"
+            , "LAST_OCCURRENCE"
+            , "CRITICAL"
+            , "FINDINGS_AUDITED"
+            , "FINDINGS_TOTAL"
+            , "FINDINGS_UNAUDITED"
+            , "HIGH"
+            , "LOW"
+            , "MEDIUM"
+            , "POLICYVIOLATIONS_AUDITED"
+            , "POLICYVIOLATIONS_FAIL"
+            , "POLICYVIOLATIONS_INFO"
+            , "POLICYVIOLATIONS_LICENSE_AUDITED"
+            , "POLICYVIOLATIONS_LICENSE_TOTAL"
+            , "POLICYVIOLATIONS_LICENSE_UNAUDITED"
+            , "POLICYVIOLATIONS_OPERATIONAL_AUDITED"
+            , "POLICYVIOLATIONS_OPERATIONAL_TOTAL"
+            , "POLICYVIOLATIONS_OPERATIONAL_UNAUDITED"
+            , "POLICYVIOLATIONS_SECURITY_AUDITED"
+            , "POLICYVIOLATIONS_SECURITY_TOTAL"
+            , "POLICYVIOLATIONS_SECURITY_UNAUDITED"
+            , "POLICYVIOLATIONS_TOTAL"
+            , "POLICYVIOLATIONS_UNAUDITED"
+            , "POLICYVIOLATIONS_WARN"
+            , "RISKSCORE"
+            , "SUPPRESSED"
+            , "UNASSIGNED_SEVERITY"
+            , "VULNERABILITIES"
+            ) VALUES (
+              :componentId
+            , :projectId
+            , :firstOccurrence
+            , :lastOccurrence
+            , :critical
+            , :findingsAudited
+            , :findingsTotal
+            , :findingsUnaudited
+            , :high
+            , :low
+            , :medium
+            , :policyViolationsAudited
+            , :policyViolationsFail
+            , :policyViolationsInfo
+            , :policyViolationsLicenseAudited
+            , :policyViolationsLicenseTotal
+            , :policyViolationsLicenseUnaudited
+            , :policyViolationsOperationalAudited
+            , :policyViolationsOperationalTotal
+            , :policyViolationsOperationalUnaudited
+            , :policyViolationsSecurityAudited
+            , :policyViolationsSecurityTotal
+            , :policyViolationsSecurityUnaudited
+            , :policyViolationsTotal
+            , :policyViolationsUnaudited
+            , :policyViolationsWarn
+            , :inheritedRiskScore
+            , :suppressed
+            , :unassigned
+            , :vulnerabilities
+            )
             RETURNING *
             """)
     @RegisterBeanMapper(DependencyMetrics.class)

--- a/migration/src/main/resources/org/dependencytrack/migration/R__compute_component_metrics.sql
+++ b/migration/src/main/resources/org/dependencytrack/migration/R__compute_component_metrics.sql
@@ -1,0 +1,195 @@
+-- NB: CREATE OR REPLACE cannot change a function's return type,
+-- so adding or removing a RETURNS TABLE column would fail on existing databases.
+-- Drop first to keep this migration repeatable even when new return columns are added.
+DROP FUNCTION IF EXISTS "COMPUTE_COMPONENT_METRICS"(BIGINT[]);
+
+CREATE FUNCTION "COMPUTE_COMPONENT_METRICS"(
+  component_ids BIGINT[]
+)
+  RETURNS TABLE (
+    component_id BIGINT
+  , vulnerabilities INT
+  , critical INT
+  , high INT
+  , medium INT
+  , low INT
+  , unassigned INT
+  , risk_score NUMERIC
+  , findings_total INT
+  , findings_audited INT
+  , findings_unaudited INT
+  , findings_suppressed INT
+  , policy_violations_total INT
+  , policy_violations_fail INT
+  , policy_violations_warn INT
+  , policy_violations_info INT
+  , policy_violations_audited INT
+  , policy_violations_unaudited INT
+  , policy_violations_license_total INT
+  , policy_violations_license_audited INT
+  , policy_violations_license_unaudited INT
+  , policy_violations_operational_total INT
+  , policy_violations_operational_audited INT
+  , policy_violations_operational_unaudited INT
+  , policy_violations_security_total INT
+  , policy_violations_security_audited INT
+  , policy_violations_security_unaudited INT
+  )
+  LANGUAGE "sql"
+  STABLE
+AS
+$$
+  WITH comp AS (
+    SELECT UNNEST(component_ids) AS id
+  ),
+  risk_score_weights AS (
+    SELECT MAX("PROPERTYVALUE"::INT) FILTER (WHERE "PROPERTYNAME" = 'weight.critical') AS w_critical
+         , MAX("PROPERTYVALUE"::INT) FILTER (WHERE "PROPERTYNAME" = 'weight.high') AS w_high
+         , MAX("PROPERTYVALUE"::INT) FILTER (WHERE "PROPERTYNAME" = 'weight.medium') AS w_medium
+         , MAX("PROPERTYVALUE"::INT) FILTER (WHERE "PROPERTYNAME" = 'weight.low') AS w_low
+         , MAX("PROPERTYVALUE"::INT) FILTER (WHERE "PROPERTYNAME" = 'weight.unassigned') AS w_unassigned
+      FROM "CONFIGPROPERTY"
+     WHERE "GROUPNAME" = 'risk-score'
+       AND "PROPERTYTYPE" = 'INTEGER'
+  ),
+  vuln_deduped AS (
+    SELECT DISTINCT ON (cv."COMPONENT_ID", va."GROUP_ID", CASE WHEN va."GROUP_ID" IS NULL THEN v."ID" END)
+           cv."COMPONENT_ID" AS component_id
+         , COALESCE(a."SEVERITY", v."SEVERITY") AS effective_severity
+      FROM "COMPONENTS_VULNERABILITIES" AS cv
+     INNER JOIN comp
+        ON comp.id = cv."COMPONENT_ID"
+     INNER JOIN "VULNERABILITY" AS v
+        ON v."ID" = cv."VULNERABILITY_ID"
+      LEFT JOIN "ANALYSIS" AS a
+        ON a."COMPONENT_ID" = cv."COMPONENT_ID"
+       AND a."VULNERABILITY_ID" = v."ID"
+      LEFT JOIN "VULNERABILITY_ALIAS" AS va
+        ON va."SOURCE" = v."SOURCE"
+       AND va."VULN_ID" = v."VULNID"
+     WHERE a."SUPPRESSED" IS DISTINCT FROM TRUE
+       AND EXISTS(
+         SELECT 1 FROM "FINDINGATTRIBUTION" AS fa
+          WHERE fa."COMPONENT_ID" = cv."COMPONENT_ID"
+            AND fa."VULNERABILITY_ID" = cv."VULNERABILITY_ID"
+            AND fa."DELETED_AT" IS NULL
+       )
+     ORDER BY cv."COMPONENT_ID"
+            , va."GROUP_ID"
+            , CASE WHEN va."GROUP_ID" IS NULL THEN v."ID" END
+            , COALESCE(a."SEVERITY", v."SEVERITY") DESC
+  ),
+  vuln_counts AS (
+    SELECT vuln_deduped.component_id
+         , COUNT(*)::INT AS vulnerabilities
+         , COUNT(*) FILTER (WHERE effective_severity = 'CRITICAL')::INT AS critical
+         , COUNT(*) FILTER (WHERE effective_severity = 'HIGH')::INT AS high
+         , COUNT(*) FILTER (WHERE effective_severity = 'MEDIUM')::INT AS medium
+         , COUNT(*) FILTER (WHERE effective_severity = 'LOW')::INT AS low
+         , COUNT(*) FILTER (WHERE effective_severity NOT IN ('CRITICAL','HIGH','MEDIUM','LOW'))::INT AS unassigned
+      FROM vuln_deduped
+     GROUP BY vuln_deduped.component_id
+  ),
+  analysis_counts AS (
+    SELECT a."COMPONENT_ID" AS component_id
+         , COUNT(*) FILTER (
+             WHERE a."SUPPRESSED" = FALSE
+               AND a."STATE" NOT IN ('NOT_SET', 'IN_TRIAGE')
+           )::INT AS findings_audited
+         , COUNT(*) FILTER (WHERE a."SUPPRESSED" = TRUE)::INT AS findings_suppressed
+      FROM "ANALYSIS" AS a
+     INNER JOIN comp
+        ON comp.id = a."COMPONENT_ID"
+     WHERE EXISTS(
+       SELECT 1 FROM "FINDINGATTRIBUTION" AS fa
+        WHERE fa."COMPONENT_ID" = a."COMPONENT_ID"
+          AND fa."VULNERABILITY_ID" = a."VULNERABILITY_ID"
+          AND fa."DELETED_AT" IS NULL
+     )
+     GROUP BY a."COMPONENT_ID"
+  ),
+  violation_counts AS (
+    SELECT pv."COMPONENT_ID" AS component_id
+         , COUNT(*)::INT AS total
+         , COUNT(*) FILTER (WHERE p."VIOLATIONSTATE" = 'FAIL')::INT AS fail
+         , COUNT(*) FILTER (WHERE p."VIOLATIONSTATE" = 'WARN')::INT AS warn
+         , COUNT(*) FILTER (WHERE p."VIOLATIONSTATE" = 'INFO')::INT AS info
+         , COUNT(*) FILTER (WHERE pv."TYPE" = 'LICENSE')::INT AS license_total
+         , COUNT(*) FILTER (WHERE pv."TYPE" = 'OPERATIONAL')::INT AS operational_total
+         , COUNT(*) FILTER (WHERE pv."TYPE" = 'SECURITY')::INT AS security_total
+      FROM "POLICYVIOLATION" AS pv
+     INNER JOIN comp
+        ON comp.id = pv."COMPONENT_ID"
+     INNER JOIN "POLICYCONDITION" AS pc
+        ON pv."POLICYCONDITION_ID" = pc."ID"
+     INNER JOIN "POLICY" AS p
+        ON pc."POLICY_ID" = p."ID"
+      LEFT JOIN "VIOLATIONANALYSIS" AS va
+        ON va."COMPONENT_ID" = pv."COMPONENT_ID"
+       AND va."POLICYVIOLATION_ID" = pv."ID"
+     WHERE (va IS NULL OR va."SUPPRESSED" = FALSE)
+     GROUP BY pv."COMPONENT_ID"
+  ),
+  violation_audit_counts AS (
+    SELECT va."COMPONENT_ID" AS component_id
+         , COUNT(*) FILTER (WHERE pv."TYPE" = 'LICENSE')::INT AS license_audited
+         , COUNT(*) FILTER (WHERE pv."TYPE" = 'OPERATIONAL')::INT AS operational_audited
+         , COUNT(*) FILTER (WHERE pv."TYPE" = 'SECURITY')::INT AS security_audited
+      FROM "VIOLATIONANALYSIS" AS va
+     INNER JOIN comp
+        ON comp.id = va."COMPONENT_ID"
+     INNER JOIN "POLICYVIOLATION" AS pv
+        ON pv."ID" = va."POLICYVIOLATION_ID"
+     WHERE va."SUPPRESSED" = FALSE
+       AND va."STATE" != 'NOT_SET'
+     GROUP BY va."COMPONENT_ID"
+  )
+  SELECT comp.id
+       , COALESCE(vc.vulnerabilities, 0)
+       , COALESCE(vc.critical, 0)
+       , COALESCE(vc.high, 0)
+       , COALESCE(vc.medium, 0)
+       , COALESCE(vc.low, 0)
+       , COALESCE(vc.unassigned, 0)
+       , COALESCE(
+           COALESCE(vc.critical, 0) * risk_score_weights.w_critical
+           + COALESCE(vc.high, 0) * risk_score_weights.w_high
+           + COALESCE(vc.medium, 0) * risk_score_weights.w_medium
+           + COALESCE(vc.low, 0) * risk_score_weights.w_low
+           + COALESCE(vc.unassigned, 0) * risk_score_weights.w_unassigned
+         , 0)::NUMERIC
+       , COALESCE(vc.vulnerabilities, 0)
+       , COALESCE(ac.findings_audited, 0)
+       , COALESCE(vc.vulnerabilities, 0) - COALESCE(ac.findings_audited, 0)
+       , COALESCE(ac.findings_suppressed, 0)
+       , COALESCE(pvc.total, 0)
+       , COALESCE(pvc.fail, 0)
+       , COALESCE(pvc.warn, 0)
+       , COALESCE(pvc.info, 0)
+       , COALESCE(pvac.license_audited, 0)
+         + COALESCE(pvac.operational_audited, 0)
+         + COALESCE(pvac.security_audited, 0)
+       , COALESCE(pvc.total, 0)
+         - (COALESCE(pvac.license_audited, 0)
+            + COALESCE(pvac.operational_audited, 0)
+            + COALESCE(pvac.security_audited, 0))
+       , COALESCE(pvc.license_total, 0)
+       , COALESCE(pvac.license_audited, 0)
+       , COALESCE(pvc.license_total, 0) - COALESCE(pvac.license_audited, 0)
+       , COALESCE(pvc.operational_total, 0)
+       , COALESCE(pvac.operational_audited, 0)
+       , COALESCE(pvc.operational_total, 0) - COALESCE(pvac.operational_audited, 0)
+       , COALESCE(pvc.security_total, 0)
+       , COALESCE(pvac.security_audited, 0)
+       , COALESCE(pvc.security_total, 0) - COALESCE(pvac.security_audited, 0)
+    FROM comp
+   CROSS JOIN risk_score_weights
+    LEFT JOIN vuln_counts AS vc
+      ON vc.component_id = comp.id
+    LEFT JOIN analysis_counts AS ac
+      ON ac.component_id = comp.id
+    LEFT JOIN violation_counts AS pvc
+      ON pvc.component_id = comp.id
+    LEFT JOIN violation_audit_counts AS pvac
+      ON pvac.component_id = comp.id
+$$;

--- a/migration/src/main/resources/org/dependencytrack/migration/R__update_component_metrics.sql
+++ b/migration/src/main/resources/org/dependencytrack/migration/R__update_component_metrics.sql
@@ -5,33 +5,10 @@ CREATE OR REPLACE PROCEDURE "UPDATE_COMPONENT_METRICS"(
 AS
 $$
 DECLARE
-  v_component                               RECORD; -- The component to update metrics for
-  v_vulnerabilities                         INT     := 0; -- Total number of vulnerabilities
-  v_critical                                INT     := 0; -- Number of vulnerabilities with critical severity
-  v_high                                    INT     := 0; -- Number of vulnerabilities with high severity
-  v_medium                                  INT     := 0; -- Number of vulnerabilities with medium severity
-  v_low                                     INT     := 0; -- Number of vulnerabilities with low severity
-  v_unassigned                              INT     := 0; -- Number of vulnerabilities with unassigned severity
-  v_risk_score                              NUMERIC := 0; -- Inherited risk score
-  v_findings_total                          INT     := 0; -- Total number of findings
-  v_findings_audited                        INT     := 0; -- Number of audited findings
-  v_findings_unaudited                      INT     := 0; -- Number of unaudited findings
-  v_findings_suppressed                     INT     := 0; -- Number of suppressed findings
-  v_policy_violations_total                 INT     := 0; -- Total number of policy violations
-  v_policy_violations_fail                  INT     := 0; -- Number of policy violations with level fail
-  v_policy_violations_warn                  INT     := 0; -- Number of policy violations with level warn
-  v_policy_violations_info                  INT     := 0; -- Number of policy violations with level info
-  v_policy_violations_audited               INT     := 0; -- Number of audited policy violations
-  v_policy_violations_unaudited             INT     := 0; -- Number of unaudited policy violations
-  v_policy_violations_license_total         INT     := 0; -- Total number of policy violations of type license
-  v_policy_violations_license_audited       INT     := 0; -- Number of audited policy violations of type license
-  v_policy_violations_license_unaudited     INT     := 0; -- Number of unaudited policy violations of type license
-  v_policy_violations_operational_total     INT     := 0; -- Total number of policy violations of type operational
-  v_policy_violations_operational_audited   INT     := 0; -- Number of audited policy violations of type operational
-  v_policy_violations_operational_unaudited INT     := 0; -- Number of unaudited policy violations of type operational
-  v_policy_violations_security_total        INT     := 0; -- Total number of policy violations of type security
-  v_policy_violations_security_audited      INT     := 0; -- Number of audited policy violations of type security
-  v_policy_violations_security_unaudited    INT     := 0; -- Number of unaudited policy violations of type security
+  v_component RECORD; -- The component to update metrics for
+  v_metrics   RECORD; -- The computed metrics of the component
+  v_latest    RECORD; -- The latest DEPENDENCYMETRICS snapshot of the component
+  v_today     TIMESTAMPTZ := DATE_TRUNC('day', NOW() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
 BEGIN
   SELECT "ID"
        , "PROJECT_ID"
@@ -42,116 +19,83 @@ BEGIN
     RAISE EXCEPTION 'Component with UUID % does not exist', component_uuid;
   END IF;
 
-  WITH deduped AS (
-    SELECT DISTINCT ON (va."GROUP_ID", CASE WHEN va."GROUP_ID" IS NULL THEN v."ID" END)
-           COALESCE(a."SEVERITY", v."SEVERITY") AS effective_severity
-      FROM "VULNERABILITY" AS v
-     INNER JOIN "COMPONENTS_VULNERABILITIES" AS cv
-        ON cv."COMPONENT_ID" = v_component."ID"
-       AND cv."VULNERABILITY_ID" = v."ID"
-      LEFT JOIN "ANALYSIS" AS a
-        ON a."COMPONENT_ID" = v_component."ID"
-       AND a."VULNERABILITY_ID" = v."ID"
-      LEFT JOIN "VULNERABILITY_ALIAS" AS va
-        ON va."SOURCE" = v."SOURCE"
-       AND va."VULN_ID" = v."VULNID"
-     WHERE (a."SUPPRESSED" != TRUE OR a."SUPPRESSED" IS NULL)
-       AND EXISTS(
-         SELECT 1 FROM "FINDINGATTRIBUTION" AS fa
-          WHERE fa."COMPONENT_ID" = cv."COMPONENT_ID"
-            AND fa."VULNERABILITY_ID" = cv."VULNERABILITY_ID"
-            AND fa."DELETED_AT" IS NULL
-       )
-     ORDER BY va."GROUP_ID"
-            , CASE WHEN va."GROUP_ID" IS NULL THEN v."ID" END
-            , COALESCE(a."SEVERITY", v."SEVERITY") DESC
-  )
-  SELECT COUNT(*)::INT
-       , COUNT(*) FILTER (WHERE effective_severity = 'CRITICAL')::INT
-       , COUNT(*) FILTER (WHERE effective_severity = 'HIGH')::INT
-       , COUNT(*) FILTER (WHERE effective_severity = 'MEDIUM')::INT
-       , COUNT(*) FILTER (WHERE effective_severity = 'LOW')::INT
-       , COUNT(*) FILTER (WHERE effective_severity NOT IN ('CRITICAL','HIGH','MEDIUM','LOW'))::INT
-    FROM deduped
-    INTO v_vulnerabilities
-       , v_critical
-       , v_high
-       , v_medium
-       , v_low
-       , v_unassigned;
+  SELECT *
+    INTO v_metrics
+    FROM "COMPUTE_COMPONENT_METRICS"(ARRAY[v_component."ID"]);
 
-  v_risk_score = COALESCE("CALC_RISK_SCORE"(v_critical, v_high, v_medium, v_low, v_unassigned), 0);
+  UPDATE "COMPONENT"
+     SET "LAST_RISKSCORE" = v_metrics.risk_score
+   WHERE "ID" = v_component."ID"
+     AND "LAST_RISKSCORE" IS DISTINCT FROM v_metrics.risk_score;
 
-  SELECT COALESCE(COUNT(*) FILTER (
-             WHERE a."SUPPRESSED" = FALSE
-               AND a."STATE" NOT IN ('NOT_SET', 'IN_TRIAGE')
-         ), 0)::INT
-       , COALESCE(COUNT(*) FILTER (
-             WHERE a."SUPPRESSED" = TRUE
-         ), 0)::INT
-    FROM "ANALYSIS" AS a
-   WHERE a."COMPONENT_ID" = v_component."ID"
-     AND EXISTS(
-       SELECT 1 FROM "FINDINGATTRIBUTION" AS fa
-        WHERE fa."COMPONENT_ID" = a."COMPONENT_ID"
-          AND fa."VULNERABILITY_ID" = a."VULNERABILITY_ID"
-          AND fa."DELETED_AT" IS NULL
-     )
-    INTO v_findings_audited
-       , v_findings_suppressed;
+  SELECT *
+    INTO v_latest
+    FROM "DEPENDENCYMETRICS"
+   WHERE "COMPONENT_ID" = v_component."ID"
+     AND "LAST_OCCURRENCE" >= v_today
+   ORDER BY "LAST_OCCURRENCE" DESC
+   LIMIT 1;
 
-  v_findings_total = v_vulnerabilities;
-  v_findings_unaudited = v_findings_total - v_findings_audited;
-
-  SELECT COUNT(*)::INT
-       , COUNT(*) FILTER (WHERE p."VIOLATIONSTATE" = 'FAIL')::INT
-       , COUNT(*) FILTER (WHERE p."VIOLATIONSTATE" = 'WARN')::INT
-       , COUNT(*) FILTER (WHERE p."VIOLATIONSTATE" = 'INFO')::INT
-       , COUNT(*) FILTER (WHERE pv."TYPE" = 'LICENSE')::INT
-       , COUNT(*) FILTER (WHERE pv."TYPE" = 'OPERATIONAL')::INT
-       , COUNT(*) FILTER (WHERE pv."TYPE" = 'SECURITY')::INT
-    FROM "POLICYVIOLATION" AS pv
-   INNER JOIN "POLICYCONDITION" AS pc
-      ON pv."POLICYCONDITION_ID" = pc."ID"
-   INNER JOIN "POLICY" AS p
-      ON pc."POLICY_ID" = p."ID"
-    LEFT JOIN "VIOLATIONANALYSIS" AS va
-      ON va."COMPONENT_ID" = v_component."ID"
-     AND va."POLICYVIOLATION_ID" = pv."ID"
-   WHERE pv."COMPONENT_ID" = v_component."ID"
-     AND (va IS NULL OR va."SUPPRESSED" = FALSE)
-    INTO v_policy_violations_total
-       , v_policy_violations_fail
-       , v_policy_violations_warn
-       , v_policy_violations_info
-       , v_policy_violations_license_total
-       , v_policy_violations_operational_total
-       , v_policy_violations_security_total;
-
-  SELECT COALESCE(COUNT(*) FILTER (WHERE pv."TYPE" = 'LICENSE'), 0)::INT
-       , COALESCE(COUNT(*) FILTER (WHERE pv."TYPE" = 'OPERATIONAL'), 0)::INT
-       , COALESCE(COUNT(*) FILTER (WHERE pv."TYPE" = 'SECURITY'), 0)::INT
-    FROM "VIOLATIONANALYSIS" AS va
-   INNER JOIN "POLICYVIOLATION" AS pv
-      ON pv."ID" = va."POLICYVIOLATION_ID"
-   WHERE va."COMPONENT_ID" = v_component."ID"
-     AND va."SUPPRESSED" = FALSE
-     AND va."STATE" != 'NOT_SET'
-    INTO v_policy_violations_license_audited
-       , v_policy_violations_operational_audited
-       , v_policy_violations_security_audited;
-
-  v_policy_violations_license_unaudited =
-      v_policy_violations_license_total - v_policy_violations_license_audited;
-  v_policy_violations_operational_unaudited =
-      v_policy_violations_operational_total - v_policy_violations_operational_audited;
-  v_policy_violations_security_unaudited =
-      v_policy_violations_security_total - v_policy_violations_security_audited;
-
-  v_policy_violations_audited = v_policy_violations_license_audited
-    + v_policy_violations_operational_audited
-    + v_policy_violations_security_audited;
-  v_policy_violations_unaudited = v_policy_violations_total - v_policy_violations_audited;
+  -- Do not proceed if a record with identical values already exists for today.
+  -- No need to pollute the metrics table with redundant data.
+  -- NB: FOUND is automatically set by Postgres: https://www.postgresql.org/docs/current/plpgsql-statements.html#PLPGSQL-STATEMENTS-DIAGNOSTICS
+  IF FOUND
+     AND ( v_latest."VULNERABILITIES"
+         , v_latest."CRITICAL"
+         , v_latest."HIGH"
+         , v_latest."MEDIUM"
+         , v_latest."LOW"
+         , v_latest."UNASSIGNED_SEVERITY"
+         , v_latest."RISKSCORE"
+         , v_latest."FINDINGS_TOTAL"
+         , v_latest."FINDINGS_AUDITED"
+         , v_latest."FINDINGS_UNAUDITED"
+         , v_latest."SUPPRESSED"
+         , v_latest."POLICYVIOLATIONS_TOTAL"
+         , v_latest."POLICYVIOLATIONS_FAIL"
+         , v_latest."POLICYVIOLATIONS_WARN"
+         , v_latest."POLICYVIOLATIONS_INFO"
+         , v_latest."POLICYVIOLATIONS_AUDITED"
+         , v_latest."POLICYVIOLATIONS_UNAUDITED"
+         , v_latest."POLICYVIOLATIONS_LICENSE_TOTAL"
+         , v_latest."POLICYVIOLATIONS_LICENSE_AUDITED"
+         , v_latest."POLICYVIOLATIONS_LICENSE_UNAUDITED"
+         , v_latest."POLICYVIOLATIONS_OPERATIONAL_TOTAL"
+         , v_latest."POLICYVIOLATIONS_OPERATIONAL_AUDITED"
+         , v_latest."POLICYVIOLATIONS_OPERATIONAL_UNAUDITED"
+         , v_latest."POLICYVIOLATIONS_SECURITY_TOTAL"
+         , v_latest."POLICYVIOLATIONS_SECURITY_AUDITED"
+         , v_latest."POLICYVIOLATIONS_SECURITY_UNAUDITED"
+         ) IS NOT DISTINCT FROM
+         ( v_metrics.vulnerabilities
+         , v_metrics.critical
+         , v_metrics.high
+         , v_metrics.medium
+         , v_metrics.low
+         , v_metrics.unassigned
+         , v_metrics.risk_score
+         , v_metrics.findings_total
+         , v_metrics.findings_audited
+         , v_metrics.findings_unaudited
+         , v_metrics.findings_suppressed
+         , v_metrics.policy_violations_total
+         , v_metrics.policy_violations_fail
+         , v_metrics.policy_violations_warn
+         , v_metrics.policy_violations_info
+         , v_metrics.policy_violations_audited
+         , v_metrics.policy_violations_unaudited
+         , v_metrics.policy_violations_license_total
+         , v_metrics.policy_violations_license_audited
+         , v_metrics.policy_violations_license_unaudited
+         , v_metrics.policy_violations_operational_total
+         , v_metrics.policy_violations_operational_audited
+         , v_metrics.policy_violations_operational_unaudited
+         , v_metrics.policy_violations_security_total
+         , v_metrics.policy_violations_security_audited
+         , v_metrics.policy_violations_security_unaudited
+         ) THEN
+    RETURN;
+  END IF;
 
   INSERT INTO "DEPENDENCYMETRICS" (
     "COMPONENT_ID"
@@ -187,32 +131,32 @@ BEGIN
   )
   SELECT v_component."ID"
        , v_component."PROJECT_ID"
-       , v_vulnerabilities
-       , v_critical
-       , v_high
-       , v_medium
-       , v_low
-       , v_unassigned
-       , v_risk_score
-       , v_findings_total
-       , v_findings_audited
-       , v_findings_unaudited
-       , v_findings_suppressed
-       , v_policy_violations_total
-       , v_policy_violations_fail
-       , v_policy_violations_warn
-       , v_policy_violations_info
-       , v_policy_violations_audited
-       , v_policy_violations_unaudited
-       , v_policy_violations_license_total
-       , v_policy_violations_license_audited
-       , v_policy_violations_license_unaudited
-       , v_policy_violations_operational_total
-       , v_policy_violations_operational_audited
-       , v_policy_violations_operational_unaudited
-       , v_policy_violations_security_total
-       , v_policy_violations_security_audited
-       , v_policy_violations_security_unaudited
+       , v_metrics.vulnerabilities
+       , v_metrics.critical
+       , v_metrics.high
+       , v_metrics.medium
+       , v_metrics.low
+       , v_metrics.unassigned
+       , v_metrics.risk_score
+       , v_metrics.findings_total
+       , v_metrics.findings_audited
+       , v_metrics.findings_unaudited
+       , v_metrics.findings_suppressed
+       , v_metrics.policy_violations_total
+       , v_metrics.policy_violations_fail
+       , v_metrics.policy_violations_warn
+       , v_metrics.policy_violations_info
+       , v_metrics.policy_violations_audited
+       , v_metrics.policy_violations_unaudited
+       , v_metrics.policy_violations_license_total
+       , v_metrics.policy_violations_license_audited
+       , v_metrics.policy_violations_license_unaudited
+       , v_metrics.policy_violations_operational_total
+       , v_metrics.policy_violations_operational_audited
+       , v_metrics.policy_violations_operational_unaudited
+       , v_metrics.policy_violations_security_total
+       , v_metrics.policy_violations_security_audited
+       , v_metrics.policy_violations_security_unaudited
        , NOW()
        , NOW()
    -- Skip insert if the component was deleted while metrics were being computed.
@@ -221,10 +165,5 @@ BEGIN
        FROM "COMPONENT"
       WHERE "ID" = v_component."ID"
    );
-
-  UPDATE "COMPONENT"
-     SET "LAST_RISKSCORE" = v_risk_score
-   WHERE "ID" = v_component."ID"
-     AND "LAST_RISKSCORE" IS DISTINCT FROM v_risk_score;
 END;
 $$;

--- a/migration/src/main/resources/org/dependencytrack/migration/R__update_project_metrics.sql
+++ b/migration/src/main/resources/org/dependencytrack/migration/R__update_project_metrics.sql
@@ -1,196 +1,349 @@
 CREATE OR REPLACE PROCEDURE "UPDATE_PROJECT_METRICS"(
-  "project_uuid" UUID
+  project_uuid UUID
 )
   LANGUAGE "plpgsql"
 AS
 $$
 DECLARE
-  "v_project_id"                              BIGINT;
-  "v_component_uuid"                          UUID;
-  "v_components"                              INT; -- Total number of components in the project
-  "v_vulnerable_components"                   INT; -- Number of vulnerable components in the project
-  "v_vulnerabilities"                         INT; -- Total number of vulnerabilities
-  "v_critical"                                INT; -- Number of vulnerabilities with critical severity
-  "v_high"                                    INT; -- Number of vulnerabilities with high severity
-  "v_medium"                                  INT; -- Number of vulnerabilities with medium severity
-  "v_low"                                     INT; -- Number of vulnerabilities with low severity
-  "v_unassigned"                              INT; -- Number of vulnerabilities with unassigned severity
-  "v_risk_score"                              NUMERIC; -- Inherited risk score
-  "v_findings_total"                          INT; -- Total number of findings
-  "v_findings_audited"                        INT; -- Number of audited findings
-  "v_findings_unaudited"                      INT; -- Number of unaudited findings
-  "v_findings_suppressed"                     INT; -- Number of suppressed findings
-  "v_policy_violations_total"                 INT; -- Total number of policy violations
-  "v_policy_violations_fail"                  INT; -- Number of policy violations with level fail
-  "v_policy_violations_warn"                  INT; -- Number of policy violations with level warn
-  "v_policy_violations_info"                  INT; -- Number of policy violations with level info
-  "v_policy_violations_audited"               INT; -- Number of audited policy violations
-  "v_policy_violations_unaudited"             INT; -- Number of unaudited policy violations
-  "v_policy_violations_license_total"         INT; -- Total number of policy violations of type license
-  "v_policy_violations_license_audited"       INT; -- Number of audited policy violations of type license
-  "v_policy_violations_license_unaudited"     INT; -- Number of unaudited policy violations of type license
-  "v_policy_violations_operational_total"     INT; -- Total number of policy violations of type operational
-  "v_policy_violations_operational_audited"   INT; -- Number of audited policy violations of type operational
-  "v_policy_violations_operational_unaudited" INT; -- Number of unaudited policy violations of type operational
-  "v_policy_violations_security_total"        INT; -- Total number of policy violations of type security
-  "v_policy_violations_security_audited"      INT; -- Number of audited policy violations of type security
-  "v_policy_violations_security_unaudited"    INT; -- Number of unaudited policy violations of type security
+  v_project_id   BIGINT; -- ID of the project to update metrics for
+  v_today        TIMESTAMPTZ := DATE_TRUNC('day', NOW() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
+  v_project      RECORD; -- Aggregated project-level metrics
 BEGIN
-  SELECT "ID" FROM "PROJECT"
-   WHERE "UUID" = "project_uuid"
-     AND "COLLECTION_LOGIC" IS NULL
-    INTO "v_project_id";
-  IF "v_project_id" IS NULL THEN
+  SELECT "ID"
+    INTO v_project_id
+    FROM "PROJECT"
+   WHERE "UUID" = project_uuid
+     AND "COLLECTION_LOGIC" IS NULL;
+  IF v_project_id IS NULL THEN
     RETURN;
   END IF;
 
-  FOR "v_component_uuid" IN SELECT "UUID" FROM "COMPONENT" WHERE "PROJECT_ID" = "v_project_id"
-  LOOP
-    CALL "UPDATE_COMPONENT_METRICS"("v_component_uuid");
-  END LOOP;
+  WITH computed AS (
+    SELECT *
+      FROM "COMPUTE_COMPONENT_METRICS"(
+        ARRAY(
+          SELECT "ID"
+            FROM "COMPONENT"
+           WHERE "PROJECT_ID" = v_project_id
+        )
+      )
+  ),
+  classified AS (
+    SELECT c.*
+         , (
+             l."VULNERABILITIES"
+           , l."CRITICAL"
+           , l."HIGH"
+           , l."MEDIUM"
+           , l."LOW"
+           , l."UNASSIGNED_SEVERITY"
+           , l."RISKSCORE"
+           , l."FINDINGS_TOTAL"
+           , l."FINDINGS_AUDITED"
+           , l."FINDINGS_UNAUDITED"
+           , l."SUPPRESSED"
+           , l."POLICYVIOLATIONS_TOTAL"
+           , l."POLICYVIOLATIONS_FAIL"
+           , l."POLICYVIOLATIONS_WARN"
+           , l."POLICYVIOLATIONS_INFO"
+           , l."POLICYVIOLATIONS_AUDITED"
+           , l."POLICYVIOLATIONS_UNAUDITED"
+           , l."POLICYVIOLATIONS_LICENSE_TOTAL"
+           , l."POLICYVIOLATIONS_LICENSE_AUDITED"
+           , l."POLICYVIOLATIONS_LICENSE_UNAUDITED"
+           , l."POLICYVIOLATIONS_OPERATIONAL_TOTAL"
+           , l."POLICYVIOLATIONS_OPERATIONAL_AUDITED"
+           , l."POLICYVIOLATIONS_OPERATIONAL_UNAUDITED"
+           , l."POLICYVIOLATIONS_SECURITY_TOTAL"
+           , l."POLICYVIOLATIONS_SECURITY_AUDITED"
+           , l."POLICYVIOLATIONS_SECURITY_UNAUDITED"
+           ) IS NOT DISTINCT FROM (
+             c.vulnerabilities
+           , c.critical
+           , c.high
+           , c.medium
+           , c.low
+           , c.unassigned
+           , c.risk_score
+           , c.findings_total
+           , c.findings_audited
+           , c.findings_unaudited
+           , c.findings_suppressed
+           , c.policy_violations_total
+           , c.policy_violations_fail
+           , c.policy_violations_warn
+           , c.policy_violations_info
+           , c.policy_violations_audited
+           , c.policy_violations_unaudited
+           , c.policy_violations_license_total
+           , c.policy_violations_license_audited
+           , c.policy_violations_license_unaudited
+           , c.policy_violations_operational_total
+           , c.policy_violations_operational_audited
+           , c.policy_violations_operational_unaudited
+           , c.policy_violations_security_total
+           , c.policy_violations_security_audited
+           , c.policy_violations_security_unaudited
+           ) AS unchanged
+      FROM computed AS c
+      LEFT JOIN LATERAL (
+        SELECT *
+          FROM "DEPENDENCYMETRICS"
+         WHERE "COMPONENT_ID" = c.component_id
+           AND "LAST_OCCURRENCE" >= v_today
+         ORDER BY "LAST_OCCURRENCE" DESC
+         LIMIT 1
+      ) AS l ON TRUE
+  ),
+  inserted AS (
+    INSERT INTO "DEPENDENCYMETRICS" (
+      "COMPONENT_ID"
+    , "PROJECT_ID"
+    , "VULNERABILITIES"
+    , "CRITICAL"
+    , "HIGH"
+    , "MEDIUM"
+    , "LOW"
+    , "UNASSIGNED_SEVERITY"
+    , "RISKSCORE"
+    , "FINDINGS_TOTAL"
+    , "FINDINGS_AUDITED"
+    , "FINDINGS_UNAUDITED"
+    , "SUPPRESSED"
+    , "POLICYVIOLATIONS_TOTAL"
+    , "POLICYVIOLATIONS_FAIL"
+    , "POLICYVIOLATIONS_WARN"
+    , "POLICYVIOLATIONS_INFO"
+    , "POLICYVIOLATIONS_AUDITED"
+    , "POLICYVIOLATIONS_UNAUDITED"
+    , "POLICYVIOLATIONS_LICENSE_TOTAL"
+    , "POLICYVIOLATIONS_LICENSE_AUDITED"
+    , "POLICYVIOLATIONS_LICENSE_UNAUDITED"
+    , "POLICYVIOLATIONS_OPERATIONAL_TOTAL"
+    , "POLICYVIOLATIONS_OPERATIONAL_AUDITED"
+    , "POLICYVIOLATIONS_OPERATIONAL_UNAUDITED"
+    , "POLICYVIOLATIONS_SECURITY_TOTAL"
+    , "POLICYVIOLATIONS_SECURITY_AUDITED"
+    , "POLICYVIOLATIONS_SECURITY_UNAUDITED"
+    , "FIRST_OCCURRENCE"
+    , "LAST_OCCURRENCE"
+    )
+    SELECT component_id
+         , v_project_id
+         , vulnerabilities
+         , critical
+         , high
+         , medium
+         , low
+         , unassigned
+         , risk_score
+         , findings_total
+         , findings_audited
+         , findings_unaudited
+         , findings_suppressed
+         , policy_violations_total
+         , policy_violations_fail
+         , policy_violations_warn
+         , policy_violations_info
+         , policy_violations_audited
+         , policy_violations_unaudited
+         , policy_violations_license_total
+         , policy_violations_license_audited
+         , policy_violations_license_unaudited
+         , policy_violations_operational_total
+         , policy_violations_operational_audited
+         , policy_violations_operational_unaudited
+         , policy_violations_security_total
+         , policy_violations_security_audited
+         , policy_violations_security_unaudited
+         , NOW()
+         , NOW()
+      FROM classified
+     WHERE NOT unchanged
+  ),
+  component_updates AS (
+    UPDATE "COMPONENT"
+       SET "LAST_RISKSCORE" = c.risk_score
+      FROM classified AS c
+     WHERE "COMPONENT"."ID" = c.component_id
+       AND "COMPONENT"."LAST_RISKSCORE" IS DISTINCT FROM c.risk_score
+  )
+  SELECT COUNT(*)::INT AS components
+       , COALESCE(SUM(CASE WHEN vulnerabilities > 0 THEN 1 ELSE 0 END)::INT, 0) AS vulnerable_components
+       , COALESCE(SUM(vulnerabilities)::INT, 0) AS vulnerabilities
+       , COALESCE(SUM(critical)::INT, 0) AS critical
+       , COALESCE(SUM(high)::INT, 0) AS high
+       , COALESCE(SUM(medium)::INT, 0) AS medium
+       , COALESCE(SUM(low)::INT, 0) AS low
+       , COALESCE(SUM(unassigned)::INT, 0) AS unassigned
+       , COALESCE(SUM(findings_total)::INT, 0) AS findings_total
+       , COALESCE(SUM(findings_audited)::INT, 0) AS findings_audited
+       , COALESCE(SUM(findings_unaudited)::INT, 0) AS findings_unaudited
+       , COALESCE(SUM(findings_suppressed)::INT, 0) AS findings_suppressed
+       , COALESCE(SUM(policy_violations_total)::INT, 0) AS policy_violations_total
+       , COALESCE(SUM(policy_violations_fail)::INT, 0) AS policy_violations_fail
+       , COALESCE(SUM(policy_violations_warn)::INT, 0) AS policy_violations_warn
+       , COALESCE(SUM(policy_violations_info)::INT, 0) AS policy_violations_info
+       , COALESCE(SUM(policy_violations_audited)::INT, 0) AS policy_violations_audited
+       , COALESCE(SUM(policy_violations_unaudited)::INT, 0) AS policy_violations_unaudited
+       , COALESCE(SUM(policy_violations_license_total)::INT, 0) AS policy_violations_license_total
+       , COALESCE(SUM(policy_violations_license_audited)::INT, 0) AS policy_violations_license_audited
+       , COALESCE(SUM(policy_violations_license_unaudited)::INT, 0) AS policy_violations_license_unaudited
+       , COALESCE(SUM(policy_violations_operational_total)::INT, 0) AS policy_violations_operational_total
+       , COALESCE(SUM(policy_violations_operational_audited)::INT, 0) AS policy_violations_operational_audited
+       , COALESCE(SUM(policy_violations_operational_unaudited)::INT, 0) AS policy_violations_operational_unaudited
+       , COALESCE(SUM(policy_violations_security_total)::INT, 0) AS policy_violations_security_total
+       , COALESCE(SUM(policy_violations_security_audited)::INT, 0) AS policy_violations_security_audited
+       , COALESCE(SUM(policy_violations_security_unaudited)::INT, 0) AS policy_violations_security_unaudited
+       , COALESCE(SUM(risk_score), 0)::NUMERIC AS risk_score
+    FROM computed
+    INTO v_project;
 
-  -- Aggregate over all most recent DEPENDENCYMETRICS.
-  -- NOTE: SUM returns NULL when no rows match the query, but COUNT returns 0.
-  -- For nullable result columns, use COALESCE(..., 0) to have a default value.
-  SELECT COUNT(*)::INT,
-    COALESCE(SUM(CASE WHEN "VULNERABILITIES" > 0 THEN 1 ELSE 0 END)::INT, 0),
-    COALESCE(SUM("VULNERABILITIES")::INT, 0),
-    COALESCE(SUM("CRITICAL")::INT, 0),
-    COALESCE(SUM("HIGH")::INT, 0),
-    COALESCE(SUM("MEDIUM")::INT, 0),
-    COALESCE(SUM("LOW")::INT, 0),
-    COALESCE(SUM("UNASSIGNED_SEVERITY")::INT, 0),
-    COALESCE(SUM("FINDINGS_TOTAL")::INT, 0),
-    COALESCE(SUM("FINDINGS_AUDITED")::INT, 0),
-    COALESCE(SUM("FINDINGS_UNAUDITED")::INT, 0),
-    COALESCE(SUM("SUPPRESSED")::INT, 0),
-    COALESCE(SUM("POLICYVIOLATIONS_TOTAL")::INT, 0),
-    COALESCE(SUM("POLICYVIOLATIONS_FAIL")::INT, 0),
-    COALESCE(SUM("POLICYVIOLATIONS_WARN")::INT, 0),
-    COALESCE(SUM("POLICYVIOLATIONS_INFO")::INT, 0),
-    COALESCE(SUM("POLICYVIOLATIONS_AUDITED")::INT, 0),
-    COALESCE(SUM("POLICYVIOLATIONS_UNAUDITED")::INT, 0),
-    COALESCE(SUM("POLICYVIOLATIONS_LICENSE_TOTAL")::INT, 0),
-    COALESCE(SUM("POLICYVIOLATIONS_LICENSE_AUDITED")::INT, 0),
-    COALESCE(SUM("POLICYVIOLATIONS_LICENSE_UNAUDITED")::INT, 0),
-    COALESCE(SUM("POLICYVIOLATIONS_OPERATIONAL_TOTAL")::INT, 0),
-    COALESCE(SUM("POLICYVIOLATIONS_OPERATIONAL_AUDITED")::INT, 0),
-    COALESCE(SUM("POLICYVIOLATIONS_OPERATIONAL_UNAUDITED")::INT, 0),
-    COALESCE(SUM("POLICYVIOLATIONS_SECURITY_TOTAL")::INT, 0),
-    COALESCE(SUM("POLICYVIOLATIONS_SECURITY_AUDITED")::INT, 0),
-    COALESCE(SUM("POLICYVIOLATIONS_SECURITY_UNAUDITED")::INT, 0)
-  FROM (
-    SELECT metrics.*
-      FROM "COMPONENT"
-     INNER JOIN LATERAL (
-       SELECT *
-         FROM "DEPENDENCYMETRICS"
-        WHERE "COMPONENT_ID" = "COMPONENT"."ID"
-        ORDER BY "LAST_OCCURRENCE" DESC
-        LIMIT 1
-     ) AS metrics ON TRUE
-     WHERE "COMPONENT"."PROJECT_ID" = "v_project_id"
-  ) AS "LATEST_COMPONENT_METRICS"
-  INTO
-    "v_components",
-    "v_vulnerable_components",
-    "v_vulnerabilities",
-    "v_critical",
-    "v_high",
-    "v_medium",
-    "v_low",
-    "v_unassigned",
-    "v_findings_total",
-    "v_findings_audited",
-    "v_findings_unaudited",
-    "v_findings_suppressed",
-    "v_policy_violations_total",
-    "v_policy_violations_fail",
-    "v_policy_violations_warn",
-    "v_policy_violations_info",
-    "v_policy_violations_audited",
-    "v_policy_violations_unaudited",
-    "v_policy_violations_license_total",
-    "v_policy_violations_license_audited",
-    "v_policy_violations_license_unaudited",
-    "v_policy_violations_operational_total",
-    "v_policy_violations_operational_audited",
-    "v_policy_violations_operational_unaudited",
-    "v_policy_violations_security_total",
-    "v_policy_violations_security_audited",
-    "v_policy_violations_security_unaudited";
-
-  "v_risk_score" = COALESCE("CALC_RISK_SCORE"("v_critical", "v_high", "v_medium", "v_low", "v_unassigned"), 0);
-
-  INSERT INTO "PROJECTMETRICS" ("PROJECT_ID",
-                                  "COMPONENTS",
-                                  "VULNERABLECOMPONENTS",
-                                  "VULNERABILITIES",
-                                  "CRITICAL",
-                                  "HIGH",
-                                  "MEDIUM",
-                                  "LOW",
-                                  "UNASSIGNED_SEVERITY",
-                                  "RISKSCORE",
-                                  "FINDINGS_TOTAL",
-                                  "FINDINGS_AUDITED",
-                                  "FINDINGS_UNAUDITED",
-                                  "SUPPRESSED",
-                                  "POLICYVIOLATIONS_TOTAL",
-                                  "POLICYVIOLATIONS_FAIL",
-                                  "POLICYVIOLATIONS_WARN",
-                                  "POLICYVIOLATIONS_INFO",
-                                  "POLICYVIOLATIONS_AUDITED",
-                                  "POLICYVIOLATIONS_UNAUDITED",
-                                  "POLICYVIOLATIONS_LICENSE_TOTAL",
-                                  "POLICYVIOLATIONS_LICENSE_AUDITED",
-                                  "POLICYVIOLATIONS_LICENSE_UNAUDITED",
-                                  "POLICYVIOLATIONS_OPERATIONAL_TOTAL",
-                                  "POLICYVIOLATIONS_OPERATIONAL_AUDITED",
-                                  "POLICYVIOLATIONS_OPERATIONAL_UNAUDITED",
-                                  "POLICYVIOLATIONS_SECURITY_TOTAL",
-                                  "POLICYVIOLATIONS_SECURITY_AUDITED",
-                                  "POLICYVIOLATIONS_SECURITY_UNAUDITED",
-                                  "FIRST_OCCURRENCE",
-                                  "LAST_OCCURRENCE")
-    SELECT "v_project_id",
-           "v_components",
-           "v_vulnerable_components",
-           "v_vulnerabilities",
-           "v_critical",
-           "v_high",
-           "v_medium",
-           "v_low",
-           "v_unassigned",
-           "v_risk_score",
-           "v_findings_total",
-           "v_findings_audited",
-           "v_findings_unaudited",
-           "v_findings_suppressed",
-           "v_policy_violations_total",
-           "v_policy_violations_fail",
-           "v_policy_violations_warn",
-           "v_policy_violations_info",
-           "v_policy_violations_audited",
-           "v_policy_violations_unaudited",
-           "v_policy_violations_license_total",
-           "v_policy_violations_license_audited",
-           "v_policy_violations_license_unaudited",
-           "v_policy_violations_operational_total",
-           "v_policy_violations_operational_audited",
-           "v_policy_violations_operational_unaudited",
-           "v_policy_violations_security_total",
-           "v_policy_violations_security_audited",
-           "v_policy_violations_security_unaudited",
-           NOW(),
-           NOW()
+  IF NOT EXISTS (
+    SELECT 1
+      FROM (
+        SELECT *
+          FROM "PROJECTMETRICS"
+         WHERE "PROJECT_ID" = v_project_id
+           AND "LAST_OCCURRENCE" >= v_today
+         ORDER BY "LAST_OCCURRENCE" DESC
+         LIMIT 1
+      ) AS pm
+     WHERE (
+             pm."COMPONENTS"
+           , pm."VULNERABLECOMPONENTS"
+           , pm."VULNERABILITIES"
+           , pm."CRITICAL"
+           , pm."HIGH"
+           , pm."MEDIUM"
+           , pm."LOW"
+           , pm."UNASSIGNED_SEVERITY"
+           , pm."RISKSCORE"
+           , pm."FINDINGS_TOTAL"
+           , pm."FINDINGS_AUDITED"
+           , pm."FINDINGS_UNAUDITED"
+           , pm."SUPPRESSED"
+           , pm."POLICYVIOLATIONS_TOTAL"
+           , pm."POLICYVIOLATIONS_FAIL"
+           , pm."POLICYVIOLATIONS_WARN"
+           , pm."POLICYVIOLATIONS_INFO"
+           , pm."POLICYVIOLATIONS_AUDITED"
+           , pm."POLICYVIOLATIONS_UNAUDITED"
+           , pm."POLICYVIOLATIONS_LICENSE_TOTAL"
+           , pm."POLICYVIOLATIONS_LICENSE_AUDITED"
+           , pm."POLICYVIOLATIONS_LICENSE_UNAUDITED"
+           , pm."POLICYVIOLATIONS_OPERATIONAL_TOTAL"
+           , pm."POLICYVIOLATIONS_OPERATIONAL_AUDITED"
+           , pm."POLICYVIOLATIONS_OPERATIONAL_UNAUDITED"
+           , pm."POLICYVIOLATIONS_SECURITY_TOTAL"
+           , pm."POLICYVIOLATIONS_SECURITY_AUDITED"
+           , pm."POLICYVIOLATIONS_SECURITY_UNAUDITED"
+           ) IS NOT DISTINCT FROM (
+             v_project.components
+           , v_project.vulnerable_components
+           , v_project.vulnerabilities
+           , v_project.critical
+           , v_project.high
+           , v_project.medium
+           , v_project.low
+           , v_project.unassigned
+           , v_project.risk_score
+           , v_project.findings_total
+           , v_project.findings_audited
+           , v_project.findings_unaudited
+           , v_project.findings_suppressed
+           , v_project.policy_violations_total
+           , v_project.policy_violations_fail
+           , v_project.policy_violations_warn
+           , v_project.policy_violations_info
+           , v_project.policy_violations_audited
+           , v_project.policy_violations_unaudited
+           , v_project.policy_violations_license_total
+           , v_project.policy_violations_license_audited
+           , v_project.policy_violations_license_unaudited
+           , v_project.policy_violations_operational_total
+           , v_project.policy_violations_operational_audited
+           , v_project.policy_violations_operational_unaudited
+           , v_project.policy_violations_security_total
+           , v_project.policy_violations_security_audited
+           , v_project.policy_violations_security_unaudited
+           )
+  ) THEN
+    INSERT INTO "PROJECTMETRICS" (
+      "PROJECT_ID"
+    , "COMPONENTS"
+    , "VULNERABLECOMPONENTS"
+    , "VULNERABILITIES"
+    , "CRITICAL"
+    , "HIGH"
+    , "MEDIUM"
+    , "LOW"
+    , "UNASSIGNED_SEVERITY"
+    , "RISKSCORE"
+    , "FINDINGS_TOTAL"
+    , "FINDINGS_AUDITED"
+    , "FINDINGS_UNAUDITED"
+    , "SUPPRESSED"
+    , "POLICYVIOLATIONS_TOTAL"
+    , "POLICYVIOLATIONS_FAIL"
+    , "POLICYVIOLATIONS_WARN"
+    , "POLICYVIOLATIONS_INFO"
+    , "POLICYVIOLATIONS_AUDITED"
+    , "POLICYVIOLATIONS_UNAUDITED"
+    , "POLICYVIOLATIONS_LICENSE_TOTAL"
+    , "POLICYVIOLATIONS_LICENSE_AUDITED"
+    , "POLICYVIOLATIONS_LICENSE_UNAUDITED"
+    , "POLICYVIOLATIONS_OPERATIONAL_TOTAL"
+    , "POLICYVIOLATIONS_OPERATIONAL_AUDITED"
+    , "POLICYVIOLATIONS_OPERATIONAL_UNAUDITED"
+    , "POLICYVIOLATIONS_SECURITY_TOTAL"
+    , "POLICYVIOLATIONS_SECURITY_AUDITED"
+    , "POLICYVIOLATIONS_SECURITY_UNAUDITED"
+    , "FIRST_OCCURRENCE"
+    , "LAST_OCCURRENCE"
+    )
+    SELECT v_project_id
+         , v_project.components
+         , v_project.vulnerable_components
+         , v_project.vulnerabilities
+         , v_project.critical
+         , v_project.high
+         , v_project.medium
+         , v_project.low
+         , v_project.unassigned
+         , v_project.risk_score
+         , v_project.findings_total
+         , v_project.findings_audited
+         , v_project.findings_unaudited
+         , v_project.findings_suppressed
+         , v_project.policy_violations_total
+         , v_project.policy_violations_fail
+         , v_project.policy_violations_warn
+         , v_project.policy_violations_info
+         , v_project.policy_violations_audited
+         , v_project.policy_violations_unaudited
+         , v_project.policy_violations_license_total
+         , v_project.policy_violations_license_audited
+         , v_project.policy_violations_license_unaudited
+         , v_project.policy_violations_operational_total
+         , v_project.policy_violations_operational_audited
+         , v_project.policy_violations_operational_unaudited
+         , v_project.policy_violations_security_total
+         , v_project.policy_violations_security_audited
+         , v_project.policy_violations_security_unaudited
+         , NOW()
+         , NOW()
      -- Skip insert if the project was deleted while metrics were being computed.
      WHERE EXISTS (
        SELECT 1
          FROM "PROJECT"
-        WHERE "ID" = "v_project_id"
+        WHERE "ID" = v_project_id
      );
+  END IF;
 
-  UPDATE "PROJECT" SET "LAST_RISKSCORE" = "v_risk_score" WHERE "ID" = "v_project_id";
-end;
+  UPDATE "PROJECT"
+     SET "LAST_RISKSCORE" = v_project.risk_score
+   WHERE "ID" = v_project_id
+     AND "LAST_RISKSCORE" IS DISTINCT FROM v_project.risk_score;
+END;
 $$;


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Improves the efficiency of project metrics updates by calculating metrics of all components of a project in bulk, rather than calling the `UPDATE_COMPONENT_METRICS` stored proc in a loop. Adds a new `COMPUTE_COMPONENT_METRICS` function so the functionality can be shared between metrics updates of full projects, and of individual components.

Also significantly reduces I/O overhead by being smarter about when to write new metrics rows. Most notably, this change skips row creation if another row with identical metrics values already exists *for the same day*.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #6642

Metrics updates showed up as main contributor to DB / system load there.

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Note that this means that the `LAST_OCCURRENCE` column can no longer be used to judge metrics freshness *within a day*. Since as of v5, metrics aggregations have day-resolution, intra-day data points with identical values provide no value there. `LAST_OCCURRENCE` still advances at least once per day, since the first update of a day always inserts. Only intra-day resolution is lost, and nothing (we know of) relies on it. The I/O savings outweigh keeping the legacy behavior in any case.

For a large project with 9k components in a test instance, runtime of `UPDATE_PROJECT_METRICS` dropped from ~3.5s to ~300ms. In the ideal case (successive runs on the same day without metrics changes), the previous implementation caused 3MB of WAL writes, where the new implementation causes single-digit kB writes.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
