### PR TITLE
dex: improve workflow task scheduling performance for deep backlogs with concurrency keys

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/dex/DexEngineInitializer.java
+++ b/apiserver/src/main/java/org/dependencytrack/dex/DexEngineInitializer.java
@@ -442,6 +442,9 @@ public final class DexEngineInitializer implements ServletContextListener {
                 .ifPresent(engineConfig.workflowTaskScheduler()::setPollInterval);
         getBackoffFunction(config, "dt.dex-engine.workflow-task-scheduler.poll-backoff")
                 .ifPresent(engineConfig.workflowTaskScheduler()::setPollBackoffFunction);
+        config.getOptionalValue("dt.dex-engine.workflow-task-scheduler.concurrency-key-wakeup-repair-interval-ms", long.class)
+                .map(Duration::ofMillis)
+                .ifPresent(engineConfig.workflowTaskScheduler()::setConcurrencyKeyWakeupRepairInterval);
 
         // Activity task scheduler.
         config.getOptionalValue("dt.dex-engine.activity-task-scheduler.poll-interval-ms", long.class)

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -1297,6 +1297,16 @@ dt.dex-engine.metrics-collector.interval-ms=30000
 # @type:     integer
 dt.dex-engine.workflow-task-scheduler.poll-interval-ms=100
 
+# Defines the interval in milliseconds in which the workflow task scheduler
+# repairs its scheduling bookkeeping from the authoritative workflow state.
+# The interval bounds how long a workflow run can be delayed if the
+# bookkeeping is lost, e.g. due to a database crash. Lower values tighten
+# that bound at the cost of more frequent background work.
+#
+# @category: Durable Execution
+# @type:     integer
+# dt.dex-engine.workflow-task-scheduler.concurrency-key-wakeup-repair-interval-ms=60000
+
 # Defines the interval in milliseconds in which the activity task scheduler polls
 # for tasks to enqueue for execution.
 #

--- a/dex/benchmark/src/main/java/org/dependencytrack/dex/benchmark/Application.java
+++ b/dex/benchmark/src/main/java/org/dependencytrack/dex/benchmark/Application.java
@@ -104,7 +104,7 @@ public class Application {
                 final var currentBatch = new ArrayList<CreateWorkflowRunRequest<?>>(currentBatchSize);
 
                 for (int j = 0; j < currentBatchSize; j++) {
-                    currentBatch.add(new CreateWorkflowRunRequest<>(DummyWorkflow.class));
+                    currentBatch.add(new CreateWorkflowRunRequest<>(DummyWorkflow.class).withConcurrencyKey("" + i + ":" + j));
                 }
 
                 LOGGER.info("Creating batch of {} workflow runs", currentBatchSize);

--- a/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngineConfig.java
+++ b/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngineConfig.java
@@ -298,6 +298,7 @@ public class DexEngineConfig {
 
         private Duration pollInterval = Duration.ofMillis(100);
         private IntervalFunction pollBackoffFunction = ofExponentialRandomBackoff(100L, 2.0, 0.3, 3000L);
+        private Duration concurrencyKeyWakeupRepairInterval = Duration.ofSeconds(60);
 
         private TaskSchedulerConfig() {
         }
@@ -318,11 +319,26 @@ public class DexEngineConfig {
             this.pollBackoffFunction = pollBackoffFunction;
         }
 
+        /**
+         * @return Interval in which missing wakeup hints are repaired from source-of-truth state.
+         */
+        public Duration concurrencyKeyWakeupRepairInterval() {
+            return concurrencyKeyWakeupRepairInterval;
+        }
+
+        public void setConcurrencyKeyWakeupRepairInterval(Duration concurrencyKeyWakeupRepairInterval) {
+            if (concurrencyKeyWakeupRepairInterval.isNegative() || concurrencyKeyWakeupRepairInterval.isZero()) {
+                throw new IllegalArgumentException("concurrencyKeyWakeupRepairInterval must be positive");
+            }
+            this.concurrencyKeyWakeupRepairInterval = concurrencyKeyWakeupRepairInterval;
+        }
+
         @Override
         public String toString() {
             return new StringJoiner(", ", getClass().getSimpleName() + "[", "]")
                     .add("pollInterval=" + pollInterval)
                     .add("pollBackoffFunction=" + pollBackoffFunction)
+                    .add("concurrencyKeyWakeupRepairInterval=" + concurrencyKeyWakeupRepairInterval)
                     .toString();
         }
 
@@ -411,7 +427,7 @@ public class DexEngineConfig {
     }
 
     /**
-     * @return Timeout for database queries.
+     * @return Timeout for database queries executed by the engine.
      */
     public Duration queryTimeout() {
         return queryTimeout;

--- a/dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration/V0.1.5__ImproveWorkflowTaskSchedulerIndexes.sql
+++ b/dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration/V0.1.5__ImproveWorkflowTaskSchedulerIndexes.sql
@@ -1,0 +1,19 @@
+-- Include visible_from so the task scheduler's visible-message lookup
+-- can be satisfied by an index-only scan, avoiding one heap fetch per
+-- inbox message during scheduling polls.
+create index concurrently if not exists dex_workflow_inbox_workflow_run_id_visible_from_idx
+    on dex_workflow_inbox (workflow_run_id, visible_from);
+
+drop index concurrently if exists dex_workflow_inbox_workflow_run_id_idx;
+
+-- Split the workflow task scheduler poll index into two partial indexes
+-- whose predicates match the scheduling query's UNION ALL arms exactly.
+create index concurrently if not exists dex_workflow_run_task_scheduler_poll_keyless_idx
+    on dex_workflow_run (task_queue_name, priority desc, id)
+ where status = 'CREATED' and concurrency_key is null;
+
+create index concurrently if not exists dex_workflow_run_task_scheduler_poll_executing_idx
+    on dex_workflow_run (task_queue_name, priority desc, id)
+ where status in ('RUNNING', 'SUSPENDED');
+
+drop index concurrently if exists dex_workflow_run_task_scheduler_poll_idx;

--- a/dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration/V0.1.6__AddConcurrencyKeyToWorkflowTask.sql
+++ b/dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration/V0.1.6__AddConcurrencyKeyToWorkflowTask.sql
@@ -1,0 +1,16 @@
+alter table dex_workflow_task
+  add column if not exists concurrency_key text;
+
+update dex_workflow_task
+   set concurrency_key = run.concurrency_key
+  from dex_workflow_run as run
+ where run.id = workflow_run_id
+   and run.concurrency_key is not null;
+
+-- squawk-ignore require-concurrent-index-creation -- CONCURRENT is not supported on partitioned tables.
+create index if not exists dex_workflow_task_queue_name_concurrency_key_idx
+    on dex_workflow_task (queue_name, concurrency_key)
+ where concurrency_key is not null;
+
+comment on index dex_workflow_task_queue_name_concurrency_key_idx
+     is 'Support the workflow task scheduler''s queued concurrency key checks';

--- a/dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration/V0.1.7__ResetWorkflowInboxFillfactor.sql
+++ b/dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration/V0.1.7__ResetWorkflowInboxFillfactor.sql
@@ -1,0 +1,4 @@
+-- Inbox rows are inserted once and deleted on consumption, never updated.
+-- Reserving page space for HOT updates via a reduced fillfactor only lowers page density.
+-- squawk-ignore prefer-robust-stmts -- RESET is a no-op when already reset.
+alter table dex_workflow_inbox reset (fillfactor);

--- a/dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration/V0.1.8__AddWorkflowConcurrencyKeyWakeupTable.sql
+++ b/dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration/V0.1.8__AddWorkflowConcurrencyKeyWakeupTable.sql
@@ -1,0 +1,21 @@
+create unlogged table if not exists dex_workflow_concurrency_key_wakeup (
+  queue_name text not null
+, concurrency_key text not null
+-- squawk-ignore prefer-bigint-over-smallint
+, priority smallint not null default 0
+, version bigint not null default 0
+, freed boolean not null default false
+, created_at timestamptz(3) not null default clock_timestamp()
+, constraint dex_workflow_concurrency_key_wakeup_pk primary key (queue_name, concurrency_key)
+) with (autovacuum_vacuum_scale_factor = 0.02, autovacuum_analyze_scale_factor = 0.02);
+
+comment on table dex_workflow_concurrency_key_wakeup
+     is 'Advisory scheduling wakeup hints per concurrency key';
+
+-- squawk-ignore require-concurrent-index-creation
+create index if not exists dex_workflow_concurrency_key_wakeup_scan_idx
+    on dex_workflow_concurrency_key_wakeup (queue_name, priority desc, freed desc, created_at);
+
+comment on index dex_workflow_concurrency_key_wakeup_scan_idx
+     is 'Support hint consumption by the workflow task scheduler';
+

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ConcurrencyKeyMaintenanceWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ConcurrencyKeyMaintenanceWorker.java
@@ -1,0 +1,363 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.dex.engine;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.Query;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.io.Closeable;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+final class ConcurrencyKeyMaintenanceWorker implements Closeable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConcurrencyKeyMaintenanceWorker.class);
+    private static final int PRIMING_REPAIR_BUDGET = 100_000;
+    private static final int LARGE_BACKLOG_THRESHOLD = 100_000;
+    private static final String TRUNCATION_MARKER = "";
+
+    private final Jdbi jdbi;
+    private final Supplier<Boolean> leadershipSupplier;
+    private final MeterRegistry meterRegistry;
+    private final long repairIntervalMillis;
+    private final Runnable onWakeupsRepaired;
+    private @Nullable Counter repairedWakeupsCounter;
+    private @Nullable ScheduledExecutorService executor;
+    private volatile boolean stopped = false;
+    private boolean wasLeader = false;
+
+    ConcurrencyKeyMaintenanceWorker(
+            Jdbi jdbi,
+            Supplier<Boolean> leadershipSupplier,
+            MeterRegistry meterRegistry,
+            Duration repairInterval,
+            Runnable onWakeupsRepaired) {
+        this.jdbi = jdbi;
+        this.leadershipSupplier = leadershipSupplier;
+        this.meterRegistry = meterRegistry;
+        this.repairIntervalMillis = repairInterval.toMillis();
+        this.onWakeupsRepaired = onWakeupsRepaired;
+    }
+
+    void start() {
+        repairedWakeupsCounter = Counter
+                .builder("dt.dex.engine.workflow.concurrency.key.wakeups.repaired")
+                .register(meterRegistry);
+        executor = Executors.newSingleThreadScheduledExecutor(
+                Thread.ofPlatform()
+                        .name(getClass().getSimpleName())
+                        .factory());
+        executor.scheduleAtFixedRate(
+                this::maybeRepair,
+                /* initialDelay */ 0,
+                repairIntervalMillis,
+                TimeUnit.MILLISECONDS);
+    }
+
+    void nudge() {
+        if (executor != null) {
+            executor.execute(this::maybeRepair);
+        }
+    }
+
+    @Override
+    public void close() {
+        stopped = true;
+        if (executor != null) {
+            executor.shutdownNow();
+            try {
+                if (!executor.awaitTermination(3, TimeUnit.SECONDS)) {
+                    LOGGER.warn("Wakeup repair did not terminate in time");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private void maybeRepair() {
+        if (stopped) {
+            return;
+        }
+
+        if (!leadershipSupplier.get()) {
+            wasLeader = false;
+            return;
+        }
+
+        final boolean leadershipAcquired = !wasLeader;
+        wasLeader = true;
+
+        try {
+            repair(leadershipAcquired);
+        } catch (RuntimeException e) {
+            LOGGER.error("Failed to repair concurrency key wakeups", e);
+        }
+    }
+
+    private void repair(boolean leadershipAcquired) {
+        // The wakeup table is unlogged so it can be truncated by database
+        // crash or standby promotion. Detect this by absense of our truncation
+        // marker sentinel row.
+        final boolean tableWasTruncated = jdbi.withHandle(handle -> handle
+                .createQuery("""
+                        select not exists(
+                          select 1
+                            from dex_workflow_concurrency_key_wakeup
+                           where queue_name = :truncationMarker
+                             and concurrency_key = :truncationMarker
+                        )
+                        """)
+                .bind("truncationMarker", TRUNCATION_MARKER)
+                .mapTo(boolean.class)
+                .one());
+
+        // We treat leadership change the same as a truncated wakeup table.
+        // A new leader node starts with zero knowledge about the backlog.
+        final boolean crashRecovery = leadershipAcquired || tableWasTruncated;
+
+        final List<String> queueNames = jdbi.withHandle(handle -> handle
+                .createQuery("""
+                        select name
+                          from dex_workflow_task_queue
+                         where status = 'ACTIVE'
+                        """)
+                .mapTo(String.class)
+                .list());
+
+        boolean repaired = false;
+        for (final String queueName : queueNames) {
+            if (stopped) {
+                return;
+            }
+
+            try (var _ = MDC.putCloseable("queueName", queueName)) {
+                repaired |= jdbi.inTransaction(
+                        handle -> repairQueue(handle, queueName, crashRecovery));
+            }
+        }
+
+        jdbi.useTransaction(handle -> handle
+                .createUpdate("""
+                        insert into dex_workflow_concurrency_key_wakeup (queue_name, concurrency_key)
+                        values (:truncationMarker, :truncationMarker)
+                        on conflict (queue_name, concurrency_key) do nothing
+                        """)
+                .bind("truncationMarker", TRUNCATION_MARKER)
+                .execute());
+        if (repaired) {
+            onWakeupsRepaired.run();
+        }
+    }
+
+    private boolean repairQueue(Handle handle, String queueName, boolean crashRecovery) {
+        // Disable JIT for this transaction. The repair queries use multiple
+        // correlated subqueries which throw off Postgres' row estimates,
+        // leading it to enable JIT. Unfortunately, JIT adds more overhead
+        // than the queries usually end up running for.
+        //
+        // Force custom query plans for this transaction. The JDBC driver uses
+        // server-side prepared statements. Generic plans cached while the
+        // tables are (close to) empty produce degenerate plans during bursts.
+        handle.execute("""
+                select set_config('jit', 'off', /* is_local */ true)
+                     , set_config('plan_cache_mode', 'force_custom_plan', /* is_local */ true)
+                """);
+
+        // Overwrite the global query timeout (10s by default) to 5min.
+        // The repair queries can genuinely run longer, especially on crash recovery.
+        final int queryTimeoutSeconds = Math.toIntExact(TimeUnit.MINUTES.toSeconds(5));
+
+        final int keyedRunBacklog = handle
+                .createQuery("""
+                        select count(*)
+                          from (
+                            select 1
+                              from dex_workflow_run
+                             where concurrency_key is not null
+                               and status = 'CREATED'
+                             limit :probeLimit
+                          ) as probe
+                        """)
+                .bind("probeLimit", LARGE_BACKLOG_THRESHOLD + 1)
+                .setQueryTimeout(queryTimeoutSeconds)
+                .mapTo(Integer.class)
+                .one();
+
+        final Query repairQuery = handle
+                .createQuery("""
+                        with
+                        <#if largeKeyedRunBacklog>
+                        -- Identify the highest priority CREATED run per concurrency key.
+                        cte_next_concurrency_key_run as (
+                          select distinct on (concurrency_key) concurrency_key
+                               , id
+                            from dex_workflow_run
+                           where concurrency_key is not null
+                             and status = 'CREATED'
+                           order by concurrency_key
+                                  , priority desc
+                                  , id
+                        ),
+                        -- Next runs whose concurrency key has no executing run and no queued task.
+                        -- NB: The `not exists(...)` checks execute as bulk anti joins,
+                        -- which require roughly correct row estimates.
+                        -- A large backlog makes this more likely to be the case, since the tables
+                        -- can't grow this far without autoanalyze refreshing statistics.
+                        cte_schedulable_concurrency_key_run_id as (
+                          select next_run.id
+                            from cte_next_concurrency_key_run as next_run
+                           where not exists(
+                             select 1
+                               from dex_workflow_run as executing
+                              where executing.concurrency_key = next_run.concurrency_key
+                                and executing.status in ('RUNNING', 'SUSPENDED')
+                           )
+                             and not exists(
+                               select 1
+                                 from dex_workflow_task as task
+                                where task.queue_name = :queueName
+                                  and task.concurrency_key = next_run.concurrency_key
+                             )
+                        ),
+                        <#else>
+                        -- Identify the highest priority CREATED run per concurrency key,
+                        -- unless the key is blocked by an executing run or queued task.
+                        -- NB: No joins or `exists()` are used, because they can degrade
+                        -- into per-row rescans when statistics are stale, which is the
+                        -- case when a burst starts on a previously idle system.
+                        cte_schedulable_concurrency_key_run_id as (
+                          select id
+                            from (
+                              select distinct on (concurrency_key) concurrency_key
+                                   , id
+                                from (
+                                  select concurrency_key
+                                       , id
+                                       , priority
+                                       , 0 as blocked
+                                    from dex_workflow_run
+                                   where concurrency_key is not null
+                                     and status = 'CREATED'
+                                  union all
+                                  select concurrency_key
+                                       , null
+                                       , null
+                                       , 1
+                                    from dex_workflow_run
+                                   where concurrency_key is not null
+                                     and status in ('RUNNING', 'SUSPENDED')
+                                  union all
+                                  select concurrency_key
+                                       , null
+                                       , null
+                                       , 1
+                                    from dex_workflow_task
+                                   where queue_name = :queueName
+                                     and concurrency_key is not null
+                                ) as contender
+                               order by concurrency_key
+                                      , blocked desc
+                                      , priority desc
+                                      , id
+                            ) as next_concurrency_key_run
+                           where id is not null
+                        ),
+                        </#if>
+                        cte_repaired_hint as (
+                          insert into dex_workflow_concurrency_key_wakeup (
+                            queue_name
+                          , concurrency_key
+                          , priority
+                          , freed
+                          )
+                          select :queueName
+                               , missing.concurrency_key
+                               , missing.priority
+                               , true
+                            from (
+                              select run.concurrency_key
+                                   , run.priority
+                                from cte_schedulable_concurrency_key_run_id as schedulable
+                               inner join dex_workflow_run as run
+                                  on run.id = schedulable.id
+                               where run.task_queue_name = :queueName
+                                 and exists(
+                                   select 1
+                                     from dex_workflow_inbox as inbox
+                                    where inbox.workflow_run_id = run.id
+                                      and inbox.visible_from <= now()
+                                 )
+                                 and not exists(
+                                   select 1
+                                     from dex_workflow_concurrency_key_wakeup as wakeup
+                                    where wakeup.queue_name = :queueName
+                                      and wakeup.concurrency_key = run.concurrency_key
+                                 )
+                            <#if crashRecovery>
+                               -- During crash recovery, repair the highest priority keys first
+                               -- in a bounded batch. If the backlog is large, this gives the
+                               -- scheduler a head-start to work on the most important work,
+                               -- instead of waiting for a potentially multi-minute full restore.
+                               order by run.priority desc
+                                      , run.concurrency_key
+                               limit :primingRepairBudget
+                            </#if>
+                            ) as missing
+                           order by missing.concurrency_key
+                          on conflict (queue_name, concurrency_key) do nothing
+                          returning 1
+                        )
+                        select count(*) as repaired_count
+                          from cte_repaired_hint
+                        """)
+                .setQueryTimeout(queryTimeoutSeconds)
+                .define("largeKeyedRunBacklog", keyedRunBacklog > LARGE_BACKLOG_THRESHOLD)
+                .define("crashRecovery", crashRecovery)
+                .bind("queueName", queueName);
+        if (crashRecovery) {
+            repairQuery.bind("primingRepairBudget", PRIMING_REPAIR_BUDGET);
+        }
+
+        return repairQuery
+                .map((rs, _) -> {
+                    final long repairedCount = rs.getLong("repaired_count");
+                    if (repairedCount > 0 && !crashRecovery) {
+                        // Outside of crash recovery, every repair means a write path failed
+                        // to leave a hint, which is a defect we should know about.
+                        repairedWakeupsCounter.increment(repairedCount);
+                        LOGGER.warn("Repaired {} missing concurrency key wakeups", repairedCount);
+                    }
+                    return repairedCount;
+                })
+                .one() > 0;
+    }
+
+}

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -75,8 +75,10 @@ import org.dependencytrack.dex.engine.persistence.command.PollWorkflowTaskComman
 import org.dependencytrack.dex.engine.persistence.command.ScheduleActivityTaskRetryCommand;
 import org.dependencytrack.dex.engine.persistence.command.UpdateAndUnlockRunCommand;
 import org.dependencytrack.dex.engine.persistence.jdbi.JdbiFactory;
+import org.dependencytrack.dex.engine.persistence.model.ConcurrencyKeyWakeup;
 import org.dependencytrack.dex.engine.persistence.model.PolledWorkflowEvents;
 import org.dependencytrack.dex.engine.persistence.model.PolledWorkflowTask;
+import org.dependencytrack.dex.engine.persistence.model.UnlockedWorkflowRun;
 import org.dependencytrack.dex.engine.persistence.request.GetWorkflowRunHistoryRequest;
 import org.dependencytrack.dex.engine.support.Buffer;
 import org.dependencytrack.dex.engine.support.CircuitBreakerStateTransitionLogger;
@@ -104,6 +106,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
@@ -248,6 +251,7 @@ final class DexEngineImpl implements DexEngine {
                     config.metrics().meterRegistry(),
                     config.workflowTaskScheduler().pollInterval(),
                     config.workflowTaskScheduler().pollBackoffFunction(),
+                    config.workflowTaskScheduler().concurrencyKeyWakeupRepairInterval(),
                     queueName -> {
                         final TaskWorker worker = workflowWorkerByQueue.get(queueName);
                         if (worker != null) {
@@ -684,6 +688,17 @@ final class DexEngineImpl implements DexEngine {
             if (createdRunIdByRequestId.isEmpty()) {
                 return Collections.emptyList();
             }
+
+            dao.upsertConcurrencyKeyWakeups(
+                    createWorkflowRunCommands.stream()
+                            .filter(cmd -> cmd.concurrencyKey() != null
+                                    && createdRunIdByRequestId.containsKey(cmd.requestId()))
+                            .map(cmd -> new ConcurrencyKeyWakeup(
+                                    cmd.taskQueueName(),
+                                    cmd.concurrencyKey(),
+                                    /* freed */ false))
+                            .collect(Collectors.toSet()));
+
             if (createdRunIdByRequestId.size() != createWorkflowRunCommands.size()) {
                 // Drop messages targeting runs that were not created due to instance ID conflict.
                 // Keeping them would cause a foreign key violation when inserting into the inbox.
@@ -1092,7 +1107,7 @@ final class DexEngineImpl implements DexEngine {
                 .map(WorkflowTaskCompletedEvent::workflowRunState)
                 .collect(Collectors.toList());
 
-        final List<UUID> updatedRunIds = workflowDao.updateAndUnlockRuns(
+        final List<UnlockedWorkflowRun> unlockedWorkflowRuns = workflowDao.updateAndUnlockRuns(
                 this.config.instanceId(),
                 events.stream()
                         .map(event -> new UpdateAndUnlockRunCommand(
@@ -1108,6 +1123,9 @@ final class DexEngineImpl implements DexEngine {
                                 event.task().lock().version()))
                         .toList());
 
+        final List<UUID> updatedRunIds = unlockedWorkflowRuns.stream()
+                .map(UnlockedWorkflowRun::id)
+                .toList();
         if (updatedRunIds.size() != events.size()) {
             final Set<UUID> notUpdatedRunIds = events.stream()
                     .map(WorkflowTaskCompletedEvent::workflowRunState)
@@ -1271,8 +1289,30 @@ final class DexEngineImpl implements DexEngine {
                     historyEntriesCreated, createHistoryEntryCommands.size());
         }
 
+        final var concurrencyKeyWakeups = new HashSet<ConcurrencyKeyWakeup>();
+        for (final UnlockedWorkflowRun unlockedWorkflowRun : unlockedWorkflowRuns) {
+            if (unlockedWorkflowRun.freedConcurrencyKey() != null) {
+                concurrencyKeyWakeups.add(
+                        new ConcurrencyKeyWakeup(
+                                unlockedWorkflowRun.queueName(),
+                                unlockedWorkflowRun.freedConcurrencyKey(),
+                                /* freed */ true));
+            }
+        }
+
         if (!createWorkflowRunCommands.isEmpty()) {
             final Map<UUID, UUID> createdRunIdByRequestId = workflowDao.createRuns(createWorkflowRunCommands);
+
+            for (final CreateWorkflowRunCommand cmd : createWorkflowRunCommands) {
+                if (cmd.concurrencyKey() != null && createdRunIdByRequestId.containsKey(cmd.requestId())) {
+                    concurrencyKeyWakeups.add(
+                            new ConcurrencyKeyWakeup(
+                                    cmd.taskQueueName(),
+                                    cmd.concurrencyKey(),
+                                    /* freed */ false));
+                }
+            }
+
             workflowDao.getJdbiHandle().afterCommit(() -> {
                 for (final CreateWorkflowRunCommand cmd : createWorkflowRunCommands) {
                     if (!createdRunIdByRequestId.containsKey(cmd.requestId())) {
@@ -1327,6 +1367,8 @@ final class DexEngineImpl implements DexEngine {
                 }
             }
         }
+
+        workflowDao.upsertConcurrencyKeyWakeups(concurrencyKeyWakeups);
 
         if (!messagesToCreate.isEmpty()) {
             final int createdMessages = workflowDao.createMessages(messagesToCreate);

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskScheduler.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskScheduler.java
@@ -27,7 +27,6 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.Query;
 import org.jdbi.v3.core.statement.StatementContext;
-import org.jdbi.v3.core.statement.Update;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +37,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
@@ -46,6 +46,7 @@ import java.util.function.Supplier;
 final class WorkflowTaskScheduler implements Closeable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WorkflowTaskScheduler.class);
+    private static final int CONCURRENCY_KEY_HINT_BUDGET_FACTOR = 4;
 
     private final Jdbi jdbi;
     private final Supplier<Boolean> leadershipSupplier;
@@ -53,12 +54,14 @@ final class WorkflowTaskScheduler implements Closeable {
     private final long pollIntervalMillis;
     private final IntervalFunction pollBackoffFunction;
     private final Consumer<String> onTasksScheduled;
+    private final ConcurrencyKeyMaintenanceWorker concurrencyKeyMaintenanceWorker;
     private final Thread pollThread;
     private volatile boolean stopped = false;
     private volatile boolean nudged = false;
     private @Nullable Counter pollsCounter;
     private @Nullable MeterProvider<Timer> taskSchedulingLatencyTimer;
     private @Nullable MeterProvider<Counter> tasksScheduledCounter;
+    private boolean wasLeader = false;
 
     WorkflowTaskScheduler(
             Jdbi jdbi,
@@ -66,6 +69,7 @@ final class WorkflowTaskScheduler implements Closeable {
             MeterRegistry meterRegistry,
             Duration pollInterval,
             IntervalFunction pollBackoffFunction,
+            Duration concurrencyKeyWakeupRepairInterval,
             Consumer<String> onTasksScheduled) {
         this.jdbi = jdbi;
         this.leadershipSupplier = leadershipSupplier;
@@ -73,6 +77,13 @@ final class WorkflowTaskScheduler implements Closeable {
         this.pollIntervalMillis = pollInterval.toMillis();
         this.pollBackoffFunction = pollBackoffFunction;
         this.onTasksScheduled = onTasksScheduled;
+        this.concurrencyKeyMaintenanceWorker =
+                new ConcurrencyKeyMaintenanceWorker(
+                        jdbi,
+                        leadershipSupplier,
+                        meterRegistry,
+                        concurrencyKeyWakeupRepairInterval,
+                        this::nudge);
         this.pollThread = Thread.ofPlatform()
                 .name(getClass().getSimpleName())
                 .unstarted(this::pollLoop);
@@ -88,7 +99,7 @@ final class WorkflowTaskScheduler implements Closeable {
         tasksScheduledCounter = Counter
                 .builder("dt.dex.engine.workflow.tasks.scheduled")
                 .withRegistry(meterRegistry);
-
+        concurrencyKeyMaintenanceWorker.start();
         pollThread.start();
     }
 
@@ -99,6 +110,8 @@ final class WorkflowTaskScheduler implements Closeable {
 
     @Override
     public void close() {
+        concurrencyKeyMaintenanceWorker.close();
+
         if (pollThread.isAlive()) {
             LOGGER.debug("Waiting for poll thread to stop");
             stopped = true;
@@ -192,7 +205,13 @@ final class WorkflowTaskScheduler implements Closeable {
     private PollResult poll() {
         if (!leadershipSupplier.get()) {
             LOGGER.debug("Not the leader; Skipping poll");
+            wasLeader = false;
             return PollResult.SKIPPED;
+        }
+
+        if (!wasLeader) {
+            wasLeader = true;
+            concurrencyKeyMaintenanceWorker.nudge();
         }
 
         final List<Queue> queues = jdbi.withHandle(this::getActiveQueuesWithCapacity);
@@ -201,30 +220,30 @@ final class WorkflowTaskScheduler implements Closeable {
             return PollResult.NO_TASKS_SCHEDULED;
         }
 
-        boolean didScheduleTasks = false;
+        boolean madeProgress = false;
         for (final Queue queue : queues) {
             final Timer.Sample latencySample = Timer.start();
             try (var _ = MDC.putCloseable("queueName", queue.name())) {
-                didScheduleTasks |= jdbi.inTransaction(handle -> processQueue(handle, queue));
+                madeProgress |= jdbi.inTransaction(handle -> processQueue(handle, queue));
             } finally {
                 latencySample.stop(
                         taskSchedulingLatencyTimer
-                                .withTag("queueName", queue.name));
+                                .withTag("queueName", queue.name()));
             }
         }
 
-        return didScheduleTasks
+        return madeProgress
                 ? PollResult.TASKS_SCHEDULED
                 : PollResult.NO_TASKS_SCHEDULED;
     }
 
-    private record Queue(String name, int capacity) {
+    private record Queue(String name, int remainingCapacity) {
 
         private static class RowMapper implements org.jdbi.v3.core.mapper.RowMapper<Queue> {
 
             @Override
             public Queue map(ResultSet rs, StatementContext ctx) throws SQLException {
-                return new Queue(rs.getString("name"), rs.getInt("capacity"));
+                return new Queue(rs.getString("name"), rs.getInt("remaining_capacity"));
             }
 
         }
@@ -233,27 +252,23 @@ final class WorkflowTaskScheduler implements Closeable {
 
     private List<Queue> getActiveQueuesWithCapacity(Handle handle) {
         final Query query = handle.createQuery("""
-                with cte_candidate as (
-                  select name
-                       , capacity
-                    from dex_workflow_task_queue
-                   where status = 'ACTIVE'
-                )
-                select queue.name
-                     , queue.capacity
-                  from dex_workflow_task_queue as queue
-                 inner join cte_candidate
-                    on cte_candidate.name = queue.name
-                 where status = 'ACTIVE'
-                   and queue.capacity - (
-                         select count(*)
-                           from (
-                             select 1
-                               from dex_workflow_task
-                              where queue_name = queue.name
-                              limit cte_candidate.capacity
-                           ) as limited
-                       ) > 0
+                select name
+                     , remaining_capacity
+                  from (
+                    select name
+                         , capacity - (
+                             select count(*)
+                               from (
+                                 select 1
+                                   from dex_workflow_task as task
+                                  where task.queue_name = queue.name
+                                  limit queue.capacity
+                               ) as limited
+                           ) as remaining_capacity
+                      from dex_workflow_task_queue as queue
+                     where status = 'ACTIVE'
+                  ) as queue_with_capacity
+                 where remaining_capacity > 0
                 """);
 
         return query
@@ -261,108 +276,15 @@ final class WorkflowTaskScheduler implements Closeable {
                 .list();
     }
 
+    private record SchedulingResult(
+            List<String> workflowNames,
+            int consumedConcurrencyKeyHints) {
+    }
+
     private boolean processQueue(Handle handle, Queue queue) {
-        // Disable JIT for this transaction. The scheduling query uses
-        // multiple correlated subqueries which throws off Postgres'
-        // row estimates, leading it to enable JIT.
-        // Unfortunately, JIT adds more overhead (>200ms) than the
-        // query actually ends up running for (<50ms even for large backlogs).
-        handle.execute("set local jit = off");
+        final SchedulingResult result = scheduleEligibleRuns(handle, queue);
 
-        final Update update = handle.createUpdate("""
-                with
-                cte_queue_depth as (
-                  select count(*) as depth
-                    from (
-                      select 1
-                        from dex_workflow_task
-                       where queue_name = :queueName
-                       limit :capacity
-                    ) as limited
-                ),
-                cte_eligible_run as (
-                  select id
-                       , workflow_name
-                       , priority
-                       , sticky_to
-                       , sticky_until
-                    from dex_workflow_run as run
-                   where task_queue_name = :queueName
-                     and status in ('CREATED', 'RUNNING', 'SUSPENDED')
-                     -- Only consider runs with visible messages in their inbox.
-                     and exists(
-                       select 1
-                         from dex_workflow_inbox as inbox
-                        where inbox.workflow_run_id = run.id
-                          and visible_from <= now()
-                     )
-                     -- Only consider runs for which no task is already queued.
-                     and not exists(
-                       select 1
-                         from dex_workflow_task as task
-                        where task.queue_name = :queueName
-                          and task.workflow_run_id = run.id
-                     )
-                     and (
-                       run.concurrency_key is null
-                       or run.status != 'CREATED'
-                       or (
-                         -- This run is the highest priority CREATED run of a concurrency key.
-                         not exists(
-                           select 1
-                             from dex_workflow_run as other
-                            where other.concurrency_key = run.concurrency_key
-                              and other.status = 'CREATED'
-                              and (other.priority, other.id) > (run.priority, run.id)
-                         )
-                         -- No other run with the same concurrency key is currently executing.
-                         and not exists(
-                           select 1
-                             from dex_workflow_run as executing
-                            where executing.concurrency_key = run.concurrency_key
-                              and executing.status in ('RUNNING', 'SUSPENDED')
-                         )
-                         -- No other run with the same concurrency key has a task already queued.
-                         and not exists(
-                           select 1
-                             from dex_workflow_task as task
-                            inner join dex_workflow_run as queued
-                               on queued.id = task.workflow_run_id
-                            where queued.concurrency_key = run.concurrency_key
-                              and task.queue_name = :queueName
-                         )
-                       )
-                     )
-                   order by priority desc
-                          , id
-                   limit greatest(0, :capacity - (select depth from cte_queue_depth))
-                )
-                insert into dex_workflow_task (
-                  queue_name
-                , workflow_run_id
-                , workflow_name
-                , priority
-                , sticky_to
-                , sticky_until
-                )
-                select :queueName
-                     , id
-                     , workflow_name
-                     , priority
-                     , sticky_to
-                     , sticky_until
-                  from cte_eligible_run
-                on conflict (queue_name, workflow_run_id) do nothing
-                returning workflow_name
-                """);
-
-        final List<String> scheduledWorkflowNames = update
-                .bind("queueName", queue.name())
-                .bind("capacity", queue.capacity())
-                .executeAndReturnGeneratedKeys()
-                .mapTo(String.class)
-                .list();
-
+        final List<String> scheduledWorkflowNames = result.workflowNames();
         final boolean didSchedule = !scheduledWorkflowNames.isEmpty();
         handle.afterCommit(() -> {
             for (final String workflowName : scheduledWorkflowNames) {
@@ -376,7 +298,268 @@ final class WorkflowTaskScheduler implements Closeable {
             }
         });
 
-        return didSchedule;
+        // Consumed hints count as progress even when nothing was admitted.
+        // Draining a flood of stale hints must not be slowed by poll backoff.
+        return didSchedule || result.consumedConcurrencyKeyHints() > 0;
+    }
+
+    private SchedulingResult scheduleEligibleRuns(Handle handle, Queue queue) {
+        // Disable JIT for this transaction. The scheduling query uses
+        // multiple correlated subqueries which throw off Postgres'
+        // row estimates, leading it to enable JIT. Unfortunately, JIT adds
+        // more overhead than the query usually ends up running for.
+        //
+        // Force custom query plans for this transaction. The JDBC driver uses
+        // server-side prepared statements. Generic plans cached while the
+        // tables are (close to) empty degrade polls by orders of magnitude
+        // during bursts.
+        handle.execute("""
+                select set_config('jit', 'off', /* is_local */ true)
+                     , set_config('plan_cache_mode', 'force_custom_plan', /* is_local */ true)
+                """);
+
+        final Query query = handle.createQuery("""
+                with
+                -- A bounded batch of wakeups. Within each priority, freed concurrency keys
+                -- come first so keys freed mid-burst are not buried behind a flood of creation wakeups.
+                -- The rest follow in arrival order, so no key is starved by newer arrivals.
+                cte_hint as (
+                  select concurrency_key
+                       , version
+                    from dex_workflow_concurrency_key_wakeup
+                   where queue_name = :queueName
+                   order by priority desc
+                          , freed desc
+                          , created_at
+                   limit :concurrencyKeyHintBudget
+                ),
+                -- Verify each hinted key against the run, task, and inbox tables before admission.
+                -- Note that hints carry no authority. A stale hint at worst costs a wasted probe,
+                -- but never a wrong admission. The result has one row per hint, so the consuming
+                -- delete stays a one-to-one join.
+                -- NB: All probes are laterals with limit 1,
+                -- immune to join commutation and bounded by the hint budget.
+                cte_verified_hint as (
+                  select cte_hint.concurrency_key
+                       , cte_hint.version
+                       , run.id
+                       , run.workflow_name
+                       , run.priority
+                       , run.sticky_to
+                       , run.sticky_until
+                       , (
+                           run.id is not null
+                           and has_executing is null
+                           and has_queued_task is null
+                           and has_message is not null
+                         ) as schedulable
+                    from cte_hint
+                    -- The key's highest priority CREATED run.
+                    left join lateral (
+                     select candidate.id
+                       from dex_workflow_run as candidate
+                      where candidate.concurrency_key = cte_hint.concurrency_key
+                        and candidate.status = 'CREATED'
+                      order by candidate.priority desc
+                             , candidate.id
+                      limit 1
+                    ) as winner on true
+                    left join dex_workflow_run as run
+                      on run.id = winner.id
+                     and run.task_queue_name = :queueName
+                    left join lateral (
+                     select 1
+                       from dex_workflow_run as executing
+                      where executing.concurrency_key = cte_hint.concurrency_key
+                        and executing.concurrency_key is not null
+                        and executing.status in ('RUNNING', 'SUSPENDED')
+                      limit 1
+                    ) as has_executing on true
+                    left join lateral (
+                     select 1
+                       from dex_workflow_task as task
+                      where task.queue_name = :queueName
+                        and task.concurrency_key = cte_hint.concurrency_key
+                      limit 1
+                    ) as has_queued_task on true
+                    left join lateral (
+                     select 1
+                       from dex_workflow_inbox as inbox
+                      where inbox.workflow_run_id = run.id
+                        and inbox.visible_from <= now()
+                      limit 1
+                    ) as has_message on true
+                ),
+                cte_locked_hint as (
+                  select wakeup.concurrency_key
+                       , wakeup.version
+                    from dex_workflow_concurrency_key_wakeup as wakeup
+                   inner join cte_verified_hint as verified
+                      on verified.concurrency_key = wakeup.concurrency_key
+                   where wakeup.queue_name = :queueName
+                     and wakeup.version = verified.version
+                     and not verified.schedulable
+                   order by wakeup.concurrency_key
+                     for update of wakeup
+                ),
+                cte_consumed_hint as (
+                  delete
+                    from dex_workflow_concurrency_key_wakeup as wakeup
+                   using cte_locked_hint as locked
+                   where wakeup.queue_name = :queueName
+                     and wakeup.concurrency_key = locked.concurrency_key
+                     and wakeup.version = locked.version
+                  returning 1
+                ),
+                cte_eligible_run as (
+                  -- CREATED runs without concurrency key.
+                  (
+                    select run.id
+                         , run.workflow_name
+                         , run.priority
+                         , run.sticky_to
+                         , run.sticky_until
+                         , run.concurrency_key
+                      from (
+                        -- NB: Selecting only id and priority keeps this an index-only scan.
+                        select candidate.id
+                             , candidate.priority
+                          from dex_workflow_run as candidate
+                         -- NB: Lateral joins with limit 1 prevent the planner from switching
+                         -- to a semi-join, which always performs worse here. DO NOT change
+                         -- these to exists(...) without prior benchmarking!
+                         cross join lateral (
+                           select 1
+                             from dex_workflow_inbox as inbox
+                            where inbox.workflow_run_id = candidate.id
+                              and inbox.visible_from <= now()
+                            limit 1
+                         ) as has_message
+                          left join lateral (
+                           select 1
+                             from dex_workflow_task as task
+                            where task.queue_name = :queueName
+                              and task.workflow_run_id = candidate.id
+                            limit 1
+                          ) as has_task on true
+                         where candidate.task_queue_name = :queueName
+                           and candidate.status = 'CREATED'
+                           and candidate.concurrency_key is null
+                           and has_task is null
+                         order by candidate.priority desc
+                                , candidate.id
+                         limit :limit
+                      ) as top
+                     inner join dex_workflow_run as run
+                        on run.id = top.id
+                     order by top.priority desc
+                            , top.id
+                     limit :limit
+                  )
+                  union all
+                  -- RUNNING / SUSPENDED runs.
+                  (
+                    select run.id
+                         , run.workflow_name
+                         , run.priority
+                         , run.sticky_to
+                         , run.sticky_until
+                         , run.concurrency_key
+                      from (
+                        select candidate.id
+                             , candidate.priority
+                          from dex_workflow_run as candidate
+                         cross join lateral (
+                           select 1
+                             from dex_workflow_inbox as inbox
+                            where inbox.workflow_run_id = candidate.id
+                              and inbox.visible_from <= now()
+                            limit 1
+                         ) as has_message
+                          left join lateral (
+                           select 1
+                             from dex_workflow_task as task
+                            where task.queue_name = :queueName
+                              and task.workflow_run_id = candidate.id
+                            limit 1
+                          ) as has_task on true
+                         where candidate.task_queue_name = :queueName
+                           and candidate.status in ('RUNNING', 'SUSPENDED')
+                           and has_task is null
+                         order by candidate.priority desc
+                                , candidate.id
+                         limit :limit
+                      ) as top
+                     inner join dex_workflow_run as run
+                        on run.id = top.id
+                     order by top.priority desc
+                            , top.id
+                     limit :limit
+                  )
+                  union all
+                  -- Schedulable CREATED runs with concurrency key.
+                  (
+                    select id
+                         , workflow_name
+                         , priority
+                         , sticky_to
+                         , sticky_until
+                         , concurrency_key
+                      from cte_verified_hint
+                     where schedulable
+                     order by priority desc
+                            , id
+                     limit :limit
+                  )
+                  order by priority desc
+                         , id
+                  limit :limit
+                ),
+                cte_scheduled_task as (
+                  insert into dex_workflow_task (
+                    queue_name
+                  , workflow_run_id
+                  , workflow_name
+                  , priority
+                  , sticky_to
+                  , sticky_until
+                  , concurrency_key
+                  )
+                  select :queueName
+                       , id
+                       , workflow_name
+                       , priority
+                       , sticky_to
+                       , sticky_until
+                       , concurrency_key
+                    from cte_eligible_run
+                  on conflict (queue_name, workflow_run_id) do nothing
+                  returning workflow_name
+                )
+                select scheduled.workflow_name
+                     , consumed.consumed_hint_count
+                  from (
+                    select count(*) as consumed_hint_count
+                      from cte_consumed_hint
+                  ) as consumed
+                  left join cte_scheduled_task as scheduled
+                    on true
+                """);
+
+        final var consumedConcurrencyKeyHints = new long[]{0};
+        final List<String> workflowNames = query
+                .bind("queueName", queue.name())
+                .bind("limit", queue.remainingCapacity())
+                .bind("concurrencyKeyHintBudget", queue.remainingCapacity() * CONCURRENCY_KEY_HINT_BUDGET_FACTOR)
+                .map((rs, _) -> {
+                    consumedConcurrencyKeyHints[0] = rs.getLong("consumed_hint_count");
+                    return rs.getString("workflow_name");
+                })
+                // NB: workflow_name is null when hints were consumed but nothing was scheduled.
+                .filter(Objects::nonNull)
+                .collectIntoList();
+
+        return new SchedulingResult(workflowNames, Math.toIntExact(consumedConcurrencyKeyHints[0]));
     }
 
 }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/WorkflowDao.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/WorkflowDao.java
@@ -33,9 +33,11 @@ import org.dependencytrack.dex.engine.persistence.command.CreateWorkflowRunHisto
 import org.dependencytrack.dex.engine.persistence.command.DeleteWorkflowMessagesCommand;
 import org.dependencytrack.dex.engine.persistence.command.PollWorkflowTaskCommand;
 import org.dependencytrack.dex.engine.persistence.command.UpdateAndUnlockRunCommand;
+import org.dependencytrack.dex.engine.persistence.model.ConcurrencyKeyWakeup;
 import org.dependencytrack.dex.engine.persistence.model.PolledWorkflowEvent;
 import org.dependencytrack.dex.engine.persistence.model.PolledWorkflowEvents;
 import org.dependencytrack.dex.engine.persistence.model.PolledWorkflowTask;
+import org.dependencytrack.dex.engine.persistence.model.UnlockedWorkflowRun;
 import org.dependencytrack.dex.engine.persistence.request.GetWorkflowRunHistoryRequest;
 import org.dependencytrack.dex.proto.event.v1.WorkflowEvent;
 import org.jdbi.v3.core.Handle;
@@ -109,7 +111,7 @@ public final class WorkflowDao extends AbstractDao {
 
         final Map.Entry<Boolean, Boolean> existsAndUpdated = query
                 .bindMethods(request)
-                .map((rs, ctx) -> Map.entry(rs.getBoolean(1), rs.getBoolean(2)))
+                .map((rs, _) -> Map.entry(rs.getBoolean(1), rs.getBoolean(2)))
                 .one();
 
         final boolean exists = existsAndUpdated.getKey();
@@ -309,16 +311,16 @@ public final class WorkflowDao extends AbstractDao {
                 .bind("priorities", priorities)
                 .bind("labelsJsons", labelsJsons)
                 .bind("createdAts", createdAts)
-                .map((rs, ctx) -> Map.entry(
+                .map((rs, _) -> Map.entry(
                         rs.getObject("request_id", UUID.class),
                         rs.getObject("run_id", UUID.class)))
                 .collectToMap(Map.Entry::getKey, Map.Entry::getValue);
     }
 
-    public List<UUID> updateAndUnlockRuns(
+    public List<UnlockedWorkflowRun> updateAndUnlockRuns(
             String engineInstanceId,
             Collection<UpdateAndUnlockRunCommand> commands) {
-        final Update update = jdbiHandle.createUpdate("""
+        final Query query = jdbiHandle.createQuery("""
                 with
                 cte_cmd as (
                   select *
@@ -335,26 +337,39 @@ public final class WorkflowDao extends AbstractDao {
                      and task.lock_version = cte_cmd.lock_version
                   returning task.workflow_run_id
                           , task.queue_name
+                ),
+                cte_updated_run as (
+                  update dex_workflow_run as run
+                     set status = coalesce(cte_cmd.status, run.status)
+                       , custom_status = coalesce(cte_cmd.custom_status, run.custom_status)
+                       , continued_as_new_generation =
+                           case
+                             when cte_cmd.continued_as_new
+                             then run.continued_as_new_generation + 1
+                             else run.continued_as_new_generation
+                           end
+                       , sticky_to = cte_cmd.sticky_to
+                       , sticky_until = case when cte_cmd.sticky_to is not null then now() + interval '30 seconds' end
+                       , updated_at = coalesce(cte_cmd.updated_at, run.updated_at)
+                       , started_at = coalesce(cte_cmd.started_at, run.started_at)
+                       , completed_at = coalesce(cte_cmd.completed_at, run.completed_at)
+                    from cte_deleted_task
+                   inner join cte_cmd
+                      on cte_cmd.id = cte_deleted_task.workflow_run_id
+                   where run.id = cte_deleted_task.workflow_run_id
+                  returning run.id
+                          , run.status
+                          , run.concurrency_key
+                          , cte_deleted_task.queue_name
                 )
-                update dex_workflow_run as run
-                   set status = coalesce(cte_cmd.status, run.status)
-                     , custom_status = coalesce(cte_cmd.custom_status, run.custom_status)
-                     , continued_as_new_generation =
-                         case
-                           when cte_cmd.continued_as_new
-                           then run.continued_as_new_generation + 1
-                           else run.continued_as_new_generation
-                         end
-                     , sticky_to = cte_cmd.sticky_to
-                     , sticky_until = case when cte_cmd.sticky_to is not null then now() + interval '30 seconds' end
-                     , updated_at = coalesce(cte_cmd.updated_at, run.updated_at)
-                     , started_at = coalesce(cte_cmd.started_at, run.started_at)
-                     , completed_at = coalesce(cte_cmd.completed_at, run.completed_at)
-                  from cte_deleted_task
-                 inner join cte_cmd
-                    on cte_cmd.id = cte_deleted_task.workflow_run_id
-                 where run.id = cte_deleted_task.workflow_run_id
-                returning run.id
+                select id
+                     , queue_name
+                     , case
+                         when concurrency_key is not null
+                          and status not in ('RUNNING', 'SUSPENDED')
+                         then concurrency_key
+                       end as freed_concurrency_key
+                  from cte_updated_run
                 """);
 
         final var ids = new UUID[commands.size()];
@@ -385,7 +400,7 @@ public final class WorkflowDao extends AbstractDao {
             i++;
         }
 
-        return update
+        return query
                 .bind("engineInstanceId", engineInstanceId)
                 .bind("ids", ids)
                 .bind("queueNames", queueNames)
@@ -397,9 +412,74 @@ public final class WorkflowDao extends AbstractDao {
                 .bind("startedAts", startedAts)
                 .bind("completedAts", completedAts)
                 .bind("lockVersions", lockVersions)
-                .executeAndReturnGeneratedKeys()
-                .mapTo(UUID.class)
+                .map((rs, _) -> new UnlockedWorkflowRun(
+                        rs.getObject("id", UUID.class),
+                        rs.getString("queue_name"),
+                        rs.getString("freed_concurrency_key")))
                 .list();
+    }
+
+    public void upsertConcurrencyKeyWakeups(Collection<ConcurrencyKeyWakeup> wakeups) {
+        if (wakeups.isEmpty()) {
+            return;
+        }
+
+        final var queueNames = new String[wakeups.size()];
+        final var concurrencyKeys = new String[wakeups.size()];
+        final var freeds = new boolean[wakeups.size()];
+
+        int i = 0;
+        for (final ConcurrencyKeyWakeup wakeup : wakeups) {
+            queueNames[i] = wakeup.queueName();
+            concurrencyKeys[i] = wakeup.concurrencyKey();
+            freeds[i] = wakeup.freed();
+            i++;
+        }
+
+        jdbiHandle
+                .createUpdate("""
+                        insert into dex_workflow_concurrency_key_wakeup (
+                          queue_name
+                        , concurrency_key
+                        , priority
+                        , freed
+                        )
+                        select hint.queue_name
+                             , hint.concurrency_key
+                             , winner.priority
+                             , hint.freed
+                          from (
+                            select queue_name
+                                 , concurrency_key
+                                 , bool_or(freed) as freed
+                              from unnest(:queueNames, :concurrencyKeys, :freeds)
+                                as t(queue_name, concurrency_key, freed)
+                             group by queue_name
+                                    , concurrency_key
+                          ) as hint
+                          left join lateral (
+                            select run.priority
+                              from dex_workflow_run as run
+                             where run.concurrency_key = hint.concurrency_key
+                               and run.status = 'CREATED'
+                             order by run.priority desc
+                                    , run.id
+                             limit 1
+                          ) as winner on true
+                         -- Skip keys without a CREATED run. There is nothing to schedule for them,
+                         -- and if a run is created later, that creation causes its own wakeup.
+                         where winner.priority is not null
+                         order by hint.queue_name
+                                , hint.concurrency_key
+                        on conflict (queue_name, concurrency_key)
+                        do update set priority = greatest(dex_workflow_concurrency_key_wakeup.priority, excluded.priority)
+                                    , version = dex_workflow_concurrency_key_wakeup.version + 1
+                                    , freed = dex_workflow_concurrency_key_wakeup.freed or excluded.freed
+                        """)
+                .bind("queueNames", queueNames)
+                .bind("concurrencyKeys", concurrencyKeys)
+                .bind("freeds", freeds)
+                .execute();
     }
 
     public @Nullable WorkflowRunMetadata getRunMetadataById(UUID id) {

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/model/ConcurrencyKeyWakeup.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/model/ConcurrencyKeyWakeup.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.dex.engine.persistence.model;
+
+/// Hint for the workflow task scheduler that a concurrency key experienced a change.
+///
+/// @param queueName      Name of the queue for which the concurrency key applies.
+/// @param concurrencyKey The concurrency key that experienced a change.
+/// @param freed          Whether the change was caused by a workflow run terminating,
+///                       freeing the concurrency key for a new run.
+public record ConcurrencyKeyWakeup(String queueName, String concurrencyKey, boolean freed) {
+}

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/model/UnlockedWorkflowRun.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/model/UnlockedWorkflowRun.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.dex.engine.persistence.model;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.UUID;
+
+/// @param id                  ID of the workflow run that got unlocked.
+/// @param queueName           Name of the task queue the workflow run resides on.
+/// @param freedConcurrencyKey The concurrency key freed by termination of this run, if any.
+public record UnlockedWorkflowRun(UUID id, String queueName, @Nullable String freedConcurrencyKey) {
+}

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
@@ -759,6 +759,227 @@ class DexEngineImplTest {
             assertThat(executionQueue).containsExactly("5", "4", "3", "2", "1");
         }
 
+        @Test
+        void shouldBlockContenderWhileConcurrencyKeyHolderIsExecuting() throws Exception {
+            registerWorkflow("holder", (ctx, _) -> {
+                ctx.waitForExternalEvent("resume", voidConverter(), Duration.ofSeconds(30)).await();
+                return null;
+            });
+            registerWorkflow("contender", (_, _) -> null);
+            registerWorkflowWorker("workflow-worker", 2);
+            engine.start();
+
+            final UUID holderRunId = engine.createRun(
+                    new CreateWorkflowRunRequest<>("holder", 1)
+                            .withConcurrencyKey("someConcurrencyKey"));
+            await("Holder to await the external event")
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(
+                            () -> assertThat(engine.getRunMetadataById(holderRunId).updatedAt())
+                                    .isNotNull());
+
+            final UUID contenderRunId = engine.createRun(
+                    new CreateWorkflowRunRequest<>("contender", 1)
+                            .withConcurrencyKey("someConcurrencyKey"));
+
+            await("Contender to stay pending while holder is executing")
+                    .during(Duration.ofMillis(750))
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(
+                            () -> assertThat(engine.getRunMetadataById(contenderRunId).status())
+                                    .isEqualTo(WorkflowRunStatus.CREATED));
+
+            // The blocked key's wakeup must have been verified and consumed.
+            // The holder's later completion is what re-creates it.
+            final Jdbi jdbi = Jdbi.create(dataSource);
+            await("Blocked key's wakeup to be consumed")
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> {
+                        final Integer wakeupCount = jdbi.withHandle(handle -> handle
+                                .createQuery("""
+                                        select count(*)
+                                          from dex_workflow_concurrency_key_wakeup
+                                         where concurrency_key = 'someConcurrencyKey'
+                                        """)
+                                .mapTo(Integer.class)
+                                .one());
+                        assertThat(wakeupCount).isZero();
+                    });
+
+            engine.sendExternalEvent(new ExternalEvent(holderRunId, "resume", null)).get(1, TimeUnit.SECONDS);
+            awaitRunStatus(holderRunId, WorkflowRunStatus.COMPLETED);
+            awaitRunStatus(contenderRunId, WorkflowRunStatus.COMPLETED);
+        }
+
+        @Test
+        void shouldBlockContenderWhileConcurrencyKeyHolderIsSuspended() throws Exception {
+            registerWorkflow("holder", (ctx, _) -> {
+                ctx.waitForExternalEvent("resume", voidConverter(), Duration.ofSeconds(30)).await();
+                return null;
+            });
+            registerWorkflow("contender", (_, _) -> null);
+            registerWorkflowWorker("workflow-worker", 2);
+            engine.start();
+
+            final UUID holderRunId = engine.createRun(
+                    new CreateWorkflowRunRequest<>("holder", 1)
+                            .withConcurrencyKey("someConcurrencyKey"));
+            await("Holder to await the external event")
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(
+                            () -> assertThat(engine.getRunMetadataById(holderRunId).updatedAt())
+                                    .isNotNull());
+            engine.requestRunSuspension(holderRunId);
+            awaitRunStatus(holderRunId, WorkflowRunStatus.SUSPENDED);
+
+            final UUID contenderRunId = engine.createRun(
+                    new CreateWorkflowRunRequest<>("contender", 1)
+                            .withConcurrencyKey("someConcurrencyKey"));
+
+            await("Contender to stay pending while holder is suspended")
+                    .during(Duration.ofMillis(750))
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(
+                            () -> assertThat(engine.getRunMetadataById(contenderRunId).status())
+                                    .isEqualTo(WorkflowRunStatus.CREATED));
+
+            engine.requestRunResumption(holderRunId);
+            engine.sendExternalEvent(new ExternalEvent(holderRunId, "resume", null)).get(1, TimeUnit.SECONDS);
+            awaitRunStatus(holderRunId, WorkflowRunStatus.COMPLETED);
+            awaitRunStatus(contenderRunId, WorkflowRunStatus.COMPLETED);
+        }
+
+        @Test
+        void shouldScheduleContenderWhenConcurrencyKeyHolderIsCancelled() {
+            registerWorkflow("holder", (ctx, _) -> {
+                ctx.waitForExternalEvent("never", voidConverter(), Duration.ofSeconds(60)).await();
+                return null;
+            });
+            registerWorkflow("contender", (_, _) -> null);
+            registerWorkflowWorker("workflow-worker", 2);
+            engine.start();
+
+            final UUID holderRunId = engine.createRun(
+                    new CreateWorkflowRunRequest<>("holder", 1)
+                            .withConcurrencyKey("someConcurrencyKey"));
+            await("Holder to await the external event")
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(
+                            () -> assertThat(engine.getRunMetadataById(holderRunId).updatedAt())
+                                    .isNotNull());
+
+            final UUID contenderRunId = engine.createRun(
+                    new CreateWorkflowRunRequest<>("contender", 1)
+                            .withConcurrencyKey("someConcurrencyKey"));
+
+            engine.requestRunCancellation(holderRunId, "someReason");
+            awaitRunStatus(holderRunId, WorkflowRunStatus.CANCELLED);
+            awaitRunStatus(contenderRunId, WorkflowRunStatus.COMPLETED);
+        }
+
+        @Test
+        void shouldBlockContenderWhileKeyHolderContinuesAsNew() throws Exception {
+            final var secondGenerationStarted = new CountDownLatch(1);
+            registerWorkflow("holder", stringConverter(), voidConverter(), (ctx, arg) -> {
+                if ("first".equals(arg)) {
+                    ctx.continueAsNew(
+                            new ContinueAsNewOptions<String>()
+                                    .withArgument("second"));
+                    return null;
+                }
+
+                secondGenerationStarted.countDown();
+                ctx.waitForExternalEvent("resume", voidConverter(), Duration.ofSeconds(30)).await();
+                return null;
+            });
+            registerWorkflow("contender", (_, _) -> null);
+            registerWorkflowWorker("workflow-worker", 2);
+            engine.start();
+
+            final UUID holderRunId = engine.createRun(
+                    new CreateWorkflowRunRequest<>("holder", 1)
+                            .withConcurrencyKey("someConcurrencyKey")
+                            .withArgument("first"));
+
+            final UUID contenderRunId = engine.createRun(
+                    new CreateWorkflowRunRequest<>("contender", 1)
+                            .withConcurrencyKey("someConcurrencyKey"));
+
+            // The continued run keeps holding its key, so the contender must
+            // stay blocked across the continue-as-new boundary.
+            assertThat(secondGenerationStarted.await(5, TimeUnit.SECONDS)).isTrue();
+            await("Contender to stay pending while holder continues as new")
+                    .during(Duration.ofMillis(750))
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(
+                            () -> assertThat(engine.getRunMetadataById(contenderRunId).status())
+                                    .isEqualTo(WorkflowRunStatus.CREATED));
+
+            engine.sendExternalEvent(new ExternalEvent(holderRunId, "resume", null)).get(1, TimeUnit.SECONDS);
+            awaitRunStatus(holderRunId, WorkflowRunStatus.COMPLETED);
+            awaitRunStatus(contenderRunId, WorkflowRunStatus.COMPLETED);
+        }
+
+        @Test
+        void shouldExecuteChildWorkflowWithConcurrencyKey() {
+            registerWorkflow("parent", (ctx, _) -> {
+                ctx.callChildWorkflow(
+                        "child", 1, null, WORKFLOW_TASK_QUEUE,
+                        "childConcurrencyKey", null, voidConverter(), voidConverter()).await();
+                return null;
+            });
+            registerWorkflow("child", (_, _) -> null);
+            registerWorkflowWorker("workflow-worker", 2);
+            engine.start();
+
+            final UUID runId = engine.createRun(new CreateWorkflowRunRequest<>("parent", 1));
+
+            awaitRunStatus(runId, WorkflowRunStatus.COMPLETED);
+        }
+
+        @Test
+        void shouldRepairLostConcurrencyKeyWakeups() throws Exception {
+            engine.close();
+
+            final var config = new DexEngineConfig(dataSource);
+            config.workflowTaskScheduler().setPollInterval(Duration.ofMillis(10));
+            config.workflowTaskScheduler().setPollBackoffFunction(IntervalFunction.of(10));
+            config.workflowTaskScheduler().setConcurrencyKeyWakeupRepairInterval(Duration.ofMillis(250));
+            config.activityTaskScheduler().setPollInterval(Duration.ofMillis(10));
+            config.activityTaskScheduler().setPollBackoffFunction(IntervalFunction.of(10));
+            config.taskEventBuffer().setFlushInterval(Duration.ofMillis(10));
+            engine = new DexEngineImpl(config);
+
+            registerWorkflow("test", (_, _) -> null);
+            registerWorkflowWorker("workflow-worker", 1);
+            engine.start();
+
+            // While the queue is paused, the scheduler leaves the wakeup alone.
+            engine.updateTaskQueue(new UpdateTaskQueueRequest(
+                    TaskType.WORKFLOW, WORKFLOW_TASK_QUEUE, TaskQueueStatus.PAUSED, null));
+            final UUID runId = engine.createRun(
+                    new CreateWorkflowRunRequest<>("test", 1)
+                            .withConcurrencyKey("someConcurrencyKey"));
+
+            final Jdbi jdbi = Jdbi.create(dataSource);
+            final Integer wakeupCount = jdbi.withHandle(handle -> handle
+                    .createQuery("""
+                            select count(*)
+                              from dex_workflow_concurrency_key_wakeup
+                             where concurrency_key = 'someConcurrencyKey'
+                            """)
+                    .mapTo(Integer.class)
+                    .one());
+            assertThat(wakeupCount).isEqualTo(1);
+
+            // Simulate the wakeup loss of a crash (the table is unlogged).
+            jdbi.useHandle(handle -> handle.execute("truncate table dex_workflow_concurrency_key_wakeup"));
+
+            // No write path will leave another wakeup for this run. Only the repair pass can revive it.
+            engine.updateTaskQueue(new UpdateTaskQueueRequest(
+                    TaskType.WORKFLOW, WORKFLOW_TASK_QUEUE, TaskQueueStatus.ACTIVE, null));
+            awaitRunStatus(runId, WorkflowRunStatus.COMPLETED, Duration.ofSeconds(10));
+        }
     }
 
     @Test
@@ -1306,7 +1527,7 @@ class DexEngineImplTest {
                 .until(activityStarted::get);
 
         engine.close();
-        
+
         final Integer attempt = Jdbi.create(dataSource).withHandle(handle -> handle
                 .createQuery("SELECT attempt FROM dex_activity_task WHERE workflow_run_id = :runId")
                 .bind("runId", runId)

--- a/docs/adr/033-dex-workflow-concurrency-key-wakeup-hints.md
+++ b/docs/adr/033-dex-workflow-concurrency-key-wakeup-hints.md
@@ -1,0 +1,264 @@
+| Status   | Date       | Author(s)                            |
+|:---------|:-----------|:-------------------------------------|
+| Accepted | 2026-07-26 | [@nscuro](https://github.com/nscuro) |
+
+## Context
+
+Dependency-Track runs almost all of its background work as [dex] workflow runs,
+and most of that work is per-project pipelines, for example:
+
+* importing a BOM or VEX
+* analyzing a project for vulnerabilities
+* evaluating policies
+* updating metrics
+
+These pipelines must not run concurrently for the same project.
+Two analyses of one project would race on its findings and metrics.
+
+The engine expresses this with concurrency keys such as `import-bom:<project uuid>`,
+where at most one run per key executes at a time. Per-project concurrency control was
+a primary motivator for adopting workflow orchestration over queue-centric job chaining
+in [ADR 002](./002-workflow-orchestration.md). Dependency-Track is the engine's only consumer,
+and concurrency keys are the primitive its correctness leans on.
+
+Keyed runs are therefore the bulk of all workflow traffic, and their volume is tied to
+portfolio size. The scheduled portfolio analysis creates one keyed run per project in a
+single burst, and every BOM upload adds more. A deployment with many projects routinely
+holds a keyed backlog in the same order of magnitude as its project count.
+Thus, >200k pending keyed runs have been observed in production.
+
+The workflow task scheduler decides on every poll which keyed runs can be scheduled.
+A key is schedulable when:
+
+* its highest priority `CREATED` run has a visible message,
+* no run holding the key is executing, and
+* no task for the key is queued.
+
+The scheduler derives this from the run, task, and inbox tables from scratch on each poll.
+
+Deriving from scratch is robust. A wrong result lasts one poll, and no write path owes the
+scheduler any bookkeeping. But each poll scans the whole keyed backlog,
+so draining a backlog costs quadratic total work. Measured on HDD-class storage:
+
+| Keyed backlog | Poll duration |
+|--------------:|--------------:|
+|          200k |        ~0.4 s |
+|            1M |        ~1.8 s |
+|            2M |        ~3.7 s |
+
+Scheduling latency thus degrades exactly when the platform's core work happens:
+while it drains a portfolio-wide burst.
+
+Postgres-backed queue systems that met this problem at scale (e.g. [Solid Queue], [Hatchet],
+[Oban Pro], [River Pro]) all converged on maintaining readiness state at write time instead
+of deriving it at read time. All of them also made that state authoritative,
+meaning dispatch trusts it without re-checking. Solid Queue and Oban Pro have a public
+record of issues in this domain:
+
+* A leaked slot wedges a key. A worker killed mid-execution leaves the semaphore held,
+  and it is released only when its configured timeout expires ([solid-queue-546], [oban-pro-1.6.4]).
+* A release race silently reduces concurrency. Solid Queue's blocked-execution query
+  range-locks every row sharing a key, so a second worker concludes nothing is blocked
+  and stops, running one worker where five were configured ([solid-queue-694], [oban-pro-0.12.2]).
+* Enqueue contention aborts the caller's transaction. Two enqueues sharing a key collide on
+  the semaphore's unique constraint, and the application sees `PG::InFailedSqlTransaction` ([solid-queue-224]).
+
+### Possible Solutions
+
+#### Keep deriving per poll, optimize further
+
+**Pro:**
+
+* No new state, no new failure modes, self-healing every poll.
+* Already implemented and hardened against planner misbehavior.
+
+**Con:**
+
+* The remaining cost is the growth rate, not the constants.
+  No further tuning changes the quadratic drain cost.
+
+#### Materialize schedulability as run status
+
+A run would carry a "parked" or "ready" state, maintained when runs are created, completed, or suspended.
+
+**Pro:**
+
+* Poll cost becomes independent of backlog size.
+
+**Con:**
+
+* Postgres offers no atomic arbitration for `UPDATE` under a unique index.
+  Races between run creation and run completion on the same key abort entire write batches.
+* Wrong materialized state changes scheduling behavior until it is repaired.
+  The surveyed systems took this path, and their production bugs live here.
+
+#### Per-key advisory locks
+
+**Pro:**
+
+* No schema changes.
+
+**Con:**
+
+* A key is held across transactions, processes, and suspensions that can last days.
+  Advisory lock lifetimes cannot represent that.
+
+#### Advisory wakeup hints
+
+Writers record which keys recently had an event that could make them schedulable. The
+scheduler only inspects hinted keys, and verifies each against the source-of-truth tables
+before admitting anything.
+
+**Pro:**
+
+* Poll cost becomes proportional to queue capacity instead of backlog size.
+* Hints carry no authority. A wrong hint cannot cause a wrong admission,
+  only a wasted index probe.
+
+**Con:**
+
+* A missing hint stalls a key until a periodic repair pass restores it.
+  Every write path that can make a key schedulable must remember to leave a hint.
+
+## Decision
+
+We will implement advisory wakeup hints, called *concurrency key wakeups*.
+
+```mermaid
+sequenceDiagram
+    actor W as Write path
+    actor P as PostgreSQL
+    actor S as Scheduler
+
+    W ->> P: Create or complete keyed runs
+    W ->> P: Upsert wakeups for affected keys (same transaction)
+
+    activate S
+    S ->> P: Read wakeups, highest priority first
+    P -->> S: Candidate keys
+    S ->> P: Verify candidates against run, task, and inbox tables
+    P -->> S: Schedulable keys
+    S ->> P: Create tasks, delete wakeups that failed verification
+    deactivate S
+
+    loop Every repair interval, on the leader
+        S ->> P: Insert wakeups for schedulable keys that lack one
+    end
+```
+
+### Schema
+
+A new `dex_workflow_concurrency_key_wakeup` table holds one row per queue and concurrency
+key that recently had a relevant event:
+
+| Column            | Type          | Key |
+|:------------------|:--------------|:----|
+| `queue_name`      | `text`        | PK  |
+| `concurrency_key` | `text`        | PK  |
+| `priority`        | `smallint`    |     |
+| `version`         | `bigint`      |     |
+| `freed`           | `boolean`     |     |
+| `created_at`      | `timestamptz` |     |
+
+* `priority` is the priority of the key's highest `CREATED` run at the time the wakeup was written.
+  It can only overstate the current winner afterwards, which costs a wasted inspection, never a wrong one.
+* `version` is bumped by every upsert. It guards wakeup deletion against a concurrent refresh.
+* `freed` marks keys freed by workflow run termination, which signals an in-flight serialized chain.
+* `created_at` is set on first insert only and orders same-priority wakeups by arrival.
+
+The table is [`UNLOGGED`] because it is derived state that can be rebuilt at any time.
+
+### Writing wakeups
+
+Creating a keyed run leaves a wakeup for its key. Terminating a keyed run leaves one as
+well, because termination frees the key for its next contender. Wakeups are written in the
+same transaction as the state change that caused them, and a wakeup write can never abort
+that transaction. This rules out the enqueue-time failures seen in the surveyed systems.
+
+The wakeup table is the engine's only shared-write table. Everywhere else, each row has
+exactly one writer, which makes the engine's write paths deadlock free by construction.
+Advisory scheduling state cannot follow that rule, because creators, completers,
+and the scheduler all mutate the same rows. However, all writes are single-statement upserts,
+and all writers process keys in the same order, so the shared table stays deadlock free as well.
+
+### Consuming wakeups
+
+On each poll, the scheduler reads a bounded batch of wakeups: highest priority first,
+then freed keys before first-time wakeups, then arrival order. Every key is verified against
+the run, task, and inbox tables before anything is admitted. Only wakeups whose key failed
+verification are consumed. Wakeups of schedulable keys survive until their key is actually
+scheduled, so no admission is lost to capacity contention. The one-run-per-key invariant
+itself stays enforced by the unique index on executing runs, independent of any wakeup state.
+
+### Repair
+
+A repair pass periodically re-derives schedulable keys from the source-of-truth tables,
+on the leader only, and inserts wakeups that are missing. It bounds the damage of the design's
+new failure mode, i.e. a lost or never-written wakeup stalls its key for at most one repair
+interval (60 seconds by default). The same pass rebuilds the table after a crash truncated it.
+On gaining leadership, a bounded, priority-first pass runs immediately, so scheduling resumes
+within seconds while subsequent passes complete the rebuild.
+
+Outside of crash recovery, a nonzero repair count means a write path failed to leave a
+wakeup. The count is exposed as a metric and logged as a warning. The pass detects a reset
+table even when the engine survived the database restart, so a crash rebuild is not
+misreported as repairs.
+
+### Standing constraints
+
+The decision rests on four properties of the current engine:
+
+* The scheduler is a cluster-wide singleton, so verification only races against writers
+  and never against another scheduler.
+* Concurrency semantics are single-run-per-key, so verification is a single probe rather
+  than a counted check (as would be the case for semaphores).
+* The unique executing index backs the one-run-per-key invariant independently.
+* No keyed `CREATED` run becomes schedulable through the passage of time alone. Inbox messages
+  can be made visible in the future, but only a workflow's own timer creates one, addressed to
+  itself while it runs. Such runs are `RUNNING` or `SUSPENDED`, and that arm is derived per poll
+  rather than from wakeups. A keyed run in `CREATED` always already has a visible message.
+
+If the scheduler is ever sharded, counted concurrency limits are introduced,
+or delayed run starts are added, this decision must be revisited.
+
+## Consequences
+
+Poll cost for the keyed arm becomes proportional to queue capacity instead of backlog size.
+At a backlog of 2M keyed `CREATED` runs, one poll drops from 3.7 seconds to around 100
+milliseconds. Mixed workloads see less, because the arm that scans executing runs is
+unaffected by this change. Draining a burst becomes linear instead of quadratic work.
+The derivation query lives on in the repair pass.
+
+Schedulability knowledge spreads from one query to two write paths plus the repair pass.
+A missed wakeup site stalls affected keys for up to one repair interval. This bug class did
+not exist before, and the repair metric exists to surface it. No runtime fallback to the
+previous derivation ships. An open source release loop cannot be relied on for timely
+feedback, so the wakeup bookkeeping of every key state transition that needs one (creation,
+completion, cancellation, continue-as-new, child workflows) is covered by tests instead.
+Suspension needs no wakeup: a suspended run keeps holding its key, and its resumption is
+scheduled from the per-poll arm.
+
+Cross-key ordering changes from strict priority and arrival order to a close approximation.
+Winner selection per key stays exact because it is re-derived on admission. Within the same
+priority, keys freed by a completion are inspected before first-time arrivals, so
+serialized chains keep flowing through creation floods. All other keys follow in strict
+arrival order, so no key can be starved by newer arrivals.
+
+A repair pass costs about a second per million pending keys, per queue, in steady state.
+Rebuilding a multi-million key backlog after a crash can take tens of seconds.
+
+The wakeup table adds roughly two upserts per keyed run lifecycle. During mass creation it
+grows to one row per distinct pending key, around 400 MB at 2M keys with typical key
+lengths. It is `UNLOGGED`, aggressively autovacuumed, and drains through consumption.
+
+[Hatchet]: https://github.com/hatchet-dev/hatchet
+[Oban Pro]: https://oban.pro/
+[River Pro]: https://riverqueue.com/pro
+[Solid Queue]: https://github.com/rails/solid_queue
+[`UNLOGGED`]: https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-UNLOGGED
+[dex]: ../../dex
+[oban-pro-0.12.2]: https://oban.pro/docs/pro/0.12.2/changelog.html
+[oban-pro-1.6.4]: https://oban.pro/docs/pro/1.6.9/changelog.html
+[solid-queue-224]: https://github.com/rails/solid_queue/issues/224
+[solid-queue-546]: https://github.com/rails/solid_queue/issues/546
+[solid-queue-694]: https://github.com/rails/solid_queue/issues/694


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

dex: improve workflow task scheduling performance for deep backlogs with concurrency keys

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

See included ADR for details.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- [x] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
