### PR TITLE
Avoid sequential scan of FINDINGATTRIBUTION in project-scoped queries

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
@@ -525,7 +525,8 @@ public interface VulnerabilityDao {
                AND EXISTS (
                  SELECT 1
                    FROM "FINDINGATTRIBUTION" AS fa
-                  WHERE fa."COMPONENT_ID" = "COMPONENT"."ID"
+                  WHERE fa."PROJECT_ID" = :projectId
+                    AND fa."COMPONENT_ID" = "COMPONENT"."ID"
                     AND fa."VULNERABILITY_ID" = "V"."ID"
                     AND fa."DELETED_AT" IS NULL
                )

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
@@ -188,7 +188,8 @@ public final class CelPolicyDao {
                            AND EXISTS (
                              SELECT 1
                                FROM "FINDINGATTRIBUTION" AS fa
-                              WHERE fa."COMPONENT_ID" = c."ID"
+                              WHERE fa."PROJECT_ID" = :projectId
+                                AND fa."COMPONENT_ID" = c."ID"
                                 AND fa."VULNERABILITY_ID" = cv."VULNERABILITY_ID"
                                 AND fa."DELETED_AT" IS NULL
                            )


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Avoids sequential scan of FINDINGATTRIBUTION in project-scoped queries.

Adds a (seemingly redundant) filter on `PROJECT_ID` to queries over `FINDINGATTRIBUTION`. The query planner was observed to occasionally flatten them into semi-joins over the entire table without this, not utilizing the indexes on `COMPONENT_ID` or `VULNERABILITY_ID` as expected.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
