### PR TITLE
Improve classification of retryable vuln analysis errors

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/notification/PublishNotificationActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/notification/PublishNotificationActivity.java
@@ -135,7 +135,7 @@ public final class PublishNotificationActivity implements Activity<PublishNotifi
             } catch (RuntimeException | IOException e) {
                 if (e instanceof final RetryablePublishException rpe) {
                     throw new ApplicationFailureException(
-                            "Failed to publish notification with retryable cause", rpe, rpe.getRetryAfter());
+                            "Failed to publish notification with retryable cause", rpe, rpe.retryAfter());
                 }
 
                 throw new TerminalApplicationFailureException(

--- a/apiserver/src/main/java/org/dependencytrack/vulnanalysis/InvokeVulnAnalyzerActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulnanalysis/InvokeVulnAnalyzerActivity.java
@@ -23,15 +23,15 @@ import org.dependencytrack.common.MdcScope;
 import org.dependencytrack.dex.api.Activity;
 import org.dependencytrack.dex.api.ActivityContext;
 import org.dependencytrack.dex.api.ActivitySpec;
+import org.dependencytrack.dex.api.failure.ApplicationFailureException;
 import org.dependencytrack.dex.api.failure.TerminalApplicationFailureException;
 import org.dependencytrack.filestorage.api.FileStorage;
 import org.dependencytrack.filestorage.proto.v1.FileMetadata;
-import org.dependencytrack.plugin.api.config.InvalidRuntimeConfigException;
-import org.dependencytrack.plugin.config.UnresolvableSecretException;
 import org.dependencytrack.plugin.runtime.NoSuchExtensionException;
 import org.dependencytrack.plugin.runtime.PluginManager;
 import org.dependencytrack.proto.internal.workflow.v1.InvokeVulnAnalyzerArg;
 import org.dependencytrack.proto.internal.workflow.v1.InvokeVulnAnalyzerRes;
+import org.dependencytrack.vulnanalysis.api.RetryableVulnAnalysisException;
 import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -112,10 +112,12 @@ public final class InvokeVulnAnalyzerActivity implements Activity<InvokeVulnAnal
     private Bom performAnalysis(String analyzerName, Bom bom) throws InterruptedException {
         try (final var vulnAnalyzer = pluginManager.getExtension(VulnAnalyzer.class, analyzerName)) {
             return vulnAnalyzer.analyze(bom);
-        } catch (NoSuchExtensionException
-                 | InvalidRuntimeConfigException
-                 | UnresolvableSecretException e) {
-            throw new TerminalApplicationFailureException(e);
+        } catch (RetryableVulnAnalysisException e) {
+            throw new ApplicationFailureException(
+                    "Failed to invoke vuln analyzer with retryable cause", e, e.retryAfter());
+        } catch (RuntimeException e) {
+            throw new TerminalApplicationFailureException(
+                    "Failed to invoke vuln analyzer with non-retryable cause", e);
         }
     }
 

--- a/apiserver/src/test/java/org/dependencytrack/vulnanalysis/VulnAnalysisWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/vulnanalysis/VulnAnalysisWorkflowTest.java
@@ -69,6 +69,7 @@ import org.dependencytrack.proto.internal.workflow.v1.PrepareVulnAnalysisRes;
 import org.dependencytrack.proto.internal.workflow.v1.ReconcileVulnAnalysisResultsArg;
 import org.dependencytrack.proto.internal.workflow.v1.VulnAnalysisWorkflowArg;
 import org.dependencytrack.proto.internal.workflow.v1.VulnAnalysisWorkflowContext;
+import org.dependencytrack.vulnanalysis.api.RetryableVulnAnalysisException;
 import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
 import org.dependencytrack.vulnanalysis.internal.InternalVulnAnalyzerConfigV1;
 import org.dependencytrack.vulnanalysis.internal.InternalVulnAnalyzerPlugin;
@@ -79,6 +80,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.net.http.HttpClient;
 import java.time.Duration;
@@ -86,6 +89,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -112,7 +116,7 @@ class VulnAnalysisWorkflowTest extends PersistenceCapableTest {
     private FileStorage fileStorage;
     private PluginManager pluginManager;
     private final AtomicReference<Function<Bom, Bom>> mockAnalyzerFunction =
-            new AtomicReference<>(bom -> Bom.getDefaultInstance());
+            new AtomicReference<>(_ -> Bom.getDefaultInstance());
 
     @BeforeEach
     void beforeEach() {
@@ -127,7 +131,7 @@ class VulnAnalysisWorkflowTest extends PersistenceCapableTest {
                         .withDefaultValue("dt.vuln-analyzer.internal.datasource.name", "default")
                         .build(),
                 new NoopCacheManager(),
-                secretName -> null,
+                _ -> null,
                 JdbiFactory.createJdbi(),
                 HttpClient.newHttpClient(),
                 List.of(VulnAnalyzer.class, VulnDataSource.class));
@@ -1136,7 +1140,7 @@ class VulnAnalysisWorkflowTest extends PersistenceCapableTest {
                         new InternalVulnAnalyzerConfigV1()
                                 .withEnabled(false));
 
-        mockAnalyzerFunction.set(bom -> null);
+        mockAnalyzerFunction.set(_ -> null);
 
         var project = new Project();
         project.setName("acme-app");
@@ -1157,6 +1161,74 @@ class VulnAnalysisWorkflowTest extends PersistenceCapableTest {
 
         qm.getPersistenceManager().refresh(project);
         assertThat(project.getLastVulnerabilityAnalysis()).isNull();
+    }
+
+    @Test
+    void shouldNotRetryAnalyzerWhenFailureIsTerminal() {
+        pluginManager
+                .getMutableConfigRegistry(VulnAnalyzer.class, "internal")
+                .setRuntimeConfig(new InternalVulnAnalyzerConfigV1().withEnabled(false));
+
+        final var invocations = new AtomicInteger();
+        mockAnalyzerFunction.set(_ -> {
+            invocations.incrementAndGet();
+            throw new UncheckedIOException("boom!", new IOException("pow!"));
+        });
+
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setPurl("pkg:maven/com.example/acme-lib@1.0.0");
+        qm.persist(component);
+
+        final UUID runId = workflowTest.getEngine().createRun(
+                new CreateWorkflowRunRequest<>(VulnAnalysisWorkflow.class)
+                        .withArgument(VulnAnalysisWorkflowArg.newBuilder()
+                                .setProjectUuid(project.getUuid().toString())
+                                .build()));
+        workflowTest.awaitRunStatus(runId, WorkflowRunStatus.FAILED);
+
+        assertThat(invocations.get()).isOne();
+    }
+
+    @Test
+    void shouldRetryAnalyzerWhenFailureIsRetryable() {
+        pluginManager
+                .getMutableConfigRegistry(VulnAnalyzer.class, "internal")
+                .setRuntimeConfig(new InternalVulnAnalyzerConfigV1().withEnabled(false));
+
+        final var invocations = new AtomicInteger();
+        mockAnalyzerFunction.set(_ -> {
+            if (invocations.incrementAndGet() == 1) {
+                throw new RetryableVulnAnalysisException(
+                        "Rate limited", null, Duration.ofMillis(100));
+            }
+
+            return Bom.getDefaultInstance();
+        });
+
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setPurl("pkg:maven/com.example/acme-lib@1.0.0");
+        qm.persist(component);
+
+        final UUID runId = workflowTest.getEngine().createRun(
+                new CreateWorkflowRunRequest<>(VulnAnalysisWorkflow.class)
+                        .withArgument(VulnAnalysisWorkflowArg.newBuilder()
+                                .setProjectUuid(project.getUuid().toString())
+                                .build()));
+        workflowTest.awaitRunStatus(runId, WorkflowRunStatus.COMPLETED);
+
+        assertThat(invocations.get()).isEqualTo(2);
     }
 
     @Test

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -185,6 +185,13 @@
 
         <dependency>
             <groupId>org.dependencytrack</groupId>
+            <artifactId>net-support</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
             <artifactId>jdbi-support</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
@@ -201,7 +201,9 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
 
         final Duration retryDelay;
         if (retryAfter != null) {
-            retryDelay = retryAfter;
+            retryDelay = retryAfter.compareTo(retryPolicy.maxDelay()) > 0
+                    ? retryPolicy.maxDelay()
+                    : retryAfter;
         } else {
             final var intervalFunc =
                     IntervalFunction.ofExponentialRandomBackoff(

--- a/notification/api/src/test/java/org/dependencytrack/notification/api/publishing/RetryablePublishExceptionTest.java
+++ b/notification/api/src/test/java/org/dependencytrack/notification/api/publishing/RetryablePublishExceptionTest.java
@@ -28,12 +28,14 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 class RetryablePublishExceptionTest {
 
     @Test
+    @SuppressWarnings("ThrowableNotThrown")
     void shouldThrowWhenRetryAfterIsNegative() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new RetryablePublishException(null, Duration.of(-1, ChronoUnit.SECONDS)));
     }
 
     @Test
+    @SuppressWarnings("ThrowableNotThrown")
     void shouldThrowWhenRetryAfterIsZero() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new RetryablePublishException(null, Duration.of(0, ChronoUnit.SECONDS)));

--- a/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/http/AbstractHttpNotificationPublisher.java
+++ b/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/http/AbstractHttpNotificationPublisher.java
@@ -29,7 +29,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse.BodyHandlers;
-import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 
 import static java.util.Objects.requireNonNull;
@@ -63,7 +62,7 @@ public abstract class AbstractHttpNotificationPublisher implements NotificationP
 
         try {
             final var response = httpClient.send(request, BodyHandlers.discarding());
-            RetryablePublishException.throwIfRetryableError(response);
+            RetryablePublishException.throwIfRetryableHttpError(response);
             final int statusCode = response.statusCode();
             if (statusCode < 200 || statusCode > 299) {
                 throw new IllegalStateException("Request failed with unexpected response code: " + statusCode);
@@ -71,8 +70,9 @@ public abstract class AbstractHttpNotificationPublisher implements NotificationP
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RetryablePublishException("Interrupted while sending request", e);
-        } catch (HttpTimeoutException e) {
-            throw new RetryablePublishException("Timed out while sending request", e);
+        } catch (IOException e) {
+            RetryablePublishException.throwIfRetryableNetworkError(e, "Request failed while sending notification");
+            throw e;
         }
     }
 

--- a/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/jira/JiraNotificationPublisher.java
+++ b/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/jira/JiraNotificationPublisher.java
@@ -31,7 +31,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
-import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Map;
@@ -87,8 +86,9 @@ final class JiraNotificationPublisher implements NotificationPublisher {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RetryablePublishException("Interrupted while sending request", e);
-        } catch (HttpTimeoutException e) {
-            throw new RetryablePublishException("Timed out while sending request", e);
+        } catch (IOException e) {
+            RetryablePublishException.throwIfRetryableNetworkError(e, "Request failed while sending notification");
+            throw e;
         }
 
         if (response.statusCode() != 201) {

--- a/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/webhook/WebhookNotificationPublisher.java
+++ b/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/webhook/WebhookNotificationPublisher.java
@@ -30,7 +30,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublisher;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse.BodyHandlers;
-import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 
 import static java.util.Objects.requireNonNull;
@@ -80,7 +79,7 @@ final class WebhookNotificationPublisher implements NotificationPublisher {
 
         try {
             final var response = httpClient.send(requestBuilder.build(), BodyHandlers.discarding());
-            RetryablePublishException.throwIfRetryableError(response);
+            RetryablePublishException.throwIfRetryableHttpError(response);
             final int statusCode = response.statusCode();
             if (statusCode < 200 || statusCode > 299) {
                 throw new IllegalStateException("Request failed with unexpected response code: " + statusCode);
@@ -88,8 +87,9 @@ final class WebhookNotificationPublisher implements NotificationPublisher {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RetryablePublishException("Interrupted while sending request", e);
-        } catch (HttpTimeoutException e) {
-            throw new RetryablePublishException("Timed out while sending request", e);
+        } catch (IOException e) {
+            RetryablePublishException.throwIfRetryableNetworkError(e, "Request failed while sending notification");
+            throw e;
         }
     }
 

--- a/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/webhook/WebhookNotificationPublisherTest.java
+++ b/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/webhook/WebhookNotificationPublisherTest.java
@@ -46,8 +46,8 @@ import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.binaryEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
@@ -373,7 +373,7 @@ class WebhookNotificationPublisherTest extends AbstractNotificationPublisherTest
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {429, 503})
+    @ValueSource(ints = {429, 502, 503, 504})
     void shouldThrowRetryableExceptionWhenDestinationRespondsWithRetryableStatus(int status) {
         WIREMOCK.stubFor(post(anyUrl())
                 .willReturn(aResponse()
@@ -381,11 +381,11 @@ class WebhookNotificationPublisherTest extends AbstractNotificationPublisherTest
 
         assertThatExceptionOfType(RetryablePublishException.class)
                 .isThrownBy(() -> publisher.publish(publishContext, createBomConsumedTestNotification()))
-                .satisfies(exception -> Assertions.assertThat(exception.getRetryAfter()).isNull());
+                .satisfies(exception -> Assertions.assertThat(exception.retryAfter()).isNull());
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {429, 503})
+    @ValueSource(ints = {429, 502, 503, 504})
     void shouldThrowRetryableExceptionWhenDestinationRespondsWithRetryableStatusAndRetryAfterHeader(int status) {
         WIREMOCK.stubFor(post(anyUrl())
                 .willReturn(aResponse()
@@ -394,11 +394,11 @@ class WebhookNotificationPublisherTest extends AbstractNotificationPublisherTest
 
         assertThatExceptionOfType(RetryablePublishException.class)
                 .isThrownBy(() -> publisher.publish(publishContext, createBomConsumedTestNotification()))
-                .satisfies(exception -> Assertions.assertThat(exception.getRetryAfter()).hasMinutes(5));
+                .satisfies(exception -> Assertions.assertThat(exception.retryAfter()).hasMinutes(5));
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {400, 401, 403, 405, 500, 504})
+    @ValueSource(ints = {400, 401, 403, 405, 500})
     void shouldThrowWhenDestinationRespondsWithNonRetryableStatus(int status) {
         WIREMOCK.stubFor(post(anyUrl())
                 .willReturn(aResponse()

--- a/package-metadata/api/pom.xml
+++ b/package-metadata/api/pom.xml
@@ -37,6 +37,11 @@
     <dependencies>
         <dependency>
             <groupId>org.dependencytrack</groupId>
+            <artifactId>net-support</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
             <artifactId>plugin-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/package-metadata/api/src/main/java/org/dependencytrack/pkgmetadata/resolution/api/RetryableResolutionException.java
+++ b/package-metadata/api/src/main/java/org/dependencytrack/pkgmetadata/resolution/api/RetryableResolutionException.java
@@ -18,15 +18,14 @@
  */
 package org.dependencytrack.pkgmetadata.resolution.api;
 
+import org.dependencytrack.support.net.HttpRetry;
+import org.dependencytrack.support.net.TransientNetworkErrors;
 import org.jspecify.annotations.Nullable;
 
+import java.io.IOException;
 import java.net.http.HttpResponse;
 import java.time.Clock;
 import java.time.Duration;
-import java.time.Instant;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 
 /**
  * Exception for resolution failures that may be retried.
@@ -64,48 +63,18 @@ public class RetryableResolutionException extends RuntimeException {
         return retryAfter;
     }
 
-    public static void throwIfRetryableError(HttpResponse<?> response, Clock clock) {
-        final int statusCode = response.statusCode();
-
-        if (statusCode == 429) {
-            throw new RetryableResolutionException(
-                    "Rate limited by %s".formatted(response.request().uri()),
-                    null,
-                    extractRetryAfter(response, clock));
+    public static void throwIfRetryableHttpError(HttpResponse<?> response, Clock clock) {
+        final HttpRetry retry = HttpRetry.of(response, clock);
+        if (!retry.isRetryable()) {
+            return;
         }
 
-        if (statusCode == 503 || statusCode == 504) {
-            throw new RetryableResolutionException(
-                    "Server error %d from %s".formatted(statusCode, response.request().uri()),
-                    null,
-                    extractRetryAfter(response, clock));
-        }
+        throw new RetryableResolutionException(retry.description(), null, retry.retryAfter());
     }
 
-    private static @Nullable Duration extractRetryAfter(HttpResponse<?> response, Clock clock) {
-        return response.headers()
-                .firstValue("Retry-After")
-                .map(value -> tryParseRetryAfterHeader(value, clock))
-                .orElse(null);
-    }
-
-    static @Nullable Duration tryParseRetryAfterHeader(String value, Clock clock) {
-        final String trimmed = value.strip();
-        try {
-            final long seconds = Long.parseLong(trimmed);
-            return seconds > 0 ? Duration.ofSeconds(seconds) : null;
-        } catch (NumberFormatException _) {
-            // Fallthrough to date parsing.
-        }
-
-        try {
-            final Instant deadline = ZonedDateTime
-                    .parse(trimmed, DateTimeFormatter.RFC_1123_DATE_TIME)
-                    .toInstant();
-            final Duration delta = Duration.between(clock.instant(), deadline);
-            return (delta.isZero() || delta.isNegative()) ? null : delta;
-        } catch (DateTimeParseException _) {
-            return null;
+    public static void throwIfRetryableNetworkError(IOException e, @Nullable String message) {
+        if (TransientNetworkErrors.isTransient(e)) {
+            throw new RetryableResolutionException(message, e);
         }
     }
 

--- a/package-metadata/api/src/test/java/org/dependencytrack/pkgmetadata/resolution/api/RetryableResolutionExceptionTest.java
+++ b/package-metadata/api/src/test/java/org/dependencytrack/pkgmetadata/resolution/api/RetryableResolutionExceptionTest.java
@@ -18,61 +18,23 @@
  */
 package org.dependencytrack.pkgmetadata.resolution.api;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.time.Clock;
 import java.time.Duration;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class RetryableResolutionExceptionTest {
 
-    private static final Instant FIXED_NOW = Instant.parse("2024-01-01T00:00:00Z");
-    private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
-
     @ParameterizedTest
     @ValueSource(longs = {-1, 0})
+    @SuppressWarnings("ThrowableNotThrown")
     void shouldRejectNonPositiveRetryAfter(long seconds) {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new RetryableResolutionException(
                         null, null, Duration.of(seconds, ChronoUnit.SECONDS)));
-    }
-
-    @Test
-    void shouldParseRetryAfterAsDelaySeconds() {
-        assertThat(RetryableResolutionException.tryParseRetryAfterHeader("60", FIXED_CLOCK))
-                .isEqualTo(Duration.ofSeconds(60));
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"0", "-5", "not-a-date"})
-    void shouldReturnNullForUnusableHeaderValue(String value) {
-        assertThat(RetryableResolutionException.tryParseRetryAfterHeader(value, FIXED_CLOCK)).isNull();
-    }
-
-    @Test
-    void shouldParseRetryAfterAsHttpDate() {
-        final Instant deadline = FIXED_NOW.plus(Duration.ofMinutes(10));
-        final String httpDate = DateTimeFormatter.RFC_1123_DATE_TIME
-                .format(deadline.atZone(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS));
-
-        assertThat(RetryableResolutionException.tryParseRetryAfterHeader(httpDate, FIXED_CLOCK))
-                .isEqualTo(Duration.ofMinutes(10));
-    }
-
-    @Test
-    void shouldReturnNullWhenHttpDateIsInPast() {
-        final String httpDate = DateTimeFormatter.RFC_1123_DATE_TIME
-                .format(FIXED_NOW.minus(Duration.ofMinutes(5)).atZone(ZoneOffset.UTC));
-
-        assertThat(RetryableResolutionException.tryParseRetryAfterHeader(httpDate, FIXED_CLOCK)).isNull();
     }
 
 }

--- a/package-metadata/resolution/pom.xml
+++ b/package-metadata/resolution/pom.xml
@@ -49,6 +49,11 @@
         </dependency>
         <dependency>
             <groupId>org.dependencytrack</groupId>
+            <artifactId>net-support</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
             <artifactId>plugin-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cache/CachingHttpClient.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cache/CachingHttpClient.java
@@ -25,6 +25,7 @@ import org.dependencytrack.cache.api.Cache;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageRepository;
 import org.dependencytrack.pkgmetadata.resolution.api.RetryableResolutionException;
 import org.dependencytrack.pkgmetadata.resolution.cache.proto.v1.CacheEntry;
+import org.dependencytrack.support.net.TransientNetworkErrors;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +39,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.net.http.HttpTimeoutException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -205,12 +205,17 @@ public final class CachingHttpClient {
             NetworkCall<T> call) throws InterruptedException {
         try {
             return call.execute();
-        } catch (HttpTimeoutException e) {
-            return fallbackOrRethrow(entry, staleExtractor, uri, e, () -> new RetryableResolutionException(e));
         } catch (RetryableResolutionException e) {
             return fallbackOrRethrow(entry, staleExtractor, uri, e, () -> e);
         } catch (IOException e) {
-            return fallbackOrRethrow(entry, staleExtractor, uri, e, () -> new UncheckedIOException(e));
+            return fallbackOrRethrow(
+                    entry,
+                    staleExtractor,
+                    uri,
+                    e,
+                    TransientNetworkErrors.isTransient(e)
+                            ? () -> new RetryableResolutionException(e)
+                            : () -> new UncheckedIOException(e));
         }
     }
 
@@ -419,7 +424,7 @@ public final class CachingHttpClient {
 
     private <T> T throwUnexpected(HttpResponse<?> response) {
         try {
-            RetryableResolutionException.throwIfRetryableError(response, clock);
+            RetryableResolutionException.throwIfRetryableHttpError(response, clock);
         } catch (RetryableResolutionException e) {
             final Duration effectiveBackoff =
                     rateLimitGate.recordRateLimit(

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nixpkgs/NixpkgsPackageIndex.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nixpkgs/NixpkgsPackageIndex.java
@@ -35,7 +35,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.net.http.HttpTimeoutException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -125,14 +124,13 @@ final class NixpkgsPackageIndex {
         final HttpResponse<InputStream> response;
         try {
             response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
-        } catch (HttpTimeoutException e) {
-            throw new RetryableResolutionException(e);
         } catch (IOException e) {
+            RetryableResolutionException.throwIfRetryableNetworkError(e, "Nixpkgs request to %s failed".formatted(url));
             throw new UncheckedIOException(e);
         }
 
         try (final InputStream body = response.body()) {
-            RetryableResolutionException.throwIfRetryableError(response, Clock.systemUTC());
+            RetryableResolutionException.throwIfRetryableHttpError(response, Clock.systemUTC());
             if (response.statusCode() != 200) {
                 throw new UncheckedIOException(new IOException(
                         "Unexpected status code %d for %s".formatted(response.statusCode(), url)));
@@ -143,6 +141,7 @@ final class NixpkgsPackageIndex {
                 return parsePackages(parser);
             }
         } catch (IOException e) {
+            RetryableResolutionException.throwIfRetryableNetworkError(e, "Nixpkgs request to %s failed".formatted(url));
             throw new UncheckedIOException(e);
         }
     }

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/cache/CachingHttpClientTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/cache/CachingHttpClientTest.java
@@ -619,13 +619,13 @@ class CachingHttpClientTest {
     }
 
     @Test
-    void shouldRethrowIoExceptionWhenNoCachedEntry(WireMockRuntimeInfo wmRuntimeInfo) {
+    void shouldThrowRetryableExceptionOnConnectionResetWhenNoCachedEntry(WireMockRuntimeInfo wmRuntimeInfo) {
         stubFor(get(urlPathEqualTo(PATH))
                 .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
 
         final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1));
 
-        assertThatExceptionOfType(UncheckedIOException.class)
+        assertThatExceptionOfType(RetryableResolutionException.class)
                 .isThrownBy(() -> cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <module>support/datanucleus-plugin</module>
         <module>support/flyway</module>
         <module>support/jdbi</module>
+        <module>support/net</module>
         <module>support/os-distro-metadata</module>
         <module>support/smallrye-config-secret-handler-file</module>
         <module>support/smallrye-config-source-memory</module>

--- a/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/TransientSqlErrors.java
+++ b/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/TransientSqlErrors.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.jdbi.exception;
+
+import java.sql.SQLException;
+import java.sql.SQLRecoverableException;
+import java.sql.SQLTransientException;
+import java.util.Set;
+
+/// @since 5.1.0
+public final class TransientSqlErrors {
+
+    // Transient SQLSTATE codes.
+    // See https://www.postgresql.org/docs/current/errcodes-appendix.html
+    private static final Set<String> TRANSIENT_SQL_STATES = Set.of(
+            "08000", // connection_exception
+            "08001", // sqlclient_unable_to_establish_sqlconnection
+            "08003", // connection_does_not_exist
+            "08004", // sqlserver_rejected_establishment_of_sqlconnection
+            "08006", // connection_failure
+            "08007", // transaction_resolution_unknown
+            "40001", // serialization_failure
+            "40P01", // deadlock_detected
+            "53300", // too_many_connections
+            "53400", // configuration_limit_exceeded
+            "55P03", // lock_not_available
+            "57P01", // admin_shutdown
+            "57P02", // crash_shutdown
+            "57P03" // cannot_connect_now
+    );
+
+    private TransientSqlErrors() {
+    }
+
+    /// @param throwable The [Throwable] to inspect.
+    /// @return `true` when `throwable` is, or was caused by, a transient SQL error.
+    public static boolean isTransient(Throwable throwable) {
+        for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+            if (cause instanceof SQLRecoverableException
+                    || cause instanceof SQLTransientException) {
+                return true;
+            }
+
+            if (cause instanceof final SQLException sqlException) {
+                final String sqlState = sqlException.getSQLState();
+                if (sqlState != null && TRANSIENT_SQL_STATES.contains(sqlState)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/support/jdbi/src/test/java/org/dependencytrack/support/jdbi/exception/TransientSqlErrorsTest.java
+++ b/support/jdbi/src/test/java/org/dependencytrack/support/jdbi/exception/TransientSqlErrorsTest.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.jdbi.exception;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.sql.SQLException;
+import java.sql.SQLRecoverableException;
+import java.sql.SQLTransientConnectionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TransientSqlErrorsTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"40001", "40P01", "08000", "08001", "08006", "08007", "53300", "55P03", "57P03"})
+    void shouldClassifyTransientSqlStatesAsTransient(String sqlState) {
+        assertThat(TransientSqlErrors.isTransient(new SQLException("boom", sqlState))).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"08P01", "23505", "23514", "23502", "42601", "22P02"})
+    void shouldClassifyPermanentSqlStatesAsNotTransient(String sqlState) {
+        assertThat(TransientSqlErrors.isTransient(new SQLException("boom", sqlState))).isFalse();
+    }
+
+    @Test
+    void shouldUnwrapCauseChainToFindSqlException() {
+        final var wrapped = new RuntimeException("wrapper", new SQLException("boom", "40001"));
+        assertThat(TransientSqlErrors.isTransient(wrapped)).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenNoSqlExceptionInCauseChain() {
+        assertThat(TransientSqlErrors.isTransient(new RuntimeException("no sql here"))).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseWhenSqlStateIsAbsent() {
+        assertThat(TransientSqlErrors.isTransient(new SQLException("boom"))).isFalse();
+    }
+
+    @Test
+    void shouldClassifySqlRecoverableExceptionAsTransient() {
+        assertThat(TransientSqlErrors.isTransient(
+                new SQLRecoverableException("Connection is closed"))).isTrue();
+    }
+
+    @Test
+    void shouldClassifySqlTransientExceptionAsTransientRegardlessOfSqlState() {
+        assertThat(TransientSqlErrors.isTransient(
+                new SQLTransientConnectionException(
+                        "Connection is not available, request timed out"))).isTrue();
+    }
+
+    @Test
+    void shouldClassifyTransientSqlStateWrappedInNonTransientSqlException() {
+        final var wrapped = new SQLException("wrapper", "23505", new SQLException("boom", "40001"));
+        assertThat(TransientSqlErrors.isTransient(wrapped)).isTrue();
+    }
+
+}

--- a/support/net/pom.xml
+++ b/support/net/pom.xml
@@ -21,14 +21,15 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.dependencytrack</groupId>
-        <artifactId>notification-parent</artifactId>
+        <artifactId>dependency-track-parent</artifactId>
         <version>5.1.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>notification-api</artifactId>
+    <artifactId>net-support</artifactId>
     <packaging>jar</packaging>
 
-    <name>Notification :: API</name>
+    <name>Support :: Networking</name>
 
     <properties>
         <project.parentBaseDir>${project.basedir}/../..</project.parentBaseDir>
@@ -36,26 +37,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.dependencytrack</groupId>
-            <artifactId>net-support</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.dependencytrack</groupId>
-            <artifactId>plugin-api</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.uuid</groupId>
-            <artifactId>java-uuid-generator</artifactId>
         </dependency>
 
         <dependency>
@@ -68,24 +52,6 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java-util</artifactId>
-        </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>io.github.ascopes</groupId>
-                <artifactId>protobuf-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/support/net/src/main/java/module-info.java
+++ b/support/net/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+module org.dependencytrack.support.net {
+    exports org.dependencytrack.support.net;
+
+    requires java.net.http;
+    requires transitive org.jspecify;
+}

--- a/support/net/src/main/java/org/dependencytrack/support/net/HttpRetry.java
+++ b/support/net/src/main/java/org/dependencytrack/support/net/HttpRetry.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.net;
+
+import org.jspecify.annotations.Nullable;
+
+import java.net.URI;
+import java.net.http.HttpResponse;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import static java.util.Objects.requireNonNull;
+
+/// @since 5.1.0
+public record HttpRetry(int statusCode, @Nullable Duration retryAfter, String description) {
+
+    public HttpRetry {
+        if (retryAfter != null && (retryAfter.isZero() || retryAfter.isNegative())) {
+            throw new IllegalArgumentException("retryAfter must be positive, but was: " + retryAfter);
+        }
+        requireNonNull(description, "description must not be null");
+    }
+
+    public static HttpRetry of(HttpResponse<?> response) {
+        return of(response, Clock.systemUTC());
+    }
+
+    public static HttpRetry of(HttpResponse<?> response, Clock clock) {
+        final int statusCode = response.statusCode();
+        final URI requestUri = response.request().uri();
+
+        return new HttpRetry(
+                statusCode,
+                isRetryableStatus(statusCode)
+                        ? extractRetryAfter(response, clock)
+                        : null,
+                statusCode == 429
+                        ? "Rate limited by %s".formatted(requestUri)
+                        : "Server error %d from %s".formatted(statusCode, requestUri));
+    }
+
+    public boolean isRetryable() {
+        return isRetryableStatus(statusCode);
+    }
+
+    private static boolean isRetryableStatus(int statusCode) {
+        return statusCode == 429 || statusCode == 502 || statusCode == 503 || statusCode == 504;
+    }
+
+    private static @Nullable Duration extractRetryAfter(HttpResponse<?> response, Clock clock) {
+        return response.headers()
+                .firstValue("Retry-After")
+                .map(value -> parseRetryAfterHeader(value, clock))
+                .orElse(null);
+    }
+
+    static @Nullable Duration parseRetryAfterHeader(String value, Clock clock) {
+        final String trimmed = value.strip();
+        try {
+            final long seconds = Long.parseLong(trimmed);
+            return seconds > 0
+                    ? Duration.ofSeconds(seconds)
+                    : null;
+        } catch (NumberFormatException _) {
+            // Fallthrough to date parsing.
+        }
+
+        try {
+            final Instant deadline = ZonedDateTime
+                    .parse(trimmed, DateTimeFormatter.RFC_1123_DATE_TIME)
+                    .toInstant();
+            final Duration delta = Duration.between(clock.instant(), deadline);
+            return (delta.isZero() || delta.isNegative()) ? null : delta;
+        } catch (DateTimeParseException _) {
+            return null;
+        }
+    }
+
+}

--- a/support/net/src/main/java/org/dependencytrack/support/net/TransientNetworkErrors.java
+++ b/support/net/src/main/java/org/dependencytrack/support/net/TransientNetworkErrors.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.net;
+
+import java.io.EOFException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.net.http.HttpTimeoutException;
+import java.nio.channels.ClosedChannelException;
+
+/// @since 5.1.0
+public final class TransientNetworkErrors {
+
+    private TransientNetworkErrors() {
+    }
+
+    /// @param throwable The [Throwable] to inspect.
+    /// @return `true` when `throwable` is, or was caused by, a transient network error.
+    public static boolean isTransient(Throwable throwable) {
+        for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+            if (cause instanceof ClosedChannelException
+                    || cause instanceof EOFException
+                    || cause instanceof HttpTimeoutException
+                    || cause instanceof SocketException
+                    || cause instanceof SocketTimeoutException
+                    || cause instanceof UnknownHostException) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/support/net/src/test/java/org/dependencytrack/support/net/HttpRetryTest.java
+++ b/support/net/src/test/java/org/dependencytrack/support/net/HttpRetryTest.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.net;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class HttpRetryTest {
+
+    private static final Instant NOW = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Clock CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    @ParameterizedTest
+    @ValueSource(ints = {429, 502, 503, 504})
+    void shouldClassifyRetryableStatusCodes(int statusCode) {
+        assertThat(new HttpRetry(statusCode, null, "description").isRetryable()).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {200, 400, 401, 402, 403, 404, 500, 501})
+    void shouldNotClassifyNonRetryableStatusCodes(int statusCode) {
+        assertThat(new HttpRetry(statusCode, null, "description").isRetryable()).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {0, -1})
+    void shouldRejectNonPositiveRetryAfter(long seconds) {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new HttpRetry(429, Duration.ofSeconds(seconds), "description"));
+    }
+
+    @Test
+    void shouldParseRetryAfterAsDelaySeconds() {
+        assertThat(HttpRetry.parseRetryAfterHeader("60", CLOCK))
+                .isEqualTo(Duration.ofSeconds(60));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0", "-5", "not-a-date"})
+    void shouldReturnNullForUnusableHeaderValue(String value) {
+        assertThat(HttpRetry.parseRetryAfterHeader(value, CLOCK)).isNull();
+    }
+
+    @Test
+    void shouldParseRetryAfterAsHttpDate() {
+        final Instant deadline = NOW.plus(Duration.ofMinutes(10));
+        final String httpDate = DateTimeFormatter.RFC_1123_DATE_TIME
+                .format(deadline.atZone(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS));
+
+        assertThat(HttpRetry.parseRetryAfterHeader(httpDate, CLOCK))
+                .isEqualTo(Duration.ofMinutes(10));
+    }
+
+    @Test
+    void shouldReturnNullWhenHttpDateIsInPast() {
+        final String httpDate = DateTimeFormatter.RFC_1123_DATE_TIME
+                .format(NOW.minus(Duration.ofMinutes(5)).atZone(ZoneOffset.UTC));
+
+        assertThat(HttpRetry.parseRetryAfterHeader(httpDate, CLOCK)).isNull();
+    }
+
+}

--- a/support/net/src/test/java/org/dependencytrack/support/net/TransientNetworkErrorsTest.java
+++ b/support/net/src/test/java/org/dependencytrack/support/net/TransientNetworkErrorsTest.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.net;
+
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLHandshakeException;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.ConnectException;
+import java.net.ProtocolException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.net.http.HttpTimeoutException;
+import java.nio.channels.ClosedChannelException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TransientNetworkErrorsTest {
+
+    @Test
+    void shouldClassifyConnectivityAndTimeoutFailuresAsTransient() {
+        assertThat(TransientNetworkErrors.isTransient(new ConnectException("refused"))).isTrue();
+        assertThat(TransientNetworkErrors.isTransient(new SocketException("reset"))).isTrue();
+        assertThat(TransientNetworkErrors.isTransient(new SocketTimeoutException("read timed out"))).isTrue();
+        assertThat(TransientNetworkErrors.isTransient(new HttpTimeoutException("timed out"))).isTrue();
+        assertThat(TransientNetworkErrors.isTransient(new EOFException())).isTrue();
+        assertThat(TransientNetworkErrors.isTransient(new ClosedChannelException())).isTrue();
+        assertThat(TransientNetworkErrors.isTransient(new UnknownHostException("resolver blip"))).isTrue();
+    }
+
+    @Test
+    void shouldClassifyPermanentFailuresAsNotTransient() {
+        assertThat(TransientNetworkErrors.isTransient(new SSLHandshakeException("bad cert"))).isFalse();
+        assertThat(TransientNetworkErrors.isTransient(new ProtocolException("invalid response"))).isFalse();
+        assertThat(TransientNetworkErrors.isTransient(new InterruptedIOException("interrupted"))).isFalse();
+        assertThat(TransientNetworkErrors.isTransient(new IOException("malformed response"))).isFalse();
+    }
+
+    @Test
+    void shouldWalkCauseChainForWrappedTransportFailure() {
+        final var wrapped = new IOException(
+                "HTTP/1.1 header parser received no bytes",
+                new SocketException("Connection reset"));
+        assertThat(TransientNetworkErrors.isTransient(wrapped)).isTrue();
+    }
+
+}

--- a/vuln-analysis/api/pom.xml
+++ b/vuln-analysis/api/pom.xml
@@ -42,8 +42,25 @@
         </dependency>
         <dependency>
             <groupId>org.dependencytrack</groupId>
+            <artifactId>net-support</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
             <artifactId>plugin-api</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/vuln-analysis/api/src/main/java/org/dependencytrack/vulnanalysis/api/RetryableVulnAnalysisException.java
+++ b/vuln-analysis/api/src/main/java/org/dependencytrack/vulnanalysis/api/RetryableVulnAnalysisException.java
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-package org.dependencytrack.notification.api.publishing;
+package org.dependencytrack.vulnanalysis.api;
 
 import org.dependencytrack.support.net.HttpRetry;
 import org.dependencytrack.support.net.TransientNetworkErrors;
@@ -26,16 +26,14 @@ import java.io.IOException;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 
-/**
- * Exception for publish failures that may be retried.
- *
- * @since 5.0.0
- */
-public class RetryablePublishException extends RuntimeException {
+/// Exception for vulnerability analysis failures that may be retried.
+///
+/// @since 5.1.0
+public class RetryableVulnAnalysisException extends RuntimeException {
 
     private final @Nullable Duration retryAfter;
 
-    public RetryablePublishException(
+    public RetryableVulnAnalysisException(
             @Nullable String message,
             @Nullable Throwable cause,
             @Nullable Duration retryAfter) {
@@ -46,16 +44,8 @@ public class RetryablePublishException extends RuntimeException {
         this.retryAfter = retryAfter;
     }
 
-    public RetryablePublishException(@Nullable String message, @Nullable Throwable cause) {
+    public RetryableVulnAnalysisException(@Nullable String message, @Nullable Throwable cause) {
         this(message, cause, null);
-    }
-
-    public RetryablePublishException(@Nullable String message, @Nullable Duration retryAfter) {
-        this(message, null, retryAfter);
-    }
-
-    public RetryablePublishException(@Nullable String message) {
-        this(message, null, null);
     }
 
     public @Nullable Duration retryAfter() {
@@ -68,12 +58,12 @@ public class RetryablePublishException extends RuntimeException {
             return;
         }
 
-        throw new RetryablePublishException(retry.description(), null, retry.retryAfter());
+        throw new RetryableVulnAnalysisException(retry.description(), null, retry.retryAfter());
     }
 
-    public static void throwIfRetryableNetworkError(IOException e, String message) {
+    public static void throwIfRetryableNetworkError(IOException e, @Nullable String message) {
         if (TransientNetworkErrors.isTransient(e)) {
-            throw new RetryablePublishException(message, e);
+            throw new RetryableVulnAnalysisException(message, e);
         }
     }
 

--- a/vuln-analysis/api/src/main/java/org/dependencytrack/vulnanalysis/api/VulnAnalyzer.java
+++ b/vuln-analysis/api/src/main/java/org/dependencytrack/vulnanalysis/api/VulnAnalyzer.java
@@ -129,6 +129,8 @@ public interface VulnAnalyzer extends ExtensionPoint {
      *
      * @param bom the CycloneDX BOM to analyze.
      * @return A CycloneDX VDR containing discovered vulnerabilities.
+     * @throws InterruptedException           When interrupted.
+     * @throws RetryableVulnAnalysisException When analysis failed with a retryable cause.
      */
     Bom analyze(Bom bom) throws InterruptedException;
 

--- a/vuln-analysis/api/src/test/java/org/dependencytrack/vulnanalysis/api/RetryableVulnAnalysisExceptionTest.java
+++ b/vuln-analysis/api/src/test/java/org/dependencytrack/vulnanalysis/api/RetryableVulnAnalysisExceptionTest.java
@@ -1,0 +1,148 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.api;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSession;
+import java.net.SocketException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class RetryableVulnAnalysisExceptionTest {
+
+    @ParameterizedTest
+    @ValueSource(longs = {-1, 0})
+    @SuppressWarnings("ThrowableNotThrown")
+    void shouldRejectNonPositiveRetryAfter(long seconds) {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new RetryableVulnAnalysisException(
+                        null, null, Duration.of(seconds, ChronoUnit.SECONDS)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {200, 400, 401, 402, 403, 404})
+    void shouldNotThrowForSuccessOrPermanentError(int statusCode) {
+        assertThatNoException().isThrownBy(
+                () -> RetryableVulnAnalysisException.throwIfRetryableHttpError(
+                        responseOf(statusCode, null)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {503, 504})
+    void shouldThrowWithoutRetryAfterOnServerError(int statusCode) {
+        assertThatExceptionOfType(RetryableVulnAnalysisException.class)
+                .isThrownBy(() -> RetryableVulnAnalysisException.throwIfRetryableHttpError(
+                        responseOf(statusCode, null)))
+                .satisfies(e -> assertThat(e.retryAfter()).isNull());
+    }
+
+    @Test
+    void shouldThrowWithRetryAfterOnTooManyRequests() {
+        assertThatExceptionOfType(RetryableVulnAnalysisException.class)
+                .isThrownBy(() -> RetryableVulnAnalysisException.throwIfRetryableHttpError(
+                        responseOf(429, "30")))
+                .satisfies(e -> assertThat(e.retryAfter()).isEqualTo(Duration.ofSeconds(30)));
+    }
+
+    @Test
+    void shouldThrowForTransientIoException() {
+        assertThatExceptionOfType(RetryableVulnAnalysisException.class).isThrownBy(
+                () -> RetryableVulnAnalysisException.throwIfRetryableNetworkError(
+                        new SocketException("reset"), "boom"));
+    }
+
+    @Test
+    void shouldNotThrowForPermanentIoException() {
+        assertThatNoException().isThrownBy(
+                () -> RetryableVulnAnalysisException.throwIfRetryableNetworkError(
+                        new SSLHandshakeException("bad cert"), "boom"));
+    }
+
+    private static HttpResponse<?> responseOf(int statusCode, @Nullable String retryAfter) {
+        final HttpHeaders headers = HttpHeaders.of(
+                retryAfter != null
+                        ? Map.of("Retry-After", List.of(retryAfter))
+                        : Map.of(),
+                (_, _) -> true);
+        final var request = HttpRequest
+                .newBuilder(URI.create("https://example.com"))
+                .GET()
+                .build();
+
+        return new HttpResponse<>() {
+            @Override
+            public int statusCode() {
+                return statusCode;
+            }
+
+            @Override
+            public HttpRequest request() {
+                return request;
+            }
+
+            @Override
+            public Optional<HttpResponse<Object>> previousResponse() {
+                return Optional.empty();
+            }
+
+            @Override
+            public HttpHeaders headers() {
+                return headers;
+            }
+
+            @Override
+            public @Nullable Object body() {
+                return null;
+            }
+
+            @Override
+            public Optional<SSLSession> sslSession() {
+                return Optional.empty();
+            }
+
+            @Override
+            public URI uri() {
+                return request.uri();
+            }
+
+            @Override
+            public HttpClient.Version version() {
+                return HttpClient.Version.HTTP_1_1;
+            }
+        };
+    }
+
+}

--- a/vuln-analysis/internal/src/main/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzer.java
+++ b/vuln-analysis/internal/src/main/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzer.java
@@ -33,10 +33,13 @@ import org.cyclonedx.proto.v1_7.Vulnerability;
 import org.cyclonedx.proto.v1_7.VulnerabilityAffects;
 import org.dependencytrack.support.distrometadata.OsDistribution;
 import org.dependencytrack.support.distrometadata.RedHatDistribution;
+import org.dependencytrack.support.jdbi.exception.TransientSqlErrors;
+import org.dependencytrack.vulnanalysis.api.RetryableVulnAnalysisException;
 import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
 import org.dependencytrack.vulnanalysis.internal.Coordinate.CpeCoordinate;
 import org.dependencytrack.vulnanalysis.internal.Coordinate.PurlCoordinate;
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.JdbiException;
 import org.jdbi.v3.core.statement.Query;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -324,14 +327,21 @@ final class InternalVulnAnalyzer implements VulnAnalyzer {
                    AND v."REJECTED" IS NULL
                 """.formatted(innerSql);
 
-        return jdbi.withHandle(handle -> {
-            final Query query = handle.createQuery(sql);
-            binder.accept(query);
-            return query
-                    .mapTo(MatchingCriteria.class)
-                    .collect(Collectors.groupingBy(
-                            criteria -> coordinates.get(criteria.coordinateIndex())));
-        });
+        try {
+            return jdbi.withHandle(handle -> {
+                final Query query = handle.createQuery(sql);
+                binder.accept(query);
+                return query
+                        .mapTo(MatchingCriteria.class)
+                        .collect(Collectors.groupingBy(
+                                criteria -> coordinates.get(criteria.coordinateIndex())));
+            });
+        } catch (JdbiException e) {
+            if (TransientSqlErrors.isTransient(e)) {
+                throw new RetryableVulnAnalysisException("Failed to query matching criteria", e);
+            }
+            throw e;
+        }
     }
 
     private void processCriteria(

--- a/vuln-analysis/internal/src/test/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzerTest.java
+++ b/vuln-analysis/internal/src/test/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzerTest.java
@@ -28,6 +28,7 @@ import org.dependencytrack.plugin.api.MutableServiceRegistry;
 import org.dependencytrack.plugin.api.config.ConfigRegistry;
 import org.dependencytrack.plugin.testing.MockConfigRegistry;
 import org.dependencytrack.testing.database.TestDatabaseExtension;
+import org.dependencytrack.vulnanalysis.api.RetryableVulnAnalysisException;
 import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
@@ -44,11 +45,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import us.springett.parsers.cpe.Cpe;
 import us.springett.parsers.cpe.CpeParser;
 
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.dependencytrack.vulnanalysis.internal.InternalVulnAnalyzerTest.Range.withRange;
 
 class InternalVulnAnalyzerTest {
@@ -911,6 +914,25 @@ class InternalVulnAnalyzerTest {
             return new Range(this.startIncluding, this.startExcluding, this.endIncluding, endExcluding);
         }
 
+    }
+
+    @Test
+    void shouldThrowRetryableExceptionOnTransientSqlError() {
+        try (final var failingAnalyzer = new InternalVulnAnalyzer(
+                Jdbi.create(() -> {
+                    throw new SQLException("connection failure", "08006");
+                }))) {
+            final var bom = Bom.newBuilder()
+                    .addComponents(Component.newBuilder()
+                            .setBomRef("1")
+                            .setName("jackson-databind")
+                            .setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.0")
+                            .build())
+                    .build();
+
+            assertThatThrownBy(() -> failingAnalyzer.analyze(bom))
+                    .isInstanceOf(RetryableVulnAnalysisException.class);
+        }
     }
 
     private long createVulnerability(Handle handle) {

--- a/vuln-analysis/oss-index/src/main/java/org/dependencytrack/vulnanalysis/ossindex/OssIndexVulnAnalyzer.java
+++ b/vuln-analysis/oss-index/src/main/java/org/dependencytrack/vulnanalysis/ossindex/OssIndexVulnAnalyzer.java
@@ -29,6 +29,7 @@ import org.cyclonedx.proto.v1_7.Property;
 import org.cyclonedx.proto.v1_7.Vulnerability;
 import org.cyclonedx.proto.v1_7.VulnerabilityAffects;
 import org.dependencytrack.cache.api.Cache;
+import org.dependencytrack.vulnanalysis.api.RetryableVulnAnalysisException;
 import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -213,6 +214,7 @@ final class OssIndexVulnAnalyzer implements VulnAnalyzer {
         try {
             batchReports = getComponentReports(purlBatch);
         } catch (IOException e) {
+            RetryableVulnAnalysisException.throwIfRetryableNetworkError(e, "Failed to retrieve component report");
             throw new UncheckedIOException("Failed to retrieve component report", e);
         }
 
@@ -257,13 +259,20 @@ final class OssIndexVulnAnalyzer implements VulnAnalyzer {
                 .POST(BodyPublishers.ofByteArray(requestBytes))
                 .build();
 
-        final HttpResponse<InputStream> response = httpClient.send(request, BodyHandlers.ofInputStream());
+        final HttpResponse<InputStream> response;
+        try {
+            response = httpClient.send(request, BodyHandlers.ofInputStream());
+        } catch (IOException e) {
+            RetryableVulnAnalysisException.throwIfRetryableNetworkError(e, "OSS Index API request failed");
+            throw new UncheckedIOException("OSS Index API request failed", e);
+        }
 
         try (final InputStream bodyInputStream = response.body()) {
             if (response.statusCode() == 200) {
                 return objectMapper.readValue(bodyInputStream, COMPONENT_REPORTS_TYPE);
             }
 
+            RetryableVulnAnalysisException.throwIfRetryableHttpError(response);
             throw new IOException("OSS Index API request failed with status " + response.statusCode());
         }
     }

--- a/vuln-analysis/oss-index/src/test/java/org/dependencytrack/vulnanalysis/ossindex/OssIndexVulnAnalyzerTest.java
+++ b/vuln-analysis/oss-index/src/test/java/org/dependencytrack/vulnanalysis/ossindex/OssIndexVulnAnalyzerTest.java
@@ -31,13 +31,16 @@ import org.dependencytrack.plugin.api.MutableServiceRegistry;
 import org.dependencytrack.plugin.api.config.ConfigRegistry;
 import org.dependencytrack.plugin.config.RuntimeConfigMapper;
 import org.dependencytrack.plugin.testing.MockConfigRegistry;
+import org.dependencytrack.vulnanalysis.api.RetryableVulnAnalysisException;
 import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -50,8 +53,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.http.Fault.CONNECTION_RESET_BY_PEER;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @WireMockTest
 class OssIndexVulnAnalyzerTest {
@@ -317,6 +322,56 @@ class OssIndexVulnAnalyzerTest {
                 .withRequestBody(matchingJsonPath("$[?(@.coordinates.size() == 128)]")));
         verify(1, postRequestedFor(anyUrl())
                 .withRequestBody(matchingJsonPath("$[?(@.coordinates.size() == 22)]")));
+    }
+
+    @Test
+    void shouldThrowNonRetryableErrorOnPaymentRequired() {
+        stubFor(post(urlPathEqualTo("/api/v3/component-report"))
+                .willReturn(aResponse().withStatus(402)));
+
+        assertThatExceptionOfType(UncheckedIOException.class)
+                .isThrownBy(() -> analyzer.analyze(bomWithSingleComponent()))
+                .isNotInstanceOf(RetryableVulnAnalysisException.class);
+    }
+
+    @Test
+    void shouldThrowRetryableErrorOnTooManyRequests() {
+        stubFor(post(urlPathEqualTo("/api/v3/component-report"))
+                .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "30")));
+
+        assertThatExceptionOfType(RetryableVulnAnalysisException.class)
+                .isThrownBy(() -> analyzer.analyze(bomWithSingleComponent()))
+                .satisfies(e -> assertThat(e.retryAfter()).isEqualTo(Duration.ofSeconds(30)));
+    }
+
+    @Test
+    void shouldThrowRetryableErrorOnServiceUnavailable() {
+        stubFor(post(urlPathEqualTo("/api/v3/component-report"))
+                .willReturn(aResponse().withStatus(503)));
+
+        assertThatExceptionOfType(RetryableVulnAnalysisException.class)
+                .isThrownBy(() -> analyzer.analyze(bomWithSingleComponent()));
+    }
+
+    @Test
+    void shouldThrowRetryableErrorOnConnectionFailure() {
+        stubFor(post(urlPathEqualTo("/api/v3/component-report"))
+                .willReturn(aResponse().withFault(CONNECTION_RESET_BY_PEER)));
+
+        assertThatExceptionOfType(RetryableVulnAnalysisException.class)
+                .isThrownBy(() -> analyzer.analyze(bomWithSingleComponent()))
+                .satisfies(e -> assertThat(e.retryAfter()).isNull());
+    }
+
+    private static Bom bomWithSingleComponent() {
+        return Bom.newBuilder()
+                .addComponents(
+                        Component.newBuilder()
+                                .setBomRef("1")
+                                .setName("jackson-databind")
+                                .setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.1")
+                                .build())
+                .build();
     }
 
     @Test

--- a/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzer.java
+++ b/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzer.java
@@ -27,6 +27,7 @@ import org.cyclonedx.proto.v1_7.Property;
 import org.cyclonedx.proto.v1_7.Vulnerability;
 import org.cyclonedx.proto.v1_7.VulnerabilityAffects;
 import org.dependencytrack.cache.api.Cache;
+import org.dependencytrack.vulnanalysis.api.RetryableVulnAnalysisException;
 import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -207,7 +208,9 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
         try {
             response = fetchIssues(purlBatch);
         } catch (IOException e) {
-            throw new UncheckedIOException("Failed to fetch Snyk issues", e);
+            final var message = "Failed to fetch Snyk issues";
+            RetryableVulnAnalysisException.throwIfRetryableNetworkError(e, message);
+            throw new UncheckedIOException(message, e);
         }
 
         final var issuesByPurl = new HashMap<String, List<SnykIssue>>(purlBatch.size());
@@ -268,13 +271,21 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
                 .POST(BodyPublishers.ofString(requestBody))
                 .build();
 
-        final HttpResponse<InputStream> response = httpClient.send(request, BodyHandlers.ofInputStream());
+        final HttpResponse<InputStream> response;
+        try {
+            response = httpClient.send(request, BodyHandlers.ofInputStream());
+        } catch (IOException e) {
+            final var message = "Snyk API request failed";
+            RetryableVulnAnalysisException.throwIfRetryableNetworkError(e, message);
+            throw new UncheckedIOException(message, e);
+        }
 
         try (final InputStream bodyInputStream = response.body()) {
             if (response.statusCode() == 200) {
                 return objectMapper.readValue(bodyInputStream, SnykIssuesResponse.class);
             }
 
+            RetryableVulnAnalysisException.throwIfRetryableHttpError(response);
             throw new IOException("Snyk API request failed with status " + response.statusCode());
         }
     }

--- a/vuln-analysis/snyk/src/test/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzerTest.java
+++ b/vuln-analysis/snyk/src/test/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzerTest.java
@@ -30,6 +30,7 @@ import org.dependencytrack.cache.memory.MemoryCacheProvider;
 import org.dependencytrack.plugin.api.MutableServiceRegistry;
 import org.dependencytrack.plugin.api.config.ConfigRegistry;
 import org.dependencytrack.plugin.testing.MockConfigRegistry;
+import org.dependencytrack.vulnanalysis.api.RetryableVulnAnalysisException;
 import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,8 +48,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.http.Fault.CONNECTION_RESET_BY_PEER;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @WireMockTest
 class SnykVulnAnalyzerTest {
@@ -90,6 +93,25 @@ class SnykVulnAnalyzerTest {
         if (cacheManager != null) {
             cacheManager.close();
         }
+    }
+
+    @Test
+    void shouldThrowRetryableErrorOnConnectionFailure() {
+        stubFor(post(urlPathEqualTo("/rest/orgs/test-org-id/packages/issues"))
+                .willReturn(aResponse().withFault(CONNECTION_RESET_BY_PEER)));
+
+        final var bom = Bom.newBuilder()
+                .addComponents(
+                        Component.newBuilder()
+                                .setBomRef("1")
+                                .setName("jackson-databind")
+                                .setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4")
+                                .build())
+                .build();
+
+        assertThatExceptionOfType(RetryableVulnAnalysisException.class)
+                .isThrownBy(() -> analyzer.analyze(bom))
+                .satisfies(e -> assertThat(e.retryAfter()).isNull());
     }
 
     @Test

--- a/vuln-analysis/trivy/src/main/java/org/dependencytrack/vulnanalysis/trivy/TrivyVulnAnalyzer.java
+++ b/vuln-analysis/trivy/src/main/java/org/dependencytrack/vulnanalysis/trivy/TrivyVulnAnalyzer.java
@@ -26,6 +26,7 @@ import org.cyclonedx.proto.v1_7.Component;
 import org.cyclonedx.proto.v1_7.Property;
 import org.cyclonedx.proto.v1_7.Vulnerability;
 import org.cyclonedx.proto.v1_7.VulnerabilityAffects;
+import org.dependencytrack.vulnanalysis.api.RetryableVulnAnalysisException;
 import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -347,13 +348,16 @@ final class TrivyVulnAnalyzer implements VulnAnalyzer {
         try {
             response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
         } catch (IOException e) {
-            throw new UncheckedIOException("Trivy API request to %s failed".formatted(url), e);
+            final String message = "Trivy API request to %s failed".formatted(url);
+            RetryableVulnAnalysisException.throwIfRetryableNetworkError(e, message);
+            throw new UncheckedIOException(message, e);
         }
 
         if (response.statusCode() >= 200 && response.statusCode() < 300) {
             return response.body();
         }
 
+        RetryableVulnAnalysisException.throwIfRetryableHttpError(response);
         throw new IllegalStateException(
                 "Trivy API request to %s failed with status %d".formatted(url, response.statusCode()));
     }

--- a/vuln-analysis/trivy/src/test/java/org/dependencytrack/vulnanalysis/trivy/TrivyVulnAnalyzerTest.java
+++ b/vuln-analysis/trivy/src/test/java/org/dependencytrack/vulnanalysis/trivy/TrivyVulnAnalyzerTest.java
@@ -27,6 +27,7 @@ import org.cyclonedx.proto.v1_7.Bom;
 import org.cyclonedx.proto.v1_7.Classification;
 import org.cyclonedx.proto.v1_7.Component;
 import org.cyclonedx.proto.v1_7.Property;
+import org.dependencytrack.vulnanalysis.api.RetryableVulnAnalysisException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import trivy.proto.cache.v1.PutBlobRequest;
@@ -205,6 +206,7 @@ class TrivyVulnAnalyzerTest {
                 .build();
 
         assertThatThrownBy(() -> analyzer.analyze(bom))
+                .isInstanceOf(RetryableVulnAnalysisException.class)
                 .hasMessageContaining("Trivy API request");
 
         verify(exactly(1), postRequestedFor(urlPathEqualTo("/twirp/trivy.cache.v1.Cache/PutBlob")));

--- a/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbApiClient.java
+++ b/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbApiClient.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.vulnanalysis.vulndb;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dependencytrack.vulnanalysis.api.RetryableVulnAnalysisException;
 import org.dependencytrack.vulnanalysis.vulndb.VulnDbApiResponse.PaginatedResponse;
 import org.dependencytrack.vulnanalysis.vulndb.VulnDbApiResponse.Vulnerability;
 
@@ -85,7 +86,8 @@ final class VulnDbApiClient {
                     .GET()
                     .build();
 
-            final HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            final HttpResponse<InputStream> response =
+                    httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
 
             try (final InputStream body = response.body()) {
                 if (response.statusCode() == 200) {
@@ -108,6 +110,8 @@ final class VulnDbApiClient {
                 if (response.statusCode() == 404) {
                     return List.of();
                 }
+
+                RetryableVulnAnalysisException.throwIfRetryableHttpError(response);
                 throw new IOException("VulnDB API request failed with status " + response.statusCode());
             }
         }

--- a/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzer.java
+++ b/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzer.java
@@ -27,6 +27,7 @@ import org.cyclonedx.proto.v1_7.Property;
 import org.cyclonedx.proto.v1_7.Vulnerability;
 import org.cyclonedx.proto.v1_7.VulnerabilityAffects;
 import org.dependencytrack.cache.api.Cache;
+import org.dependencytrack.vulnanalysis.api.RetryableVulnAnalysisException;
 import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -157,7 +158,9 @@ final class VulnDbVulnAnalyzer implements VulnAnalyzer {
             try {
                 vulns = apiClient.getVulnerabilitiesByCpe(cpe);
             } catch (IOException e) {
-                throw new UncheckedIOException("Failed to fetch vulnerabilities for CPE '%s'".formatted(cpe), e);
+                final var message = "Failed to fetch vulnerabilities for CPE '%s'".formatted(cpe);
+                RetryableVulnAnalysisException.throwIfRetryableNetworkError(e, message);
+                throw new UncheckedIOException(message, e);
             }
 
             if (!vulns.isEmpty()) {

--- a/vuln-analysis/vuln-db/src/test/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzerTest.java
+++ b/vuln-analysis/vuln-db/src/test/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzerTest.java
@@ -30,6 +30,7 @@ import org.dependencytrack.cache.memory.MemoryCacheProvider;
 import org.dependencytrack.plugin.api.MutableServiceRegistry;
 import org.dependencytrack.plugin.api.config.ConfigRegistry;
 import org.dependencytrack.plugin.testing.MockConfigRegistry;
+import org.dependencytrack.vulnanalysis.api.RetryableVulnAnalysisException;
 import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,8 +48,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.http.Fault.CONNECTION_RESET_BY_PEER;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @WireMockTest
 class VulnDbVulnAnalyzerTest {
@@ -98,6 +101,25 @@ class VulnDbVulnAnalyzerTest {
         if (cacheManager != null) {
             cacheManager.close();
         }
+    }
+
+    @Test
+    void shouldThrowRetryableErrorOnConnectionFailure() {
+        stubFor(get(urlPathEqualTo("/api/v1/vulnerabilities/find_by_cpe"))
+                .willReturn(aResponse().withFault(CONNECTION_RESET_BY_PEER)));
+
+        final var bom = Bom.newBuilder()
+                .addComponents(
+                        Component.newBuilder()
+                                .setBomRef("1")
+                                .setName("example-lib")
+                                .setCpe("cpe:2.3:a:example:lib:1.0:*:*:*:*:*:*:*")
+                                .build())
+                .build();
+
+        assertThatExceptionOfType(RetryableVulnAnalysisException.class)
+                .isThrownBy(() -> analyzer.analyze(bom))
+                .satisfies(e -> assertThat(e.retryAfter()).isNull());
     }
 
     @Test


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Improves classification of retryable vuln analysis errors.

Introduces `RetryableVulnAnalysisException`, similar to the other existing `Retryable*Exception`s. Only schedules the corresponding dex activity for retry when analyzers throw this exception, otherwise treats them as terminal.

Centralizes the decisions whether an HTTP response is a transient error, or whether an exception is a transient network error, in a new `support-net` module. Uses this new module across notification/api, package-metadata-api, and vuln-analysis/api.

Because the internal vuln analyzer doesn't use HTTP, adds corresponding classification logic for SQL errors to the `jdbi-support` module.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6641

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
