### PR TITLE
Backport: dex: improve activity task scheduler polling efficiency for deep backlogs

### DIFF
--- a/dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration/V0.1.4__ReplaceActivityTaskSchedulerPollIndex.sql
+++ b/dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration/V0.1.4__ReplaceActivityTaskSchedulerPollIndex.sql
@@ -1,0 +1,10 @@
+-- squawk-ignore require-concurrent-index-creation -- CONCURRENT is not supported on partitioned tables.
+create index if not exists dex_activity_task_scheduler_poll_v2_idx
+    on dex_activity_task (priority desc, created_at, visible_from)
+ where status != 'QUEUED';
+
+comment on index dex_activity_task_scheduler_poll_v2_idx
+     is 'Support polling of the activity task scheduler';
+
+-- squawk-ignore require-concurrent-index-deletion -- CONCURRENT is not supported on partitioned tables.
+drop index if exists dex_activity_task_scheduler_poll_idx;

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskScheduler.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskScheduler.java
@@ -276,8 +276,7 @@ final class ActivityTaskScheduler implements Closeable {
                     ) as limited
                 ),
                 cte_eligible_task as (
-                  select workflow_run_id
-                       , created_event_id
+                  select ctid
                     from dex_activity_task
                    where queue_name = :queueName
                      -- Only consider tasks that are not already queued.
@@ -297,10 +296,10 @@ final class ActivityTaskScheduler implements Closeable {
                 update dex_activity_task as wat
                    set status = 'QUEUED'
                      , updated_at = now()
-                  from cte_eligible_task
                  where wat.queue_name = :queueName
-                   and wat.workflow_run_id = cte_eligible_task.workflow_run_id
-                   and wat.created_event_id = cte_eligible_task.created_event_id
+                   -- NB: the non-constant limit in cte_eligible_task causes the query planner
+                   -- to over-estimate row counts. A CTID scan bypasses the suboptimal plan.
+                   and wat.ctid = any(array(select ctid from cte_eligible_task))
                 returning activity_name
                 """);
 


### PR DESCRIPTION

### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

dex: improves activity task scheduler polling efficiency for deep backlogs.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #6642
Backports #6723

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Replaces the index meant to support task scheduler polling such that `visible_from` is no longer the leading column.

The previous index format was unusable by the query planner when the backlog was deep and most tasks were visible. This lead to sorting spilling to disk, which is mostly fine for NVMe / SSD but slow on HDD. In both cases it adds I/O cost that is entirely avoidable.

Also fixes suboptimal query plans caused by over-estimation of row counts due to the non-constant `limit` clause.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
