### PR TITLE
dex: fix eager too consumption of concurrency key wakeup hints

### DIFF
--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskScheduler.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskScheduler.java
@@ -353,6 +353,17 @@ final class WorkflowTaskScheduler implements Closeable {
                            and has_queued_task is null
                            and has_message is not null
                          ) as schedulable
+                       -- Only consume hints for reasons that don't depend on the clock.
+                       -- `has_message` must NOT be one of them: `now()` is this transaction's
+                       -- start time, but this statement sees rows committed after it, since we use
+                       -- READ_COMMITTED isolation. Such a run is visible here, yet its message looks
+                       -- not-yet-due (i.e. `visible_from > now()`), and deleting its just-written
+                       -- hint would stall it until the next repair.
+                       , (
+                           run.id is null
+                           or has_executing is not null
+                           or has_queued_task is not null
+                         ) as consumable
                     from cte_hint
                     -- The key's highest priority CREATED run.
                     left join lateral (
@@ -398,7 +409,7 @@ final class WorkflowTaskScheduler implements Closeable {
                       on verified.concurrency_key = wakeup.concurrency_key
                    where wakeup.queue_name = :queueName
                      and wakeup.version = verified.version
-                     and not verified.schedulable
+                     and verified.consumable
                    order by wakeup.concurrency_key
                      for update of wakeup
                 ),


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

dex: fix eager too consumption of concurrency key wakeup hints.

Noticed through test flakiness in CI, where assertions for workflow run completion would time out after 30s.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #6811 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
