### PR TITLE
Add onlyLatestVersions filter to project listing

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
@@ -668,6 +668,9 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
         if (query.onlyRoot()) {
             whereConditions.add("\"PROJECT\".\"PARENT_PROJECT_ID\" IS NULL");
         }
+        if (query.onlyLatestVersions()) {
+            whereConditions.add("\"PROJECT\".\"IS_LATEST\"");
+        }
         if (query.searchText() != null) {
             whereConditions.add(/* language=SQL */ """
                     (

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/query/ListProjectsQuery.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/query/ListProjectsQuery.java
@@ -34,10 +34,11 @@ public record ListProjectsQuery(
         @Nullable String searchText,
         boolean excludeInactive,
         boolean onlyRoot,
+        boolean onlyLatestVersions,
         boolean includeMetrics) {
 
     public ListProjectsQuery() {
-        this(null, null, null, null, null, null, null, null, false, false, false);
+        this(null, null, null, null, null, null, null, null, false, false, false, false);
     }
 
     public ListProjectsQuery withNameFilter(@Nullable String nameFilter) {
@@ -52,6 +53,7 @@ public record ListProjectsQuery(
                 this.searchText,
                 this.excludeInactive,
                 this.onlyRoot,
+                this.onlyLatestVersions,
                 this.includeMetrics);
     }
 
@@ -67,6 +69,7 @@ public record ListProjectsQuery(
                 this.searchText,
                 this.excludeInactive,
                 this.onlyRoot,
+                this.onlyLatestVersions,
                 this.includeMetrics);
     }
 
@@ -82,6 +85,7 @@ public record ListProjectsQuery(
                 this.searchText,
                 this.excludeInactive,
                 this.onlyRoot,
+                this.onlyLatestVersions,
                 this.includeMetrics);
     }
 
@@ -97,6 +101,7 @@ public record ListProjectsQuery(
                 this.searchText,
                 this.excludeInactive,
                 this.onlyRoot,
+                this.onlyLatestVersions,
                 this.includeMetrics);
     }
 
@@ -112,6 +117,7 @@ public record ListProjectsQuery(
                 this.searchText,
                 this.excludeInactive,
                 this.onlyRoot,
+                this.onlyLatestVersions,
                 this.includeMetrics);
     }
 
@@ -127,6 +133,7 @@ public record ListProjectsQuery(
                 this.searchText,
                 this.excludeInactive,
                 this.onlyRoot,
+                this.onlyLatestVersions,
                 this.includeMetrics);
     }
 
@@ -142,6 +149,7 @@ public record ListProjectsQuery(
                 this.searchText,
                 this.excludeInactive,
                 this.onlyRoot,
+                this.onlyLatestVersions,
                 this.includeMetrics);
     }
 
@@ -157,6 +165,7 @@ public record ListProjectsQuery(
                 searchText,
                 this.excludeInactive,
                 this.onlyRoot,
+                this.onlyLatestVersions,
                 this.includeMetrics);
     }
 
@@ -172,6 +181,7 @@ public record ListProjectsQuery(
                 this.searchText,
                 excludeInactive,
                 this.onlyRoot,
+                this.onlyLatestVersions,
                 this.includeMetrics);
     }
 
@@ -187,6 +197,23 @@ public record ListProjectsQuery(
                 this.searchText,
                 this.excludeInactive,
                 onlyRoot,
+                this.onlyLatestVersions,
+                this.includeMetrics);
+    }
+
+    public ListProjectsQuery withOnlyLatestVersions(boolean onlyLatestVersions) {
+        return new ListProjectsQuery(
+                this.nameFilter,
+                this.classifierFilter,
+                this.tagFilter,
+                this.teamFilter,
+                this.notAssignedToTeamWithUuidFilter,
+                this.parentUuidFilter,
+                this.excludeDescendantsOfUuid,
+                this.searchText,
+                this.excludeInactive,
+                this.onlyRoot,
+                onlyLatestVersions,
                 this.includeMetrics);
     }
 
@@ -202,6 +229,7 @@ public record ListProjectsQuery(
                 this.searchText,
                 this.excludeInactive,
                 this.onlyRoot,
+                this.onlyLatestVersions,
                 includeMetrics);
     }
 

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -140,6 +140,8 @@ public class ProjectResource extends AbstractApiResource {
                                 @QueryParam("excludeInactive") boolean excludeInactive,
                                 @Parameter(description = "Optionally excludes children projects from being returned")
                                 @QueryParam("onlyRoot") boolean onlyRoot,
+                                @Parameter(description = "Optionally includes only projects flagged as the latest version of their name")
+                                @QueryParam("onlyLatestVersions") boolean onlyLatestVersions,
                                 @Parameter(description = "The UUID of the team which projects shall be excluded", schema = @Schema(format = "uuid", type = "string"))
                                 @QueryParam("notAssignedToTeamWithUuid") @ValidUuid String notAssignedToTeamWithUuid) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
@@ -159,6 +161,7 @@ public class ProjectResource extends AbstractApiResource {
                                     .withSearchText(getAlpineRequest().getFilter())
                                     .withExcludeInactive(excludeInactive)
                                     .withOnlyRoot(onlyRoot)
+                                    .withOnlyLatestVersions(onlyLatestVersions)
                                     .withIncludeMetrics(true)));
             return Response
                     .ok(ListProjectsResponseItem.of(projectsPage.items()))

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -679,6 +679,50 @@ class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
+    void getProjectsOnlyLatestVersionsTest() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+        final var projectV1 = new Project();
+        projectV1.setName("acme-app");
+        projectV1.setVersion("1.0.0");
+        projectV1.setIsLatest(false);
+        qm.persist(projectV1);
+
+        final var projectV2 = new Project();
+        projectV2.setName("acme-app");
+        projectV2.setVersion("2.0.0");
+        projectV2.setIsLatest(true);
+        qm.persist(projectV2);
+
+        // Should return both when onlyLatestVersions=false.
+        var response = jersey.target(V1_PROJECT)
+                .queryParam("onlyLatestVersions", "false")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("2");
+
+        // Should return only the latest version when onlyLatestVersions=true.
+        response = jersey.target(V1_PROJECT)
+                .queryParam("onlyLatestVersions", "true")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                [ {
+                   "name" : "acme-app",
+                   "version" : "2.0.0",
+                   "uuid" : "${json-unit.any-string}",
+                   "isLatest" : true,
+                   "active" : true,
+                   "hasChildren" : false
+                 } ]
+                """);
+    }
+
+    @Test
     void getProjectLookupTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
         for (int i = 0; i < 500; i++) {


### PR DESCRIPTION


### Description

Support filtering projects by "is latest", analogous to the support added to components in #6085

Frontend counterpart is https://github.com/DependencyTrack/frontend/pull/1713

### Addressed Issue

Partially addresses https://github.com/DependencyTrack/frontend/issues/1165


### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
