### PR TITLE
Backport: Add Squawk for migration linting

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -109,6 +109,24 @@ jobs:
       - name: Lint OpenAPI Spec
         run: make lint-openapi
 
+  lint-migrations:
+    name: Lint Migrations
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Fetch base ref
+        run: git fetch --no-tags origin "${{ github.base_ref }}"
+      - name: Lint changed migrations
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: make lint-migrations
+
   openapi-breaking-changes:
     name: OpenAPI Breaking Changes
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -126,6 +126,10 @@ jobs:
         env:
           BASE_REF: origin/${{ github.base_ref }}
         run: make lint-migrations
+      - name: Lint changed dex migrations
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: make lint-dex-migration
 
   openapi-breaking-changes:
     name: OpenAPI Breaking Changes

--- a/.squawk.toml
+++ b/.squawk.toml
@@ -1,0 +1,26 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+pg_version = "14.0.0"
+
+excluded_rules = [
+    # Disabled because its per-statement fix does not fit our Flyway setup.
+    # Squawk suggests session-level `set statement_timeout = '5s'`, but each
+    # migration runs inside a transaction, so the correct form would be `set local`.
+    # Lock / statement timeouts should be configured once at connection init,
+    # outside the migration scripts.
+    "require-timeout-settings"
+]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ If Maven needs to be invoked directly, only do so from the repository root.
 * Lint (Java): `make lint-java`
 * Lint (OpenAPI): `make lint-openapi`
 * Lint (Protobuf): `make lint-proto`
+* Lint (Flyway migrations): `make lint-migrations`
 
 > [!NOTE]
 > When running Maven via `make … AGENT=1`, Maven is invoked in quiet mode (`-q`), so successful test runs may produce little or no output.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -207,6 +207,77 @@ For repeatable migrations, edit the relevant `R__*.sql` file directly, no new fi
 > Flyway rejects checksum mismatches on existing deployments.
 > Add a new migration instead.
 
