### PR TITLE
dex: add missing indexes on workflow_run_id in task tables

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -126,6 +126,10 @@ jobs:
         env:
           BASE_REF: origin/${{ github.base_ref }}
         run: make lint-migrations
+      - name: Lint changed dex migrations
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: make lint-dex-migration
 
   openapi-breaking-changes:
     name: OpenAPI Breaking Changes

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@
 
 BASE_REF ?= origin/main
 MIGRATION_DIR := migration/src/main/resources/org/dependencytrack/migration
+DEX_MIGRATION_DIR := dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration
 SQUAWK_IMAGE := ghcr.io/sbdchd/squawk:2.58.0
 
 MVN := $(shell command -v mvn 2>/dev/null)
@@ -103,6 +104,10 @@ lint-migrations:
 		lint $$changed
 .PHONY: lint-migrations
 
+lint-dex-migration:
+	@$(MAKE) lint-migrations MIGRATION_DIR="$(DEX_MIGRATION_DIR)"
+.PHONY: lint-dex-migration
+
 lint-openapi:
 	@dups=$$(find api/src/main/openapi -path '*/schemas/*.yaml' -exec basename {} \; \
 		| sort | uniq -d); \
@@ -123,7 +128,7 @@ lint-proto:
 	buf lint
 .PHONY: lint-proto
 
-lint: lint-java lint-migrations lint-openapi lint-proto
+lint: lint-java lint-migrations lint-dex-migration lint-openapi lint-proto
 .PHONY: lint
 
 test:

--- a/dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration/V0.1.3__AddTaskWorkflowRunIdIndexes.sql
+++ b/dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration/V0.1.3__AddTaskWorkflowRunIdIndexes.sql
@@ -1,0 +1,11 @@
+create index if not exists dex_workflow_task_workflow_run_id_idx
+    on dex_workflow_task (workflow_run_id);
+
+comment on index dex_workflow_task_workflow_run_id_idx
+     is 'Support cascading deletes from dex_workflow_run during retention enforcement';
+
+create index if not exists dex_activity_task_workflow_run_id_idx
+    on dex_activity_task (workflow_run_id);
+
+comment on index dex_activity_task_workflow_run_id_idx
+     is 'Support cascading deletes from dex_workflow_run during retention enforcement';

--- a/dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration/V0.1.3__AddTaskWorkflowRunIdIndexes.sql
+++ b/dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration/V0.1.3__AddTaskWorkflowRunIdIndexes.sql
@@ -1,9 +1,11 @@
+-- squawk-ignore require-concurrent-index-creation -- CONCURRENT is not supported on partitioned tables.
 create index if not exists dex_workflow_task_workflow_run_id_idx
     on dex_workflow_task (workflow_run_id);
 
 comment on index dex_workflow_task_workflow_run_id_idx
      is 'Support cascading deletes from dex_workflow_run during retention enforcement';
 
+-- squawk-ignore require-concurrent-index-creation -- CONCURRENT is not supported on partitioned tables.
 create index if not exists dex_activity_task_workflow_run_id_idx
     on dex_activity_task (workflow_run_id);
 


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

dex: adds missing indexes on workflow_run_id in task tables.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #6710 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

The PK of both tables *contains* `workflow_run_id`, but not at the first position, so querying them by only `workflow_run_id` (as is the case during cascading deletes) can't use them for index lookups.

During retention enforcement of workflow runs, we rely on cascading deletes on task tables. Currently, Postgres is forced to fall back to sequential scans, which *could* be slow when the tables have a large backlog.

Note that the migration does NOT use `CONCURRENTLY` for index creation. The reason being that it's not supported for partitioned table parents. However, blocking is limited because all queries executed by dex set a timeout of 10s. And index creation itself should be fast, as table size is usually small and most importantly self-draining.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
