### PR TITLE
Fix BufferTest flakiness

### DIFF
--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/support/BufferTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/support/BufferTest.java
@@ -25,7 +25,11 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -33,6 +37,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -109,7 +114,7 @@ class BufferTest {
     @Test
     void shouldOpenCircuitBreakerAfterRepeatedFailures() throws Exception {
         final var flushAttempts = new AtomicInteger();
-        final Consumer<List<String>> batchConsumer = batch -> {
+        final Consumer<List<String>> batchConsumer = _ -> {
             flushAttempts.incrementAndGet();
             throw new RuntimeException("downstream broken");
         };
@@ -162,6 +167,7 @@ class BufferTest {
             flushedBatches.add(List.copyOf(batch));
         };
 
+        final var clock = new MutableClock();
         final var registry = CircuitBreakerRegistry.of(
                 CircuitBreakerConfig.custom()
                         .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
@@ -170,6 +176,7 @@ class BufferTest {
                         .failureRateThreshold(50.0f)
                         .waitDurationInOpenState(Duration.ofMillis(200))
                         .permittedNumberOfCallsInHalfOpenState(1)
+                        .clock(clock)
                         .build());
 
         final var buffer = new Buffer<>(
@@ -194,16 +201,14 @@ class BufferTest {
 
             shouldFail.set(false);
 
-            await().atMost(Duration.ofSeconds(5))
-                    .pollInterval(Duration.ofMillis(50))
-                    .until(() -> {
-                        try {
-                            buffer.add("recovery").get(200, TimeUnit.MILLISECONDS);
-                            return true;
-                        } catch (Exception e) {
-                            return false;
-                        }
-                    });
+            // Advance past waitDurationInOpenState so the next flush tick moves
+            // the circuit breaker from OPEN to HALF_OPEN.
+            clock.advance(Duration.ofSeconds(1));
+
+            final CompletableFuture<Void> recovery = buffer.add("recovery");
+
+            await().atMost(Duration.ofSeconds(5)).until(recovery::isDone);
+            recovery.get();
 
             assertThat(flushedBatches).contains(List.of("recovery"));
             assertThat(buffer.acceptsWork()).isTrue();
@@ -212,7 +217,7 @@ class BufferTest {
 
     @Test
     void addShouldFailFastWhileBreakerIsOpen() throws Exception {
-        final Consumer<List<String>> batchConsumer = batch -> {
+        final Consumer<List<String>> batchConsumer = _ -> {
             throw new RuntimeException("downstream broken");
         };
 
@@ -250,6 +255,31 @@ class BufferTest {
                     .isThrownBy(() -> future.get(500, TimeUnit.MILLISECONDS))
                     .withCauseInstanceOf(CallNotPermittedException.class);
         }
+    }
+
+    private static final class MutableClock extends Clock {
+
+        private final AtomicReference<Instant> now = new AtomicReference<>(Instant.EPOCH);
+
+        @Override
+        public Instant instant() {
+            return now.get();
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            throw new UnsupportedOperationException();
+        }
+
+        void advance(Duration delta) {
+            now.updateAndGet(current -> current.plus(delta));
+        }
+
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes `BufferTest` flakiness.

Uses a custom `Clock` to drive time-based state transitions of the circuit breaker.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
