### PR TITLE
fix(notifications): improve Jira Perform Test logging and status handling

### DIFF
--- a/src/main/java/org/dependencytrack/notification/publisher/AbstractWebhookPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/AbstractWebhookPublisher.java
@@ -95,13 +95,8 @@ public abstract class AbstractWebhookPublisher implements Publisher {
             request.setEntity(new StringEntity(content, StandardCharsets.UTF_8));
             try (final CloseableHttpResponse response = HttpClientPool.getClient().execute(request)) {
                 final int statusCode = response.getStatusLine().getStatusCode();
-                if (statusCode < 200 || statusCode >= 300) {
-                    logger.warn("Destination responded with with status code {}, likely indicating a processing failure ({})",
-                            statusCode, ctx);
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Response headers: {}", (Object[]) response.getAllHeaders());
-                        logger.debug("Response body: {}", EntityUtils.toString(response.getEntity()));
-                    }
+                if (!isSuccessfulResponse(statusCode)) {
+                    handleUnsuccessfulResponse(ctx, logger, response, statusCode);
                 } else if (ctx.shouldLogSuccess()) {
                     logger.info("Destination acknowledged reception of notification with status code {} ({})",
                             statusCode, ctx);
@@ -134,6 +129,26 @@ public abstract class AbstractWebhookPublisher implements Publisher {
     }
 
     protected record AuthCredentials(String user, String password) {
+    }
+
+    /**
+     * @return {@code true} when the destination response indicates successful processing
+     */
+    protected boolean isSuccessfulResponse(final int statusCode) {
+        return statusCode >= 200 && statusCode < 300;
+    }
+
+    protected void handleUnsuccessfulResponse(
+            final PublishContext ctx,
+            final Logger logger,
+            final CloseableHttpResponse response,
+            final int statusCode) throws IOException {
+        logger.warn("Destination responded with with status code {}, likely indicating a processing failure ({})",
+                statusCode, ctx);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Response headers: {}", (Object[]) response.getAllHeaders());
+            logger.debug("Response body: {}", EntityUtils.toString(response.getEntity()));
+        }
     }
 
     protected void handleRequestException(final PublishContext ctx, final Logger logger, final Exception e) {

--- a/src/main/java/org/dependencytrack/notification/publisher/JiraPublisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/JiraPublisher.java
@@ -21,11 +21,13 @@ package org.dependencytrack.notification.publisher;
 import alpine.common.logging.Logger;
 import alpine.model.ConfigProperty;
 import alpine.notification.Notification;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.dependencytrack.exception.PublisherException;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.DebugDataEncryption;
 
 import jakarta.json.JsonObject;
+import java.io.IOException;
 import java.util.Map;
 
 import static org.dependencytrack.model.ConfigPropertyConstants.JIRA_PASSWORD;
@@ -95,4 +97,20 @@ public class JiraPublisher extends AbstractWebhookPublisher implements Publisher
         context.put("jiraProjectKey", jiraProjectKey);
         context.put("jiraTicketType", jiraTicketType);
     }
+
+    @Override
+    protected boolean isSuccessfulResponse(final int statusCode) {
+        return statusCode == 201;
+    }
+
+    @Override
+    protected void handleUnsuccessfulResponse(
+            final PublishContext ctx,
+            final org.slf4j.Logger logger,
+            final CloseableHttpResponse response,
+            final int statusCode) throws IOException {
+        super.handleUnsuccessfulResponse(ctx, logger, response, statusCode);
+        throw new PublisherException("Request failed with unexpected response code: %d".formatted(statusCode));
+    }
+
 }

--- a/src/main/java/org/dependencytrack/notification/publisher/PublishContext.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/PublishContext.java
@@ -151,6 +151,28 @@ public record PublishContext(
                 rule.isLogSuccessfulPublish());
     }
 
