### PR TITLE
Fix NotificationOutboxRelayTest flakiness

### DIFF
--- a/apiserver/src/test/java/org/dependencytrack/notification/NotificationOutboxRelayTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/notification/NotificationOutboxRelayTest.java
@@ -156,11 +156,11 @@ class NotificationOutboxRelayTest extends PersistenceCapableTest {
         doReturn(List.of(new NotificationRouter.Result(notification, Set.of(rule.getName()))))
                 .when(routerMock).route(anyCollection());
 
-        relay.start();
-
         doThrow(new IllegalStateException("Boom!"))
                 .doReturn(List.of(UUID.fromString("2777be5d-5a95-40b3-9226-311874a21bf6")))
                 .when(dexEngineMock).createRuns(anyCollection());
+
+        relay.start();
 
         final ArgumentCaptor<Collection<CreateWorkflowRunRequest<?>>> requestsCaptor = ArgumentCaptor.captor();
 


### PR DESCRIPTION

### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes NotificationOutboxRelayTest flakiness.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Mocking of failure behavior was racing with the relay starting and executing its first poll. Under contention in CI that lead to flakiness.


### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
