### PR TITLE
Fix activity task backlog age widget in Grafana dashboard

### DIFF
--- a/dev/monitoring/grafana/dashboards/apiserver-dex.json
+++ b/dev/monitoring/grafana/dashboards/apiserver-dex.json
@@ -534,7 +534,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "Activity tasks ready to schedule that are waiting in the database.",
+      "description": "Activity tasks ready to schedule that are waiting in the database. The count is capped at 10000; a series flat-lining at that value is saturated, and the real backlog may be higher.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -570,7 +570,7 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "off"
+              "mode": "line"
             }
           },
           "mappings": [],
@@ -580,6 +580,10 @@
               {
                 "color": "green",
                 "value": 0
+              },
+              {
+                "color": "red",
+                "value": 10000
               }
             ]
           },
@@ -713,7 +717,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "max by (queueName) (dt_dex_engine_activity_task_queue_backlog_age{instance=~\"$instance\",queueName=~\"$activityQueue\"})",
+          "expr": "max by (queueName) (dt_dex_engine_activity_task_queue_backlog_age_seconds{instance=~\"$instance\",queueName=~\"$activityQueue\"})",
           "instant": false,
           "range": true,
           "legendFormat": "{{queueName}}",


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes *activity task backlog age* widget in Grafana dashboard.

The backing metric has a `_seconds` prefix.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
