### PR TITLE
Exclude project from components loaded during ImportBomActivity

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
@@ -55,6 +55,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
+import javax.jdo.FetchGroup;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import java.io.ByteArrayInputStream;
@@ -862,6 +863,25 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
 
     private static List<Component> getAllComponents(final QueryManager qm, final Project project) {
         final Query<Component> query = qm.getPersistenceManager().newQuery(Component.class);
+
+        // Every component contains a reference to its parent project, which also contains the set of direct references
+        // it has. For large BOM uploads, this results in massively duplicated data being fetched that we don't
+        // actually need. Unfortunately, a lot of other code relies on the project being part of the default fetch
+        // group, so it can't just be removed everywhere just yet. Instead, we'll selectively remove it here.
+        final var trimmedFetchGroup = qm.getPersistenceManager().getFetchGroup(Component.class, "DEFAULT_TRIMMED");
+        if (!trimmedFetchGroup.isUnmodifiable()) {
+            final var defaultFetchGroup = qm.getPersistenceManager().getFetchGroup(Component.class, FetchGroup.DEFAULT);
+            for (final var member : defaultFetchGroup.getMembers()) {
+                trimmedFetchGroup.addMembers(member.toString());
+            }
+
+            trimmedFetchGroup.removeMember("project");
+            trimmedFetchGroup.setUnmodifiable();
+        }
+
+        query.getFetchPlan().removeGroup(FetchGroup.DEFAULT);
+        query.getFetchPlan().addGroup("DEFAULT_TRIMMED");
+
         query.getFetchPlan().addGroup(Component.FetchGroup.BOM_UPLOAD_PROCESSING.name());
         query.getFetchPlan().setFetchSize(FETCH_SIZE_GREEDY);
         query.setFilter("project.id == :projectId");
@@ -876,6 +896,22 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
 
     private static List<ServiceComponent> getAllServices(final QueryManager qm, final Project project) {
         final Query<ServiceComponent> query = qm.getPersistenceManager().newQuery(ServiceComponent.class);
+
+        // Every service component contains a reference to its parent project, which also contains the set of direct
+        // references it has. For large BOM uploads, this results in massively duplicated data being fetched that we don't
+        // actually need. Unfortunately, a lot of other code relies on the project being part of the default fetch
+        // group, so it can't just be removed everywhere just yet. Instead, we'll selectively remove it here.
+        final var trimmedFetchGroup = qm.getPersistenceManager().getFetchGroup(ServiceComponent.class, "DEFAULT_TRIMMED");
+        if (!trimmedFetchGroup.isUnmodifiable()) {
+            final var defaultFetchGroup = qm.getPersistenceManager().getFetchGroup(ServiceComponent.class, FetchGroup.DEFAULT);
+            for (final var member : defaultFetchGroup.getMembers()) {
+                trimmedFetchGroup.addMembers(member.toString());
+            }
+
+            trimmedFetchGroup.removeMember("project");
+            trimmedFetchGroup.setUnmodifiable();
+        }
+
         query.getFetchPlan().setFetchSize(FETCH_SIZE_GREEDY);
         query.setFilter("project.id == :projectId");
         query.setParameters(project.getId());


### PR DESCRIPTION
### Description
This PR alters ImportBomActivity to exclude the project from components loaded during an import.

### Addressed Issue
Closes #6810.

### Additional Details
The project a component belongs to contains a full JSON string of all direct dependencies by default. For projects with large component counts, this results in a massive memory runaway as the entire project object is loaded for every component. Potential load sizes of 10TB have been observed in production (50MB per directDependencies field,
\>200k components), which far exceeds the resources of most computers on the planet.

By excluding the project from the default load set during BOM imports, we drastically reduce memory usage without affecting other parts of the application. Ideally, we'd remove the project or the direct dependency field from the default load sets of `Project` and `Component`, but there are many parts of the code that depend on that behavior today.

### Checklist
- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [ ] ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- [ ] ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
