### PR TITLE
dex: execute multiple deletion batches per maintenance cycle

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/dex/DexEngineInitializer.java
+++ b/apiserver/src/main/java/org/dependencytrack/dex/DexEngineInitializer.java
@@ -486,6 +486,8 @@ public final class DexEngineInitializer implements ServletContextListener {
                 .ifPresent(engineConfig.maintenance()::setRunRetentionDuration);
         config.getOptionalValue("dt.dex-engine.maintenance.run-deletion-batch-size", int.class)
                 .ifPresent(engineConfig.maintenance()::setRunDeletionBatchSize);
+        config.getOptionalValue("dt.dex-engine.maintenance.run-deletion-max-batches-per-cycle", int.class)
+                .ifPresent(engineConfig.maintenance()::setRunDeletionMaxBatchesPerCycle);
 
         return engineConfig;
     }

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -1564,13 +1564,25 @@ dt.dex-engine.maintenance.worker-interval-ms=1800000
 # @type:     integer
 dt.dex-engine.maintenance.run-retention-ms=86400000
 
-# Defines the maximum number of completed workflow runs to delete during a single execution
-# of the maintenance worker. Deletion of large volumes of runs in one pass can lead to I/O
-# spikes and increased table bloat.
+# Defines the maximum number of completed workflow runs to delete in a single batch.
+# Deletion of large volumes of runs in one pass can lead to I/O spikes and increased table bloat.
 # <br/><br/>
-# If retention is not able to keep up with the volumes of
-# runs, consider increasing the interval of the maintenance worker first.
+# Each maintenance cycle executes up to dt.dex-engine.maintenance.run-deletion-max-batches-per-cycle batches.
+# <br/><br/>
+# If retention is not able to keep up with the volumes of runs,
+# consider increasing the interval of the maintenance worker,
+# or the number of batches per cycle first.
 #
 # @category: Durable Execution
 # @type:     integer
 dt.dex-engine.maintenance.run-deletion-batch-size=1000
+
+# Defines the maximum number of deletion batches the maintenance worker executes per cycle.
+# <br/><br/>
+# Bounds the WAL burst when draining a large backlog. A backlog exceeding
+# dt.dex-engine.maintenance.run-deletion-batch-size * dt.dex-engine.maintenance.run-deletion-max-batches-per-cycle
+# is drained across multiple cycles.
+#
+# @category: Durable Execution
+# @type:     integer
+dt.dex-engine.maintenance.run-deletion-max-batches-per-cycle=100

