### PR TITLE
dex: automatically heartbeat activities

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/dex/DexEngineInitializer.java
+++ b/apiserver/src/main/java/org/dependencytrack/dex/DexEngineInitializer.java
@@ -236,8 +236,7 @@ public final class DexEngineInitializer implements ServletContextListener {
                 engine,
                 new IdentifyInternalComponentsActivity(),
                 voidConverter(),
-                voidConverter(),
-                Duration.ofMinutes(30));
+                voidConverter());
         registerActivity(
                 engine,
                 new ImportBomActivity(
@@ -245,64 +244,52 @@ public final class DexEngineInitializer implements ServletContextListener {
                         engine,
                         config.getOptionalValue("dt.tmp.delay-bom-processed-notification", boolean.class).orElse(false)),
                 protoConverter(ImportBomArg.class),
-                voidConverter(),
-                Duration.ofMinutes(5));
+                voidConverter());
         registerActivity(
                 engine,
                 new ImportVexActivity(fileStorage),
                 protoConverter(ImportVexArg.class),
-                voidConverter(),
-                Duration.ofMinutes(5));
+                voidConverter());
         registerActivity(
                 engine,
                 new DeleteFilesActivity(fileStorage),
                 protoConverter(DeleteFilesArgument.class),
-                voidConverter(),
-                Duration.ofMinutes(1));
+                voidConverter());
         registerActivity(
                 engine,
                 new EvalProjectPoliciesActivity(new CelPolicyEngine()),
                 protoConverter(EvalProjectPoliciesArg.class),
-                voidConverter(),
-                Duration.ofMinutes(5));
+                voidConverter());
         registerActivity(
                 engine,
                 new FetchPackageMetadataResolutionCandidatesActivity(pluginManager),
                 voidConverter(),
-                protoConverter(FetchPackageMetadataResolutionCandidatesRes.class),
-                Duration.ofMinutes(1));
+                protoConverter(FetchPackageMetadataResolutionCandidatesRes.class));
         registerActivity(
                 engine,
                 new FetchProjectMetricsUpdateCandidatesActivity(),
                 voidConverter(),
-                protoConverter(FetchProjectMetricsUpdateCandidatesRes.class),
-                Duration.ofMinutes(1));
+                protoConverter(FetchProjectMetricsUpdateCandidatesRes.class));
         registerActivity(
                 engine,
                 new InvokeVulnAnalyzerActivity(fileStorage, pluginManager),
                 protoConverter(InvokeVulnAnalyzerArg.class),
-                protoConverter(InvokeVulnAnalyzerRes.class),
-                Duration.ofMinutes(5));
+                protoConverter(InvokeVulnAnalyzerRes.class));
         registerActivity(
                 engine,
                 new MirrorVulnDataSourceActivity(pluginManager),
                 protoConverter(MirrorVulnDataSourceArg.class),
-                voidConverter(),
-                // NB: Account for slow downloads, mainly of sources relying on data dumps.
-                // Activities can't heartbeat while blocked on I/O.
-                Duration.ofMinutes(15));
+                voidConverter());
         registerActivity(
                 engine,
                 new MirrorKevDataSourceActivity(pluginManager),
                 protoConverter(MirrorKevDataSourceArg.class),
-                voidConverter(),
-                Duration.ofMinutes(5));
+                voidConverter());
         registerActivity(
                 engine,
                 new PrepareVulnAnalysisActivity(fileStorage, pluginManager),
                 protoConverter(PrepareVulnAnalysisArg.class),
-                protoConverter(PrepareVulnAnalysisRes.class),
-                Duration.ofMinutes(5));
+                protoConverter(PrepareVulnAnalysisRes.class));
         registerActivity(
                 engine,
                 new ProcessScheduledNotificationRuleActivity(
@@ -310,8 +297,7 @@ public final class DexEngineInitializer implements ServletContextListener {
                         fileStorage,
                         config.getValue(ConfigKeys.NOTIFICATION_OUTBOX_RELAY_LARGE_NOTIFICATION_THRESHOLD_BYTES, int.class)),
                 protoConverter(ProcessScheduledNotificationRuleArg.class),
-                voidConverter(),
-                Duration.ofMinutes(5));
+                voidConverter());
         registerActivity(
                 engine,
                 new PublishNotificationActivity(
@@ -320,8 +306,7 @@ public final class DexEngineInitializer implements ServletContextListener {
                         secretManager::getSecretValue,
                         templateRendererFactory),
                 protoConverter(PublishNotificationActivityArg.class),
-                voidConverter(),
-                Duration.ofMinutes(1));
+                voidConverter());
         registerActivity(
                 engine,
                 new ReconcileVulnAnalysisResultsActivity(
@@ -329,38 +314,32 @@ public final class DexEngineInitializer implements ServletContextListener {
                         pluginManager,
                         new CelVulnerabilityPolicyEvaluator()),
                 protoConverter(ReconcileVulnAnalysisResultsArg.class),
-                voidConverter(),
-                Duration.ofMinutes(5));
+                voidConverter());
         registerActivity(
                 engine,
                 new RefreshGlobalPortfolioMetricsActivity(),
                 voidConverter(),
-                voidConverter(),
-                Duration.ofMinutes(5));
+                voidConverter());
         registerActivity(
                 engine,
                 new RefreshVulnerabilityMetricsActivity(),
                 voidConverter(),
-                voidConverter(),
-                Duration.ofMinutes(5));
+                voidConverter());
         registerActivity(
                 engine,
                 new ResolvePackageMetadataActivity(pluginManager, secretManager),
                 protoConverter(ResolvePackageMetadataActivityArg.class),
-                voidConverter(),
-                Duration.ofMinutes(10));
+                voidConverter());
         registerActivity(
                 engine,
                 new SyncVulnPolicyBundleActivity(config, HttpClient.INSTANCE),
                 protoConverter(SyncVulnPolicyBundleArg.class),
-                voidConverter(),
-                Duration.ofMinutes(5));
+                voidConverter());
         registerActivity(
                 engine,
                 new UpdateProjectMetricsActivity(),
                 protoConverter(UpdateProjectMetricsArg.class),
-                voidConverter(),
-                Duration.ofMinutes(5));
+                voidConverter());
 
         ensureTaskQueues(engine, List.of(
                 new CreateTaskQueueRequest(TaskType.WORKFLOW, "default", 1000),
@@ -438,6 +417,9 @@ public final class DexEngineInitializer implements ServletContextListener {
                 .map(Duration::ofMillis)
                 .ifPresent(engineConfig::setQueryTimeout);
 
+        config.getOptionalValue("dt.dex-engine.activity.lock-timeout-ms", long.class)
+                .map(Duration::ofMillis)
+                .ifPresent(engineConfig::setDefaultActivityLockTimeout);
         config.getOptionalValue("dt.dex-engine.activity.execution-timeout-ms", long.class)
                 .map(Duration::ofMillis)
                 .ifPresent(engineConfig::setDefaultActivityExecutionTimeout);
@@ -623,8 +605,7 @@ public final class DexEngineInitializer implements ServletContextListener {
             DexEngine engine,
             Activity<A, R> activity,
             PayloadConverter<A> argumentConverter,
-            PayloadConverter<R> resultConverter,
-            Duration lockTimeout) {
+            PayloadConverter<R> resultConverter) {
         final var activitySpec = activity.getClass().getAnnotation(ActivitySpec.class);
         requireNonNull(activitySpec, "Activity class must be annotated with @" + ActivitySpec.class.getSimpleName());
 
@@ -634,7 +615,12 @@ public final class DexEngineInitializer implements ServletContextListener {
                 .map(Duration::ofMillis)
                 .orElse(null);
 
-        engine.registerActivity(activity, argumentConverter, resultConverter, lockTimeout, executionTimeout);
+        engine.registerActivity(
+                activity,
+                argumentConverter,
+                resultConverter,
+                /* lockTimeout */ null,
+                executionTimeout);
     }
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/kevdatasource/MirrorKevDataSourceActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/kevdatasource/MirrorKevDataSourceActivity.java
@@ -90,7 +90,6 @@ public final class MirrorKevDataSourceActivity implements Activity<MirrorKevData
                         throw new InterruptedException(
                                 "Interrupted before all KEV assertions could be consumed");
                     }
-                    ctx.maybeHeartbeat();
 
                     final KevAssertion assertion = dataSource.next();
                     batch.add(assertion);

--- a/apiserver/src/main/java/org/dependencytrack/pkgmetadata/ResolvePackageMetadataActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/pkgmetadata/ResolvePackageMetadataActivity.java
@@ -137,7 +137,6 @@ public final class ResolvePackageMetadataActivity implements Activity<ResolvePac
                         resultBuffer.flush();
                         throw new InterruptedException("Interrupted before all PURLs could be resolved");
                     }
-                    ctx.maybeHeartbeat();
 
                     MDC.put(MDC_PURL, purlStr);
                     try {

--- a/apiserver/src/main/java/org/dependencytrack/tasks/IdentifyInternalComponentsActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/IdentifyInternalComponentsActivity.java
@@ -70,7 +70,6 @@ public final class IdentifyInternalComponentsActivity implements Activity<Void, 
             if (Thread.interrupted()) {
                 throw new InterruptedException("Interrupted before all components could be processed");
             }
-            ctx.maybeHeartbeat();
 
             for (final Component component : components) {
                 String coordinates = component.getName();

--- a/apiserver/src/main/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivity.java
@@ -120,7 +120,6 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
                     if (Thread.interrupted()) {
                         throw new InterruptedException("Interrupted before all vulnerabilities could be consumed");
                     }
-                    ctx.maybeHeartbeat();
 
                     final Bom bov = dataSource.next();
                     bovBatch.add(bov);
@@ -136,7 +135,6 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
                 }
 
                 if (!bovBatch.isEmpty()) {
-                    ctx.maybeHeartbeat();
                     processBatch(dataSource, bovBatch, source, arg.getDataSourceName(), updatePolicy);
                     vulnsProcessed += bovBatch.size();
                     bovBatch.clear();

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -1240,6 +1240,19 @@ dt.dex-engine.datasource.name=default
 # @type:     integer
 # dt.dex-engine.query-timeout-ms=10000
 
+# Defines the duration in milliseconds for which activity tasks are locked while executing.
+# <br/><br/>
+# Locks are renewed for as long as an activity executes, so this does not limit how long an
+# activity may run. It primarily determines how quickly the tasks of a dead node are picked up
+# by another one. Lowering it speeds up failover, at the risk of tasks being taken over
+# while their original node is merely slow to renew.
+# <br/><br/>
+# Values too short for the engine to renew a lock before it expires are rejected on startup.
+#
+# @category: Durable Execution
+# @type:     integer
+# dt.dex-engine.activity.lock-timeout-ms=300000
+
 # Defines the maximum duration in milliseconds a single activity execution attempt may take.
 # <br/><br/>
 # Applies to all activities that do not define their own `dt.dex-engine.activity.<name>.execution-timeout-ms`.

--- a/apiserver/src/test/java/org/dependencytrack/analysis/AnalyzeProjectWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/analysis/AnalyzeProjectWorkflowTest.java
@@ -87,13 +87,11 @@ class AnalyzeProjectWorkflowTest extends PersistenceCapableTest {
         engine.registerActivity(
                 evalProjectPoliciesActivityMock,
                 protoConverter(EvalProjectPoliciesArg.class),
-                voidConverter(),
-                Duration.ofSeconds(5));
+                voidConverter());
         engine.registerActivity(
                 updateProjectMetricsActivityMock,
                 protoConverter(UpdateProjectMetricsArg.class),
-                voidConverter(),
-                Duration.ofSeconds(5));
+                voidConverter());
 
         engine.createTaskQueue(new CreateTaskQueueRequest(TaskType.WORKFLOW, "default", 1));
         engine.createTaskQueue(new CreateTaskQueueRequest(TaskType.ACTIVITY, "default", 1));

--- a/apiserver/src/test/java/org/dependencytrack/metrics/UpdatePortfolioMetricsWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/metrics/UpdatePortfolioMetricsWorkflowTest.java
@@ -79,18 +79,15 @@ class UpdatePortfolioMetricsWorkflowTest extends AbstractMetricsUpdateTaskTest {
         engine.registerActivity(
                 new FetchProjectMetricsUpdateCandidatesActivity(),
                 voidConverter(),
-                protoConverter(FetchProjectMetricsUpdateCandidatesRes.class),
-                Duration.ofSeconds(10));
+                protoConverter(FetchProjectMetricsUpdateCandidatesRes.class));
         engine.registerActivity(
                 new RefreshGlobalPortfolioMetricsActivity(),
                 voidConverter(),
-                voidConverter(),
-                Duration.ofSeconds(10));
+                voidConverter());
         engine.registerActivity(
                 new UpdateProjectMetricsActivity(),
                 protoConverter(UpdateProjectMetricsArg.class),
-                voidConverter(),
-                Duration.ofSeconds(10));
+                voidConverter());
 
         engine.createTaskQueue(new CreateTaskQueueRequest(TaskType.WORKFLOW, "default", 1));
         engine.createTaskQueue(new CreateTaskQueueRequest(TaskType.ACTIVITY, "default", 1));

--- a/apiserver/src/test/java/org/dependencytrack/notification/ProcessScheduledNotificationsWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/notification/ProcessScheduledNotificationsWorkflowTest.java
@@ -80,8 +80,7 @@ class ProcessScheduledNotificationsWorkflowTest extends PersistenceCapableTest {
                         new MemoryFileStorage(),
                         Integer.MAX_VALUE),
                 protoConverter(ProcessScheduledNotificationRuleArg.class),
-                voidConverter(),
-                Duration.ofSeconds(15));
+                voidConverter());
 
         engine.createTaskQueue(new CreateTaskQueueRequest(TaskType.WORKFLOW, "default", 1));
         engine.createTaskQueue(new CreateTaskQueueRequest(TaskType.ACTIVITY, "notifications", 1));

