### PR TITLE
Add Checkmarx SCA vulnerability analyser

### DIFF
--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -139,6 +139,11 @@
         </dependency>
         <dependency>
             <groupId>org.dependencytrack</groupId>
+            <artifactId>vuln-analyzer-checkmarx</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
             <artifactId>package-metadata-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/apiserver/src/test/java/org/dependencytrack/plugin/PluginInitializerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/plugin/PluginInitializerTest.java
@@ -30,6 +30,7 @@ import org.dependencytrack.plugin.runtime.ExtensionPointMetadata;
 import org.dependencytrack.plugin.runtime.PluginManager;
 import org.dependencytrack.secret.TestSecretManager;
 import org.dependencytrack.secret.management.SecretManager;
+import org.dependencytrack.vulnanalysis.checkmarx.CheckmarxVulnAnalyzerPlugin;
 import org.dependencytrack.vulnanalysis.internal.InternalVulnAnalyzerPlugin;
 import org.dependencytrack.vulnanalysis.ossindex.OssIndexVulnAnalyzerPlugin;
 import org.dependencytrack.vulnanalysis.snyk.SnykVulnAnalyzerPlugin;
@@ -99,6 +100,7 @@ class PluginInitializerTest extends PersistenceCapableTest {
                         "vuln-data-source");
         assertThat(pluginManager.getLoadedPlugins()).satisfiesExactlyInAnyOrder(
                 plugin -> assertThat(plugin).isInstanceOf(BuiltinKevDataSourcePlugin.class),
+                plugin -> assertThat(plugin).isInstanceOf(CheckmarxVulnAnalyzerPlugin.class),
                 plugin -> assertThat(plugin).isInstanceOf(DefaultNotificationPublishersPlugin.class),
                 plugin -> assertThat(plugin).isInstanceOf(DefaultPackageMetadataResolutionPlugin.class),
                 plugin -> assertThat(plugin).isInstanceOf(GitHubVulnDataSourcePlugin.class),

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -256,6 +256,12 @@
         </dependency>
         <dependency>
             <groupId>org.dependencytrack</groupId>
+            <artifactId>vuln-analyzer-checkmarx</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
             <artifactId>vuln-analyzer-oss-index</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/vuln-analysis/checkmarx/pom.xml
+++ b/vuln-analysis/checkmarx/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This file is part of Dependency-Track.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright (c) OWASP Foundation. All Rights Reserved.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.dependencytrack</groupId>
+        <artifactId>vuln-analysis-parent</artifactId>
+        <version>5.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>vuln-analyzer-checkmarx</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Vulnerability Analysis :: Analyzer :: Checkmarx</name>
+
+    <properties>
+        <project.parentBaseDir>${project.basedir}/../..</project.parentBaseDir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
+            <artifactId>cache-provider-memory</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
+            <artifactId>plugin-testing</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
+            <artifactId>vuln-analysis-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.metaeffekt.core</groupId>
+            <artifactId>ae-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.package-url</groupId>
+            <artifactId>packageurl-java</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jsonschema2pojo</groupId>
+                <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sourceDirectory>${basedir}/src/main/resources/org/dependencytrack/vulnanalysis/checkmarx</sourceDirectory>
+                    <targetPackage>org.dependencytrack.vulnanalysis.checkmarx</targetPackage>
+                    <generateBuilders>true</generateBuilders>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxAccessTokenManager.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxAccessTokenManager.java
@@ -1,0 +1,125 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.checkmarx;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
+
+final class CheckmarxAccessTokenManager {
+
+    private static final Duration EXPIRY_BUFFER = Duration.ofSeconds(30);
+    private static final String CLIENT_ID = "ast-app";
+    private static final String GRANT_TYPE = "refresh_token";
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final ReentrantLock lock = new ReentrantLock();
+
+    private @Nullable String accessToken;
+    private @Nullable Instant accessTokenExpiresAt;
+    private @Nullable URI authApiBaseUrl;
+    private @Nullable String orgId;
+    private @Nullable String refreshToken;
+
+    CheckmarxAccessTokenManager(HttpClient httpClient, ObjectMapper objectMapper) {
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Gets a valid access token, fetching a new one via refresh token if necessary.
+     *
+     * @param authApiBaseUrl the Checkmarx authentication API base URL
+     * @param orgId the organization ID
+     * @param refreshToken the refresh token (apiKey from config)
+     * @return a valid access token
+     */
+    String getAccessToken(URI authApiBaseUrl, String orgId, String refreshToken) throws IOException, InterruptedException {
+        lock.lockInterruptibly();
+        try {
+            if (accessToken != null
+                    && accessTokenExpiresAt != null
+                    && Instant.now().isBefore(accessTokenExpiresAt)
+                    && Objects.equals(authApiBaseUrl, this.authApiBaseUrl)
+                    && Objects.equals(orgId, this.orgId)
+                    && Objects.equals(refreshToken, this.refreshToken)) {
+                return accessToken;
+            }
+
+            final var request = HttpRequest.newBuilder()
+                    .uri(authApiBaseUrl.resolve("/auth/realms/" + orgId + "/protocol/openid-connect/token"))
+                    .header("Content-Type", "application/json")
+                    .header("Accept", "application/json")
+                    .timeout(Duration.ofSeconds(10))
+                    .POST(HttpRequest.BodyPublishers.ofString(
+                            objectMapper.writeValueAsString(new TokenRequest(refreshToken))))
+                    .build();
+
+            final HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+            if (response.statusCode() != 200) {
+                throw new IOException("Checkmarx auth API request failed with status " + response.statusCode());
+            }
+
+            final var tokenResponse = objectMapper.readValue(response.body(), TokenResponse.class);
+            accessToken = tokenResponse.accessToken();
+            accessTokenExpiresAt = Instant.now().plusSeconds(tokenResponse.expiresIn()).minus(EXPIRY_BUFFER);
+            this.authApiBaseUrl = authApiBaseUrl;
+            this.refreshToken = refreshToken;
+
+            return accessToken;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private record TokenRequest(
+            @JsonProperty("client_id") String clientId,
+            @JsonProperty("grant_type") String grantType,
+            @JsonProperty("refresh_token") String refreshToken) {
+
+        TokenRequest(String refreshToken) {
+            this(CLIENT_ID, GRANT_TYPE, refreshToken);
+        }
+
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record TokenResponse(
+            @JsonProperty("access_token") String accessToken,
+            @JsonProperty("expires_in") long expiresIn,
+            @JsonProperty("refresh_token") String refreshToken,
+            @JsonProperty("refresh_expires_in") long refreshExpiresIn) {
+    }
+
+}
+
+
+

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxAccessTokenManager.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxAccessTokenManager.java
@@ -92,6 +92,7 @@ final class CheckmarxAccessTokenManager {
             accessToken = tokenResponse.accessToken();
             accessTokenExpiresAt = Instant.now().plusSeconds(tokenResponse.expiresIn()).minus(EXPIRY_BUFFER);
             this.authApiBaseUrl = authApiBaseUrl;
+            this.orgId = orgId;
             this.refreshToken = refreshToken;
 
             return accessToken;

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxAccessTokenManager.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxAccessTokenManager.java
@@ -21,9 +21,12 @@ package org.dependencytrack.vulnanalysis.checkmarx;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dependencytrack.vulnanalysis.api.RetryableVulnAnalysisException;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -83,9 +86,17 @@ final class CheckmarxAccessTokenManager {
                             objectMapper.writeValueAsString(new TokenRequest(refreshToken))))
                     .build();
 
-            final HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+            final HttpResponse<InputStream> response;
+            try {
+                response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            } catch (IOException e) {
+                RetryableVulnAnalysisException.throwIfRetryableNetworkError(e, "Checkmarx Auth API request failed");
+                throw new UncheckedIOException("Checkmarx Auth API request failed", e);
+            }
+
             if (response.statusCode() != 200) {
-                throw new IOException("Checkmarx auth API request failed with status " + response.statusCode());
+                RetryableVulnAnalysisException.throwIfRetryableHttpError(response);
+                throw new IOException("Checkmarx Auth API request failed with status " + response.statusCode());
             }
 
             final var tokenResponse = objectMapper.readValue(response.body(), TokenResponse.class);

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxAccessTokenManager.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxAccessTokenManager.java
@@ -50,7 +50,7 @@ final class CheckmarxAccessTokenManager {
     private @Nullable Instant accessTokenExpiresAt;
     private @Nullable URI authApiBaseUrl;
     private @Nullable String orgId;
-    private @Nullable String refreshToken;
+    private @Nullable String apiKey;
 
     CheckmarxAccessTokenManager(HttpClient httpClient, ObjectMapper objectMapper) {
         this.httpClient = httpClient;
@@ -58,14 +58,14 @@ final class CheckmarxAccessTokenManager {
     }
 
     /**
-     * Gets a valid access token, fetching a new one via refresh token if necessary.
+     * Gets a valid access token, fetching a new one via API Key if necessary.
      *
      * @param authApiBaseUrl the Checkmarx authentication API base URL
      * @param orgId the organization ID
-     * @param refreshToken the refresh token (apiKey from config)
+     * @param apiKey the API Key
      * @return a valid access token
      */
-    String getAccessToken(URI authApiBaseUrl, String orgId, String refreshToken) throws IOException, InterruptedException {
+    String getAccessToken(URI authApiBaseUrl, String orgId, String apiKey) throws IOException, InterruptedException {
         lock.lockInterruptibly();
         try {
             if (accessToken != null
@@ -73,7 +73,7 @@ final class CheckmarxAccessTokenManager {
                     && Instant.now().isBefore(accessTokenExpiresAt)
                     && Objects.equals(authApiBaseUrl, this.authApiBaseUrl)
                     && Objects.equals(orgId, this.orgId)
-                    && Objects.equals(refreshToken, this.refreshToken)) {
+                    && Objects.equals(apiKey, this.apiKey)) {
                 return accessToken;
             }
 
@@ -83,7 +83,7 @@ final class CheckmarxAccessTokenManager {
                     .header("Accept", "application/json")
                     .timeout(Duration.ofSeconds(10))
                     .POST(HttpRequest.BodyPublishers.ofString(
-                            objectMapper.writeValueAsString(new TokenRequest(refreshToken))))
+                            objectMapper.writeValueAsString(new TokenRequest(apiKey))))
                     .build();
 
             final HttpResponse<InputStream> response;
@@ -104,7 +104,7 @@ final class CheckmarxAccessTokenManager {
             accessTokenExpiresAt = Instant.now().plusSeconds(tokenResponse.expiresIn()).minus(EXPIRY_BUFFER);
             this.authApiBaseUrl = authApiBaseUrl;
             this.orgId = orgId;
-            this.refreshToken = refreshToken;
+            this.apiKey = apiKey;
 
             return accessToken;
         } finally {
@@ -115,10 +115,10 @@ final class CheckmarxAccessTokenManager {
     private record TokenRequest(
             @JsonProperty("client_id") String clientId,
             @JsonProperty("grant_type") String grantType,
-            @JsonProperty("refresh_token") String refreshToken) {
+            @JsonProperty("refresh_token") String apiKey) {
 
-        TokenRequest(String refreshToken) {
-            this(CLIENT_ID, GRANT_TYPE, refreshToken);
+        TokenRequest(String apiKey) {
+            this(CLIENT_ID, GRANT_TYPE, apiKey);
         }
 
     }
@@ -127,7 +127,7 @@ final class CheckmarxAccessTokenManager {
     private record TokenResponse(
             @JsonProperty("access_token") String accessToken,
             @JsonProperty("expires_in") long expiresIn,
-            @JsonProperty("refresh_token") String refreshToken,
+            @JsonProperty("refresh_token") String apiKey,
             @JsonProperty("refresh_expires_in") long refreshExpiresIn) {
     }
 

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxApiClient.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxApiClient.java
@@ -72,12 +72,15 @@ final class CheckmarxApiClient {
      * @param purls the package URLs to analyze
      * @return vulnerabilities response from Checkmarx API
      */
-    CheckmarxVulnerabilitiesResponse fetchVulnerabilities(Collection<String> purls) throws IOException, InterruptedException {
+    CheckmarxApiResponse fetchVulnerabilities(Collection<String> purls) throws IOException, InterruptedException {
         if (purls.isEmpty()) {
-            return new CheckmarxVulnerabilitiesResponse(List.of());
+            return new CheckmarxApiResponse(List.of());
         }
 
         LOGGER.debug("Fetching Checkmarx vulnerabilities for {} PURLs", purls.size());
+
+        final URI requestUrl = apiBaseUrl.resolve("/api/sca/packages/vulnerabilities"
+                                + "?IncludeRiskDetails=true" + "&IncludeVersionDetails=true" + "&IncludeVersionRemediation=true");
 
         // Ensure valid access token (will be cached if still valid)
         final String accessToken = tokenManager.getAccessToken(authApiBaseUrl, orgId, refreshToken);
@@ -85,7 +88,7 @@ final class CheckmarxApiClient {
         final String requestBody = objectMapper.writeValueAsString(new VulnerabilityRequest(new ArrayList<>(purls)));
 
         final var request = HttpRequest.newBuilder()
-                .uri(apiBaseUrl.resolve("/api/sca/packages/vulnerabilities"))
+                .uri(requestUrl)
                 .header("Authorization", "Bearer " + accessToken)
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json")
@@ -97,14 +100,14 @@ final class CheckmarxApiClient {
 
         try (final InputStream body = response.body()) {
             if (response.statusCode() == 200) {
-                return objectMapper.readValue(body, CheckmarxVulnerabilitiesResponse.class);
+                return objectMapper.readValue(body, CheckmarxApiResponse.class);
             }
 
             body.transferTo(OutputStream.nullOutputStream());
 
             if (response.statusCode() == 404) {
                 LOGGER.debug("No vulnerabilities found for provided PURLs");
-                return new CheckmarxVulnerabilitiesResponse(List.of());
+                return new CheckmarxApiResponse(List.of());
             }
 
             throw new IOException("Checkmarx API request failed with status " + response.statusCode());

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxApiClient.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxApiClient.java
@@ -1,0 +1,118 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.checkmarx;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Client for Checkmarx vulnerability API.
+ */
+final class CheckmarxApiClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CheckmarxApiClient.class);
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final CheckmarxAccessTokenManager tokenManager;
+    private final String refreshToken;
+    private final String orgId;
+    private final URI authApiBaseUrl;
+    private final URI apiBaseUrl;
+
+    CheckmarxApiClient(
+            HttpClient httpClient,
+            ObjectMapper objectMapper,
+            CheckmarxAccessTokenManager tokenManager,
+            String refreshToken,
+            String orgId,
+            URI authApiBaseUrl,
+            URI apiBaseUrl) {
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+        this.tokenManager = tokenManager;
+        this.refreshToken = refreshToken;
+        this.orgId = orgId;
+        this.authApiBaseUrl = authApiBaseUrl;
+        this.apiBaseUrl = apiBaseUrl;
+    }
+
+    /**
+     * Fetches vulnerabilities for a batch of PURLs.
+     *
+     * @param purls the package URLs to analyze
+     * @return vulnerabilities response from Checkmarx API
+     */
+    CheckmarxVulnerabilitiesResponse fetchVulnerabilities(Collection<String> purls) throws IOException, InterruptedException {
+        if (purls.isEmpty()) {
+            return new CheckmarxVulnerabilitiesResponse(List.of());
+        }
+
+        LOGGER.debug("Fetching Checkmarx vulnerabilities for {} PURLs", purls.size());
+
+        // Ensure valid access token (will be cached if still valid)
+        final String accessToken = tokenManager.getAccessToken(authApiBaseUrl, orgId, refreshToken);
+
+        final String requestBody = objectMapper.writeValueAsString(new VulnerabilityRequest(new ArrayList<>(purls)));
+
+        final var request = HttpRequest.newBuilder()
+                .uri(apiBaseUrl.resolve("/api/sca/packages/vulnerabilities"))
+                .header("Authorization", "Bearer " + accessToken)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .timeout(Duration.ofSeconds(30))
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .build();
+
+        final HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+
+        try (final InputStream body = response.body()) {
+            if (response.statusCode() == 200) {
+                return objectMapper.readValue(body, CheckmarxVulnerabilitiesResponse.class);
+            }
+
+            body.transferTo(OutputStream.nullOutputStream());
+
+            if (response.statusCode() == 404) {
+                LOGGER.debug("No vulnerabilities found for provided PURLs");
+                return new CheckmarxVulnerabilitiesResponse(List.of());
+            }
+
+            throw new IOException("Checkmarx API request failed with status " + response.statusCode());
+        }
+    }
+
+    private record VulnerabilityRequest(List<String> packageUrls) {
+    }
+
+}
+

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxApiClient.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxApiClient.java
@@ -79,7 +79,7 @@ final class CheckmarxApiClient {
 
         LOGGER.debug("Fetching Checkmarx vulnerabilities for {} PURLs", purls.size());
 
-        final URI requestUrl = apiBaseUrl.resolve("/api/sca/packages/vulnerabilities"
+        final URI requestUrl = apiBaseUrl.resolve("/api/v1/packages/risks"
                                 + "?IncludeRiskDetails=true" + "&IncludeVersionDetails=true" + "&IncludeVersionRemediation=true");
 
         // Ensure valid access token (will be cached if still valid)

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxApiClient.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxApiClient.java
@@ -46,7 +46,7 @@ final class CheckmarxApiClient {
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
     private final CheckmarxAccessTokenManager tokenManager;
-    private final String refreshToken;
+    private final String apiKey;
     private final String orgId;
     private final URI authApiBaseUrl;
     private final URI apiBaseUrl;
@@ -55,14 +55,14 @@ final class CheckmarxApiClient {
             HttpClient httpClient,
             ObjectMapper objectMapper,
             CheckmarxAccessTokenManager tokenManager,
-            String refreshToken,
+            String apiKey,
             String orgId,
             URI authApiBaseUrl,
             URI apiBaseUrl) {
         this.httpClient = httpClient;
         this.objectMapper = objectMapper;
         this.tokenManager = tokenManager;
-        this.refreshToken = refreshToken;
+        this.apiKey = apiKey;
         this.orgId = orgId;
         this.authApiBaseUrl = authApiBaseUrl;
         this.apiBaseUrl = apiBaseUrl;
@@ -85,7 +85,7 @@ final class CheckmarxApiClient {
                                 + "?IncludeRiskDetails=true" + "&IncludeVersionDetails=true" + "&IncludeVersionRemediation=true");
 
         // Ensure valid access token (will be cached if still valid)
-        final String accessToken = tokenManager.getAccessToken(authApiBaseUrl, orgId, refreshToken);
+        final String accessToken = tokenManager.getAccessToken(authApiBaseUrl, orgId, apiKey);
 
         final String requestBody = objectMapper.writeValueAsString(new VulnerabilityRequest(new ArrayList<>(purls)));
 

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxApiClient.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxApiClient.java
@@ -19,12 +19,14 @@
 package org.dependencytrack.vulnanalysis.checkmarx;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dependencytrack.vulnanalysis.api.RetryableVulnAnalysisException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -96,7 +98,13 @@ final class CheckmarxApiClient {
                 .POST(HttpRequest.BodyPublishers.ofString(requestBody))
                 .build();
 
-        final HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        final HttpResponse<InputStream> response;
+        try {
+            response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        } catch (IOException e) {
+            RetryableVulnAnalysisException.throwIfRetryableNetworkError(e, "Checkmarx API request failed");
+            throw new UncheckedIOException("Checkmarx API request failed", e);
+        }
 
         try (final InputStream body = response.body()) {
             if (response.statusCode() == 200) {
@@ -110,6 +118,7 @@ final class CheckmarxApiClient {
                 return new CheckmarxApiResponse(List.of());
             }
 
+            RetryableVulnAnalysisException.throwIfRetryableHttpError(response);
             throw new IOException("Checkmarx API request failed with status " + response.statusCode());
         }
     }

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxApiResponse.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxApiResponse.java
@@ -20,18 +20,14 @@ package org.dependencytrack.vulnanalysis.checkmarx;
 
 import org.jspecify.annotations.Nullable;
 
+import java.util.List;
+
 /**
- * Represents a vulnerability from Checkmarx API response.
+ * Represents the response from Checkmarx vulnerabilities API.
  *
  * @since 5.0.0
  */
-public record CheckmarxVulnerability(
-        String id,
-        @Nullable String cveName,
-        @Nullable String purl,
-        @Nullable String severity,
-        @Nullable String description,
-        @Nullable String score,
-        @Nullable String recommendation) {
+public record CheckmarxApiResponse(
+        @Nullable List<CheckmarxDataObject> data) {
 }
 

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxApiResponse.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxApiResponse.java
@@ -18,7 +18,7 @@
  */
 package org.dependencytrack.vulnanalysis.checkmarx;
 
-import org.jspecify.annotations.Nullable;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
 import java.util.List;
 
@@ -28,6 +28,10 @@ import java.util.List;
  * @since 5.0.0
  */
 public record CheckmarxApiResponse(
-        @Nullable List<CheckmarxDataObject> data) {
-}
+        List<CheckmarxDataObject> packageRisks) {
 
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public CheckmarxApiResponse {
+    }
+
+}

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxDataObject.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxDataObject.java
@@ -25,10 +25,12 @@ import java.util.List;
 
 /**
  * Represents package and vulnerability data from Checkmarx API response.
+ * Schema reference:
+ * https://checkmarx.stoplight.io/docs/checkmarx-one-api-reference-guide/drwbfz2dzursa-retrieve-package-risks-data#response-body
  */
-public record CheckmarxDataObject(Package pkg, List<Vulnerability> vulnerabilities) {
+public record CheckmarxDataObject(@JsonProperty("package") Package pkg, List<Vulnerability> vulnerabilities) {
 
-    record Package(String purl, String name, String version, @Nullable Remediation remediation) {}
+    record Package(String status, String purl, String name, String version, @Nullable Remediation remediation) {}
 
     record Vulnerability(String cve, String cxId, Double score, String severity, VulnerabilityDetail details) {}
 
@@ -52,4 +54,3 @@ public record CheckmarxDataObject(Package pkg, List<Vulnerability> vulnerabiliti
 
     record RemedyVersion(String version) {}
 }
-

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxDataObject.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxDataObject.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.checkmarx;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Represents package and vulnerability data from Checkmarx API response.
+ */
+public record CheckmarxDataObject(Package pkg, List<Vulnerability> vulnerabilities) {
+
+    record Package(String purl, String name, String version, @Nullable Remediation remediation) {}
+
+    record Vulnerability(String cve, String cxId, Double score, String severity, VulnerabilityDetail details) {}
+
+    record VulnerabilityDetail(
+            @Nullable String description,
+            @Nullable String cwe,
+            @JsonProperty("created") String created,
+            @JsonProperty("published") String published,
+            @JsonProperty("updatedTime") String updatedTime,
+            @Nullable List<Reference> references,
+            @Nullable Cvss cvss2,
+            @Nullable Cvss cvss3,
+            @Nullable Cvss cvss4
+    ) {}
+
+    record Reference(String url) {}
+
+    record Cvss(Double baseScore, String severity, @Nullable String vector) {}
+
+    record Remediation(RemedyVersion latest, RemedyVersion nearest) {}
+
+    record RemedyVersion(String version) {}
+}
+

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxModelConverter.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxModelConverter.java
@@ -1,0 +1,174 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.checkmarx;
+
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import org.cyclonedx.proto.v1_7.Advisory;
+import org.cyclonedx.proto.v1_7.Severity;
+import org.cyclonedx.proto.v1_7.Source;
+import org.cyclonedx.proto.v1_7.Vulnerability;
+import org.cyclonedx.proto.v1_7.VulnerabilityRating;
+import org.cyclonedx.proto.v1_7.VulnerabilityReference;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.cyclonedx.proto.v1_7.ScoreMethod.SCORE_METHOD_CVSSV2;
+import static org.cyclonedx.proto.v1_7.ScoreMethod.SCORE_METHOD_CVSSV3;
+import static org.cyclonedx.proto.v1_7.ScoreMethod.SCORE_METHOD_CVSSV4;
+import static org.cyclonedx.proto.v1_7.Severity.SEVERITY_CRITICAL;
+import static org.cyclonedx.proto.v1_7.Severity.SEVERITY_HIGH;
+import static org.cyclonedx.proto.v1_7.Severity.SEVERITY_LOW;
+import static org.cyclonedx.proto.v1_7.Severity.SEVERITY_MEDIUM;
+import static org.cyclonedx.proto.v1_7.Severity.SEVERITY_UNKNOWN;
+
+/**
+ * Converts Checkmarx vulnerability data to CycloneDX vulnerability format.
+ */
+final class CheckmarxModelConverter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CheckmarxModelConverter.class);
+    private static final Pattern CWE_PATTERN = Pattern.compile("(CWE-)?(\\d+)", Pattern.CASE_INSENSITIVE);
+    private static final Source SOURCE_CX = Source.newBuilder().setName("CX").build();
+    private static final Source SOURCE_NVD = Source.newBuilder().setName("NVD").build();
+    private static final List<String> SEVERITY_SOURCE_PRIORITY = List.of("NVD", "CX");
+
+    private CheckmarxModelConverter() {
+    }
+
+    static Vulnerability.Builder convert(CheckmarxDataObject.Vulnerability cxVuln, CheckmarxDataObject.Remediation remediation, boolean aliasSyncEnabled) {
+        final var vulnBuilder = Vulnerability.newBuilder();
+
+        vulnBuilder.setId(cxVuln.cxId());
+        vulnBuilder.setSource(SOURCE_CX);
+
+        var vulnDetails = cxVuln.details();
+
+        if (vulnDetails.description() != null) {
+            vulnBuilder.setDescription(vulnDetails.description());
+        }
+
+        convertTimestamp(vulnDetails.created()).ifPresent(vulnBuilder::setCreated);
+        convertTimestamp(vulnDetails.updatedTime()).ifPresent(vulnBuilder::setUpdated);
+        convertTimestamp(vulnDetails.published()).ifPresent(vulnBuilder::setPublished);
+
+        if (aliasSyncEnabled && cxVuln.cve() != null) {
+            vulnBuilder.addReferences(VulnerabilityReference.newBuilder()
+                    .setId(cxVuln.cve())
+                    .setSource(SOURCE_NVD).build());
+        }
+
+        final Integer cweId = convertToCwe(vulnDetails.cwe());
+        if (cweId != null) {
+            vulnBuilder.addCwes(cweId);
+        }
+
+        if (vulnDetails.references() != null) {
+            for (final var ref : vulnDetails.references()) {
+                vulnBuilder.addAdvisories(Advisory.newBuilder().setUrl(ref.url()));
+            }
+        }
+
+        if (remediation != null) {
+            final var recommendations = new ArrayList<String>();
+            if (remediation.nearest() != null) {
+                recommendations.add("Smallest package upgrade that resolves the identified risks in the current package version: " + remediation.nearest());
+            }
+            if (remediation.latest() != null) {
+                recommendations.add("Latest version of the package: " + remediation.latest());
+            }
+            if (!recommendations.isEmpty()) {
+                vulnBuilder.setRecommendation(String.join(System.lineSeparator(), recommendations));
+            }
+        }
+
+        if (vulnDetails.cvss4() != null) {
+            final var cvss4 = vulnDetails.cvss4();
+            final var ratingBuilder = VulnerabilityRating.newBuilder()
+                    .setMethod(SCORE_METHOD_CVSSV4)
+                    .setVector(cvss4.vector())
+                    .setScore(cvss4.baseScore())
+                    .setSeverity(convertSeverity(cvss4.severity()));
+            vulnBuilder.addRatings(ratingBuilder.build());
+        }
+
+        if (vulnDetails.cvss3() != null) {
+            final var cvss3 = vulnDetails.cvss3();
+            final var ratingBuilder = VulnerabilityRating.newBuilder()
+                    .setMethod(SCORE_METHOD_CVSSV3)
+                    .setVector(cvss3.vector())
+                    .setScore(cvss3.baseScore())
+                    .setSeverity(convertSeverity(cvss3.severity()));
+            vulnBuilder.addRatings(ratingBuilder.build());
+        }
+
+        if (vulnDetails.cvss2() != null) {
+            final var cvss2 = vulnDetails.cvss2();
+            final var ratingBuilder = VulnerabilityRating.newBuilder()
+                    .setMethod(SCORE_METHOD_CVSSV2)
+                    .setVector(cvss2.vector())
+                    .setScore(cvss2.baseScore())
+                    .setSeverity(convertSeverity(cvss2.severity()));
+            vulnBuilder.addRatings(ratingBuilder.build());
+        }
+
+        return vulnBuilder;
+    }
+
+    private static Severity convertSeverity(String severity) {
+        return switch (severity) {
+            case "CRITICAL" -> SEVERITY_CRITICAL;
+            case "HIGH" -> SEVERITY_HIGH;
+            case "MEDIUM" -> SEVERITY_MEDIUM;
+            case "LOW" -> SEVERITY_LOW;
+            default -> SEVERITY_UNKNOWN;
+        };
+    }
+
+    private static @Nullable Integer convertToCwe(String cwe) {
+        final Matcher matcher = CWE_PATTERN.matcher(cwe);
+        if (matcher.matches()) {
+            return Integer.parseInt(matcher.group(2));
+        }
+        return null;
+    }
+
+    private static Optional<Timestamp> convertTimestamp(@Nullable String isoTimestamp) {
+        if (isoTimestamp == null || isoTimestamp.isBlank()) {
+            return Optional.empty();
+        }
+
+        try {
+            final Instant instant = Instant.parse(isoTimestamp);
+            return Optional.of(Timestamps.fromMillis(instant.toEpochMilli()));
+        } catch (DateTimeParseException e) {
+            LOGGER.warn("Failed to parse timestamp '{}'; Ignoring", isoTimestamp, e);
+            return Optional.empty();
+        }
+    }
+}

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxModelConverter.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxModelConverter.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -56,7 +55,6 @@ final class CheckmarxModelConverter {
     private static final Pattern CWE_PATTERN = Pattern.compile("(CWE-)?(\\d+)", Pattern.CASE_INSENSITIVE);
     private static final Source SOURCE_CX = Source.newBuilder().setName("CX").build();
     private static final Source SOURCE_NVD = Source.newBuilder().setName("NVD").build();
-    private static final List<String> SEVERITY_SOURCE_PRIORITY = List.of("NVD", "CX");
 
     private CheckmarxModelConverter() {
     }
@@ -97,10 +95,10 @@ final class CheckmarxModelConverter {
         if (remediation != null) {
             final var recommendations = new ArrayList<String>();
             if (remediation.nearest() != null) {
-                recommendations.add("Smallest package upgrade that resolves the identified risks in the current package version: " + remediation.nearest());
+                recommendations.add("Smallest package upgrade that resolves the identified risks in the current package version: " + remediation.nearest().version());
             }
             if (remediation.latest() != null) {
-                recommendations.add("Latest version of the package: " + remediation.latest());
+                recommendations.add("Latest version of the package: " + remediation.latest().version());
             }
             if (!recommendations.isEmpty()) {
                 vulnBuilder.setRecommendation(String.join(System.lineSeparator(), recommendations));
@@ -142,10 +140,10 @@ final class CheckmarxModelConverter {
 
     private static Severity convertSeverity(String severity) {
         return switch (severity) {
-            case "CRITICAL" -> SEVERITY_CRITICAL;
-            case "HIGH" -> SEVERITY_HIGH;
-            case "MEDIUM" -> SEVERITY_MEDIUM;
-            case "LOW" -> SEVERITY_LOW;
+            case "Critical" -> SEVERITY_CRITICAL;
+            case "High" -> SEVERITY_HIGH;
+            case "Medium" -> SEVERITY_MEDIUM;
+            case "Low" -> SEVERITY_LOW;
             default -> SEVERITY_UNKNOWN;
         };
     }

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxModelConverter.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxModelConverter.java
@@ -59,7 +59,7 @@ final class CheckmarxModelConverter {
     private CheckmarxModelConverter() {
     }
 
-    static Vulnerability.Builder convert(CheckmarxDataObject.Vulnerability cxVuln, CheckmarxDataObject.Remediation remediation, boolean aliasSyncEnabled) {
+    static Vulnerability.Builder convert(CheckmarxDataObject.Vulnerability cxVuln, CheckmarxDataObject.@Nullable Remediation remediation, boolean aliasSyncEnabled) {
         final var vulnBuilder = Vulnerability.newBuilder();
 
         vulnBuilder.setId(cxVuln.cxId());
@@ -75,7 +75,7 @@ final class CheckmarxModelConverter {
         convertTimestamp(vulnDetails.updatedTime()).ifPresent(vulnBuilder::setUpdated);
         convertTimestamp(vulnDetails.published()).ifPresent(vulnBuilder::setPublished);
 
-        if (aliasSyncEnabled && cxVuln.cve() != null) {
+        if (aliasSyncEnabled) {
             vulnBuilder.addReferences(VulnerabilityReference.newBuilder()
                     .setId(cxVuln.cve())
                     .setSource(SOURCE_NVD).build());
@@ -94,24 +94,20 @@ final class CheckmarxModelConverter {
 
         if (remediation != null) {
             final var recommendations = new ArrayList<String>();
-            if (remediation.nearest() != null) {
-                recommendations.add("Smallest package upgrade that resolves the identified risks in the current package version: " + remediation.nearest().version());
-            }
-            if (remediation.latest() != null) {
-                recommendations.add("Latest version of the package: " + remediation.latest().version());
-            }
-            if (!recommendations.isEmpty()) {
-                vulnBuilder.setRecommendation(String.join(System.lineSeparator(), recommendations));
-            }
+            recommendations.add("Smallest package upgrade that resolves the identified risks in the current package version: " + remediation.nearest().version());
+            recommendations.add("Latest version of the package: " + remediation.latest().version());
+            vulnBuilder.setRecommendation(String.join(System.lineSeparator(), recommendations));
         }
 
         if (vulnDetails.cvss4() != null) {
             final var cvss4 = vulnDetails.cvss4();
             final var ratingBuilder = VulnerabilityRating.newBuilder()
                     .setMethod(SCORE_METHOD_CVSSV4)
-                    .setVector(cvss4.vector())
                     .setScore(cvss4.baseScore())
                     .setSeverity(convertSeverity(cvss4.severity()));
+            if (cvss4.vector() != null) {
+                ratingBuilder.setVector(cvss4.vector());
+            }
             vulnBuilder.addRatings(ratingBuilder.build());
         }
 
@@ -119,9 +115,11 @@ final class CheckmarxModelConverter {
             final var cvss3 = vulnDetails.cvss3();
             final var ratingBuilder = VulnerabilityRating.newBuilder()
                     .setMethod(SCORE_METHOD_CVSSV3)
-                    .setVector(cvss3.vector())
                     .setScore(cvss3.baseScore())
                     .setSeverity(convertSeverity(cvss3.severity()));
+            if (cvss3.vector() != null) {
+                ratingBuilder.setVector(cvss3.vector());
+            }
             vulnBuilder.addRatings(ratingBuilder.build());
         }
 
@@ -129,9 +127,11 @@ final class CheckmarxModelConverter {
             final var cvss2 = vulnDetails.cvss2();
             final var ratingBuilder = VulnerabilityRating.newBuilder()
                     .setMethod(SCORE_METHOD_CVSSV2)
-                    .setVector(cvss2.vector())
                     .setScore(cvss2.baseScore())
                     .setSeverity(convertSeverity(cvss2.severity()));
+            if (cvss2.vector() != null) {
+                ratingBuilder.setVector(cvss2.vector());
+            }
             vulnBuilder.addRatings(ratingBuilder.build());
         }
 
@@ -148,7 +148,10 @@ final class CheckmarxModelConverter {
         };
     }
 
-    private static @Nullable Integer convertToCwe(String cwe) {
+    private static @Nullable Integer convertToCwe(@Nullable String cwe) {
+        if (cwe == null) {
+            return null;
+        }
         final Matcher matcher = CWE_PATTERN.matcher(cwe);
         if (matcher.matches()) {
             return Integer.parseInt(matcher.group(2));

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzer.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzer.java
@@ -1,0 +1,238 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.checkmarx;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import org.cyclonedx.proto.v1_7.Bom;
+import org.cyclonedx.proto.v1_7.Component;
+import org.cyclonedx.proto.v1_7.Property;
+import org.cyclonedx.proto.v1_7.Vulnerability;
+import org.cyclonedx.proto.v1_7.VulnerabilityAffects;
+import org.dependencytrack.cache.api.Cache;
+import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Gatherers;
+
+/**
+ * Checkmarx vulnerability analyzer for Dependency-Track.
+ * Analyzes components for vulnerabilities using Checkmarx SCA API.
+ */
+final class CheckmarxVulnAnalyzer implements VulnAnalyzer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CheckmarxVulnAnalyzer.class);
+    private static final int REQUEST_BATCH_SIZE = 100;
+    private static final int CACHE_BATCH_SIZE = 500;
+
+    private final Cache resultsCache;
+    private final ObjectMapper objectMapper;
+    private final CheckmarxApiClient apiClient;
+    private final boolean aliasSyncEnabled;
+
+    CheckmarxVulnAnalyzer(
+            Cache resultsCache,
+            ObjectMapper objectMapper,
+            CheckmarxApiClient apiClient,
+            boolean aliasSyncEnabled) {
+        this.resultsCache = resultsCache;
+        this.objectMapper = objectMapper;
+        this.apiClient = apiClient;
+        this.aliasSyncEnabled = aliasSyncEnabled;
+    }
+
+    @Override
+    public Bom analyze(Bom bom) throws InterruptedException {
+        final Map<String, Set<String>> bomRefsByPurl = collectAnalyzablePurls(bom);
+        if (bomRefsByPurl.isEmpty()) {
+            LOGGER.debug("No analyzable PURLs found; Skipping analysis");
+            return Bom.getDefaultInstance();
+        }
+
+        final var vulnerabilitiesByPurl = new HashMap<String, List<CheckmarxVulnerability>>(bomRefsByPurl.size());
+        final var purlsToAnalyze = new LinkedHashSet<>(bomRefsByPurl.keySet());
+
+        for (final var purlBatch : (Iterable<List<String>>) () -> bomRefsByPurl.keySet().stream()
+                .gather(Gatherers.windowFixed(CACHE_BATCH_SIZE))
+                .iterator()) {
+            if (Thread.interrupted()) {
+                throw new InterruptedException("Interrupted before all cache lookups could complete");
+            }
+
+            final Map<String, byte[]> cachedBytesByPurl = resultsCache.getMany(Set.copyOf(purlBatch));
+            LOGGER.debug("Found cached results for {}/{} PURLs", cachedBytesByPurl.size(), purlBatch.size());
+
+            for (final var entry : cachedBytesByPurl.entrySet()) {
+                final String purl = entry.getKey();
+                final byte[] cachedBytes = entry.getValue();
+
+                purlsToAnalyze.remove(purl);
+
+                if (cachedBytes == null) {
+                    continue;
+                }
+
+                try {
+                    final CheckmarxVulnerability[] vulns = objectMapper.readValue(cachedBytes, CheckmarxVulnerability[].class);
+                    vulnerabilitiesByPurl.put(purl, List.of(vulns));
+                } catch (IOException e) {
+                    LOGGER.warn("Failed to deserialize cached results for PURL '{}'; Will re-fetch", purl, e);
+                    purlsToAnalyze.add(purl);
+                }
+            }
+        }
+
+        vulnerabilitiesByPurl.putAll(fetchAndCacheVulnerabilities(purlsToAnalyze));
+
+        return assembleVdr(vulnerabilitiesByPurl, bomRefsByPurl);
+    }
+
+    private Map<String, Set<String>> collectAnalyzablePurls(Bom bom) {
+        final var bomRefsByPurl = new LinkedHashMap<String, Set<String>>();
+
+        for (final Component component : bom.getComponentsList()) {
+            if (!component.hasBomRef() || !component.hasPurl()) {
+                continue;
+            }
+            if (component.getPropertiesCount() > 0
+                    && component.getPropertiesList().stream()
+                    .map(Property::getName)
+                    .anyMatch("dependencytrack:internal:is-internal-component"::equalsIgnoreCase)) {
+                continue;
+            }
+
+            try {
+                final var purl = new PackageURL(component.getPurl());
+                // Lowercase PURL coordinates for consistent cache keys
+                bomRefsByPurl
+                        .computeIfAbsent(purl.getCoordinates().toLowerCase(), _ -> new HashSet<>())
+                        .add(component.getBomRef());
+            } catch (MalformedPackageURLException e) {
+                LOGGER.warn("Failed to parse PURL '{}'; Skipping", component.getPurl(), e);
+            }
+        }
+
+        return bomRefsByPurl;
+    }
+
+    private Map<String, List<CheckmarxVulnerability>> fetchAndCacheVulnerabilities(
+            Collection<String> purls) throws InterruptedException {
+        if (purls.isEmpty()) {
+            return Map.of();
+        }
+
+        LOGGER.debug("Fetching vulnerabilities for {} PURLs from Checkmarx", purls.size());
+
+        final var entriesToCache = new HashMap<String, byte @Nullable []>(purls.size());
+        final var vulnerabilitiesByPurl = new HashMap<String, List<CheckmarxVulnerability>>();
+
+        try {
+            final CheckmarxVulnerabilitiesResponse response = apiClient.fetchVulnerabilities(purls);
+
+            if (response.data() != null && !response.data().isEmpty()) {
+                for (final CheckmarxVulnerability vuln : response.data()) {
+                    final String vulnPurl = vuln.purl();
+                    if (vulnPurl == null) {
+                        LOGGER.warn("Unable to extract PURL from vulnerability '{}'; Skipping", vuln.id());
+                        continue;
+                    }
+
+                    final String vulnPurlLower = vulnPurl.toLowerCase();
+                    vulnerabilitiesByPurl
+                            .computeIfAbsent(vulnPurlLower, _ -> new ArrayList<>())
+                            .add(vuln);
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to fetch vulnerabilities from Checkmarx", e);
+        }
+
+        for (final var entry : vulnerabilitiesByPurl.entrySet()) {
+            try {
+                entriesToCache.put(entry.getKey(), objectMapper.writeValueAsBytes(entry.getValue()));
+            } catch (IOException e) {
+                LOGGER.warn("Failed to serialize results for PURL '{}'; Skipping cache", entry.getKey(), e);
+            }
+        }
+
+        for (final String purl : purls) {
+            if (!vulnerabilitiesByPurl.containsKey(purl)) {
+                entriesToCache.put(purl, null);
+            }
+        }
+
+        resultsCache.putMany(entriesToCache);
+        return vulnerabilitiesByPurl;
+    }
+
+    private Bom assembleVdr(
+            Map<String, List<CheckmarxVulnerability>> vulnerabilitiesByPurl,
+            Map<String, Set<String>> bomRefsByPurl) {
+        final var vulnBuilderByVulnId = new HashMap<String, Vulnerability.Builder>();
+
+        for (final var entry : vulnerabilitiesByPurl.entrySet()) {
+            final String purl = entry.getKey();
+            final List<CheckmarxVulnerability> vulns = entry.getValue();
+
+            final Set<String> bomRefs = bomRefsByPurl.get(purl);
+            if (bomRefs == null) {
+                LOGGER.warn("""
+                        Received vulnerabilities for PURL '{}', but no component \
+                        with this PURL was submitted for analysis""", purl);
+                continue;
+            }
+
+            for (final CheckmarxVulnerability vuln : vulns) {
+                final Vulnerability.Builder vulnBuilder =
+                        vulnBuilderByVulnId.computeIfAbsent(
+                                vuln.id(),
+                                _ -> CheckmarxModelConverter.convert(vuln, aliasSyncEnabled));
+
+                for (final String bomRef : bomRefs) {
+                    vulnBuilder.addAffects(
+                            VulnerabilityAffects.newBuilder()
+                                    .setRef(bomRef)
+                                    .build());
+                }
+            }
+        }
+
+        return Bom.newBuilder()
+                .addAllVulnerabilities(
+                        vulnBuilderByVulnId.values().stream()
+                                .map(Vulnerability.Builder::build)
+                                .toList())
+                .build();
+    }
+
+}

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzer.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzer.java
@@ -157,8 +157,14 @@ final class CheckmarxVulnAnalyzer implements VulnAnalyzer {
         final var vulnerabilitiesByPurl = new HashMap<String, List<CheckmarxDataObject>>();
         final var entriesToCache = new HashMap<String, byte @Nullable []>(purlBatch.size());
 
-        if (response.data() != null && !response.data().isEmpty()) {
-            for (final CheckmarxDataObject cxDataObject : response.data()) {
+        if (!response.packageRisks().isEmpty()) {
+            for (final CheckmarxDataObject cxDataObject : response.packageRisks()) {
+                final var status = cxDataObject.pkg().status();
+                if (!status.equalsIgnoreCase("Ok")) {
+                    LOGGER.warn("Received non-OK status '{}' for package '{}:{}'; Skipping", status, cxDataObject.pkg().name(), cxDataObject.pkg().version());
+                    continue;
+                }
+
                 final String vulnPurl = cxDataObject.pkg().purl();
                 if (vulnPurl == null) {
                     LOGGER.warn("Unable to extract PURL for package '{}:{}'; Skipping", cxDataObject.pkg().name(), cxDataObject.pkg().version());

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzer.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzer.java
@@ -79,7 +79,7 @@ final class CheckmarxVulnAnalyzer implements VulnAnalyzer {
             return Bom.getDefaultInstance();
         }
 
-        final var vulnerabilitiesByPurl = new HashMap<String, List<CheckmarxVulnerability>>(bomRefsByPurl.size());
+        final var vulnerabilitiesByPurl = new HashMap<String, List<CheckmarxDataObject>>(bomRefsByPurl.size());
         final var purlsToAnalyze = new LinkedHashSet<>(bomRefsByPurl.keySet());
 
         for (final var purlBatch : (Iterable<List<String>>) () -> bomRefsByPurl.keySet().stream()
@@ -103,8 +103,8 @@ final class CheckmarxVulnAnalyzer implements VulnAnalyzer {
                 }
 
                 try {
-                    final CheckmarxVulnerability[] vulns = objectMapper.readValue(cachedBytes, CheckmarxVulnerability[].class);
-                    vulnerabilitiesByPurl.put(purl, List.of(vulns));
+                    final CheckmarxDataObject[] cxDataObjects = objectMapper.readValue(cachedBytes, CheckmarxDataObject[].class);
+                    vulnerabilitiesByPurl.put(purl, List.of(cxDataObjects));
                 } catch (IOException e) {
                     LOGGER.warn("Failed to deserialize cached results for PURL '{}'; Will re-fetch", purl, e);
                     purlsToAnalyze.add(purl);
@@ -112,9 +112,87 @@ final class CheckmarxVulnAnalyzer implements VulnAnalyzer {
             }
         }
 
-        vulnerabilitiesByPurl.putAll(fetchAndCacheVulnerabilities(purlsToAnalyze));
+        vulnerabilitiesByPurl.putAll(analyzePurls(purlsToAnalyze, bomRefsByPurl));
 
         return assembleVdr(vulnerabilitiesByPurl, bomRefsByPurl);
+    }
+
+    private Map<String,? extends List<CheckmarxDataObject>> analyzePurls(
+            Collection<String> purls,
+            Map<String, Set<String>> bomRefsByPurl) throws InterruptedException {
+        if (purls.isEmpty()) {
+            return Map.of();
+        }
+
+        final var vulnerabilitiesByPurl = new HashMap<String, List<CheckmarxDataObject>>(purls.size());
+        for (final var purlBatch : (Iterable<List<String>>) () -> purls.stream()
+                .gather(Gatherers.windowFixed(REQUEST_BATCH_SIZE))
+                .iterator()) {
+            if (Thread.interrupted()) {
+                throw new InterruptedException("Interrupted before all components could be analyzed");
+            }
+
+            vulnerabilitiesByPurl.putAll(analyzePurlBatch(purlBatch, bomRefsByPurl));
+        }
+
+        return vulnerabilitiesByPurl;
+    }
+
+    private Map<String,? extends List<CheckmarxDataObject>> analyzePurlBatch(
+            Collection<String> purlBatch,
+            Map<String, Set<String>> bomRefsByPurl) throws InterruptedException {
+        if (purlBatch.isEmpty()) {
+            return Map.of();
+        }
+
+        LOGGER.debug("Fetching vulnerabilities for {} PURLs from Checkmarx", purlBatch.size());
+
+        final CheckmarxApiResponse  response;
+        try {
+            response = apiClient.fetchVulnerabilities(purlBatch);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to fetch Checkmarx vulnerabilities", e);
+        }
+
+        final var vulnerabilitiesByPurl = new HashMap<String, List<CheckmarxDataObject>>();
+        final var entriesToCache = new HashMap<String, byte @Nullable []>(purlBatch.size());
+
+        if (response.data() != null && !response.data().isEmpty()) {
+            for (final CheckmarxDataObject cxDataObject : response.data()) {
+                final String vulnPurl = cxDataObject.pkg().purl();
+                if (vulnPurl == null) {
+                    LOGGER.warn("Unable to extract PURL for package '{}:{}'; Skipping", cxDataObject.pkg().name(), cxDataObject.pkg().version());
+                    continue;
+                }
+
+                final String vulnPurlLower = vulnPurl.toLowerCase();
+                if (!bomRefsByPurl.containsKey(vulnPurlLower)) {
+                    LOGGER.warn("Received vulnerability data for PURL '{}', but no component with this PURL was submitted", vulnPurl);
+                    continue;
+                }
+
+                vulnerabilitiesByPurl
+                        .computeIfAbsent(vulnPurlLower, _ -> new ArrayList<>())
+                        .add(cxDataObject);
+            }
+        }
+
+        for (final var entry : vulnerabilitiesByPurl.entrySet()) {
+            try {
+                entriesToCache.put(entry.getKey(), objectMapper.writeValueAsBytes(entry.getValue()));
+            } catch (IOException e) {
+                LOGGER.warn("Failed to serialize data for PURL '{}'; Skipping cache", entry.getKey(), e);
+            }
+        }
+
+        for (final String purl : purlBatch) {
+            if (!vulnerabilitiesByPurl.containsKey(purl)) {
+                entriesToCache.put(purl, null);
+            }
+        }
+
+        resultsCache.putMany(entriesToCache);
+        return vulnerabilitiesByPurl;
     }
 
     private Map<String, Set<String>> collectAnalyzablePurls(Bom bom) {
@@ -145,64 +223,14 @@ final class CheckmarxVulnAnalyzer implements VulnAnalyzer {
         return bomRefsByPurl;
     }
 
-    private Map<String, List<CheckmarxVulnerability>> fetchAndCacheVulnerabilities(
-            Collection<String> purls) throws InterruptedException {
-        if (purls.isEmpty()) {
-            return Map.of();
-        }
-
-        LOGGER.debug("Fetching vulnerabilities for {} PURLs from Checkmarx", purls.size());
-
-        final var entriesToCache = new HashMap<String, byte @Nullable []>(purls.size());
-        final var vulnerabilitiesByPurl = new HashMap<String, List<CheckmarxVulnerability>>();
-
-        try {
-            final CheckmarxVulnerabilitiesResponse response = apiClient.fetchVulnerabilities(purls);
-
-            if (response.data() != null && !response.data().isEmpty()) {
-                for (final CheckmarxVulnerability vuln : response.data()) {
-                    final String vulnPurl = vuln.purl();
-                    if (vulnPurl == null) {
-                        LOGGER.warn("Unable to extract PURL from vulnerability '{}'; Skipping", vuln.id());
-                        continue;
-                    }
-
-                    final String vulnPurlLower = vulnPurl.toLowerCase();
-                    vulnerabilitiesByPurl
-                            .computeIfAbsent(vulnPurlLower, _ -> new ArrayList<>())
-                            .add(vuln);
-                }
-            }
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to fetch vulnerabilities from Checkmarx", e);
-        }
-
-        for (final var entry : vulnerabilitiesByPurl.entrySet()) {
-            try {
-                entriesToCache.put(entry.getKey(), objectMapper.writeValueAsBytes(entry.getValue()));
-            } catch (IOException e) {
-                LOGGER.warn("Failed to serialize results for PURL '{}'; Skipping cache", entry.getKey(), e);
-            }
-        }
-
-        for (final String purl : purls) {
-            if (!vulnerabilitiesByPurl.containsKey(purl)) {
-                entriesToCache.put(purl, null);
-            }
-        }
-
-        resultsCache.putMany(entriesToCache);
-        return vulnerabilitiesByPurl;
-    }
-
     private Bom assembleVdr(
-            Map<String, List<CheckmarxVulnerability>> vulnerabilitiesByPurl,
+            Map<String, List<CheckmarxDataObject>> vulnerabilitiesByPurl,
             Map<String, Set<String>> bomRefsByPurl) {
         final var vulnBuilderByVulnId = new HashMap<String, Vulnerability.Builder>();
 
         for (final var entry : vulnerabilitiesByPurl.entrySet()) {
             final String purl = entry.getKey();
-            final List<CheckmarxVulnerability> vulns = entry.getValue();
+            final List<CheckmarxDataObject> cxDataObjects = entry.getValue();
 
             final Set<String> bomRefs = bomRefsByPurl.get(purl);
             if (bomRefs == null) {
@@ -212,18 +240,20 @@ final class CheckmarxVulnAnalyzer implements VulnAnalyzer {
                 continue;
             }
 
-            for (final CheckmarxVulnerability vuln : vulns) {
-                final Vulnerability.Builder vulnBuilder =
-                        vulnBuilderByVulnId.computeIfAbsent(
-                                vuln.id(),
-                                _ -> CheckmarxModelConverter.convert(vuln, aliasSyncEnabled));
+            for (final CheckmarxDataObject cxObject : cxDataObjects) {
+                cxObject.vulnerabilities().forEach(cxVuln -> {
+                    final Vulnerability.Builder vulnBuilder =
+                            vulnBuilderByVulnId.computeIfAbsent(
+                                    cxVuln.cxId(),
+                                    _ -> CheckmarxModelConverter.convert(cxVuln, cxObject.pkg().remediation(), aliasSyncEnabled));
 
-                for (final String bomRef : bomRefs) {
-                    vulnBuilder.addAffects(
-                            VulnerabilityAffects.newBuilder()
-                                    .setRef(bomRef)
-                                    .build());
-                }
+                    for (final String bomRef : bomRefs) {
+                        vulnBuilder.addAffects(
+                                VulnerabilityAffects.newBuilder()
+                                        .setRef(bomRef)
+                                        .build());
+                    }
+                });
             }
         }
 
@@ -234,5 +264,4 @@ final class CheckmarxVulnAnalyzer implements VulnAnalyzer {
                                 .toList())
                 .build();
     }
-
 }

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerFactory.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerFactory.java
@@ -1,0 +1,130 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.checkmarx;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dependencytrack.cache.api.CacheManager;
+import org.dependencytrack.plugin.api.RuntimeConfigurable;
+import org.dependencytrack.plugin.api.ServiceRegistry;
+import org.dependencytrack.plugin.api.config.ConfigRegistry;
+import org.dependencytrack.plugin.api.config.InvalidRuntimeConfigException;
+import org.dependencytrack.plugin.api.config.RuntimeConfigSpec;
+import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
+import org.dependencytrack.vulnanalysis.api.VulnAnalyzerFactory;
+import org.dependencytrack.vulnanalysis.api.VulnAnalyzerRequirement;
+import org.jspecify.annotations.Nullable;
+
+import java.net.http.HttpClient;
+import java.util.EnumSet;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static java.util.Objects.requireNonNull;
+
+final class CheckmarxVulnAnalyzerFactory implements VulnAnalyzerFactory, RuntimeConfigurable {
+
+    private @Nullable ConfigRegistry configRegistry;
+    private @Nullable CacheManager cacheManager;
+    private @Nullable HttpClient httpClient;
+    private @Nullable ObjectMapper objectMapper;
+
+    @Override
+    public String extensionName() {
+        return "checkmarx";
+    }
+
+    @Override
+    public Class<? extends VulnAnalyzer> extensionClass() {
+        return CheckmarxVulnAnalyzer.class;
+    }
+
+    @Override
+    public void init(ServiceRegistry serviceRegistry) {
+        configRegistry = serviceRegistry.require(ConfigRegistry.class);
+        cacheManager = serviceRegistry.require(CacheManager.class);
+        httpClient = serviceRegistry.require(HttpClient.class);
+        objectMapper = new ObjectMapper()
+                .disable(FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    @Override
+    public VulnAnalyzer create() {
+        requireNonNull(configRegistry);
+        requireNonNull(cacheManager);
+        requireNonNull(httpClient);
+        requireNonNull(objectMapper);
+
+        final var config = configRegistry.getRuntimeConfig(CheckmarxVulnAnalyzerConfigV1.class);
+        if (!config.isEnabled()) {
+            throw new IllegalStateException("Analyzer is disabled");
+        }
+
+        final var tokenManager = new CheckmarxAccessTokenManager(httpClient, objectMapper);
+        final var apiClient = new CheckmarxApiClient(
+                httpClient,
+                objectMapper,
+                tokenManager,
+                config.getRefreshToken(),
+                config.getOrgId(),
+                config.getAuthApiBaseUrl(),
+                config.getApiBaseUrl());
+
+        return new CheckmarxVulnAnalyzer(
+                cacheManager.getCache("results"),
+                objectMapper,
+                apiClient,
+                config.isAliasSyncEnabled());
+    }
+
+    @Override
+    public boolean isEnabled() {
+        requireNonNull(configRegistry);
+        return configRegistry.getRuntimeConfig(CheckmarxVulnAnalyzerConfigV1.class).isEnabled();
+    }
+
+    @Override
+    public EnumSet<VulnAnalyzerRequirement> analyzerRequirements() {
+        return EnumSet.of(VulnAnalyzerRequirement.COMPONENT_PURL);
+    }
+
+    @Override
+    public RuntimeConfigSpec runtimeConfigSpec() {
+        return RuntimeConfigSpec.of(
+                new CheckmarxVulnAnalyzerConfigV1()
+                        .withEnabled(false),
+                config -> {
+                    if (!config.isEnabled()) {
+                        return;
+                    }
+                    if (config.getAuthApiBaseUrl() == null) {
+                        throw new InvalidRuntimeConfigException("No authentication API base URL provided");
+                    }
+                    if (config.getApiBaseUrl() == null) {
+                        throw new InvalidRuntimeConfigException("No API base URL provided");
+                    }
+                    if (config.getRefreshToken() == null) {
+                        throw new InvalidRuntimeConfigException("No Refresh Token provided");
+                    }
+                    if (config.getOrgId() == null) {
+                        throw new InvalidRuntimeConfigException("No Organization ID provided");
+                    }
+                });
+    }
+
+}
+

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerFactory.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerFactory.java
@@ -36,7 +36,7 @@ import java.util.EnumSet;
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static java.util.Objects.requireNonNull;
 
-final class CheckmarxVulnAnalyzerFactory implements VulnAnalyzerFactory, RuntimeConfigurable {
+public final class CheckmarxVulnAnalyzerFactory implements VulnAnalyzerFactory, RuntimeConfigurable {
 
     private @Nullable ConfigRegistry configRegistry;
     private @Nullable CacheManager cacheManager;

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerFactory.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerFactory.java
@@ -79,7 +79,7 @@ public final class CheckmarxVulnAnalyzerFactory implements VulnAnalyzerFactory, 
                 httpClient,
                 objectMapper,
                 tokenManager,
-                config.getRefreshToken(),
+                config.getApiKey(),
                 config.getOrgId(),
                 config.getAuthApiBaseUrl(),
                 config.getApiBaseUrl());
@@ -117,8 +117,8 @@ public final class CheckmarxVulnAnalyzerFactory implements VulnAnalyzerFactory, 
                     if (config.getApiBaseUrl() == null) {
                         throw new InvalidRuntimeConfigException("No API base URL provided");
                     }
-                    if (config.getRefreshToken() == null) {
-                        throw new InvalidRuntimeConfigException("No Refresh Token provided");
+                    if (config.getApiKey() == null) {
+                        throw new InvalidRuntimeConfigException("No API Key provided");
                     }
                     if (config.getOrgId() == null) {
                         throw new InvalidRuntimeConfigException("No Organization ID provided");

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerPlugin.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerPlugin.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.checkmarx;
+
+import org.dependencytrack.plugin.api.ExtensionFactory;
+import org.dependencytrack.plugin.api.ExtensionPoint;
+import org.dependencytrack.plugin.api.Plugin;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Plugin for Checkmarx vulnerability analyzer.
+ *
+ * @since 5.0.0
+ */
+public final class CheckmarxVulnAnalyzerPlugin implements Plugin {
+
+    @Override
+    public Collection<? extends ExtensionFactory<? extends ExtensionPoint>> extensionFactories() {
+        return List.of(new CheckmarxVulnAnalyzerFactory());
+    }
+
+}
+

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnerabilitiesResponse.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnerabilitiesResponse.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.checkmarx;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Represents the response from Checkmarx vulnerabilities API.
+ *
+ * @since 5.0.0
+ */
+public record CheckmarxVulnerabilitiesResponse(
+        @Nullable List<CheckmarxVulnerability> data) {
+}
+

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnerability.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnerability.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.checkmarx;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents a vulnerability from Checkmarx API response.
+ *
+ * @since 5.0.0
+ */
+public record CheckmarxVulnerability(
+        String id,
+        @Nullable String cveName,
+        @Nullable String purl,
+        @Nullable String severity,
+        @Nullable String description,
+        @Nullable String score,
+        @Nullable String recommendation) {
+}
+

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/package-info.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+@NullMarked
+package org.dependencytrack.vulnanalysis.checkmarx;
+
+import org.jspecify.annotations.NullMarked;

--- a/vuln-analysis/checkmarx/src/main/resources/META-INF/services/org.dependencytrack.plugin.api.Plugin
+++ b/vuln-analysis/checkmarx/src/main/resources/META-INF/services/org.dependencytrack.plugin.api.Plugin
@@ -1,0 +1,1 @@
+org.dependencytrack.vulnanalysis.checkmarx.CheckmarxVulnAnalyzerPlugin

--- a/vuln-analysis/checkmarx/src/main/resources/org/dependencytrack/vulnanalysis/checkmarx/checkmarx-vuln-analyzer-config-v1.schema.json
+++ b/vuln-analysis/checkmarx/src/main/resources/org/dependencytrack/vulnanalysis/checkmarx/checkmarx-vuln-analyzer-config-v1.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dependencytrack.org/schemas/checkmarx-vuln-analyzer-config-v1.schema.json",
+  "type": "object",
+  "javaInterfaces": [
+    "org.dependencytrack.plugin.api.config.RuntimeConfig"
+  ],
+  "properties": {
+    "enabled": {
+      "type": "boolean",
+      "title": "Enabled",
+      "description": "Whether the Checkmarx vulnerability analyzer should be enabled.",
+      "existingJavaType": "boolean"
+    },
+    "aliasSyncEnabled": {
+      "type": "boolean",
+      "title": "Alias Synchronization Enabled",
+      "description": "Whether to include alias information in vulnerability data.",
+      "existingJavaType": "boolean"
+    },
+    "authApiBaseUrl": {
+      "type": "string",
+      "title": "Authentication API Base URL",
+      "description": "Base URL of Checkmarx's authentication API.",
+      "format": "uri",
+      "minLength": 1
+    },
+    "apiBaseUrl": {
+      "type": "string",
+      "title": "API Base URL",
+      "description": "Base URL of Checkmarx's REST API.",
+      "format": "uri",
+      "minLength": 1
+    },
+    "orgId": {
+      "type": "string",
+      "title": "Organization ID",
+      "description": "Organization ID to authenticate with the Checkmarx REST API.",
+      "minLength": 1
+    },
+    "refreshToken": {
+      "type": "string",
+      "title": "Refresh Token",
+      "description": "Refresh token (API Key) to authenticate with the Checkmarx REST API.",
+      "minLength": 1,
+      "x-secret-ref": true
+    }
+  },
+  "required": [
+    "enabled"
+  ]
+}

--- a/vuln-analysis/checkmarx/src/main/resources/org/dependencytrack/vulnanalysis/checkmarx/checkmarx-vuln-analyzer-config-v1.schema.json
+++ b/vuln-analysis/checkmarx/src/main/resources/org/dependencytrack/vulnanalysis/checkmarx/checkmarx-vuln-analyzer-config-v1.schema.json
@@ -38,10 +38,10 @@
       "description": "Organization ID to authenticate with the Checkmarx REST API.",
       "minLength": 1
     },
-    "refreshToken": {
+    "apiKey": {
       "type": "string",
-      "title": "Refresh Token",
-      "description": "Refresh token (API Key) to authenticate with the Checkmarx REST API.",
+      "title": "API Key",
+      "description": "API key to authenticate with the Checkmarx REST API.",
       "minLength": 1,
       "x-secret-ref": true
     }

--- a/vuln-analysis/checkmarx/src/test/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxAccessTokenManagerTest.java
+++ b/vuln-analysis/checkmarx/src/test/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxAccessTokenManagerTest.java
@@ -1,0 +1,149 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.checkmarx;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@WireMockTest
+class CheckmarxAccessTokenManagerTest {
+
+    private CheckmarxAccessTokenManager tokenManager;
+    private URI apiBaseUrl;
+
+    @BeforeEach
+    void beforeEach(WireMockRuntimeInfo wmRuntimeInfo) {
+        apiBaseUrl = URI.create(wmRuntimeInfo.getHttpBaseUrl());
+        tokenManager = new CheckmarxAccessTokenManager(
+                HttpClient.newHttpClient(),
+                new ObjectMapper());
+    }
+
+    @Test
+    void shouldAcquireToken() throws Exception {
+        stubFor(post(urlPathEqualTo("/auth/realms/org-id/protocol/openid-connect/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(/* language=JSON */ """
+                                {"access_token": "tok-123", "token_type": "Bearer", "expires_in": 3600}
+                                """)));
+
+        final String token = tokenManager.getAccessToken(apiBaseUrl, "org-id", "refresh-token");
+        assertThat(token).isEqualTo("tok-123");
+    }
+
+    @Test
+    void shouldCacheToken() throws Exception {
+        stubFor(post(urlPathEqualTo("/auth/realms/org-id/protocol/openid-connect/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(/* language=JSON */ """
+                                {"access_token": "tok-cached", "token_type": "Bearer", "expires_in": 3600}
+                                """)));
+
+        final String token1 = tokenManager.getAccessToken(apiBaseUrl, "org-id", "refresh-token");
+        final String token2 = tokenManager.getAccessToken(apiBaseUrl, "org-id", "refresh-token");
+
+        assertThat(token1).isEqualTo("tok-cached");
+        assertThat(token2).isEqualTo("tok-cached");
+        verify(1, postRequestedFor(urlPathEqualTo("/auth/realms/org-id/protocol/openid-connect/token")));
+    }
+
+    @Test
+    void shouldRefreshExpiredToken() throws Exception {
+        stubFor(post(urlPathEqualTo("/auth/realms/org-id/protocol/openid-connect/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(/* language=JSON */ """
+                                {"access_token": "tok-expired", "token_type": "Bearer", "expires_in": 0}
+                                """)));
+
+        tokenManager.getAccessToken(apiBaseUrl, "org-id", "refresh-token");
+
+        stubFor(post(urlPathEqualTo("/auth/realms/org-id/protocol/openid-connect/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(/* language=JSON */ """
+                                {"access_token": "tok-refreshed", "token_type": "Bearer", "expires_in": 3600}
+                                """)));
+
+        final String token = tokenManager.getAccessToken(apiBaseUrl, "org-id", "refresh-token");
+        assertThat(token).isEqualTo("tok-refreshed");
+        verify(2, postRequestedFor(urlPathEqualTo("/auth/realms/org-id/protocol/openid-connect/token")));
+    }
+
+    @Test
+    void shouldInvalidateOnCredentialChange() throws Exception {
+        stubFor(post(urlPathEqualTo("/auth/realms/org-id-1/protocol/openid-connect/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(/* language=JSON */ """
+                                {"access_token": "tok-old", "token_type": "Bearer", "expires_in": 3600}
+                                """)));
+
+        tokenManager.getAccessToken(apiBaseUrl, "org-id-1", "refresh-token-1");
+
+        stubFor(post(urlPathEqualTo("/auth/realms/org-id-2/protocol/openid-connect/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(/* language=JSON */ """
+                                {"access_token": "tok-new", "token_type": "Bearer", "expires_in": 3600}
+                                """)));
+
+        final String token = tokenManager.getAccessToken(apiBaseUrl, "org-id-2", "refresh-token-2");
+        assertThat(token).isEqualTo("tok-new");
+        verify(1, postRequestedFor(urlPathMatching("/auth/realms/org-id-1/protocol/openid-connect/token")));
+        verify(1, postRequestedFor(urlPathMatching("/auth/realms/org-id-2/protocol/openid-connect/token")));
+    }
+
+    @Test
+    void shouldThrowOnTokenEndpointError() {
+        stubFor(post(urlPathEqualTo("/auth/realms/bad-id/protocol/openid-connect/token"))
+                .willReturn(aResponse()
+                        .withStatus(401)
+                        .withBody("Unauthorized")));
+
+        assertThatThrownBy(() -> tokenManager.getAccessToken(apiBaseUrl, "bad-id", "bad-token"))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("401");
+    }
+}

--- a/vuln-analysis/checkmarx/src/test/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxAccessTokenManagerTest.java
+++ b/vuln-analysis/checkmarx/src/test/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxAccessTokenManagerTest.java
@@ -62,7 +62,7 @@ class CheckmarxAccessTokenManagerTest {
                                 {"access_token": "tok-123", "token_type": "Bearer", "expires_in": 3600}
                                 """)));
 
-        final String token = tokenManager.getAccessToken(apiBaseUrl, "org-id", "refresh-token");
+        final String token = tokenManager.getAccessToken(apiBaseUrl, "org-id", "api-key");
         assertThat(token).isEqualTo("tok-123");
     }
 
@@ -76,8 +76,8 @@ class CheckmarxAccessTokenManagerTest {
                                 {"access_token": "tok-cached", "token_type": "Bearer", "expires_in": 3600}
                                 """)));
 
-        final String token1 = tokenManager.getAccessToken(apiBaseUrl, "org-id", "refresh-token");
-        final String token2 = tokenManager.getAccessToken(apiBaseUrl, "org-id", "refresh-token");
+        final String token1 = tokenManager.getAccessToken(apiBaseUrl, "org-id", "api-key");
+        final String token2 = tokenManager.getAccessToken(apiBaseUrl, "org-id", "api-key");
 
         assertThat(token1).isEqualTo("tok-cached");
         assertThat(token2).isEqualTo("tok-cached");
@@ -94,7 +94,7 @@ class CheckmarxAccessTokenManagerTest {
                                 {"access_token": "tok-expired", "token_type": "Bearer", "expires_in": 0}
                                 """)));
 
-        tokenManager.getAccessToken(apiBaseUrl, "org-id", "refresh-token");
+        tokenManager.getAccessToken(apiBaseUrl, "org-id", "api-key");
 
         stubFor(post(urlPathEqualTo("/auth/realms/org-id/protocol/openid-connect/token"))
                 .willReturn(aResponse()
@@ -104,7 +104,7 @@ class CheckmarxAccessTokenManagerTest {
                                 {"access_token": "tok-refreshed", "token_type": "Bearer", "expires_in": 3600}
                                 """)));
 
-        final String token = tokenManager.getAccessToken(apiBaseUrl, "org-id", "refresh-token");
+        final String token = tokenManager.getAccessToken(apiBaseUrl, "org-id", "api-key");
         assertThat(token).isEqualTo("tok-refreshed");
         verify(2, postRequestedFor(urlPathEqualTo("/auth/realms/org-id/protocol/openid-connect/token")));
     }
@@ -119,7 +119,7 @@ class CheckmarxAccessTokenManagerTest {
                                 {"access_token": "tok-old", "token_type": "Bearer", "expires_in": 3600}
                                 """)));
 
-        tokenManager.getAccessToken(apiBaseUrl, "org-id-1", "refresh-token-1");
+        tokenManager.getAccessToken(apiBaseUrl, "org-id-1", "api-key-1");
 
         stubFor(post(urlPathEqualTo("/auth/realms/org-id-2/protocol/openid-connect/token"))
                 .willReturn(aResponse()
@@ -129,7 +129,7 @@ class CheckmarxAccessTokenManagerTest {
                                 {"access_token": "tok-new", "token_type": "Bearer", "expires_in": 3600}
                                 """)));
 
-        final String token = tokenManager.getAccessToken(apiBaseUrl, "org-id-2", "refresh-token-2");
+        final String token = tokenManager.getAccessToken(apiBaseUrl, "org-id-2", "api-key-2");
         assertThat(token).isEqualTo("tok-new");
         verify(1, postRequestedFor(urlPathMatching("/auth/realms/org-id-1/protocol/openid-connect/token")));
         verify(1, postRequestedFor(urlPathMatching("/auth/realms/org-id-2/protocol/openid-connect/token")));
@@ -142,7 +142,7 @@ class CheckmarxAccessTokenManagerTest {
                         .withStatus(401)
                         .withBody("Unauthorized")));
 
-        assertThatThrownBy(() -> tokenManager.getAccessToken(apiBaseUrl, "bad-id", "bad-token"))
+        assertThatThrownBy(() -> tokenManager.getAccessToken(apiBaseUrl, "bad-id", "bad-key"))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("401");
     }

--- a/vuln-analysis/checkmarx/src/test/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerFactoryTest.java
+++ b/vuln-analysis/checkmarx/src/test/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerFactoryTest.java
@@ -18,16 +18,13 @@
  */
 package org.dependencytrack.vulnanalysis.checkmarx;
 
-import org.jspecify.annotations.Nullable;
+import org.dependencytrack.plugin.testing.AbstractExtensionFactoryTest;
+import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
 
-import java.util.List;
+class CheckmarxVulnAnalyzerFactoryTest extends AbstractExtensionFactoryTest<VulnAnalyzer, CheckmarxVulnAnalyzerFactory> {
 
-/**
- * Represents the response from Checkmarx vulnerabilities API.
- *
- * @since 5.0.0
- */
-public record CheckmarxVulnerabilitiesResponse(
-        @Nullable List<CheckmarxVulnerability> data) {
+    CheckmarxVulnAnalyzerFactoryTest() {
+        super(CheckmarxVulnAnalyzerFactory.class);
+    }
+
 }
-

--- a/vuln-analysis/checkmarx/src/test/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerTest.java
+++ b/vuln-analysis/checkmarx/src/test/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerTest.java
@@ -1,0 +1,331 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.checkmarx;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.google.protobuf.util.JsonFormat;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import org.cyclonedx.proto.v1_7.Bom;
+import org.cyclonedx.proto.v1_7.Component;
+import org.cyclonedx.proto.v1_7.Property;
+import org.dependencytrack.cache.api.CacheManager;
+import org.dependencytrack.cache.memory.MemoryCacheProvider;
+import org.dependencytrack.plugin.api.MutableServiceRegistry;
+import org.dependencytrack.plugin.api.config.ConfigRegistry;
+import org.dependencytrack.plugin.testing.MockConfigRegistry;
+import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.util.ArrayList;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WireMockTest
+class CheckmarxVulnAnalyzerTest {
+
+    private CacheManager cacheManager;
+    private CheckmarxVulnAnalyzerFactory analyzerFactory;
+    private VulnAnalyzer analyzer;
+
+    @BeforeEach
+    void beforeEach(WireMockRuntimeInfo wmRuntimeInfo) {
+        final var cacheProvider = new MemoryCacheProvider(new SmallRyeConfigBuilder().build());
+        cacheManager = cacheProvider.create();
+
+        analyzerFactory = new CheckmarxVulnAnalyzerFactory();
+
+        final var configRegistry = new MockConfigRegistry(
+                analyzerFactory.runtimeConfigSpec(),
+                new CheckmarxVulnAnalyzerConfigV1()
+                        .withEnabled(true)
+                        .withAliasSyncEnabled(true)
+                        .withApiBaseUrl(URI.create(wmRuntimeInfo.getHttpBaseUrl()))
+                        .withOrgId("test-org-id")
+                        .withAuthApiBaseUrl(URI.create(wmRuntimeInfo.getHttpBaseUrl()))
+                        .withRefreshToken("test-refresh-token"));
+
+        analyzerFactory.init(
+                new MutableServiceRegistry()
+                        .register(ConfigRegistry.class, configRegistry)
+                        .register(CacheManager.class, cacheManager)
+                        .register(HttpClient.class, HttpClient.newHttpClient()));
+
+        // Stub auth token endpoint used by CheckmarxAccessTokenManager
+        stubFor(post(urlPathMatching("/auth/realms/test-org-id/protocol/openid-connect/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                             {   "access_token": "test-access-token",
+                                 "expires_in": 3600,
+                                 "refresh_token": "test-refresh-token",
+                                 "refresh_expires_in": 3600
+                             }""")));
+
+        analyzer = analyzerFactory.create();
+    }
+
+    @AfterEach
+    void afterEach() throws Exception {
+        if (analyzerFactory != null) {
+            analyzerFactory.close();
+        }
+        if (cacheManager != null) {
+            cacheManager.close();
+        }
+    }
+
+    @Test
+    void shouldAnalyzeAndCacheWithNoVulns() throws Exception {
+        stubFor(post(urlPathEqualTo("/api/sca/packages/vulnerabilities"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile("chx-no-issues-response.json")));
+
+        final var bom = Bom.newBuilder()
+                .addComponents(
+                        Component.newBuilder()
+                                .setBomRef("1")
+                                .setName("jackson-databind")
+                                .setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4")
+                                .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThat(vdr).isEqualTo(Bom.getDefaultInstance());
+
+        final Bom secondVdr = analyzer.analyze(bom);
+        assertThat(secondVdr).isEqualTo(vdr);
+
+        verify(1, postRequestedFor(anyUrl())
+                .withHeader("Authorization", equalTo("Bearer test-access-token")));
+    }
+
+    @Test
+    void shouldAnalyzeAndCacheWithVulns() throws Exception {
+        stubFor(post(urlPathEqualTo("/api/sca/packages/vulnerabilities"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile("chx-response-with-vulns.json")));
+
+        final var bom = Bom.newBuilder()
+                .addComponents(
+                        Component.newBuilder()
+                                .setBomRef("1")
+                                .setName("jackson-databind")
+                                .setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4")
+                                .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThatJson(JsonFormat.printer().print(vdr)).isEqualTo(/* language=JSON */ """
+                {
+                  "vulnerabilities" : [ {
+                    "id" : "cx987654-32g1",
+                    "source" : {
+                      "name" : "CX"
+                    },
+                    "references" : [ {
+                      "id" : "CVE-2021-25649",
+                      "source" : {
+                        "name" : "NVD"
+                      }
+                    } ],
+                    "ratings" : [ {
+                      "score" : 5.0,
+                      "severity" : "SEVERITY_MEDIUM",
+                      "method" : "SCORE_METHOD_CVSSV4",
+                      "vector" : "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
+                    } ],
+                    "cwes" : [ 501 ],
+                    "description" : "A vulnerability was found in jackson-databind.",
+                    "recommendation" : "Smallest package upgrade that resolves the identified risks in the current package version: 2.13.4\\nLatest version of the package: 2.13.4",
+                    "advisories" : [ {
+                      "url" : "https://nvd.nist.gov/vuln/detail/CVE-2021-25649"
+                    }, {
+                      "url" : "https://spring.io/security/CVE-2021-25649"
+                    } ],
+                    "created" : "2020-12-15T00:00:00Z",
+                    "published" : "2021-10-15T00:00:00Z",
+                    "updated" : "2021-12-15T00:00:00Z",
+                    "affects" : [ {
+                      "ref" : "1"
+                    } ]
+                  }, {
+                    "id" : "cx123456-78c9",
+                    "source" : {
+                      "name" : "CX"
+                    },
+                    "references" : [ {
+                      "id" : "CVE-2020-25649",
+                      "source" : {
+                        "name" : "NVD"
+                      }
+                    } ],
+                    "ratings" : [ {
+                      "score" : 7.5,
+                      "severity" : "SEVERITY_HIGH",
+                      "method" : "SCORE_METHOD_CVSSV3",
+                      "vector" : "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+                    } ],
+                    "cwes" : [ 502 ],
+                    "description" : "A vulnerability was found in jackson-databind.",
+                    "recommendation" : "Smallest package upgrade that resolves the identified risks in the current package version: 2.13.4\\nLatest version of the package: 2.13.4",
+                    "advisories" : [ {
+                      "url" : "https://nvd.nist.gov/vuln/detail/CVE-2020-25649"
+                    }, {
+                      "url" : "https://spring.io/security/CVE-2020-25649"
+                    } ],
+                    "created" : "2020-12-15T00:00:00Z",
+                    "published" : "2021-10-15T00:00:00Z",
+                    "updated" : "2021-12-15T00:00:00Z",
+                    "affects" : [ {
+                      "ref" : "1"
+                    } ]
+                  } ]
+                }
+                """);
+
+        final Bom secondVdr = analyzer.analyze(bom);
+        assertThat(secondVdr).isEqualTo(vdr);
+
+        verify(1, postRequestedFor(anyUrl())
+                .withHeader("Authorization", equalTo("Bearer test-access-token")));
+    }
+
+    @Test
+    void shouldNotAnalyzeComponentWithoutBomRef() throws Exception {
+        final var bom = Bom.newBuilder()
+                .addComponents(
+                        Component.newBuilder()
+                                .setName("acme-lib")
+                                .setPurl("pkg:maven/com.acme/acme-lib@1.0.0")
+                                .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThat(vdr).isEqualTo(Bom.getDefaultInstance());
+
+        verify(0, postRequestedFor(anyUrl()));
+    }
+
+    @Test
+    void shouldNotAnalyzeComponentWithoutPurl() throws Exception {
+        final var bom = Bom.newBuilder()
+                .addComponents(
+                        Component.newBuilder()
+                                .setBomRef("1")
+                                .setName("acme-lib")
+                                .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThat(vdr).isEqualTo(Bom.getDefaultInstance());
+
+        verify(0, postRequestedFor(anyUrl()));
+    }
+
+    @Test
+    void shouldNotAnalyzeComponentWithUnsupportedPackageType() throws Exception {
+        stubFor(post(urlPathEqualTo("/api/sca/packages/vulnerabilities"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile("chx-non-okay-response.json")));
+
+        final var bom = Bom.newBuilder()
+                .addComponents(
+                        Component.newBuilder()
+                                .setBomRef("1")
+                                .setName("acme-lib")
+                                .setPurl("pkg:rpm/acme-artefact@1.2.3")
+                                .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThat(vdr).isEqualTo(Bom.getDefaultInstance());
+    }
+
+    @Test
+    void shouldNotAnalyzeInternalComponents() throws Exception {
+        final var bom = Bom.newBuilder()
+                .addComponents(
+                        Component.newBuilder()
+                                .setBomRef("1")
+                                .setName("acme-lib")
+                                .setPurl("pkg:maven/com.acme/acme-lib@1.0.0")
+                                .addProperties(
+                                        Property.newBuilder()
+                                                .setName("dependencytrack:internal:is-internal-component")
+                                                .setValue("does-not-matter")
+                                                .build())
+                                .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThat(vdr).isEqualTo(Bom.getDefaultInstance());
+
+        verify(0, postRequestedFor(anyUrl()));
+    }
+
+    @Test
+    void shouldBatchRequestsWithUpTo100Purls() throws Exception {
+        stubFor(post(urlPathEqualTo("/api/sca/packages/vulnerabilities"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[]")));
+
+        final var components = new ArrayList<Component>(150);
+        for (int i = 0; i < 150; i++) {
+            components.add(
+                    Component.newBuilder()
+                            .setBomRef(String.valueOf(i))
+                            .setName("acme-lib")
+                            .setPurl("pkg:maven/com.acme/acme-lib@1.0." + i)
+                            .build());
+        }
+
+        final var bom = Bom.newBuilder()
+                .addAllComponents(components)
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThat(vdr).isEqualTo(Bom.getDefaultInstance());
+
+        verify(2, postRequestedFor(urlPathEqualTo("/api/sca/packages/vulnerabilities")));
+    }
+}

--- a/vuln-analysis/checkmarx/src/test/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerTest.java
+++ b/vuln-analysis/checkmarx/src/test/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerTest.java
@@ -108,7 +108,7 @@ class CheckmarxVulnAnalyzerTest {
 
     @Test
     void shouldAnalyzeAndCacheWithNoVulns() throws Exception {
-        stubFor(post(urlPathEqualTo("/api/sca/packages/vulnerabilities"))
+        stubFor(post(urlPathEqualTo("/api/v1/packages/risks"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")
@@ -135,7 +135,7 @@ class CheckmarxVulnAnalyzerTest {
 
     @Test
     void shouldAnalyzeAndCacheWithVulns() throws Exception {
-        stubFor(post(urlPathEqualTo("/api/sca/packages/vulnerabilities"))
+        stubFor(post(urlPathEqualTo("/api/v1/packages/risks"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")
@@ -260,7 +260,7 @@ class CheckmarxVulnAnalyzerTest {
 
     @Test
     void shouldNotAnalyzeComponentWithUnsupportedPackageType() throws Exception {
-        stubFor(post(urlPathEqualTo("/api/sca/packages/vulnerabilities"))
+        stubFor(post(urlPathEqualTo("/api/v1/packages/risks"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")
@@ -303,7 +303,7 @@ class CheckmarxVulnAnalyzerTest {
 
     @Test
     void shouldBatchRequestsWithUpTo100Purls() throws Exception {
-        stubFor(post(urlPathEqualTo("/api/sca/packages/vulnerabilities"))
+        stubFor(post(urlPathEqualTo("/api/v1/packages/risks"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")
@@ -326,6 +326,6 @@ class CheckmarxVulnAnalyzerTest {
         final Bom vdr = analyzer.analyze(bom);
         assertThat(vdr).isEqualTo(Bom.getDefaultInstance());
 
-        verify(2, postRequestedFor(urlPathEqualTo("/api/sca/packages/vulnerabilities")));
+        verify(2, postRequestedFor(urlPathEqualTo("/api/v1/packages/risks")));
     }
 }

--- a/vuln-analysis/checkmarx/src/test/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerTest.java
+++ b/vuln-analysis/checkmarx/src/test/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerTest.java
@@ -73,7 +73,7 @@ class CheckmarxVulnAnalyzerTest {
                         .withApiBaseUrl(URI.create(wmRuntimeInfo.getHttpBaseUrl()))
                         .withOrgId("test-org-id")
                         .withAuthApiBaseUrl(URI.create(wmRuntimeInfo.getHttpBaseUrl()))
-                        .withRefreshToken("test-refresh-token"));
+                        .withApiKey("test-api-key"));
 
         analyzerFactory.init(
                 new MutableServiceRegistry()
@@ -89,7 +89,7 @@ class CheckmarxVulnAnalyzerTest {
                         .withBody("""
                              {   "access_token": "test-access-token",
                                  "expires_in": 3600,
-                                 "refresh_token": "test-refresh-token",
+                                 "refresh_token": "test-api-key",
                                  "refresh_expires_in": 3600
                              }""")));
 

--- a/vuln-analysis/checkmarx/src/test/resources/__files/chx-no-issues-response.json
+++ b/vuln-analysis/checkmarx/src/test/resources/__files/chx-no-issues-response.json
@@ -1,0 +1,12 @@
+[
+  {
+    "package": {
+      "status": "Ok",
+      "remediation": {},
+      "name": "com.fasterxml.jackson.core:jackson-databind",
+      "version": "2.13.4",
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4"
+    },
+    "vulnerabilities": []
+  }
+]

--- a/vuln-analysis/checkmarx/src/test/resources/__files/chx-non-okay-response.json
+++ b/vuln-analysis/checkmarx/src/test/resources/__files/chx-non-okay-response.json
@@ -1,0 +1,12 @@
+[
+  {
+    "package": {
+      "status": "UnsupportedPackageType",
+      "remediation": {},
+      "name": "acme.lib:acme-artefact",
+      "version": "1.2.3",
+      "purl": "pkg:rpm/acme-artefact@1.2.3"
+    },
+    "vulnerabilities": []
+  }
+]

--- a/vuln-analysis/checkmarx/src/test/resources/__files/chx-response-with-vulns.json
+++ b/vuln-analysis/checkmarx/src/test/resources/__files/chx-response-with-vulns.json
@@ -1,0 +1,73 @@
+[
+  {
+    "package": {
+      "status": "Ok",
+      "remediation": {
+        "latest": {
+            "version": "2.13.4"
+        },
+        "nearest": {
+          "version": "2.13.4"
+        }
+      },
+      "type": "Maven",
+      "name": "com.fasterxml.jackson.core:jackson-databind",
+      "version": "2.13.4",
+      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4"
+    },
+    "vulnerabilities": [
+      {
+        "details": {
+          "description": "A vulnerability was found in jackson-databind.",
+          "created": "2020-12-15T00:00:00.000Z",
+          "updatedTime": "2021-12-15T00:00:00.000Z",
+          "published": "2021-10-15T00:00:00.000Z",
+          "cwe": "CWE-502",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-25649"
+            },
+            {
+              "url": "https://spring.io/security/CVE-2020-25649"
+            }
+          ],
+          "cvss3": {
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "baseScore": 7.5,
+            "severity": "High"
+          }
+        },
+        "cve": "CVE-2020-25649",
+        "cxId": "cx123456-78c9",
+        "severity": "High",
+        "score": 7.5
+      },
+      {
+        "details": {
+          "description": "A vulnerability was found in jackson-databind.",
+          "created": "2020-12-15T00:00:00.000Z",
+          "updatedTime": "2021-12-15T00:00:00.000Z",
+          "published": "2021-10-15T00:00:00.000Z",
+          "cwe": "CWE-501",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-25649"
+            },
+            {
+              "url": "https://spring.io/security/CVE-2021-25649"
+            }
+          ],
+          "cvss4": {
+            "vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N",
+            "baseScore": 5.0,
+            "severity": "Medium"
+          }
+        },
+        "cve": "CVE-2021-25649",
+        "cxId": "cx987654-32g1",
+        "severity": "Medium",
+        "score": 5.0
+      }
+    ]
+  }
+]

--- a/vuln-analysis/pom.xml
+++ b/vuln-analysis/pom.xml
@@ -32,6 +32,7 @@
 
     <modules>
         <module>api</module>
+        <module>checkmarx</module>
         <module>internal</module>
         <module>oss-index</module>
         <module>snyk</module>


### PR DESCRIPTION
### Description

Add an optional Checkmarx SCA analyzer, enabled only when configured (credentials, feature flag, org/project identifiers as required by Checkmarx APIs), analogous to Snyk.

https://checkmarx.stoplight.io/docs/checkmarx-one-api-reference-guide 
**Batch PURL API**: https://checkmarx.stoplight.io/docs/checkmarx-one-api-reference-guide/drwbfz2dzursa-retrieve-package-risks-data 

### Addressed Issue

Closes https://github.com/DependencyTrack/dependency-track/issues/6203

### Additional Details

Frontend changes not required, part of existing extension system.

<img width="1257" height="738" alt="Screenshot 2026-08-05 at 11 37 46" src="https://github.com/user-attachments/assets/166594aa-4424-43ff-a86d-2bbd48f20fa6" />

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
