### PR TITLE
Backport: Fix NPE and redundant queries in VEX/VDR export

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
@@ -930,8 +930,14 @@ public class ModelConverter {
     public static org.cyclonedx.model.vulnerability.Vulnerability convert(final QueryManager qm, final CycloneDXExporter.Variant variant,
                                                                           final Finding finding) {
         final Component component = qm.getObjectByUuid(Component.class, finding.getComponent().get("uuid").toString());
+        if (component == null) {
+            return null;
+        }
         final Project project = component.getProject();
         final Vulnerability vulnerability = qm.getObjectByUuid(Vulnerability.class, finding.getVulnerability().get("uuid").toString());
+        if (vulnerability == null) {
+            return null;
+        }
 
         final org.cyclonedx.model.vulnerability.Vulnerability cdxVulnerability = new org.cyclonedx.model.vulnerability.Vulnerability();
         cdxVulnerability.setBomRef(vulnerability.getUuid().toString());
@@ -1037,10 +1043,7 @@ public class ModelConverter {
         }
 
         if (CycloneDXExporter.Variant.VEX == variant || CycloneDXExporter.Variant.VDR == variant) {
-            final Analysis analysis = qm.getAnalysis(
-                    qm.getObjectByUuid(Component.class, component.getUuid()),
-                    qm.getObjectByUuid(Vulnerability.class, vulnerability.getUuid())
-            );
+            final Analysis analysis = qm.getAnalysis(component, vulnerability);
             if (analysis != null) {
                 final org.cyclonedx.model.vulnerability.Vulnerability.Analysis cdxAnalysis = new org.cyclonedx.model.vulnerability.Vulnerability.Analysis();
                 if (analysis.getAnalysisResponse() != null) {
@@ -1291,6 +1294,7 @@ public class ModelConverter {
         final var vulnerabilitiesSeen = new HashSet<org.cyclonedx.model.vulnerability.Vulnerability>();
         return findings.stream()
                 .map(finding -> convert(qm, variant, finding))
+                .filter(Objects::nonNull)
                 .filter(vulnerabilitiesSeen::add)
                 .toList();
     }

--- a/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/ModelConverterTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/ModelConverterTest.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.parser.cyclonedx;
+
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Finding;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.Severity;
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.parser.cyclonedx.util.ModelConverter;
+import org.dependencytrack.persistence.jdbi.ComponentDao;
+import org.dependencytrack.persistence.jdbi.FindingDao;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
+
+class ModelConverterTest extends PersistenceCapableTest {
+
+    @Test
+    void shouldSkipFindingWhoseComponentWasDeleted() {
+        final Project project = qm.createProject("acme-app", null, "1.0.0", null, null, null, null, false);
+
+        var vulnerability = new Vulnerability();
+        vulnerability.setVulnId("INT-001");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.HIGH);
+        vulnerability = qm.createVulnerability(vulnerability);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("1.0.0");
+        component = qm.createComponent(component, false);
+        qm.addVulnerability(vulnerability, component, "internal");
+
+        // Resolve the findings up front, mirroring what the exporter does before conversion.
+        final List<Finding> findings = withJdbiHandle(handle ->
+                handle.attach(FindingDao.class).getFindings(project.getId(), true));
+        assertThat(findings).hasSize(1);
+
+        // Simulate the component being deleted in the window between the findings query
+        // and the export (e.g. a concurrent re-analysis or manual deletion).
+        final Component deletedComponent = component;
+        withJdbiHandle(handle -> handle.attach(ComponentDao.class).deleteComponent(deletedComponent.getUuid()));
+
+        // Before the fix this threw a NullPointerException and aborted the whole export.
+        assertThatNoException().isThrownBy(() ->
+                ModelConverter.generateVulnerabilities(qm, CycloneDXExporter.Variant.VEX, findings));
+
+        final List<org.cyclonedx.model.vulnerability.Vulnerability> result =
+                ModelConverter.generateVulnerabilities(qm, CycloneDXExporter.Variant.VEX, findings);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldConvertFindingWithResolvableComponent() {
+        final Project project = qm.createProject("acme-app", null, "1.0.0", null, null, null, null, false);
+
+        var vulnerability = new Vulnerability();
+        vulnerability.setVulnId("INT-001");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.HIGH);
+        vulnerability = qm.createVulnerability(vulnerability);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("1.0.0");
+        component = qm.createComponent(component, false);
+        qm.addVulnerability(vulnerability, component, "internal");
+
+        final List<Finding> findings = withJdbiHandle(handle ->
+                handle.attach(FindingDao.class).getFindings(project.getId(), true));
+
+        final List<org.cyclonedx.model.vulnerability.Vulnerability> result =
+                ModelConverter.generateVulnerabilities(qm, CycloneDXExporter.Variant.VEX, findings);
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getId()).isEqualTo("INT-001");
+    }
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes NPE and redundant queries in VEX/VDR export.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6613
Backports #6739 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
