### PR TITLE
Improve default data source config

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/dev/DevServices.java
+++ b/apiserver/src/main/java/org/dependencytrack/dev/DevServices.java
@@ -101,7 +101,6 @@ public class DevServices implements AutoCloseable {
             postgresContainerClass.getMethod("withUsername", String.class).invoke(postgresContainer, postgresUsername);
             postgresContainerClass.getMethod("withPassword", String.class).invoke(postgresContainer, postgresPassword);
             postgresContainerClass.getMethod("withDatabaseName", String.class).invoke(postgresContainer, postgresDatabase);
-            postgresContainerClass.getMethod("withUrlParam", String.class, String.class).invoke(postgresContainer, "reWriteBatchedInserts", "true");
             withReuseMethod.invoke(postgresContainer, shouldReuseContainers);
             withLabelMethod.invoke(postgresContainer, DEV_SERVICES_LABEL, "true");
             addFixedExposedPortMethod.invoke(postgresContainer, /* hostPort */ postgresPort, /* containerPort */  5432);

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -44,7 +44,7 @@ dt.auth.session-timeout-ms=28800000
 # Defines the JDBC URL to use for the default data source.
 #
 # @category: Database
-# @example:  jdbc:postgresql://localhost:5432/dtrack?reWriteBatchedInserts=true
+# @example:  jdbc:postgresql://localhost:5432/dtrack
 # @type:     string
 # @required
 dt.datasource.url=
@@ -97,6 +97,22 @@ dt.datasource.pool.idle-timeout-ms=300000
 # @category: Database
 # @type:     integer
 dt.datasource.pool.max-lifetime-ms=600000
+
+# Defines the interval in milliseconds in which idle pooled connections are validated, and dead ones evicted.
+# <br/><br/>
+# Should be lower than dt.datasource.pool.max-lifetime-ms to take effect,
+# as otherwise connections will be evicted before keepalive can kick in.
+#
+# @category: Database
+# @type:     integer
+dt.datasource.pool.keepalive-interval-ms=60000
+
+# Defines the duration in milliseconds after which a connection that was checked out from the pool
+# is considered leaked (i.e., not released properly). A detected leak will cause a warning to be logged.
+#
+# @category: Database
+# @type:     integer
+# dt.datasource.pool.leak-detection-threshold-ms=
 
 # Defines the cache provider to use.
 #

--- a/apiserver/src/test/resources/application.properties
+++ b/apiserver/src/test/resources/application.properties
@@ -12,3 +12,7 @@ dt.management.port=0
 # time is more harmful than it helps.
 dt.datasource.pool.max-size=3
 dt.datasource.pool.min-idle=3
+
+# HikariCP logs a warning when max-size == min-idle while idle-timeout is set.
+# Explicitly unset idle-timeout to avoid that (harmless) warning.
+dt.datasource.pool.idle-timeout-ms=

--- a/common/datasource/src/main/java/org/dependencytrack/common/datasource/DataSourceConfig.java
+++ b/common/datasource/src/main/java/org/dependencytrack/common/datasource/DataSourceConfig.java
@@ -80,6 +80,10 @@ final class DataSourceConfig {
         return config.getOptionalValue(PREFIX + "%s.pool.idle-timeout-ms".formatted(name), long.class);
     }
 
+    Optional<Long> getPoolLeakDetectionThresholdMillis() {
+        return config.getOptionalValue(PREFIX + "%s.pool.leak-detection-threshold-ms".formatted(name), long.class);
+    }
+
     Optional<Long> getPoolMaxLifetimeMillis() {
         return config.getOptionalValue(PREFIX + "%s.pool.max-lifetime-ms".formatted(name), long.class);
     }

--- a/common/datasource/src/main/java/org/dependencytrack/common/datasource/DataSourceFactory.java
+++ b/common/datasource/src/main/java/org/dependencytrack/common/datasource/DataSourceFactory.java
@@ -39,11 +39,16 @@ final class DataSourceFactory {
     private DataSourceFactory() {
     }
 
-    static DataSource createDataSource(final DataSourceConfig config) {
+    static DataSource createDataSource(DataSourceConfig config) {
+        final String appName = "dependency-track[%s]".formatted(config.getName());
+
         if (config.isPoolEnabled()) {
             final var hikariConfig = new HikariConfig();
             hikariConfig.setPoolName(config.getName());
             hikariConfig.setJdbcUrl(config.getUrl());
+            hikariConfig.addDataSourceProperty("ApplicationName", appName);
+            hikariConfig.addDataSourceProperty("reWriteBatchedInserts", "true");
+            hikariConfig.addDataSourceProperty("tcpKeepAlive", "true");
             hikariConfig.setMaximumPoolSize(config.getPoolMaxSize());
             hikariConfig.setMinimumIdle(config.getPoolMinIdle());
             hikariConfig.setMetricRegistry(Metrics.globalRegistry);
@@ -51,23 +56,34 @@ final class DataSourceFactory {
             getPassword(config).ifPresent(hikariConfig::setPassword);
             config.getConnectionTimeoutMillis().ifPresent(hikariConfig::setConnectionTimeout);
             config.getPoolIdleTimeoutMillis().ifPresent(hikariConfig::setIdleTimeout);
+            config.getPoolLeakDetectionThresholdMillis().ifPresent(hikariConfig::setLeakDetectionThreshold);
             config.getPoolMaxLifetimeMillis().ifPresent(hikariConfig::setMaxLifetime);
             config.getPoolKeepaliveIntervalMillis().ifPresent(hikariConfig::setKeepaliveTime);
             return new HikariDataSource(hikariConfig);
         }
 
         final var dataSource = new PGSimpleDataSource();
-        dataSource.setUrl(config.getUrl());
-        config.getUsername().ifPresent(dataSource::setUser);
-        getPassword(config).ifPresent(dataSource::setPassword);
+
+        // NB: These properties must be set BEFORE setUrl is called,
+        // as the driver only then loops over all properties and applies
+        // them to the URL. Setting the URL first would cause these
+        // properties to no-op.
+        dataSource.setApplicationName(appName);
         config.getConnectionTimeoutMillis()
                 .map(TimeUnit.MILLISECONDS::toSeconds)
                 .map(Math::toIntExact)
                 .ifPresent(dataSource::setConnectTimeout);
+        dataSource.setReWriteBatchedInserts(true);
+        dataSource.setTcpKeepAlive(true);
+
+        dataSource.setUrl(config.getUrl());
+        config.getUsername().ifPresent(dataSource::setUser);
+        getPassword(config).ifPresent(dataSource::setPassword);
+
         return dataSource;
     }
 
-    private static Optional<String> getPassword(final DataSourceConfig config) {
+    private static Optional<String> getPassword(DataSourceConfig config) {
         final Path passwordFilePath = config.getPasswordFilePath().orElse(null);
         if (passwordFilePath != null) {
             try {

--- a/support/test-database/src/main/java/org/dependencytrack/testing/database/PostgresTestContainer.java
+++ b/support/test-database/src/main/java/org/dependencytrack/testing/database/PostgresTestContainer.java
@@ -46,7 +46,6 @@ public final class PostgresTestContainer extends PostgreSQLContainer {
         withUsername("dtrack");
         withPassword("dtrack");
         withDatabaseName("dtrack");
-        withUrlParam("reWriteBatchedInserts", "true");
         withTmpFs(Map.of("/var/lib/postgresql/data", "rw"));
         withLabel("org.dependencytrack.test-database", "true");
 


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Improves default data source config:

* Enables TCP keepalive for connections by default so truly dead connections can be detected.
* Enables connection keepalive for pooled data sources, setting it to 60s on the default data source.
* Sets an application name so `pg_stat_activity` etc. show a useful `dependencytrack[<pool-name>]` identifier instead of a generic `PostgreSQL JDBC Driver` (or so).
* Enables `reWriteBatchedInserts` for all connections so users don't have to configure it explicitly. It's only a minor optimization anyway so not critical, but setting it centrally at least means its applied uniformly.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