--- a/apiserver/src/test/java/org/dependencytrack/notification/PublishNotificationWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/notification/PublishNotificationWorkflowTest.java
@@ -104,13 +104,11 @@ class PublishNotificationWorkflowTest extends PersistenceCapableTest {
                         secretName -> null,
                         new PebbleNotificationTemplateRendererFactory(Collections.emptyMap())),
                 protoConverter(PublishNotificationActivityArg.class),
-                voidConverter(),
-                Duration.ofSeconds(15));
+                voidConverter());
         engine.registerActivity(
                 new DeleteFilesActivity(fileStorage),
                 protoConverter(DeleteFilesArgument.class),
-                voidConverter(),
-                Duration.ofSeconds(15));
+                voidConverter());
 
         engine.createTaskQueue(new CreateTaskQueueRequest(TaskType.WORKFLOW, "default", 1));
         engine.createTaskQueue(new CreateTaskQueueRequest(TaskType.ACTIVITY, "default", 1));

--- a/apiserver/src/test/java/org/dependencytrack/pkgmetadata/ResolvePackageMetadataWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/pkgmetadata/ResolvePackageMetadataWorkflowTest.java
@@ -99,13 +99,11 @@ class ResolvePackageMetadataWorkflowTest extends PersistenceCapableTest {
         engine.registerActivity(
                 new FetchPackageMetadataResolutionCandidatesActivity(pluginManager),
                 voidConverter(),
-                protoConverter(FetchPackageMetadataResolutionCandidatesRes.class),
-                Duration.ofSeconds(5));
+                protoConverter(FetchPackageMetadataResolutionCandidatesRes.class));
         engine.registerActivity(
                 new ResolvePackageMetadataActivity(pluginManager, new TestSecretManager()),
                 protoConverter(ResolvePackageMetadataActivityArg.class),
-                voidConverter(),
-                Duration.ofSeconds(10));
+                voidConverter());
 
         engine.createTaskQueue(new CreateTaskQueueRequest(TaskType.WORKFLOW, "default", 1));
         engine.createTaskQueue(new CreateTaskQueueRequest(TaskType.ACTIVITY, "default", 1));

--- a/apiserver/src/test/java/org/dependencytrack/tasks/ImportBomWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/ImportBomWorkflowTest.java
@@ -90,13 +90,11 @@ class ImportBomWorkflowTest extends PersistenceCapableTest {
                 new ImportBomActivity(
                         fileStorage, mock(DexEngine.class), false),
                 protoConverter(ImportBomArg.class),
-                voidConverter(),
-                Duration.ofSeconds(30));
+                voidConverter());
         engine.registerActivity(
                 new DeleteFilesActivity(fileStorage),
                 protoConverter(DeleteFilesArgument.class),
-                voidConverter(),
-                Duration.ofSeconds(5));
+                voidConverter());
 
         engine.createTaskQueue(new CreateTaskQueueRequest(TaskType.WORKFLOW, "default", 1));
         engine.createTaskQueue(new CreateTaskQueueRequest(TaskType.ACTIVITY, "default", 1));

--- a/apiserver/src/test/java/org/dependencytrack/tasks/ImportVexWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/ImportVexWorkflowTest.java
@@ -81,13 +81,11 @@ class ImportVexWorkflowTest extends PersistenceCapableTest {
         engine.registerActivity(
                 new ImportVexActivity(fileStorage),
                 protoConverter(ImportVexArg.class),
-                voidConverter(),
-                Duration.ofSeconds(30));
+                voidConverter());
         engine.registerActivity(
                 new DeleteFilesActivity(fileStorage),
                 protoConverter(DeleteFilesArgument.class),
-                voidConverter(),
-                Duration.ofSeconds(5));
+                voidConverter());
 
         engine.createTaskQueue(new CreateTaskQueueRequest(TaskType.WORKFLOW, "default", 1));
         engine.createTaskQueue(new CreateTaskQueueRequest(TaskType.ACTIVITY, "default", 1));

--- a/apiserver/src/test/java/org/dependencytrack/vulnanalysis/VulnAnalysisWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/vulnanalysis/VulnAnalysisWorkflowTest.java
@@ -149,26 +149,22 @@ class VulnAnalysisWorkflowTest extends PersistenceCapableTest {
         engine.registerActivity(
                 new DeleteFilesActivity(fileStorage),
                 protoConverter(DeleteFilesArgument.class),
-                voidConverter(),
-                Duration.ofSeconds(5));
+                voidConverter());
         engine.registerActivity(
                 new InvokeVulnAnalyzerActivity(fileStorage, pluginManager),
                 protoConverter(InvokeVulnAnalyzerArg.class),
-                protoConverter(InvokeVulnAnalyzerRes.class),
-                Duration.ofSeconds(5));
+                protoConverter(InvokeVulnAnalyzerRes.class));
         engine.registerActivity(
                 new PrepareVulnAnalysisActivity(fileStorage, pluginManager),
                 protoConverter(PrepareVulnAnalysisArg.class),
-                protoConverter(PrepareVulnAnalysisRes.class),
-                Duration.ofSeconds(5));
+                protoConverter(PrepareVulnAnalysisRes.class));
         engine.registerActivity(
                 new ReconcileVulnAnalysisResultsActivity(
                         fileStorage,
                         pluginManager,
                         new CelVulnerabilityPolicyEvaluator()),
                 protoConverter(ReconcileVulnAnalysisResultsArg.class),
-                voidConverter(),
-                Duration.ofSeconds(5));
+                voidConverter());
 
         engine.createTaskQueue(new CreateTaskQueueRequest(TaskType.WORKFLOW, "default", 1));
         engine.createTaskQueue(new CreateTaskQueueRequest(TaskType.ACTIVITY, "default", 1));

--- a/dex/benchmark/src/main/java/org/dependencytrack/dex/benchmark/Application.java
+++ b/dex/benchmark/src/main/java/org/dependencytrack/dex/benchmark/Application.java
@@ -204,8 +204,7 @@ public class Application {
         dexEngine.registerActivity(
                 new DummyActivity(),
                 voidConverter(),
-                voidConverter(),
-                Duration.ofSeconds(30));
+                voidConverter());
 
         return dexEngine;
     }