+    /**
+     * Context for notification rule tests. Includes rule metadata and always emits a log message upon
+     * successful publishing to aid in debugging of notification configuration.
+     */
+    public PublishContext forRuleTest(final NotificationRule rule) {
+        return withRule(rule).withLogSuccess(true);
+    }
+
+    public PublishContext withLogSuccess(final boolean logSuccess) {
+        return new PublishContext(
+                this.notificationGroup,
+                this.notificationLevel,
+                this.notificationScope,
+                this.notificationTimestamp,
+                this.notificationSubjects,
+                this.ruleId,
+                this.ruleName,
+                this.ruleScope,
+                this.ruleLevel,
+                logSuccess);
+    }
+
     public boolean shouldLogSuccess() {
         return logSuccess != null && logSuccess;
     }

--- a/src/main/java/org/dependencytrack/resources/v1/NotificationPublisherResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/NotificationPublisherResource.java
@@ -35,6 +35,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.exception.PublisherException;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.NotificationPublisher;
 import org.dependencytrack.model.NotificationRule;
@@ -371,19 +372,20 @@ public class NotificationPublisherResource extends AlpineResource {
                         .level(rule.getNotificationLevel())
                         .subject(NotificationUtil.generateSubject(rule, group));
 
-                publisher.inform(PublishContext.from(notification), notification, config);
+                publisher.inform(PublishContext.from(notification).forRuleTest(rule), notification, config);
             }
 
             return Response.ok().build();
         } catch (
-                InvocationTargetException
+                PublisherException
+                | InvocationTargetException
                 | InstantiationException
                 | IllegalAccessException
                 | NoSuchMethodException e) {
             LOGGER.error(e.getMessage(), e);
             return Response
                     .status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity("Exception occurred while sending the notification.")
+                    .entity("Exception occurred while sending the notification. Check the logs for more details.")
                     .build();
         }
     }

--- a/src/test/java/org/dependencytrack/notification/publisher/JiraPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/JiraPublisherTest.java
@@ -19,16 +19,32 @@
 package org.dependencytrack.notification.publisher;
 
 import alpine.model.ConfigProperty;
+import alpine.notification.Notification;
+import alpine.notification.NotificationLevel;
 import alpine.security.crypto.DataEncryption;
 import jakarta.json.JsonObjectBuilder;
+import org.dependencytrack.exception.PublisherException;
+import org.dependencytrack.notification.NotificationConstants;
+import org.dependencytrack.notification.NotificationGroup;
+import org.dependencytrack.notification.NotificationScope;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.notification.vo.BomConsumedOrProcessed;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.dependencytrack.model.ConfigPropertyConstants.JIRA_PASSWORD;
 import static org.dependencytrack.model.ConfigPropertyConstants.JIRA_URL;
 import static org.dependencytrack.model.ConfigPropertyConstants.JIRA_USERNAME;
@@ -61,6 +77,37 @@ class JiraPublisherTest extends AbstractWebhookPublisherTest<JiraPublisher> {
                 JIRA_PASSWORD.getPropertyType(),
                 JIRA_PASSWORD.getDescription()
         );
+
+        stubFor(post(anyUrl())
+                .willReturn(aResponse()
+                        .withStatus(201)));
+    }
+
+    @Test
+    void testInformRejectsNon201Response() {
+        stubFor(post(anyUrl())
+                .willReturn(aResponse()
+                        .withStatus(200)));
+
+        final var project = new Project();
+        project.setName("projectName");
+        project.setVersion("projectVersion");
+        qm.persist(project);
+
+        final var subject = new BomConsumedOrProcessed(
+                project, "bomContent", org.dependencytrack.model.Bom.Format.CYCLONEDX, "1.5");
+        final var notification = new Notification()
+                .scope(NotificationScope.PORTFOLIO)
+                .group(NotificationGroup.BOM_CONSUMED)
+                .title(NotificationConstants.Title.BOM_CONSUMED)
+                .content("A CycloneDX BOM was consumed and will be processed")
+                .level(NotificationLevel.INFORMATIONAL)
+                .timestamp(LocalDateTime.ofEpochSecond(66666, 666, ZoneOffset.UTC))
+                .subject(subject);
+
+        assertThatThrownBy(() -> publisherInstance.inform(PublishContext.from(notification), notification, createConfig()))
+                .isInstanceOf(PublisherException.class)
+                .hasMessageContaining("unexpected response code: 200");
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
@@ -455,9 +455,9 @@ public class NotificationPublisherResourceTest extends ResourceTest {
                     ConfigPropertyConstants.JIRA_PASSWORD.getPropertyType(),
                     ConfigPropertyConstants.JIRA_PASSWORD.getDescription());
 
-            stubFor(WireMock.post(WireMock.anyUrl())
+            wireMock.stubFor(WireMock.post(WireMock.anyUrl())
                     .willReturn(aResponse()
-                            .withStatus(200)));
+                            .withStatus(201)));
 
             final Response response = jersey.target(V1_NOTIFICATION_PUBLISHER + "/test/" + notificationRule.getUuid()).request()
                     .header(X_API_KEY, apiKey)