--- a/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngineConfig.java
+++ b/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngineConfig.java
@@ -165,6 +165,7 @@ public class DexEngineConfig {
 
         private Duration runRetentionDuration = Duration.ofDays(1);
         private int runDeletionBatchSize = 1000;
+        private int runDeletionMaxBatchesPerCycle = 100;
         private Duration workerInitialDelay = Duration.ofMinutes(1);
         private Duration workerInterval = Duration.ofMinutes(30);
 
@@ -194,6 +195,17 @@ public class DexEngineConfig {
         }
 
         /**
+         * @return The maximum number of deletion batches to execute per worker cycle.
+         */
+        public int runDeletionMaxBatchesPerCycle() {
+            return runDeletionMaxBatchesPerCycle;
+        }
+
+        public void setRunDeletionMaxBatchesPerCycle(int runDeletionMaxBatchesPerCycle) {
+            this.runDeletionMaxBatchesPerCycle = runDeletionMaxBatchesPerCycle;
+        }
+
+        /**
          * @return Initial delay before the maintenance worker first runs.
          */
         public Duration workerInitialDelay() {
@@ -220,6 +232,7 @@ public class DexEngineConfig {
             return new StringJoiner(", ", getClass().getSimpleName() + "[", "]")
                     .add("runRetentionDuration=" + runRetentionDuration)
                     .add("runDeletionBatchSize=" + runDeletionBatchSize)
+                    .add("runDeletionMaxBatchesPerCycle=" + runDeletionMaxBatchesPerCycle)
                     .add("workerInitialDelay=" + workerInitialDelay)
                     .add("workerInterval=" + workerInterval)
                     .toString();

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -350,6 +350,7 @@ final class DexEngineImpl implements DexEngine {
                     leaderElection::isLeader,
                     config.maintenance().runRetentionDuration(),
                     config.maintenance().runDeletionBatchSize(),
+                    config.maintenance().runDeletionMaxBatchesPerCycle(),
                     config.maintenance().workerInitialDelay(),
                     config.maintenance().workerInterval());
             maintenanceWorker.start();

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/MaintenanceWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/MaintenanceWorker.java
@@ -39,6 +39,7 @@ final class MaintenanceWorker implements Closeable {
     private final Supplier<Boolean> leadershipSupplier;
     private final Duration runRetentionDuration;
     private final int runDeletionBatchSize;
+    private final int runDeletionMaxBatchesPerCycle;
     private final Duration initialDelay;
     private final Duration interval;
     private @Nullable ScheduledExecutorService executor;
@@ -48,12 +49,14 @@ final class MaintenanceWorker implements Closeable {
             Supplier<Boolean> leadershipSupplier,
             Duration runRetentionDuration,
             int runDeletionBatchSize,
+            int runDeletionMaxBatchesPerCycle,
             Duration initialDelay,
             Duration interval) {
         this.jdbi = jdbi;
         this.leadershipSupplier = leadershipSupplier;
         this.runRetentionDuration = runRetentionDuration;
         this.runDeletionBatchSize = runDeletionBatchSize;
+        this.runDeletionMaxBatchesPerCycle = runDeletionMaxBatchesPerCycle;
         this.initialDelay = initialDelay;
         this.interval = interval;
     }
@@ -91,32 +94,48 @@ final class MaintenanceWorker implements Closeable {
 
         LOGGER.debug("Enforcing run retention");
 
-        jdbi.useTransaction(handle -> {
-            final Update update = handle.createUpdate("""
-                    with cte_candidates as (
-                      select id
-                        from dex_workflow_run
-                       where completed_at < (NOW() - (:retentionDuration))
-                       order by completed_at
-                       limit :batchSize
-                         for no key update
-                        skip locked
-                    )
-                    delete from dex_workflow_run
-                     where id in (select id from cte_candidates)
-                    """);
+        long totalDeleted = 0;
+        int batchDeleted;
+        int batchesExecuted = 0;
 
-            final int runsDeleted = update
-                    .bind("retentionDuration", runRetentionDuration)
-                    .bind("batchSize", runDeletionBatchSize)
-                    .execute();
-
-            if (runsDeleted > 0) {
-                LOGGER.info("Deleted {} completed workflow run(s)", runsDeleted);
-            } else {
-                LOGGER.debug("No completed workflow runs deleted");
+        do {
+            if (!leadershipSupplier.get()) {
+                LOGGER.debug("Leadership lost after {} batch(es)", batchesExecuted);
+                break;
             }
-        });
+
+            batchDeleted = jdbi.inTransaction(handle -> {
+                final Update update = handle.createUpdate("""
+                        with cte_candidates as (
+                          select id
+                            from dex_workflow_run
+                           where completed_at < (NOW() - (:retentionDuration))
+                           order by completed_at
+                           limit :batchSize
+                             for no key update
+                            skip locked
+                        )
+                        delete from dex_workflow_run
+                         where id in (select id from cte_candidates)
+                        """);
+
+                return update
+                        .bind("retentionDuration", runRetentionDuration)
+                        .bind("batchSize", runDeletionBatchSize)
+                        .execute();
+            });
+
+            totalDeleted += batchDeleted;
+        } while (batchDeleted == runDeletionBatchSize
+                && ++batchesExecuted < runDeletionMaxBatchesPerCycle);
+
+        if (totalDeleted > 0) {
+            LOGGER.info(
+                    "Deleted {} completed workflow run(s) in {} batch(es)",
+                    totalDeleted, batchesExecuted);
+        } else {
+            LOGGER.debug("No completed workflow runs deleted");
+        }
     }
 
 }

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/MaintenanceWorkerTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/MaintenanceWorkerTest.java
@@ -75,7 +75,8 @@ class MaintenanceWorkerTest {
                 jdbi,
                 /* leadershipSupplier */ () -> true,
                 /* runRetentionDuration */ Duration.ofDays(3),
-                /* runRetentionBatchSize */ 10,
+                /* runDeletionBatchSize */ 10,
+                /* runDeletionMaxBatchesPerCycle */ 100,
                 /* initialDelay */ Duration.ZERO,
                 /* interval */ Duration.ofMillis(100));
 


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

dex: executes multiple deletion batches per maintenance cycle.

Allows maintenance to keep up with fast-growing backlogs more easily without requiring operator attention.

The number of batches per cycle is capped at a configurable limit, defaulting to 100, in order to prevent unbounded WAL bursts.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #6710

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
