### PR TITLE
Implement support for compressed SBOMs in multipart uploads

### DIFF
--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -347,6 +347,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.compression</groupId>
+            <artifactId>jetty-compression-zstandard</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.compression</groupId>
             <artifactId>jetty-compression-server</artifactId>
         </dependency>
         <dependency>

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -21,6 +21,7 @@ package org.dependencytrack.resources.v1;
 import alpine.model.ConfigProperty;
 import alpine.server.auth.PermissionRequired;
 import com.fasterxml.uuid.Generators;
+import com.github.luben.zstd.ZstdInputStream;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -108,6 +109,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
 
 import static java.util.function.Predicate.not;
 import static org.dependencytrack.common.MdcKeys.MDC_BOM_UPLOAD_TOKEN;
@@ -529,7 +531,10 @@ public class BomResource extends AbstractApiResource {
                       or <strong>PROJECT_CREATION_UPLOAD</strong> permission.
                     </p>
                     <p>
-                      MediaType supported for BOM artifact is 'application/xml' or 'application/json'.
+                      The BOM artifact may be supplied uncompressed or compressed. If the BOM is uncompressed,
+                      the supported MediaType is 'application/xml' or 'application/json'. If the BOM is compressed,
+                      the supported MediaType is 'application/gzip' or 'application/zstd' and must match the actual 
+                      compression of the data.
                       The BOM will be validated against the CycloneDX schema. If schema validation fails,
                       a response with problem details in RFC 9457 format will be returned. In this case,
                       the response's content type will be <code>application/problem+json</code>.
@@ -704,9 +709,16 @@ public class BomResource extends AbstractApiResource {
         }
 
         final FormDataBodyPart firstPart = artifactParts.getFirst();
+        final var encoding = firstPart.getHeaders().getFirst("Content-Type");
+
         final byte[] bomBytes;
         try (final var inputStream = ((BodyPartEntity) firstPart.getEntity()).getInputStream();
-             final var byteOrderMarkInputStream = BOMInputStream.builder().setInputStream(inputStream).get()) {
+             final var encodingStream = (switch (encoding) {
+                 case "application/gzip", "application/x-gzip" -> new GZIPInputStream(inputStream);
+                 case "application/zstd", "application/x-zstd" -> new ZstdInputStream(inputStream);
+                 case null, default -> inputStream;
+             });
+             final var byteOrderMarkInputStream = BOMInputStream.builder().setInputStream(encodingStream).get()) {
             bomBytes = IOUtils.toByteArray(byteOrderMarkInputStream);
         } catch (IOException e) {
             LOGGER.error("An unexpected error occurred while reading BOM from upload", e);

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -26,6 +26,7 @@ import alpine.server.auth.SessionTokenService;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthFeature;
 import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.github.luben.zstd.ZstdOutputStream;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
@@ -79,6 +80,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -100,6 +102,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.zip.GZIPOutputStream;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
@@ -2698,5 +2701,52 @@ class BomResourceTest extends ResourceTest {
         assertThat(project).isNotNull();
         assertThat(project.isActive()).isFalse();
         assertThat(project.getInactiveSince()).isNotNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"gzip", "zstd"})
+    void uploadBomAcceptsCompressedBomTest(String encoding) throws Exception {
+        initializeWithPermissions(Permissions.BOM_UPLOAD);
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.createProject(project, List.of(), false);
+
+        final var bomBytes = resourceToByteArray("/unit/bom-1.xml");
+        var encodedBomStream = new ByteArrayOutputStream();
+        final var encoder = switch (encoding) {
+            case "gzip" -> new GZIPOutputStream(encodedBomStream);
+            case "zstd" -> new ZstdOutputStream(encodedBomStream);
+            default -> null;
+        };
+
+        assertThat(encoder).isNotNull();
+
+        encoder.write(bomBytes);
+        encoder.close();
+
+        final var encodedBomBytes = encodedBomStream.toByteArray();
+
+        final var multiPart = new FormDataMultiPart()
+                .field("project", project.getUuid().toString())
+                .field("bom", encodedBomBytes, new MediaType("application", encoding))
+                .field("isActive", "true");
+
+        // NB: The GrizzlyConnectorProvider doesn't work with MultiPart requests.
+        // https://github.com/eclipse-ee4j/jersey/issues/5094
+        final var client = ClientBuilder.newClient(new ClientConfig()
+                .register(MultiPartFeature.class)
+                .connectorProvider(new HttpUrlConnectorProvider()));
+
+        final Response response = client.target(jersey.target(V1_BOM).getUri()).request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.entity(multiPart, multiPart.getMediaType()));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "token": "${json-unit.any-string}",
+                  "projectUuid": "${json-unit.any-string}"
+                }
+                """);
     }
 }


### PR DESCRIPTION
### Description
This PR adds support for pre-compressed SBOMs in the bodies of multipart uploads, enabling faster transfer of already-compressed SBOMs to DependencyTrack.

### Addressed Issue

Partly addresses #6194 by implementing support for compressed SBOMs in the API server.

### Additional Details
Brotli and Zstandard compression have also been added to the overall transparent compression support for the API server for the sake of greater compatibility and API symmetry. gzip, brotli, and zstd together account for >99.5% of all compressed web traffic as of 2026, which should ensure that DT is as compatible as possible with other systems.

There is one caveat - Brotli compression is not tested in the integration test suite due to the lack of an encoding stream in org.brotli. A JNI-based implementation exists, but I was unable to make it work properly during testing and it would add a test-only dependency which may be undesirable. I have tested Brotli-encoded uploads outside of the test suite and they work fine.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