@@ -481,6 +481,59 @@ public class NotificationPublisherResourceTest extends ResourceTest {
                                       }
                                     }
                                     """))));
+        } finally {
+            wireMock.stop();
+        }
+    }
+
+    @Test
+    public void testNotificationRuleJiraTestRejectsNon201Response() throws Exception {
+        new DefaultObjectGenerator().loadDefaultNotificationPublishers();
+
+        final NotificationPublisher jiraPublisher = qm.getNotificationPublisher(
+                DefaultNotificationPublishers.JIRA.getPublisherName());
+        assertThat(jiraPublisher).isNotNull();
+
+        final var notificationRule = new NotificationRule();
+        notificationRule.setPublisher(jiraPublisher);
+        notificationRule.setPublisherConfig("""
+                {
+                  "destination": "FOO",
+                  "jiraTicketType": "Task"
+                }
+                """);
+        notificationRule.setName("Jira Test");
+        notificationRule.setNotifyOn(Set.of(NotificationGroup.NEW_VULNERABILITY));
+        notificationRule.setNotificationLevel(NotificationLevel.INFORMATIONAL);
+        notificationRule.setScope(NotificationScope.PORTFOLIO);
+        notificationRule.setTriggerType(NotificationTriggerType.EVENT);
+        qm.persist(notificationRule);
+
+        final var wireMock = new WireMockServer(options().dynamicPort());
+        wireMock.start();
+
+        try {
+            qm.createConfigProperty(
+                    ConfigPropertyConstants.JIRA_URL.getGroupName(),
+                    ConfigPropertyConstants.JIRA_URL.getPropertyName(),
+                    wireMock.baseUrl(),
+                    ConfigPropertyConstants.JIRA_URL.getPropertyType(),
+                    ConfigPropertyConstants.JIRA_URL.getDescription());
+            qm.createConfigProperty(
+                    ConfigPropertyConstants.JIRA_PASSWORD.getGroupName(),
+                    ConfigPropertyConstants.JIRA_PASSWORD.getPropertyName(),
+                    DataEncryption.encryptAsString("authToken"),
+                    ConfigPropertyConstants.JIRA_PASSWORD.getPropertyType(),
+                    ConfigPropertyConstants.JIRA_PASSWORD.getDescription());
+
+            wireMock.stubFor(WireMock.post(WireMock.anyUrl())
+                    .willReturn(aResponse()
+                            .withStatus(200)));
+
+            final Response response = jersey.target(V1_NOTIFICATION_PUBLISHER + "/test/" + notificationRule.getUuid()).request()
+                    .header(X_API_KEY, apiKey)
+                    .post(null);
+            assertThat(response.getStatus()).isEqualTo(500);
         } finally {
             wireMock.stop();
         }


### PR DESCRIPTION
## Summary

- Perform Test now always logs successful publishes via `PublishContext.forRuleTest()`, regardless of the rule's `logSuccessfulPublish` setting
- Jira publisher requires HTTP **201** (issue created) instead of accepting any 2xx, aligning with v5 behavior
- Perform Test returns **500** when Jira publishing fails (e.g. proxy/SSO returning 200 instead of 201)

## Background

Perform Test previously used `PublishContext.from(notification)` without rule context, so success logging was skipped even when `logSuccessfulPublish` was enabled. Additionally, v4 treated any 2xx as success for Jira, which masked misconfigured destinations that return 200 (login pages, proxies) without creating an issue.