--- a/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngine.java
+++ b/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngine.java
@@ -78,7 +78,6 @@ public interface DexEngine extends Closeable {
      * @param executor          The {@link Activity} of the activity.
      * @param argumentConverter The {@link PayloadConverter} to use for arguments.
      * @param resultConverter   The {@link PayloadConverter} to use for results.
-     * @param lockTimeout       How instances of this activity shall be locked for execution.
      * @param <A>               Type of the activity's argument.
      * @param <R>               Type of the activity's result.
      * @throws IllegalStateException When the engine was already started.
@@ -86,9 +85,8 @@ public interface DexEngine extends Closeable {
     default <A, R> void registerActivity(
             Activity<A, R> executor,
             PayloadConverter<A> argumentConverter,
-            PayloadConverter<R> resultConverter,
-            Duration lockTimeout) {
-        registerActivity(executor, argumentConverter, resultConverter, lockTimeout, null);
+            PayloadConverter<R> resultConverter) {
+        registerActivity(executor, argumentConverter, resultConverter, null, null);
     }
 
     /**
@@ -100,6 +98,7 @@ public interface DexEngine extends Closeable {
      * @param argumentConverter The {@link PayloadConverter} to use for arguments.
      * @param resultConverter   The {@link PayloadConverter} to use for results.
      * @param lockTimeout       How instances of this activity shall be locked for execution.
+     *                          When {@code null}, {@link DexEngineConfig#defaultActivityLockTimeout()} is assumed.
      * @param executionTimeout  Maximum time the activity may execute before it is cancelled.
      *                          When {@code null}, {@link DexEngineConfig#defaultActivityExecutionTimeout()} is assumed.
      * @param <A>               Type of the activity's argument.
@@ -110,7 +109,7 @@ public interface DexEngine extends Closeable {
             Activity<A, R> executor,
             PayloadConverter<A> argumentConverter,
             PayloadConverter<R> resultConverter,
-            Duration lockTimeout,
+            @Nullable Duration lockTimeout,
             @Nullable Duration executionTimeout);
 
     /**

--- a/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngineConfig.java
+++ b/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngineConfig.java
@@ -357,8 +357,10 @@ public class DexEngineConfig {
     private final TaskSchedulerConfig activityTaskSchedulerConfig = new TaskSchedulerConfig();
 
     private Duration queryTimeout = Duration.ofSeconds(10);
+    private Duration defaultActivityLockTimeout = Duration.ofMinutes(5);
     private Duration defaultActivityExecutionTimeout = Duration.ofHours(1);
     private PageTokenEncoder pageTokenEncoder = new SimplePageTokenEncoder();
+    private Duration activityHeartbeatInterval = Duration.ofSeconds(5);
 
     public DexEngineConfig(DataSource dataSource) {
         this.instanceId = generateInstanceId();
@@ -406,6 +408,22 @@ public class DexEngineConfig {
     }
 
     /**
+     * @return Interval at which the activity heartbeat scheduler renews locks close to expiry.
+     * Must be much smaller than the smallest activity lock timeout.
+     */
+    public Duration activityHeartbeatInterval() {
+        return activityHeartbeatInterval;
+    }
+
+    public void setActivityHeartbeatInterval(Duration activityHeartbeatInterval) {
+        requireNonNull(activityHeartbeatInterval, "activityHeartbeatInterval must not be null");
+        if (!activityHeartbeatInterval.isPositive()) {
+            throw new IllegalArgumentException("activityHeartbeatInterval must not be negative or zero");
+        }
+        this.activityHeartbeatInterval = activityHeartbeatInterval;
+    }
+
+    /**
      * @return Maintenance config.
      */
     public MaintenanceConfig maintenance() {
@@ -440,6 +458,21 @@ public class DexEngineConfig {
             throw new IllegalArgumentException("queryTimeout must not be negative or zero");
         }
         this.queryTimeout = queryTimeout;
+    }
+
+    /**
+     * @return Lock timeout applied to activities registered without an explicit one.
+     */
+    public Duration defaultActivityLockTimeout() {
+        return defaultActivityLockTimeout;
+    }
+
+    public void setDefaultActivityLockTimeout(Duration defaultActivityLockTimeout) {
+        requireNonNull(defaultActivityLockTimeout, "defaultActivityLockTimeout must not be null");
+        if (!defaultActivityLockTimeout.isPositive()) {
+            throw new IllegalArgumentException("defaultActivityLockTimeout must not be negative or zero");
+        }
+        this.defaultActivityLockTimeout = defaultActivityLockTimeout;
     }
 
     /**
@@ -480,6 +513,7 @@ public class DexEngineConfig {
                 .add("workflowTaskSchedulerConfig=" + workflowTaskSchedulerConfig)
                 .add("activityTaskSchedulerConfig=" + activityTaskSchedulerConfig)
                 .add("queryTimeout=" + queryTimeout)
+                .add("defaultActivityLockTimeout=" + defaultActivityLockTimeout)
                 .add("defaultActivityExecutionTimeout=" + defaultActivityExecutionTimeout)
                 .add("pageTokenEncoder=" + pageTokenEncoder)
                 .toString();

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityContextImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityContextImpl.java
@@ -20,62 +20,19 @@ package org.dependencytrack.dex.engine;
 
 import org.dependencytrack.dex.api.ActivityContext;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 
 final class ActivityContextImpl implements ActivityContext {
 
-    private final DexEngineImpl engine;
     private final ActivityTask task;
-    private final Duration lockTimeout;
 
-    ActivityContextImpl(
-            final DexEngineImpl engine,
-            final ActivityTask task,
-            final Duration lockTimeout) {
-        this.engine = engine;
+    ActivityContextImpl(final ActivityTask task) {
         this.task = task;
-        this.lockTimeout = lockTimeout;
     }
 
     @Override
     public UUID workflowRunId() {
         return task.id().workflowRunId();
-    }
-
-    @Override
-    public boolean maybeHeartbeat() {
-        // Debounce heartbeats such that they're only emitted if the current
-        // lock is almost expired. "Almost" in this case referring to 1/3 of
-        // or less of the lock timeout remaining.
-        final Instant now = Instant.now();
-        final Instant threshold = task.lock().expiresAt().minus(lockTimeout.dividedBy(3));
-        if (now.isBefore(threshold)) {
-            return false;
-        }
-
-        final CompletableFuture<TaskLock> newLockFuture =
-                engine.heartbeatActivityTask(task.id(), task.lock(), lockTimeout);
-
-        final TaskLock newLock;
-        try {
-            newLock = newLockFuture.join();
-        } catch (CompletionException e) {
-            // The completion exception has no meaning to callers of this method.
-            // Unwrap its cause if possible.
-            switch (e.getCause()) {
-                case RuntimeException re -> throw re;
-                case Error err -> throw err;
-                case null -> throw e;
-                default -> throw new IllegalStateException(e.getCause());
-            }
-        }
-
-        task.setLock(newLock);
-        return true;
     }
 
 }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityHeartbeatRegistration.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityHeartbeatRegistration.java
@@ -16,18 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-package org.dependencytrack.dex.api;
+package org.dependencytrack.dex.engine;
 
-import java.util.UUID;
+@FunctionalInterface
+interface ActivityHeartbeatRegistration extends AutoCloseable {
 
-/**
- * Context available to {@link Activity}s.
- */
-public interface ActivityContext {
-
-    /**
-     * @return ID of the workflow run that this activity execution is part of.
-     */
-    UUID workflowRunId();
+    @Override
+    void close();
 
 }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityHeartbeatScheduler.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityHeartbeatScheduler.java
@@ -1,0 +1,293 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.dex.engine;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.io.Closeable;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static org.dependencytrack.dex.engine.MdcKeys.MDC_ACTIVITY_NAME;
+import static org.dependencytrack.dex.engine.MdcKeys.MDC_ACTIVITY_TASK_EXECUTION_ID;
+import static org.dependencytrack.dex.engine.MdcKeys.MDC_WORKFLOW_RUN_ID;
+
+final class ActivityHeartbeatScheduler implements Closeable {
+
+    @FunctionalInterface
+    interface LockRenewer {
+
+        @Nullable CompletableFuture<TaskLock> tryRenew(
+                ActivityTaskId taskId,
+                TaskLock currentLock,
+                Duration lockTimeout);
+
+    }
+
+    private record Registration(
+            String activityName,
+            ActivityTaskId taskId,
+            String executionId,
+            Duration lockTimeout,
+            Supplier<TaskLock> lockGetter,
+            Consumer<TaskLock> lockSetter,
+            Future<?> activityFuture,
+            AtomicReference<@Nullable CompletableFuture<TaskLock>> pendingLockRenewal) {
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ActivityHeartbeatScheduler.class);
+    private static final int LOCK_RENEWAL_MARGIN_DIVISOR = 3;
+    private static final int GIVE_UP_MARGIN_INTERVALS = 2;
+    private static final Duration UNREGISTER_RENEWAL_SETTLE_TIMEOUT = Duration.ofSeconds(10);
+
+    private final LockRenewer lockRenewer;
+    private final Duration interval;
+    private final Duration giveUpMargin;
+    private final Clock clock;
+    private final Map<Future<?>, Registration> registrationByActivityFuture;
+    private final ScheduledExecutorService scheduler;
+
+    ActivityHeartbeatScheduler(LockRenewer lockRenewer, Duration interval) {
+        this(lockRenewer, interval, Clock.systemUTC());
+    }
+
+    ActivityHeartbeatScheduler(LockRenewer lockRenewer, Duration interval, Clock clock) {
+        this.lockRenewer = lockRenewer;
+        this.interval = interval;
+        this.giveUpMargin = interval.multipliedBy(GIVE_UP_MARGIN_INTERVALS);
+        this.clock = clock;
+        this.registrationByActivityFuture = new ConcurrentHashMap<>();
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            final var thread = new Thread(runnable, "DexEngine-ActivityHeartbeatScheduler");
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    void start() {
+        scheduler.scheduleWithFixedDelay(
+                this::processRegistrations,
+                interval.toMillis(),
+                interval.toMillis(),
+                TimeUnit.MILLISECONDS);
+    }
+
+    void register(
+            String activityName,
+            ActivityTaskId taskId,
+            String executionId,
+            Duration lockTimeout,
+            Supplier<TaskLock> lockGetter,
+            Consumer<TaskLock> lockSetter,
+            Future<?> activityFuture) {
+        registrationByActivityFuture.put(
+                activityFuture,
+                new Registration(
+                        activityName,
+                        taskId,
+                        executionId,
+                        lockTimeout,
+                        lockGetter,
+                        lockSetter,
+                        activityFuture,
+                        new AtomicReference<>()));
+    }
+
+    void unregister(Future<?> activityFuture) {
+        final Registration registration = registrationByActivityFuture.get(activityFuture);
+        if (registration == null) {
+            return;
+        }
+
+        final CompletableFuture<TaskLock> pendingRenewal;
+        synchronized (registration) {
+            registrationByActivityFuture.remove(activityFuture);
+            pendingRenewal = registration.pendingLockRenewal().get();
+        }
+        if (pendingRenewal == null || pendingRenewal.isDone()) {
+            return;
+        }
+
+        // An in-flight renewal may already have bumped the lock version in the database.
+        // Completing the task with the previous version would fail the version check,
+        // discarding the finished execution and provoking a duplicate run. Wait for the
+        // renewal to settle so the task holds its current lock before it is completed.
+        try {
+            pendingRenewal.get(UNREGISTER_RENEWAL_SETTLE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.debug("Interrupted while waiting for pending renewal to complete");
+        } catch (ExecutionException e) {
+            if (isLockLost(e.getCause())) {
+                LOGGER.warn("""
+                        Lock was taken over by another worker while the activity was completing; \
+                        the completion will be rejected, and the task will be executed again""");
+            } else {
+                // A transient renewal failure did not bump the lock version,
+                // so the version check on task completion passes against the previous lock.
+                LOGGER.debug("Lock renewal failed while waiting for it to complete", e.getCause());
+            }
+        } catch (TimeoutException e) {
+            LOGGER.warn("""
+                            Lock renewal did not complete within {}; completing the task may \
+                            race the renewal and be rejected, provoking a duplicate execution""",
+                    UNREGISTER_RENEWAL_SETTLE_TIMEOUT);
+        }
+    }
+
+    void processRegistrations() {
+        for (final Registration registration : registrationByActivityFuture.values()) {
+            MDC.put(MDC_WORKFLOW_RUN_ID, registration.taskId().workflowRunId().toString());
+            MDC.put(MDC_ACTIVITY_NAME, registration.activityName());
+            MDC.put(MDC_ACTIVITY_TASK_EXECUTION_ID, registration.executionId());
+            try {
+                process(registration);
+            } catch (RuntimeException e) {
+                LOGGER.error("Failed to process heartbeat", e);
+            } finally {
+                MDC.remove(MDC_WORKFLOW_RUN_ID);
+                MDC.remove(MDC_ACTIVITY_NAME);
+                MDC.remove(MDC_ACTIVITY_TASK_EXECUTION_ID);
+            }
+        }
+    }
+
+    private void process(Registration registration) {
+        // NB: We must read the pending renewal before the lock, because the renewal callback
+        // publishes the new lock before its future completes, so an absent or completed pending
+        // renewal guarantees the lock read below is current.
+        final CompletableFuture<TaskLock> pendingRenewal = registration.pendingLockRenewal().get();
+        final boolean isRenewalInFlight = pendingRenewal != null && !pendingRenewal.isDone();
+
+        final Instant now = clock.instant();
+        final Instant expiresAt = registration.lockGetter().get().expiresAt();
+
+        if (isRenewalInFlight) {
+            // The pending renewal will either extend the lock or cancel the activity
+            // when it completes, and the local expiry may be stale until then.
+            // But once the lock has fully expired, stop the activity regardless.
+            // It must not keep running under a lock we no longer hold.
+            if (!now.isBefore(expiresAt)) {
+                onLockLost(registration, "its lock expired before an in-flight renewal completed");
+            }
+
+            return;
+        }
+
+        // The lock will expire before it can be renewed again, or already has.
+        // Another worker may take the task over, so stop the activity now instead of
+        // letting it run under a lock we no longer hold.
+        if (!now.isBefore(expiresAt.minus(giveUpMargin))) {
+            onLockLost(registration, "its lock expired before it could be renewed");
+            return;
+        }
+
+        // Debounce heartbeats such that they're only emitted once the current
+        // lock is close to expiry, i.e. within the renewal margin.
+        if (now.isBefore(expiresAt.minus(registration.lockTimeout().dividedBy(LOCK_RENEWAL_MARGIN_DIVISOR)))) {
+            return;
+        }
+
+        synchronized (registration) {
+            if (!registrationByActivityFuture.containsKey(registration.activityFuture())) {
+                return;
+            }
+
+            final CompletableFuture<TaskLock> renewalFuture =
+                    lockRenewer.tryRenew(
+                            registration.taskId(),
+                            registration.lockGetter().get(),
+                            registration.lockTimeout());
+            if (renewalFuture == null) {
+                return;
+            }
+
+            // NB: The stored future completes only after the callback ran and the new
+            // lock was set. unregister() relies on that. Since only the scheduler thread
+            // starts renewals, and never while one is pending, no two renewals can
+            // update the same lock at once.
+            registration.pendingLockRenewal().set(
+                    renewalFuture.whenComplete((newLock, error) -> {
+                        if (error == null && newLock != null) {
+                            registration.lockSetter().accept(newLock);
+                        } else if (isLockLost(error)) {
+                            onLockLost(registration, "its lock was taken over by another worker");
+                        }
+
+                        // NB: Any other error is transient. The deadline checks earlier in the
+                        // method cancel the activity if we cannot renew before the lock expires.
+                    }));
+        }
+    }
+
+    @Override
+    public void close() {
+        scheduler.shutdownNow();
+        try {
+            if (!scheduler.awaitTermination(3, TimeUnit.SECONDS)) {
+                LOGGER.warn("Heartbeat scheduler did not terminate in time");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        registrationByActivityFuture.clear();
+    }
+
+    static Duration minSupportedLockTimeout(Duration interval) {
+        // To guarantee a scheduler run happens between the start of the renewal window and
+        // the give-up deadline, the window must span at least one interval, i.e.:
+        //   lockTimeout / RENEWAL_MARGIN_DIVISOR - GIVE_UP_MARGIN_INTERVALS * interval >= interval
+        // Shorter locks would be cancelled without a renewal ever being attempted.
+        return interval.multipliedBy(LOCK_RENEWAL_MARGIN_DIVISOR * (GIVE_UP_MARGIN_INTERVALS + 1));
+    }
+
+    private void onLockLost(Registration registration, String reason) {
+        if (registrationByActivityFuture.remove(registration.activityFuture()) == null) {
+            return;
+        }
+
+        LOGGER.warn("Cancelling execution because {}", reason);
+        registration.activityFuture().cancel(/* mayInterruptIfRunning */ true);
+    }
+
+    private static boolean isLockLost(@Nullable Throwable error) {
+        final Throwable cause = error instanceof CompletionException
+                ? error.getCause()
+                : error;
+        return cause instanceof TaskLockLostException;
+    }
+
+}

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTask.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTask.java
@@ -23,6 +23,8 @@ import org.dependencytrack.dex.engine.persistence.model.PolledActivityTask;
 import org.dependencytrack.dex.proto.payload.v1.Payload;
 import org.jspecify.annotations.Nullable;
 
+import java.util.UUID;
+
 public final class ActivityTask implements Task {
 
     private final String activityName;
@@ -30,7 +32,8 @@ public final class ActivityTask implements Task {
     private final @Nullable Payload argument;
     private final RetryPolicy retryPolicy;
     private final int attempt;
-    private TaskLock lock;
+    private final String executionId;
+    private volatile TaskLock lock;
 
     private ActivityTask(
             final String activityName,
@@ -38,12 +41,14 @@ public final class ActivityTask implements Task {
             final @Nullable Payload argument,
             final RetryPolicy retryPolicy,
             final int attempt,
+            final String executionId,
             final TaskLock lock) {
         this.activityName = activityName;
         this.id = id;
         this.argument = argument;
         this.retryPolicy = retryPolicy;
         this.attempt = attempt;
+        this.executionId = executionId;
         this.lock = lock;
     }
 
@@ -57,6 +62,7 @@ public final class ActivityTask implements Task {
                 polledTask.argument(),
                 RetryPolicy.fromProto(polledTask.retryPolicy()),
                 polledTask.attempt(),
+                UUID.randomUUID().toString(),
                 new TaskLock(
                         polledTask.lockedUntil(),
                         polledTask.lockVersion()));
@@ -85,6 +91,10 @@ public final class ActivityTask implements Task {
 
     public int attempt() {
         return attempt;
+    }
+
+    public String executionId() {
+        return executionId;
     }
 
     public TaskLock lock() {

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskScheduler.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskScheduler.java
@@ -43,6 +43,8 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import static org.dependencytrack.dex.engine.MdcKeys.MDC_QUEUE_NAME;
+
 final class ActivityTaskScheduler implements Closeable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ActivityTaskScheduler.class);
@@ -204,7 +206,7 @@ final class ActivityTaskScheduler implements Closeable {
         boolean didScheduleTasks = false;
         for (final Queue queue : queues) {
             final Timer.Sample latencySample = Timer.start();
-            try (var _ = MDC.putCloseable("queueName", queue.name())) {
+            try (var _ = MDC.putCloseable(MDC_QUEUE_NAME, queue.name())) {
                 didScheduleTasks |= jdbi.inTransaction(handle -> processQueue(handle, queue));
             } finally {
                 latencySample.stop(

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
@@ -35,6 +35,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -46,6 +47,10 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
 
 import static java.util.Objects.requireNonNull;
+import static org.dependencytrack.dex.engine.MdcKeys.MDC_ACTIVITY_NAME;
+import static org.dependencytrack.dex.engine.MdcKeys.MDC_ACTIVITY_TASK_ATTEMPT;
+import static org.dependencytrack.dex.engine.MdcKeys.MDC_ACTIVITY_TASK_EXECUTION_ID;
+import static org.dependencytrack.dex.engine.MdcKeys.MDC_WORKFLOW_RUN_ID;
 
 final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
 
@@ -86,9 +91,10 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
     @Override
     @SuppressWarnings({"rawtypes", "unchecked"})
     void process(final ActivityTask task) {
-        try (var _ = MDC.putCloseable("workflowRunId", task.id().workflowRunId().toString());
-             var _ = MDC.putCloseable("activityName", task.activityName());
-             var _ = MDC.putCloseable("activityTaskAttempt", String.valueOf(task.attempt()))) {
+        try (var _ = MDC.putCloseable(MDC_WORKFLOW_RUN_ID, task.id().workflowRunId().toString());
+             var _ = MDC.putCloseable(MDC_ACTIVITY_NAME, task.activityName());
+             var _ = MDC.putCloseable(MDC_ACTIVITY_TASK_ATTEMPT, String.valueOf(task.attempt()));
+             var _ = MDC.putCloseable(MDC_ACTIVITY_TASK_EXECUTION_ID, task.executionId())) {
             final ActivityMetadata activityMetadata;
             try {
                 activityMetadata = metadataRegistry.getActivityMetadata(task.activityName());
@@ -98,21 +104,15 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
                 return;
             }
 
-            final var ctx = new ActivityContextImpl(engine, task, activityMetadata.lockTimeout());
-
             final Object arg;
             try {
                 arg = activityMetadata.argumentConverter().convertFromPayload(task.argument());
             } catch (RuntimeException e) {
-                logger.warn("Failed to deserialize activity argument; Failing task terminally", e);
-                engine.onTaskEvent(
-                        new ActivityTaskFailedEvent(
-                                task,
-                                new TerminalApplicationFailureException(e),
-                                /* retryAt */ null));
+                fail(task, "Failed to deserialize activity argument", new TerminalApplicationFailureException(e));
                 return;
             }
 
+            final var ctx = new ActivityContextImpl(task);
             final var executionStoppedLatch = new CountDownLatch(1);
             final Future<Object> executionFuture;
             try {
@@ -130,84 +130,57 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
             }
 
             final Duration executionTimeout = activityMetadata.executionTimeout();
-            try {
-                final Object activityResult = executionFuture.get(executionTimeout.toMillis(), TimeUnit.MILLISECONDS);
-                final Payload result;
-                try {
-                    result = activityMetadata.resultConverter().convertToPayload(activityResult);
-                } catch (RuntimeException e) {
-                    logger.warn("Failed to serialize activity result; Failing task terminally", e);
-                    engine.onTaskEvent(
-                            new ActivityTaskFailedEvent(
-                                    task,
-                                    new TerminalApplicationFailureException(e),
-                                    /* retryAt */ null));
-                    return;
-                }
-                engine.onTaskEvent(new ActivityTaskCompletedEvent(task, result));
+            final ActivityHeartbeatRegistration heartbeatRegistration =
+                    engine.registerActivityHeartbeat(
+                            task,
+                            activityMetadata.lockTimeout(),
+                            executionFuture);
+            final Object activityResult;
+
+            try (heartbeatRegistration) {
+                activityResult = executionFuture.get(executionTimeout.toMillis(), TimeUnit.MILLISECONDS);
+            } catch (CancellationException e) {
+                tryAwaitExecutionCompletion(executionStoppedLatch);
+                logger.warn("""
+                        Activity task lock was lost; discarding this execution as \
+                        another worker has taken over the task""");
+                return;
             } catch (TimeoutException e) {
                 executionFuture.cancel(/* interruptIfRunning */ true);
+                tryAwaitExecutionCompletion(executionStoppedLatch);
 
-                // Wait a short moment for the activity task to terminate before moving on.
-                //
-                // NB: Calling Future#get after cancellation returns immediately even
-                // when the backing task is still executing. Hence, using a latch instead.
-                try {
-                    if (!executionStoppedLatch.await(5, TimeUnit.SECONDS)) {
-                        logger.warn("""
-                                Activity did not complete within 5s after cancellation; \
-                                the next attempt may run concurrently with it""");
-                    }
-                } catch (InterruptedException _) {
-                    logger.debug("Interrupted while waiting for cancelled task execution to complete");
-                }
-
-                final var cause = new TimeoutException(
-                        "Activity execution exceeded timeout of %s".formatted(
-                                executionTimeout));
+                final String message = "Activity execution exceeded timeout of %s".formatted(executionTimeout);
+                final var cause = new TimeoutException(message);
                 cause.initCause(e);
 
-                final Instant retryAt = computeRetryAt(task, cause);
-                if (retryAt == null) {
-                    logger.warn(
-                            "Activity execution exceeded timeout of {}; Failing task terminally",
-                            executionTimeout);
-                } else {
-                    logger.warn(
-                            "Activity execution exceeded timeout of {}; Next retry due at {} (attempt {}/{})",
-                            executionTimeout,
-                            retryAt,
-                            task.attempt() + 1,
-                            task.retryPolicy().maxAttempts());
-                }
-                engine.onTaskEvent(new ActivityTaskFailedEvent(task, cause, retryAt));
+                fail(task, message, cause);
+                return;
             } catch (ExecutionException e) {
                 final Throwable cause = e.getCause();
                 if (cause instanceof InterruptedException || executionExecutor.isShutdown()) {
                     logger.debug("Activity was interrupted or worker is shutting down; abandoning task");
                     abandon(task);
-                } else if (cause instanceof TaskLockLostException) {
-                    logger.warn("""
-                            Activity task lock was lost, likely because execution took longer than \
-                            the lock timeout without a heartbeat; discarding this execution as \
-                            another worker has taken over the task""");
                 } else {
-                    final Instant retryAt = computeRetryAt(task, cause);
-                    if (retryAt == null) {
-                        logger.warn("Activity failed terminally after {} attempt(s)", task.attempt(), cause);
-                    } else {
-                        logger.warn(
-                                "Activity failed; Next retry due at {} (attempt {}/{})",
-                                retryAt, task.attempt() + 1, task.retryPolicy().maxAttempts(), cause);
-                    }
-                    engine.onTaskEvent(new ActivityTaskFailedEvent(task, cause, retryAt));
+                    fail(task, "Activity failed", cause);
                 }
+                return;
             } catch (InterruptedException e) {
                 logger.debug("Interrupted while waiting for activity execution to complete; Abandoning task");
                 executionFuture.cancel(true);
                 abandon(task);
                 Thread.currentThread().interrupt();
+                return;
             }
+
+            final Payload result;
+            try {
+                result = activityMetadata.resultConverter().convertToPayload(activityResult);
+            } catch (RuntimeException e) {
+                fail(task, "Failed to serialize activity result", new TerminalApplicationFailureException(e));
+                return;
+            }
+
+            engine.onTaskEvent(new ActivityTaskCompletedEvent(task, result));
         }
     }
 
@@ -228,6 +201,35 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
             Thread.currentThread().interrupt();
         }
         super.close();
+    }
+
+    private void tryAwaitExecutionCompletion(CountDownLatch executionStoppedLatch) {
+        // Wait a short moment for the activity task to terminate before moving on.
+        //
+        // NB: Calling Future#get after cancellation returns immediately even
+        // when the backing task is still executing. Hence, using a latch instead.
+        try {
+            if (!executionStoppedLatch.await(5, TimeUnit.SECONDS)) {
+                logger.warn("""
+                        Activity did not complete within 5s after cancellation; \
+                        the next attempt may run concurrently with it""");
+            }
+        } catch (InterruptedException _) {
+            logger.debug("Interrupted while waiting for cancelled task execution to complete");
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void fail(ActivityTask task, String message, Throwable cause) {
+        final Instant retryAt = computeRetryAt(task, cause);
+        if (retryAt == null) {
+            logger.warn("{}; Failing task terminally after {} attempt(s)", message, task.attempt(), cause);
+        } else {
+            logger.warn(
+                    "{}; Next retry due at {} (attempt {}/{})",
+                    message, retryAt, task.attempt() + 1, task.retryPolicy().maxAttempts(), cause);
+        }
+        engine.onTaskEvent(new ActivityTaskFailedEvent(task, cause, retryAt));
     }
 
     private static @Nullable Instant computeRetryAt(ActivityTask task, Throwable cause) {

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -118,6 +118,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReentrantLock;
@@ -172,13 +173,16 @@ final class DexEngineImpl implements DexEngine {
     private @Nullable Buffer<ExternalEvent> externalEventBuffer;
     private @Nullable Buffer<TaskEvent> taskEventBuffer;
     private @Nullable Buffer<ActivityTaskHeartbeat> activityTaskHeartbeatBuffer;
+    private @Nullable ActivityHeartbeatScheduler activityHeartbeatScheduler;
     private @Nullable CircuitBreakerRegistry bufferFlushCircuitBreakerRegistry;
     private @Nullable MaintenanceWorker maintenanceWorker;
     private @Nullable Cache<WorkflowRunHistoryCacheKey, CachedWorkflowRunHistory> runHistoryCache;
 
     DexEngineImpl(DexEngineConfig config) {
         this.config = requireNonNull(config);
-        this.metadataRegistry = new MetadataRegistry(config.defaultActivityExecutionTimeout());
+        this.metadataRegistry = new MetadataRegistry(
+                config.defaultActivityLockTimeout(),
+                config.defaultActivityExecutionTimeout());
         this.jdbi = JdbiFactory.create(config.dataSource(), config.queryTimeout(), config.pageTokenEncoder());
         this.runsCreatedCounter = Counter
                 .builder("dt.dex.engine.runs.created")
@@ -190,6 +194,8 @@ final class DexEngineImpl implements DexEngine {
 
     @Override
     public void start() {
+        requireSupportedActivityLockTimeouts();
+
         setStatus(Status.STARTING);
         LOGGER.debug("Starting");
 
@@ -348,6 +354,12 @@ final class DexEngineImpl implements DexEngine {
                 bufferFlushCircuitBreakerRegistry);
         activityTaskHeartbeatBuffer.start();
 
+        LOGGER.debug("Starting activity heartbeat scheduler");
+        activityHeartbeatScheduler = new ActivityHeartbeatScheduler(
+                this::tryHeartbeatActivityTask,
+                config.activityHeartbeatInterval());
+        activityHeartbeatScheduler.start();
+
         if (config.leaderElection().isEnabled()) {
             LOGGER.debug("Starting maintenance worker");
             maintenanceWorker = new MaintenanceWorker(
@@ -413,6 +425,12 @@ final class DexEngineImpl implements DexEngine {
             LOGGER.debug("Waiting for external event buffer to stop");
             externalEventBuffer.close();
             externalEventBuffer = null;
+        }
+
+        if (activityHeartbeatScheduler != null) {
+            LOGGER.debug("Stopping activity heartbeat scheduler");
+            activityHeartbeatScheduler.close();
+            activityHeartbeatScheduler = null;
         }
 
         if (activityTaskHeartbeatBuffer != null) {
@@ -516,7 +534,7 @@ final class DexEngineImpl implements DexEngine {
             Activity<A, R> activity,
             PayloadConverter<A> argumentConverter,
             PayloadConverter<R> resultConverter,
-            Duration lockTimeout,
+            @Nullable Duration lockTimeout,
             @Nullable Duration executionTimeout) {
         requireStatusAnyOf(Status.CREATED, Status.STOPPED);
         metadataRegistry.registerActivity(
@@ -528,7 +546,7 @@ final class DexEngineImpl implements DexEngine {
             PayloadConverter<A> argumentConverter,
             PayloadConverter<R> resultConverter,
             String defaultTaskQueueName,
-            Duration lockTimeout,
+            @Nullable Duration lockTimeout,
             Activity<A, R> activity) {
         registerActivityInternal(
                 activityName,
@@ -545,7 +563,7 @@ final class DexEngineImpl implements DexEngine {
             PayloadConverter<A> argumentConverter,
             PayloadConverter<R> resultConverter,
             String defaultTaskQueueName,
-            Duration lockTimeout,
+            @Nullable Duration lockTimeout,
             @Nullable Duration executionTimeout,
             Activity<A, R> activity) {
         requireStatusAnyOf(Status.CREATED, Status.STOPPED);
@@ -1582,21 +1600,73 @@ final class DexEngineImpl implements DexEngine {
         }
     }
 
-    CompletableFuture<TaskLock> heartbeatActivityTask(
+    @SuppressWarnings("rawtypes")
+    private void requireSupportedActivityLockTimeouts() {
+        final Duration minLockTimeout =
+                ActivityHeartbeatScheduler.minSupportedLockTimeout(
+                        config.activityHeartbeatInterval());
+
+        for (final ActivityMetadata metadata : metadataRegistry.getAllActivityMetadata()) {
+            if (metadata.lockTimeout().compareTo(minLockTimeout) < 0) {
+                throw new IllegalStateException("""
+                        Lock timeout %s of activity %s is too short for the activity heartbeat \
+                        interval %s: the heartbeat scheduler would give up on the lock before ever \
+                        attempting a renewal. Increase the lock timeout to at least %s, or decrease \
+                        the heartbeat interval.""".formatted(
+                        metadata.lockTimeout(),
+                        metadata.name(),
+                        config.activityHeartbeatInterval(),
+                        minLockTimeout));
+            }
+        }
+    }
+
+    ActivityHeartbeatRegistration registerActivityHeartbeat(
+            ActivityTask task,
+            Duration lockTimeout,
+            Future<?> activityFuture) {
+        // NB: STOPPING is permitted because workers keep processing already polled
+        // tasks while the engine shuts down. Those executions must keep their lock.
+        requireStatusAnyOf(Status.RUNNING, Status.STOPPING);
+        final ActivityHeartbeatScheduler scheduler = requireNonNull(
+                activityHeartbeatScheduler,
+                "activityHeartbeatScheduler must not be null");
+
+        scheduler.register(
+                task.activityName(),
+                task.id(),
+                task.executionId(),
+                lockTimeout,
+                task::lock,
+                task::setLock,
+                activityFuture);
+        return () -> scheduler.unregister(activityFuture);
+    }
+
+    private @Nullable CompletableFuture<TaskLock> tryHeartbeatActivityTask(
             ActivityTaskId taskId,
             TaskLock taskLock,
             Duration lockTimeout) {
+        final Buffer<ActivityTaskHeartbeat> buffer = activityTaskHeartbeatBuffer;
+        if (buffer == null) {
+            return null;
+        }
+
         final var future = new CompletableFuture<TaskLock>();
         final var heartbeat = new ActivityTaskHeartbeat(taskId, taskLock, lockTimeout, future);
-
-        try {
-            activityTaskHeartbeatBuffer.add(heartbeat);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            future.completeExceptionally(e);
-        } catch (TimeoutException e) {
-            future.completeExceptionally(e);
+        final CompletableFuture<Void> bufferFuture = buffer.offer(heartbeat);
+        if (bufferFuture == null) {
+            return null;
         }
+
+        // The buffer may fail an item without ever invoking the batch consumer,
+        // e.g. when its circuit breaker is open. Propagate such failures, or the
+        // renewal would never settle and the scheduler would wait for it forever.
+        bufferFuture.whenComplete((_, error) -> {
+            if (error != null) {
+                future.completeExceptionally(error);
+            }
+        });
 
         return future;
     }
@@ -1607,7 +1677,7 @@ final class DexEngineImpl implements DexEngine {
             lockByTaskId = jdbi.inTransaction(handle -> {
                 final Update update = handle.createUpdate("""
                         update dex_activity_task as task
-                           set locked_until = locked_until + t.lock_timeout
+                           set locked_until = now() + t.lock_timeout
                              , lock_version = task.lock_version + 1
                              , updated_at = now()
                           from unnest(:queueNames, :workflowRunIds, :createdEventIds, :lockTimeouts, :lockVersions)

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/MdcKeys.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/MdcKeys.java
@@ -16,18 +16,19 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-package org.dependencytrack.dex.api;
+package org.dependencytrack.dex.engine;
 
-import java.util.UUID;
+final class MdcKeys {
 
-/**
- * Context available to {@link Activity}s.
- */
-public interface ActivityContext {
+    static final String MDC_ACTIVITY_NAME = "activityName";
+    static final String MDC_ACTIVITY_TASK_ATTEMPT = "activityTaskAttempt";
+    static final String MDC_ACTIVITY_TASK_EXECUTION_ID = "activityTaskExecutionId";
+    static final String MDC_QUEUE_NAME = "queueName";
+    static final String MDC_WORKFLOW_INSTANCE_ID = "workflowInstanceId";
+    static final String MDC_WORKFLOW_NAME = "workflowName";
+    static final String MDC_WORKFLOW_RUN_ID = "workflowRunId";
 
-    /**
-     * @return ID of the workflow run that this activity execution is part of.
-     */
-    UUID workflowRunId();
+    private MdcKeys() {
+    }
 
 }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/MetadataRegistry.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/MetadataRegistry.java
@@ -39,6 +39,7 @@ final class MetadataRegistry {
 
     private static final Pattern WORKFLOW_NAME_PATTERN = Pattern.compile("^[\\w-]+");
     private static final Pattern ACTIVITY_NAME_PATTERN = WORKFLOW_NAME_PATTERN;
+    private final Duration defaultActivityLockTimeout;
     private final Duration defaultActivityExecutionTimeout;
 
     @SuppressWarnings("rawtypes")
@@ -53,7 +54,12 @@ final class MetadataRegistry {
     @SuppressWarnings("rawtypes")
     private final Map<String, ActivityMetadata> activityMetadataByName = new HashMap<>();
 
-    MetadataRegistry(Duration defaultActivityExecutionTimeout) {
+    MetadataRegistry(
+            Duration defaultActivityLockTimeout,
+            Duration defaultActivityExecutionTimeout) {
+        this.defaultActivityLockTimeout = requireNonNull(
+                defaultActivityLockTimeout,
+                "defaultActivityLockTimeout must not be null");
         this.defaultActivityExecutionTimeout = requireNonNull(
                 defaultActivityExecutionTimeout,
                 "defaultActivityExecutionTimeout must not be null");
@@ -120,15 +126,7 @@ final class MetadataRegistry {
             Activity<A, R> activity,
             PayloadConverter<A> argumentConverter,
             PayloadConverter<R> resultConverter,
-            Duration lockTimeout) {
-        registerActivity(activity, argumentConverter, resultConverter, lockTimeout, null);
-    }
-
-    <A, R> void registerActivity(
-            Activity<A, R> activity,
-            PayloadConverter<A> argumentConverter,
-            PayloadConverter<R> resultConverter,
-            Duration lockTimeout,
+            @Nullable Duration lockTimeout,
             @Nullable Duration executionTimeout) {
         requireNonNull(activity, "activity must not be null");
 
@@ -149,32 +147,20 @@ final class MetadataRegistry {
             PayloadConverter<A> argumentConverter,
             PayloadConverter<R> resultConverter,
             String defaultTaskQueueName,
-            Duration lockTimeout,
-            Activity<A, R> activity) {
-        registerActivity(
-                name,
-                argumentConverter,
-                resultConverter,
-                defaultTaskQueueName,
-                lockTimeout,
-                null,
-                activity);
-    }
-
-    <A, R> void registerActivity(
-            String name,
-            PayloadConverter<A> argumentConverter,
-            PayloadConverter<R> resultConverter,
-            String defaultTaskQueueName,
-            Duration lockTimeout,
+            @Nullable Duration lockTimeout,
             @Nullable Duration executionTimeout,
             Activity<A, R> activity) {
         requireValidActivityName(name);
         requireNonNull(argumentConverter, "argumentConverter must not be null");
         requireNonNull(resultConverter, "resultConverter must not be null");
         requireValidTaskQueueName(defaultTaskQueueName);
-        requireValidLockTimeout(lockTimeout);
         requireNonNull(activity, "activity must not be null");
+
+        final Duration effectiveLockTimeout =
+                lockTimeout == null
+                        ? defaultActivityLockTimeout
+                        : lockTimeout;
+        requireValidLockTimeout(effectiveLockTimeout);
 
         final Duration effectiveExecutionTimeout =
                 executionTimeout == null
@@ -198,7 +184,7 @@ final class MetadataRegistry {
                 argumentConverter,
                 resultConverter,
                 defaultTaskQueueName,
-                lockTimeout,
+                effectiveLockTimeout,
                 effectiveExecutionTimeout);
         activityNameByExecutorClass.put(activity.getClass(), name);
         activityMetadataByName.put(name, metadata);

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskScheduler.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskScheduler.java
@@ -43,6 +43,8 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import static org.dependencytrack.dex.engine.MdcKeys.MDC_QUEUE_NAME;
+
 final class WorkflowTaskScheduler implements Closeable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WorkflowTaskScheduler.class);
@@ -223,7 +225,7 @@ final class WorkflowTaskScheduler implements Closeable {
         boolean madeProgress = false;
         for (final Queue queue : queues) {
             final Timer.Sample latencySample = Timer.start();
-            try (var _ = MDC.putCloseable("queueName", queue.name())) {
+            try (var _ = MDC.putCloseable(MDC_QUEUE_NAME, queue.name())) {
                 madeProgress |= jdbi.inTransaction(handle -> processQueue(handle, queue));
             } finally {
                 latencySample.stop(

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskWorker.java
@@ -36,6 +36,9 @@ import java.util.NoSuchElementException;
 import java.util.function.BooleanSupplier;
 
 import static java.util.Objects.requireNonNull;
+import static org.dependencytrack.dex.engine.MdcKeys.MDC_WORKFLOW_INSTANCE_ID;
+import static org.dependencytrack.dex.engine.MdcKeys.MDC_WORKFLOW_NAME;
+import static org.dependencytrack.dex.engine.MdcKeys.MDC_WORKFLOW_RUN_ID;
 
 final class WorkflowTaskWorker extends AbstractTaskWorker<WorkflowTask> {
 
@@ -71,9 +74,9 @@ final class WorkflowTaskWorker extends AbstractTaskWorker<WorkflowTask> {
     @Override
     @SuppressWarnings({"rawtypes", "unchecked"})
     void process(final WorkflowTask task) {
-        try (var _ = MDC.putCloseable("workflowName", task.workflowName());
-             var _ = MDC.putCloseable("workflowInstanceId", task.workflowInstanceId());
-             var _ = MDC.putCloseable("workflowRunId", task.workflowRunId().toString())) {
+        try (var _ = MDC.putCloseable(MDC_WORKFLOW_NAME, task.workflowName());
+             var _ = MDC.putCloseable(MDC_WORKFLOW_INSTANCE_ID, task.workflowInstanceId());
+             var _ = MDC.putCloseable(MDC_WORKFLOW_RUN_ID, task.workflowRunId().toString())) {
             final WorkflowMetadata workflowMetadata;
             try {
                 workflowMetadata = metadataRegistry.getWorkflowMetadata(task.workflowName());

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/support/Buffer.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/support/Buffer.java
@@ -234,14 +234,33 @@ public final class Buffer<T> implements Closeable {
             throw new TimeoutException("Timed out while waiting for buffer queue to accept the item");
         }
 
+        maybeRequestFlush();
+
+        return future;
+    }
+
+    public @Nullable CompletableFuture<Void> offer(T item) {
+        if (status != Status.RUNNING) {
+            return null;
+        }
+
+        final var future = new CompletableFuture<Void>();
+
+        final boolean added = itemsQueue.offer(new BufferedItem<>(item, System.nanoTime(), future));
+        if (!added) {
+            return null;
+        }
+
+        maybeRequestFlush();
+
+        return future;
+    }
+
+    private void maybeRequestFlush() {
         if (itemsQueue.size() >= maxBatchSize) {
-            // Request a flush to be performed, but don't block
-            // if the queue already has a pending request.
             LOGGER.debug("{}: Requesting another flush because {} items are still queued", name, itemsQueue.size());
             boolean _ = flushRequestQueue.offer(true);
         }
-
-        return future;
     }
 
     private void flushLoop() {

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/ActivityHeartbeatSchedulerTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/ActivityHeartbeatSchedulerTest.java
@@ -1,0 +1,294 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.dex.engine;
+
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ActivityHeartbeatSchedulerTest {
+
+    private static final Duration HEARTBEAT_INTERVAL = Duration.ofSeconds(1);
+    private static final Duration LOCK_TIMEOUT = Duration.ofSeconds(30);
+
+    private MutableClock clock;
+    private RecordingLockRenewer lockRenewer;
+    private ActivityHeartbeatScheduler scheduler;
+
+    @BeforeEach
+    void beforeEach() {
+        clock = new MutableClock(Instant.parse("2026-01-01T00:00:00Z"));
+        lockRenewer = new RecordingLockRenewer();
+        scheduler = new ActivityHeartbeatScheduler(lockRenewer, HEARTBEAT_INTERVAL, clock);
+    }
+
+    @AfterEach
+    void afterEach() {
+        scheduler.close();
+    }
+
+    @Test
+    void shouldNotRenewWhenLockHasPlentyOfTimeLeft() {
+        final var lock = new AtomicReference<>(lockExpiringIn(Duration.ofSeconds(30)));
+        final var activityFuture = new CompletableFuture<Void>();
+        register(lock, activityFuture);
+
+        scheduler.processRegistrations();
+
+        assertThat(lockRenewer.calls.get()).isZero();
+        assertThat(activityFuture).isNotCancelled();
+    }
+
+    @Test
+    void shouldRenewWhenLockIsCloseToExpiry() {
+        final var lock = new AtomicReference<>(lockExpiringIn(Duration.ofSeconds(5), 1));
+        final var activityFuture = new CompletableFuture<Void>();
+        register(lock, activityFuture);
+
+        final TaskLock renewedLock = lockExpiringIn(Duration.ofSeconds(35), 2);
+        lockRenewer.respondWith(() -> completedFuture(renewedLock));
+
+        scheduler.processRegistrations();
+
+        assertThat(lockRenewer.calls.get()).isOne();
+        assertThat(lock.get()).isEqualTo(renewedLock);
+        assertThat(activityFuture).isNotCancelled();
+    }
+
+    @Test
+    void shouldRetryRenewalOnNextRunAfterBufferRejection() {
+        final var lock = new AtomicReference<>(lockExpiringIn(Duration.ofSeconds(5)));
+        register(lock, new CompletableFuture<>());
+
+        lockRenewer.respondWith(() -> null);
+        scheduler.processRegistrations();
+        assertThat(lockRenewer.calls.get()).isOne();
+
+        scheduler.processRegistrations();
+        assertThat(lockRenewer.calls.get()).isEqualTo(2);
+        assertThat(lock.get().version()).isOne();
+    }
+
+    @Test
+    void shouldNotCancelActivityWhenRenewalFailsTransiently() {
+        final var lock = new AtomicReference<>(lockExpiringIn(Duration.ofSeconds(5)));
+        final var activityFuture = new CompletableFuture<Void>();
+        register(lock, activityFuture);
+
+        // A transient failure (NOT a lost lock!) must neither cancel the activity nor
+        // advance the lock, so a completion can still succeed against the current version.
+        lockRenewer.respondWith(() -> failedFuture(new IllegalStateException("transient")));
+        scheduler.processRegistrations();
+        assertThat(activityFuture).isNotCancelled();
+        assertThat(lockRenewer.calls.get()).isOne();
+        assertThat(lock.get().version()).isOne();
+
+        // The lock is still close to expiry, so the next run retries the renewal.
+        final TaskLock renewedLock = lockExpiringIn(Duration.ofSeconds(35), 2);
+        lockRenewer.respondWith(() -> completedFuture(renewedLock));
+        scheduler.processRegistrations();
+        assertThat(lockRenewer.calls.get()).isEqualTo(2);
+        assertThat(lock.get()).isEqualTo(renewedLock);
+        assertThat(activityFuture).isNotCancelled();
+    }
+
+    @Test
+    void shouldCancelActivityWhenLockWasTakenOver() {
+        final var lock = new AtomicReference<>(lockExpiringIn(Duration.ofSeconds(5)));
+        final var activityFuture = new CompletableFuture<Void>();
+        register(lock, activityFuture);
+
+        lockRenewer.respondWith(() -> failedFuture(new TaskLockLostException()));
+        scheduler.processRegistrations();
+
+        assertThat(activityFuture).isCancelled();
+
+        lockRenewer.respondWith(() -> completedFuture(lockExpiringIn(Duration.ofSeconds(35))));
+        scheduler.processRegistrations();
+        assertThat(lockRenewer.calls.get()).isOne();
+    }
+
+    @Test
+    void shouldCancelActivityWhenLockExpiresBeforeItCanBeRenewed() {
+        final var lock = new AtomicReference<>(lockExpiringIn(Duration.ofSeconds(1)));
+        final var activityFuture = new CompletableFuture<Void>();
+        register(lock, activityFuture);
+
+        scheduler.processRegistrations();
+
+        assertThat(activityFuture).isCancelled();
+        assertThat(lockRenewer.calls.get()).isZero();
+    }
+
+    @Test
+    void shouldNotStartOverlappingRenewalsForTheSameTask() {
+        final var lock = new AtomicReference<>(lockExpiringIn(Duration.ofSeconds(5)));
+        register(lock, new CompletableFuture<>());
+
+        lockRenewer.respondWith(CompletableFuture::new);
+        scheduler.processRegistrations();
+        scheduler.processRegistrations();
+
+        assertThat(lockRenewer.calls.get()).isOne();
+    }
+
+    @Test
+    void shouldNotGiveUpWhileRenewalIsInFlight() {
+        final var lock = new AtomicReference<>(lockExpiringIn(Duration.ofSeconds(5)));
+        final var activityFuture = new CompletableFuture<Void>();
+        register(lock, activityFuture);
+
+        final var renewalFuture = new CompletableFuture<TaskLock>();
+        lockRenewer.respondWith(() -> renewalFuture);
+        scheduler.processRegistrations();
+        assertThat(lockRenewer.calls.get()).isOne();
+
+        // Local lock view is close to expiry, but the pending renewal may still extend it.
+        clock.setInstant(clock.instant().plus(Duration.ofMillis(4_500)));
+        scheduler.processRegistrations();
+        assertThat(activityFuture).isNotCancelled();
+
+        // Once the local lock view has fully expired, pending renewal or not,
+        // the activity must no longer run under it.
+        clock.setInstant(clock.instant().plus(Duration.ofSeconds(1)));
+        scheduler.processRegistrations();
+        assertThat(activityFuture).isCancelled();
+    }
+
+    @Test
+    void shouldAwaitInFlightRenewalOnUnregister() {
+        final var lock = new AtomicReference<>(lockExpiringIn(Duration.ofSeconds(5), 1));
+        final var activityFuture = new CompletableFuture<Void>();
+        register(lock, activityFuture);
+
+        final var renewalFuture = new CompletableFuture<TaskLock>();
+        lockRenewer.respondWith(() -> renewalFuture);
+        scheduler.processRegistrations();
+        assertThat(lockRenewer.calls.get()).isOne();
+
+        final TaskLock renewedLock = lockExpiringIn(Duration.ofSeconds(35), 2);
+        Thread.ofPlatform().start(() -> {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            renewalFuture.complete(renewedLock);
+        });
+        scheduler.unregister(activityFuture);
+
+        // unregister must only return once the renewed lock is published,
+        // so the task is completed under its current lock version.
+        assertThat(lock.get()).isEqualTo(renewedLock);
+    }
+
+    @Test
+    void shouldStopRenewingAfterUnregister() {
+        final var lock = new AtomicReference<>(lockExpiringIn(Duration.ofSeconds(5)));
+        final var activityFuture = new CompletableFuture<>();
+        register(lock, activityFuture);
+
+        scheduler.unregister(activityFuture);
+        scheduler.processRegistrations();
+
+        assertThat(lockRenewer.calls.get()).isZero();
+    }
+
+    private void register(
+            AtomicReference<TaskLock> lock,
+            CompletableFuture<?> activityFuture) {
+        final var taskId = new ActivityTaskId("queue", UUID.randomUUID(), 1);
+        scheduler.register("activityName", taskId, "test-execution", LOCK_TIMEOUT, lock::get, lock::set, activityFuture);
+    }
+
+    private TaskLock lockExpiringIn(Duration remaining) {
+        return lockExpiringIn(remaining, 1);
+    }
+
+    private TaskLock lockExpiringIn(Duration remaining, int version) {
+        return new TaskLock(clock.instant().plus(remaining), version);
+    }
+
+    private static final class RecordingLockRenewer implements ActivityHeartbeatScheduler.LockRenewer {
+
+        private final AtomicInteger calls = new AtomicInteger();
+        private volatile Supplier<CompletableFuture<TaskLock>> response =
+                () -> completedFuture(new TaskLock(Instant.now(), 1));
+
+        void respondWith(Supplier<CompletableFuture<TaskLock>> response) {
+            this.response = response;
+        }
+
+        @Override
+        public CompletableFuture<TaskLock> tryRenew(
+                @NonNull ActivityTaskId taskId,
+                @NonNull TaskLock currentLock,
+                @NonNull Duration lockTimeout) {
+            calls.incrementAndGet();
+            return response.get();
+        }
+
+    }
+
+    private static final class MutableClock extends Clock {
+
+        private volatile Instant instant;
+
+        MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        void setInstant(Instant instant) {
+            this.instant = instant;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+    }
+
+}

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
@@ -117,6 +117,7 @@ class DexEngineImplTest {
         dataSource = new HikariDataSource(hikariConfig);
 
         final var config = new DexEngineConfig(dataSource);
+        config.setActivityHeartbeatInterval(Duration.ofMillis(250));
         config.activityTaskScheduler().setPollInterval(Duration.ofMillis(10));
         config.activityTaskScheduler().setPollBackoffFunction(IntervalFunction.of(10));
         config.workflowTaskScheduler().setPollInterval(Duration.ofMillis(10));
@@ -1397,71 +1398,127 @@ class DexEngineImplTest {
                 entry -> assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.WORKFLOW_TASK_COMPLETED));
     }
 
-    @Test
-    void shouldHeartbeatActivity() {
-        final var heartbeatsPerformed = new ArrayBlockingQueue<Boolean>(3);
+    @Nested
+    class ActivityHeartbeatTest {
 
-        registerWorkflow("test", (ctx, _) -> {
-            ctx.callActivity("test", ACTIVITY_TASK_QUEUE, null, voidConverter(), voidConverter(), RetryPolicy.ofDefault()).await();
-            return null;
-        });
-        registerActivity("test", (ctx, _) -> {
-            heartbeatsPerformed.add(ctx.maybeHeartbeat());
-            Thread.sleep(3_500);
-            heartbeatsPerformed.add(ctx.maybeHeartbeat());
-            heartbeatsPerformed.add(ctx.maybeHeartbeat());
-            return null;
-        });
-        registerWorkflowWorker("workflow-worker", 1);
-        registerTaskWorker("activity-worker", 1);
-        engine.start();
+        @Test
+        void shouldRefuseToStartWhenActivityLockTimeoutIsTooShortForHeartbeatInterval() {
+            engine.registerActivityInternal("test", voidConverter(), voidConverter(), ACTIVITY_TASK_QUEUE, Duration.ofSeconds(1), (_, _) -> null);
 
-        final UUID runId = engine.createRun(new CreateWorkflowRunRequest<>("test", 1));
-        awaitRunStatus(runId, WorkflowRunStatus.COMPLETED);
+            assertThatExceptionOfType(IllegalStateException.class)
+                    .isThrownBy(engine::start)
+                    .withMessageContaining("is too short for the activity heartbeat interval");
+        }
 
-        assertThat(heartbeatsPerformed).containsExactly(false, true, false);
-    }
+        @Test
+        void shouldDiscardActivityExecutionWhenLockIsLost() throws Exception {
+            final var invocations = new AtomicInteger();
+            final var lockLostObserved = new AtomicBoolean();
+            final var firstAttemptStarted = new CountDownLatch(1);
 
-    @Test
-    void shouldDiscardActivityExecutionWhenLockIsLost() {
-        final var invocations = new AtomicInteger();
-        final var lockLostObserved = new AtomicBoolean();
-        final var successorStarted = new CountDownLatch(1);
+            registerWorkflow("test", (ctx, _) -> {
+                ctx.callActivity("test", ACTIVITY_TASK_QUEUE, null, voidConverter(), voidConverter(), RetryPolicy.ofDefault()).await();
+                return null;
+            });
 
-        registerWorkflow("test", (ctx, _) -> {
-            ctx.callActivity("test", ACTIVITY_TASK_QUEUE, null, voidConverter(), voidConverter(), RetryPolicy.ofDefault()).await();
-            return null;
-        });
+            engine.registerActivityInternal(
+                    "test", voidConverter(), voidConverter(), ACTIVITY_TASK_QUEUE, Duration.ofSeconds(3),
+                    (_, _) -> {
+                        if (invocations.incrementAndGet() > 1) {
+                            return null;
+                        }
 
-        engine.registerActivityInternal(
-                "test", voidConverter(), voidConverter(), ACTIVITY_TASK_QUEUE, Duration.ofSeconds(1),
-                (ctx, _) -> {
-                    if (invocations.incrementAndGet() > 1) {
-                        successorStarted.countDown();
+                        // First attempt: block while the test steals the lock.
+                        // The heartbeat scheduler's renewal is rejected, so it should cancel this
+                        // execution by interrupting it, and another worker should reclaim and complete the task.
+                        firstAttemptStarted.countDown();
+                        try {
+                            Thread.sleep(Duration.ofSeconds(30));
+                        } catch (InterruptedException e) {
+                            lockLostObserved.set(true);
+                            Thread.currentThread().interrupt();
+                            throw e;
+                        }
+
                         return null;
-                    }
+                    });
+            registerWorkflowWorker("workflow-worker", 1);
+            registerTaskWorker("activity-worker", 2);
+            engine.start();
 
-                    assertThat(successorStarted.await(30, TimeUnit.SECONDS)).isTrue();
+            final UUID runId = engine.createRun(new CreateWorkflowRunRequest<>("test", 1));
+            assertThat(firstAttemptStarted.await(30, TimeUnit.SECONDS)).isTrue();
 
-                    try {
-                        ctx.maybeHeartbeat();
-                    } catch (TaskLockLostException e) {
-                        lockLostObserved.set(true);
-                        throw e;
-                    }
+            // Steal the lock, as another worker taking over the task would.
+            final int updatedTasks = Jdbi.create(dataSource).withHandle(handle -> handle
+                    .createUpdate("""
+                            update dex_activity_task
+                               set lock_version = lock_version + 1
+                             where workflow_run_id = :runId
+                            """)
+                    .bind("runId", runId)
+                    .execute());
+            assertThat(updatedTasks).isOne();
 
-                    return null;
-                });
-        registerWorkflowWorker("workflow-worker", 1);
-        registerTaskWorker("activity-worker", 2);
-        engine.start();
+            awaitRunStatus(runId, WorkflowRunStatus.COMPLETED);
 
-        final UUID runId = engine.createRun(new CreateWorkflowRunRequest<>("test", 1));
-        awaitRunStatus(runId, WorkflowRunStatus.COMPLETED);
+            await("Displaced execution to observe the lost lock")
+                    .untilAsserted(() -> assertThat(lockLostObserved).isTrue());
+            assertThat(invocations.get()).isGreaterThanOrEqualTo(2);
+        }
 
-        await("Displaced execution to observe the lost lock")
-                .untilAsserted(() -> assertThat(lockLostObserved).isTrue());
-        assertThat(invocations.get()).isGreaterThanOrEqualTo(2);
+        @Test
+        void shouldNotDoubleCommitWhenDisplacedExecutionIgnoresLockLoss() throws Exception {
+            final var invocations = new AtomicInteger();
+            final var firstAttemptStarted = new CountDownLatch(1);
+            final var lockStolen = new CountDownLatch(1);
+
+            registerWorkflow("test", (ctx, _) -> ctx.callActivity("test", ACTIVITY_TASK_QUEUE, null, voidConverter(), voidConverter(), RetryPolicy.ofDefault()).await());
+
+            engine.registerActivityInternal(
+                    "test", voidConverter(), voidConverter(), ACTIVITY_TASK_QUEUE, Duration.ofSeconds(3),
+                    (_, _) -> {
+                        if (invocations.incrementAndGet() > 1) {
+                            return null;
+                        }
+
+                        // First attempt: wait until the test steals the lock, then return
+                        // normally while swallowing the cancellation interrupt.
+                        // Either the scheduler cancels this execution before it returns,
+                        // or its stale completion is rejected by the lock version check.
+                        // Neither may commit, and the worker that took the task over must complete the run.
+                        firstAttemptStarted.countDown();
+                        try {
+                            boolean _ = lockStolen.await(30, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                            // Simulate an activity that does not honor the interrupt after losing its lock.
+                        }
+
+                        return null;
+                    });
+            registerWorkflowWorker("workflow-worker", 1);
+            registerTaskWorker("activity-worker", 2);
+            engine.start();
+
+            final UUID runId = engine.createRun(new CreateWorkflowRunRequest<>("test", 1));
+            assertThat(firstAttemptStarted.await(30, TimeUnit.SECONDS)).isTrue();
+
+            final int updatedTasks = Jdbi.create(dataSource).withHandle(handle -> handle
+                    .createUpdate("""
+                            update dex_activity_task
+                               set lock_version = lock_version + 1
+                             where workflow_run_id = :runId
+                            """)
+                    .bind("runId", runId)
+                    .execute());
+            assertThat(updatedTasks).isOne();
+            lockStolen.countDown();
+
+            // The run completes exactly once via the worker that took the task over.
+            awaitRunStatus(runId, WorkflowRunStatus.COMPLETED);
+            assertThat(invocations.get()).isGreaterThanOrEqualTo(2);
+        }
+
     }
 
     @Test

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/MetadataRegistryTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/MetadataRegistryTest.java
@@ -30,13 +30,14 @@ import static org.dependencytrack.dex.api.payload.PayloadConverters.voidConverte
 
 class MetadataRegistryTest {
 
+    private static final Duration DEFAULT_LOCK_TIMEOUT = Duration.ofMinutes(5);
     private static final Duration DEFAULT_EXECUTION_TIMEOUT = Duration.ofHours(1);
 
     private MetadataRegistry metadataRegistry;
 
     @BeforeEach
     void beforeEach() {
-        metadataRegistry = new MetadataRegistry(DEFAULT_EXECUTION_TIMEOUT);
+        metadataRegistry = new MetadataRegistry(DEFAULT_LOCK_TIMEOUT, DEFAULT_EXECUTION_TIMEOUT);
     }
 
     @Test
@@ -45,6 +46,22 @@ class MetadataRegistryTest {
 
         assertThat(metadataRegistry.getActivityMetadata("test").executionTimeout())
                 .isEqualTo(DEFAULT_EXECUTION_TIMEOUT);
+    }
+
+    @Test
+    void shouldApplyDefaultLockTimeoutWhenNoneIsProvided() {
+        registerActivity("test", /* lockTimeout */ null, /* executionTimeout */ null);
+
+        assertThat(metadataRegistry.getActivityMetadata("test").lockTimeout())
+                .isEqualTo(DEFAULT_LOCK_TIMEOUT);
+    }
+
+    @Test
+    void shouldPreferProvidedLockTimeoutOverDefault() {
+        registerActivity("test", Duration.ofMinutes(15), /* executionTimeout */ null);
+
+        assertThat(metadataRegistry.getActivityMetadata("test").lockTimeout())
+                .isEqualTo(Duration.ofMinutes(15));
     }
 
     @Test
@@ -62,7 +79,10 @@ class MetadataRegistryTest {
                 .withMessageContaining("executionTimeout must be positive");
     }
 
-    private void registerActivity(String name, Duration lockTimeout, @Nullable Duration executionTimeout) {
+    private void registerActivity(
+            String name,
+            @Nullable Duration lockTimeout,
+            @Nullable Duration executionTimeout) {
         metadataRegistry.registerActivity(
                 name,
                 voidConverter(),

--- a/dex/testing/src/main/java/org/dependencytrack/dex/testing/WorkflowTestExtension.java
+++ b/dex/testing/src/main/java/org/dependencytrack/dex/testing/WorkflowTestExtension.java
@@ -73,6 +73,7 @@ public final class WorkflowTestExtension implements BeforeEachCallback, AfterEac
         // Reduce buffer flush, poll intervals, backoffs, and leader election
         // check interval to make tests more responsive.
         engineConfig.leaderElection().setLeaseCheckInterval(Duration.ofSeconds(5));
+        engineConfig.setActivityHeartbeatInterval(Duration.ofMillis(500));
         engineConfig.activityTaskHeartbeatBuffer().setFlushInterval(Duration.ofMillis(10));
         engineConfig.externalEventBuffer().setFlushInterval(Duration.ofMillis(10));
         engineConfig.taskEventBuffer().setFlushInterval(Duration.ofMillis(10));

--- a/docs/adr/034-auto-heartbeat-activity-locks.md
+++ b/docs/adr/034-auto-heartbeat-activity-locks.md
@@ -1,0 +1,176 @@
+| Status   | Date       | Author(s)                            |
+|:---------|:-----------|:-------------------------------------|
+| Accepted | 2026-07-24 | [@nscuro](https://github.com/nscuro) |
+
+## Context
+
+The durable execution engine (dex) runs units of work called activities. When a worker picks up an
+activity task, it holds a lock on the task for a fixed lock timeout. While the lock is held, no other
+worker may take the task. If the lock expires, the engine assumes the worker died and lets another
+worker take over.
+
+This breaks for activities that legitimately run longer than the lock timeout. The lock expires
+mid-run, a second worker starts a duplicate, and the first worker can no longer complete its task.
+The workflow then re-attempts every few minutes until an operator intervenes (see [issue 6795]).
+
+The engine already has a heartbeat feature, but activity code must call it. The long-running work
+often lives in domain code (for example the policy evaluator) that should not know the engine exists.
+A separate change ([PR 6741]) added a per-attempt execution timeout in the worker. That is a different concern,
+a hard upper bound on one attempt. This ADR is about keeping the lock held during legitimate long work.
+
+Two forces conflict:
+
+- The lock timeout should be short, so a dead worker fails over fast.
+- The activity should be free to run long.
+
+> [!NOTE]
+> Correctness does not depend on the lock. A worker may only commit an activity's result if it still
+> holds the lock version it started with. If it lost the lock, its completion is rejected, and the
+> worker that took the task over owns it. Detecting a dead worker is always timing-based, so a lock
+> can be lost to a garbage collection pause or clock skew. Such a loss results at most in a duplicate execution,
+> never a duplicate commit. The engine already runs activities at least once, so their effects must be
+> safe to repeat. Everything below only reduces wasted duplicate runs. The heartbeat is a liveness
+> optimization, not mutual exclusion.
+
+### Possible Solutions
+
+#### A: Raise the lock timeout per activity
+
+Give slow activities a much longer lock timeout, sized to their worst case.
+This is what the codebase already does for the vulnerability mirror activity.
+
+*Pro*:
+
+1. Trivial, no new code.
+
+*Con*:
+
+1. Must guess the worst case per activity, and a wrong guess brings the bug back.
+2. A long timeout means slow failover when a worker dies.
+3. Does not adapt to workloads that vary in size.
+
+#### B: Automatic background heartbeat
+
+The engine renews the lock on a schedule for every running activity.
+Activities and domain code do nothing.
+
+*Pro*:
+
+1. Domain code stays clean.
+2. Covers work blocked on I/O, and work inside one long transaction.
+3. One renewal path, so automatic and manual renewal cannot fight each other.
+
+*Con*:
+
+1. The engine must handle the renewal path, lock-loss notification, and stuck activities with care.
+2. Renewal is tied to a live thread, not to progress.
+
+#### C: Manual heartbeat in the activity and domain code
+
+Keep the current heartbeat method and call it from the long-running work.
+
+*Pro*:
+
+1. The lock is tied to real progress. A stalled activity loses its lock and is recovered.
+2. Failure is simple to deliver, straight out of the call.
+
+*Con*:
+
+1. The engine concept leaks into domain code, which requires a heartbeat parameter and calls.
+2. A missing call silently reintroduces the bug.
+
+## Decision
+
+We propose to follow solution **B**. The lock is renewed automatically in the engine.
+Activities and domain code call no heartbeat method, and the manual heartbeat method is *removed*.
+
+Structure:
+
+- One heartbeat scheduler per engine instance, *not* per worker or per activity.
+- A registry of running activities. A worker adds one before it runs and removes it after.
+- On a fixed short interval the scheduler renews the locks that are close to expiry.
+
+Two independent time limits govern an activity:
+
+- **Lock timeout**: length of one lock, the length a renewal sets it to, and the failover delay after a worker dies.
+  Renewals set the lock to *now* plus this value rather than extending the previous expiry,
+  so the failover delay is the lock timeout and not some multiple of it.
+- **Execution timeout**: hard upper bound on one attempt. At least the worst legitimate run.
+
+Both limits have an engine-wide default, applied to activities registered without an explicit value,
+so neither can be forgotten. Locks default to five minutes and executions to one hour,
+configurable via `dt.dex-engine.activity.lock-timeout-ms` and `dt.dex-engine.activity.execution-timeout-ms`.
+Individual activities may deviate from the execution default via `dt.dex-engine.activity.<name>.execution-timeout-ms`.
+
+The lock timeout is usually much smaller than the execution timeout, and the heartbeat covers the
+time in between. The engine does not require this, because both orders are safe. If the lock is
+shorter than the attempt, renewal keeps it alive until the attempt ends. If the lock is longer than
+the execution timeout, it is never renewed, because the attempt is cancelled before that. The
+second case is not wrong, it only makes failover slower than it has to be.
+
+Without the heartbeat, the lock timeout must be as long as the run itself, which is what causes [issue 6795].
+
+On each run, the scheduler decides per activity, in order:
+
+```mermaid
+flowchart TD
+    A[The scheduler visits a running activity] --> B{Renewal already in flight?}
+    B -- yes --> C{Lock fully expired?}
+    C -- yes --> D[Cancel the activity. Stop renewing.]
+    C -- no --> F[Do nothing this run]
+    B -- no --> E{Lock expires before it can be renewed again?}
+    E -- yes --> D
+    E -- no --> G{Lock close to expiry?}
+    G -- no --> F
+    G -- yes --> H[Offer a renewal to the buffer without blocking]
+    H --> I{Buffer accepted it?}
+    I -- no --> J[Skip. Retry next run.]
+    I -- yes --> K[On success extend the lock. On lock takeover cancel.]
+```
+
+The execution timeout is *not* part of this decision. It is enforced by the worker, which cancels
+the activity when a single attempt runs longer than it (see [PR 6741]). The scheduler only renews
+the lock and reacts to its loss.
+
+Further rules:
+
+- Renewals use the engine's existing batching buffer. The scheduler never blocks on it. A full
+  buffer means skip and retry. A buffer full for a whole lock means the database is unreachable, and
+  the activity should lose its lock.
+- The engine refuses to start when a lock timeout leaves no scheduler run between the start of its
+  renewal window and its give-up deadline, because such a lock would be given up on before a renewal
+  is ever attempted. With the margins below, that floor is nine times the heartbeat interval.
+- When an activity finishes, the worker waits for an in-flight renewal to complete before completing
+  the task. Otherwise the renewal could bump the lock version behind the completion's back,
+  and the engine would discard its own finished work as a lost lock.
+- On lock loss (rejected renewal or a passed local deadline), the engine cancels the activity via the
+  same thread interrupt the execution timeout uses.
+- A cancelled activity that ignores the interrupt cannot corrupt the task, see [Context](#context).
+  It does, however, keep performing side effects that the other worker performs again.
+  The engine already runs activities at least once, so activity effects must be safe to repeat.
+- The execution timeout guards against an alive-but-stuck activity, whose lock would otherwise be
+  renewed forever. This is why every activity has one.
+- The scheduler runs on a platform thread, so heavy activities cannot starve it.
+- Because renewal decouples the lock from the length of a run, the same default applies to all
+  activities, and an activity only deviates for a documented reason. Operators tune the default
+  rather than individual activities, since the value expresses how quickly the work of a dead node
+  is picked up, not how long any single workload may take.
+- The heartbeat interval is engine configuration, not a deployment property. It is meaningful only
+  in relation to the lock timeout it renews, and exposing both invites combinations the engine
+  refuses to start with.
+
+## Consequences
+
+- Domain code stays clean and never learns about locks or heartbeats.
+- Long activities keep their lock during legitimate work, fixing [issue 6795].
+- Lock timeouts stay short, so failover stays fast while attempts may run long. The previous
+  timeouts were sized for a world without heartbeats and ranged from one to thirty minutes.
+  Failover after a worker dies therefore improves for portfolio-wide activities, and degrades
+  for the short ones.
+- One scheduler per instance keeps overhead low across many workers.
+- A hung-but-alive activity holds its lock until the execution timeout.
+- A lock can still be lost to a garbage collection pause or clock skew, so duplicate executions remain possible.
+- The engine gains a scheduler thread, a shared registry, and a lock value read across threads.
+
+[PR 6741]: https://github.com/DependencyTrack/dependency-track/pull/6741
+[issue 6795]: https://github.com/DependencyTrack/dependency-track/issues/6795


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

dex: automatically heartbeat activities.

Removes the need to manually heartbeat activities by scheduling heartbeats automatically in the background.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6740
Fixes #6771
Fixes #6795

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

See included ADR.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- [x] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