+### Linting Migrations
+
+New and modified migrations are linted with [squawk](https://squawkhq.com) to catch operationally
+unsafe DDL (missing `CONCURRENTLY` on indexes, blocking locks, `NOT NULL` columns without defaults, etc.)
+before they hit production deployments.
+
+Run the linter locally:
+
+```shell
+make lint-migrations
+```
+
+The target only lints migrations changed relative to `BASE_REF` (default `origin/main`).
+For fork-based setups, point it at the upstream main branch:
+
+```shell
+make lint-migrations BASE_REF=upstream/main
+```
+
+The same check runs in CI on every pull request via the `Lint Migrations` job in
+[`ci-lint.yaml`](./.github/workflows/ci-lint.yaml). PRs that introduce squawk findings
+will fail this job.
+
+Suppress an individual finding only when justified, by annotating the SQL statement
+(see [Disabling rules via comments](https://squawkhq.com/docs/cli#disabling-rules-via-comments)):
+
+```sql
+-- squawk-ignore <rule-name>
+ALTER TABLE ...;
+```
+
+### Migrations and Transactions
+
+Flyway wraps each migration script in a single transaction by default.
+A few Postgres DDL statements *cannot run inside a transaction*, most notably:
+
+* `CREATE INDEX CONCURRENTLY`
+* `DROP INDEX CONCURRENTLY`
+* `REINDEX CONCURRENTLY`
+* `ALTER TYPE ... ADD VALUE`
+
+Running them in the default transactional mode will fail.
+Squawk may push you towards using these constructs, but it doesn't know about Flyway executing
+migrations in transactions implicitly.
+
+Disable the transaction wrapper for that specific migration by adding a sidecar configuration
+file with the same name as the migration plus a `.conf` suffix, for example:
+
+```text
+V202606151200__add_foo_bar_idx.sql
+V202606151200__add_foo_bar_idx.sql.conf
+```
+
+```properties
+# V202606151200__add_foo_bar_idx.sql.conf
+executeInTransaction=false
+```
+
+```sql
+-- V202606151200__add_foo_bar_idx.sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "FOO_BAR_IDX" ON "FOO" ("BAR");
+```
+
+See Flyway's [script configuration docs](https://documentation.red-gate.com/fd/script-configuration-277578847.html)
+for the full list of per-script overrides.
+
+> [!WARNING]
+> When `executeInTransaction=false`, the migration is no longer atomic.
+> Keep these files small and idempotent (e.g. `IF NOT EXISTS`) so a partial
+> failure can be safely re-run.
+
 ## Build Cache
 
 We use Maven [build caching](https://maven.apache.org/extensions/maven-build-cache-extension/) to speed

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
 
+BASE_REF ?= origin/main
+MIGRATION_DIR := migration/src/main/resources/org/dependencytrack/migration
+SQUAWK_IMAGE := ghcr.io/sbdchd/squawk:2.58.0
+
 MVN := $(shell command -v mvn 2>/dev/null)
 MVND := $(shell command -v mvnd 2>/dev/null)
 ifeq ($(MVND),)
@@ -69,6 +73,32 @@ lint-java:
 	$(MVND) $(MVN_FLAGS) -Dmaven.build.cache.enabled=false validate
 .PHONY: lint-java
 
+lint-migrations:
+	@if ! git rev-parse --verify --quiet "$(BASE_REF)" >/dev/null; then \
+		echo "BASE_REF '$(BASE_REF)' does not resolve to a git ref."; \
+		echo "Override on the command line, e.g.: make lint-migrations BASE_REF=upstream/main"; \
+		exit 1; \
+	fi; \
+	changed=$$( \
+		{ \
+			git diff --name-only --diff-filter=AM "$(BASE_REF)...HEAD" -- '$(MIGRATION_DIR)/*.sql'; \
+			git diff --name-only --diff-filter=AM -- '$(MIGRATION_DIR)/*.sql'; \
+			git ls-files --others --exclude-standard -- '$(MIGRATION_DIR)/*.sql'; \
+		} | sort -u); \
+	if [ -z "$$changed" ]; then \
+		echo "No migration changes to lint (BASE_REF=$(BASE_REF))."; \
+		exit 0; \
+	fi; \
+	echo "Linting migrations:"; \
+	echo "$$changed" | sed 's/^/  /'; \
+	docker run --rm -i \
+		--platform linux/amd64 \
+		-v "$(CURDIR):/work" \
+		-w /work \
+		$(SQUAWK_IMAGE) \
+		lint $$changed
+.PHONY: lint-migrations
+
 lint-openapi:
 	@dups=$$(find api/src/main/openapi -path '*/schemas/*.yaml' -exec basename {} \; \
 		| sort | uniq -d); \
@@ -89,7 +119,7 @@ lint-proto:
 	buf lint
 .PHONY: lint-proto
 
-lint: lint-java lint-openapi lint-proto
+lint: lint-java lint-migrations lint-openapi lint-proto
 .PHONY: lint
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@
 
 BASE_REF ?= origin/main
 MIGRATION_DIR := migration/src/main/resources/org/dependencytrack/migration
+DEX_MIGRATION_DIR := dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration
 SQUAWK_IMAGE := ghcr.io/sbdchd/squawk:2.58.0
 
 MVN := $(shell command -v mvn 2>/dev/null)
@@ -99,6 +100,10 @@ lint-migrations:
 		lint $$changed
 .PHONY: lint-migrations
 
+lint-dex-migration:
+	@$(MAKE) lint-migrations MIGRATION_DIR="$(DEX_MIGRATION_DIR)"
+.PHONY: lint-dex-migration
+
 lint-openapi:
 	@dups=$$(find api/src/main/openapi -path '*/schemas/*.yaml' -exec basename {} \; \
 		| sort | uniq -d); \
@@ -119,7 +124,7 @@ lint-proto:
 	buf lint
 .PHONY: lint-proto
 
-lint: lint-java lint-migrations lint-openapi lint-proto
+lint: lint-java lint-migrations lint-dex-migration lint-openapi lint-proto
 .PHONY: lint
 
 test:


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds Squawk for migration linting.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #6413
Backports `ci-lint.yaml` and `Makefile` changes from #6721

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Backported so the `Lint / Lint Migrations` job can be used for branch protection rules on `5.0.x`.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
