### PR TITLE
Issue-6654 : Skip malformed PURLs instead of assigning to empty resolver

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/pkgmetadata/FetchPackageMetadataResolutionCandidatesActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/pkgmetadata/FetchPackageMetadataResolutionCandidatesActivity.java
@@ -73,10 +73,9 @@ public final class FetchPackageMetadataResolutionCandidatesActivity
             try {
                 purl = new PackageURL(purlStr);
             } catch (MalformedPackageURLException e) {
-                LOGGER.warn("Failed to parse PURL '{}'; Assigning to empty resolver", purlStr, e);
-                purlsByResolver
-                        .computeIfAbsent("", k -> new ArrayList<>())
-                        .add(purlStr);
+                // Malformed PURL cannot be resolved and is data quality issue.
+                // Skip to avoid resolution attempts and spamming WARN logs on every cycle.
+                LOGGER.debug("Skipping malformed PURL '{}'", purlStr, e);
                 continue;
             }
 

--- a/apiserver/src/test/java/org/dependencytrack/pkgmetadata/ResolvePackageMetadataWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/pkgmetadata/ResolvePackageMetadataWorkflowTest.java
@@ -277,6 +277,65 @@ class ResolvePackageMetadataWorkflowTest extends PersistenceCapableTest {
     }
 
     @Test
+    void shouldSkipMalformedPurlAndNotReselectIt() {
+        final String malformedPurl = "pkg:nuget/serilog.sinks.file%A%20...5.0.0@5.0.0";
+        final Instant resolvedAt = Instant.now();
+        mockResolveFnRef.set(purl -> new PackageMetadata("9.9.9", Instant.now(), resolvedAt, null));
+
+        var project = new Project();
+        project.setName("test-project");
+        project = qm.persist(project);
+
+        final var malformedComponent = new Component();
+        malformedComponent.setProject(project);
+        malformedComponent.setName("serilog.sinks.file");
+        malformedComponent.setVersion("5.0.0");
+        malformedComponent.setPurl(malformedPurl);
+        qm.persist(malformedComponent);
+
+        final var componentFoo = new Component();
+        componentFoo.setProject(project);
+        componentFoo.setGroup("org.acme");
+        componentFoo.setName("foo");
+        componentFoo.setVersion("1.0");
+        componentFoo.setPurl("pkg:maven/org.acme/foo@1.0");
+        qm.persist(componentFoo);
+
+        final var fetchActivity = new FetchPackageMetadataResolutionCandidatesActivity(pluginManager);
+        final List<String> candidatePurls = fetchActivity.execute(null, null)
+                .getCandidateGroupsList().stream()
+                .flatMap(group -> group.getPurlsList().stream())
+                .toList();
+        assertThat(candidatePurls).contains("pkg:maven/org.acme/foo@1.0")
+                .doesNotContain(malformedPurl);
+
+        // Running workflow again should not reselect the malformed PURL
+        for (int i = 0; i < 2; i++) {
+            final UUID runId = workflowTest.getEngine().createRun(
+                    new CreateWorkflowRunRequest<>(ResolvePackageMetadataWorkflow.class));
+            workflowTest.awaitRunStatus(runId, WorkflowRunStatus.COMPLETED);
+        }
+
+        List<String> metadataPurls = withJdbiHandle(handle -> handle
+                .createQuery("""
+                        SELECT "PURL"
+                          FROM "PACKAGE_METADATA"
+                        """)
+                .mapTo(String.class)
+                .list());
+        assertThat(metadataPurls).containsExactly("pkg:maven/org.acme/foo");
+
+        metadataPurls = withJdbiHandle(handle -> handle
+                .createQuery("""
+                        SELECT "PURL"
+                          FROM "PACKAGE_ARTIFACT_METADATA"
+                        """)
+                .mapTo(String.class)
+                .list());
+        assertThat(metadataPurls).containsExactly("pkg:maven/org.acme/foo@1.0");
+    }
+
+    @Test
     void shouldPassPriorArtifactMetadataToResolverWhenAvailable() {
         useJdbiTransaction(handle -> {
             new PackageMetadataDao(handle).upsertAll(List.of(


### PR DESCRIPTION
### Description

When a PURL fails to parse, skip it entirely rather than assigning it to an empty resolver. This prevents unnecessary resolution attempts and reduces log spam from recurring WARN messages on each cycle. Malformed PURLs are a data quality issue and should not be processed.

Added test verifying malformed PURLs are excluded from candidates and not reselected across workflow runs.

### Addressed Issue

Closes https://github.com/DependencyTrack/dependency-track/issues/6654

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
