### PR TITLE
Drop "strong" from possible dt.ldap.security-auth values

### DIFF
--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -373,13 +373,13 @@ dt.ldap.server-url=
 # @type:     string
 dt.ldap.base-dn=
 
-# Specifies the LDAP security authentication level to use. Its value is one of
-# the following strings: "none", "simple", "strong". If this property is empty
-# or unspecified, the behaviour is determined by the service provider.
+# Specifies the LDAP security authentication level to use.
+# <br/><br/>
+# If this property is empty or unspecified, the behaviour is determined by the service provider.
 #
 # @category:     LDAP
 # @type:         enum
-# @valid-values: [none, simple, strong]
+# @valid-values: [none, simple]
 dt.ldap.security-auth=simple
 
 # If anonymous access is not permitted, specify a username with limited access


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Drops "strong" from possible `dt.ldap.security-auth` values.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

It's a JNDI-specific alias for "some strong authentication mechanism" and has no meaning in LDAP. It currently ends up falling back to SASL which doesn't make sense for how DT uses LDAP, which is always username+password based.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
