### PR TITLE
Backport: Fix project sorting by version

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
@@ -515,7 +515,7 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
                  , "PROJECT"."PURL"
                  , "PROJECT"."SWIDTAGID"
                  , "PROJECT"."UUID"
-                 , "PROJECT"."VERSION"
+                 , "PROJECT"."VERSION" AS "version"
                  , "PROJECT"."SUPPLIER"
                  , "PROJECT"."MANUFACTURER"
                  , "PROJECT"."AUTHORS"

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -138,6 +138,28 @@ class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
+    void shouldSortProjectListByVersion() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+
+        qm.createProject("acme-app", null, "3.0.0", null, null, null, null, false);
+        qm.createProject("acme-app", null, "1.0.0", null, null, null, null, false);
+        qm.createProject("acme-app", null, "2.0.0", null, null, null, null, false);
+
+        final Response response = jersey.target(V1_PROJECT)
+                .queryParam("sortName", "version")
+                .queryParam("sortOrder", "asc")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        final JsonArray json = parseJsonArray(response);
+        assertThat(json)
+                .extracting(value -> ((JsonObject) value).getString("version"))
+                .containsExactly("1.0.0", "2.0.0", "3.0.0");
+    }
+
+    @Test
     void shouldReturn400WhenSortNameIsNotSupportedForGetProjects() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes project sorting by version.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6651
Backports #6652

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
