### PR TITLE
fix: exit the JVM when init tasks fail instead of hanging unready

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/Application.java
+++ b/apiserver/src/main/java/org/dependencytrack/Application.java
@@ -159,20 +159,28 @@ public final class Application {
         }
 
         // Execute init tasks.
+        // Failures must exit the JVM explicitly: the management server started above
+        // keeps the JVM alive with its non-daemon threads, so an exception escaping
+        // the main thread would leave the process running but forever unready.
         final var dataSourceRegistry = DataSourceRegistry.getInstance();
         if (config.getValue(ConfigKeys.INIT_TASKS_ENABLED, boolean.class)) {
-            final String dataSourceName = config.getValue(ConfigKeys.INIT_TASKS_DATASOURCE_NAME, String.class);
-            final var initTaskExecutor = new InitTaskExecutor(
-                    config, dataSourceRegistry.get(dataSourceName),
-                    initTasksHealthCheck);
-            initTaskExecutor.execute();
+            try {
+                final String dataSourceName = config.getValue(ConfigKeys.INIT_TASKS_DATASOURCE_NAME, String.class);
+                final var initTaskExecutor = new InitTaskExecutor(
+                        config, dataSourceRegistry.get(dataSourceName),
+                        initTasksHealthCheck);
+                initTaskExecutor.execute();
 
-            if (config.getValue(ConfigKeys.INIT_TASKS_DATASOURCE_CLOSE_AFTER_COMPLETION, boolean.class)) {
-                dataSourceRegistry.close(dataSourceName);
-            }
-            if (config.getValue(ConfigKeys.INIT_TASKS_EXIT_AFTER_COMPLETION, boolean.class)) {
-                LOGGER.info("Exiting because dt.init-tasks.exit-after-completion is enabled");
-                System.exit(0);
+                if (config.getValue(ConfigKeys.INIT_TASKS_DATASOURCE_CLOSE_AFTER_COMPLETION, boolean.class)) {
+                    dataSourceRegistry.close(dataSourceName);
+                }
+                if (config.getValue(ConfigKeys.INIT_TASKS_EXIT_AFTER_COMPLETION, boolean.class)) {
+                    LOGGER.info("Exiting because dt.init-tasks.exit-after-completion is enabled");
+                    System.exit(0);
+                }
+            } catch (Exception e) {
+                LOGGER.error("Failed to execute init tasks", e);
+                System.exit(-1);
             }
         }
         initTasksHealthCheck.markInitialized();


### PR DESCRIPTION
The management server is started before init tasks run so that health and metrics endpoints are available during initialization. Its non-daemon threads keep the JVM alive, so when init task execution throws - e.g. HikariPool$PoolInitializationException when the database is briefly unreachable during a simultaneous cold start - the exception kills the main thread but the process stays up, serving "not ready" until an operator (or a ~30 minute Kubernetes startup probe budget) intervenes.

Wrap the init task execution in try/catch and log + System.exit(-1) on failure, matching how management server and Jetty server startup failures are already handled in main. A clean exit lets the container runtime apply its restart policy immediately, which typically resolves the transient condition on the next attempt.

### Description

When init task execution fails, most commonly HikariPool$PoolInitializationException because the database isn't reachable yet during a simultaneous cold start (e.g. docker compose up, a fresh Helm install where the api-server and PostgreSQL start together), the exception kills the main thread, but the JVM keeps running: the management server is intentionally started before init tasks so health/metrics are available during initialization, and its non-daemon threads keep the process alive. The container then sits in a zombie state (Running, never ready), with no retry, until an operator intervenes or the Kubernetes startup probe budget (30 minutes with the Helm chart defaults) finally lapses.

This change wraps init task execution in try/catch and does log + System.exit(-1) on failure, the same pattern main already uses for management server and Jetty server startup failures. With a clean exit, the container runtime's restart policy kicks in immediately, and the retry typically succeeds once the database is up.

Observed on Dependency-Track 5.0.2 deployed via the dependency-track Helm chart (2.0.0-rc.2) on k3s: first install raced PostgreSQL, the api-server logged Exception in thread "main" ... PoolInitializationException ... Connection refused and then hung unready with 0 restarts until the pod was deleted manually.

### Addressed Issue
Fixes #6689


### Additional Details
Tests provided as description, no scripted test feasible.

### Checklist
- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [~] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [~] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [~] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [~] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
