### PR TITLE
dex: define default activity execution timeout

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/dex/DexEngineInitializer.java
+++ b/apiserver/src/main/java/org/dependencytrack/dex/DexEngineInitializer.java
@@ -31,6 +31,9 @@ import org.dependencytrack.common.datasource.DataSourceRegistry;
 import org.dependencytrack.common.health.HealthCheckRegistry;
 import org.dependencytrack.common.pagination.SimplePageTokenEncoder;
 import org.dependencytrack.dex.activity.DeleteFilesActivity;
+import org.dependencytrack.dex.api.Activity;
+import org.dependencytrack.dex.api.ActivitySpec;
+import org.dependencytrack.dex.api.payload.PayloadConverter;
 import org.dependencytrack.dex.engine.api.DexEngine;
 import org.dependencytrack.dex.engine.api.DexEngineConfig;
 import org.dependencytrack.dex.engine.api.DexEngineFactory;
@@ -229,12 +232,14 @@ public final class DexEngineInitializer implements ServletContextListener {
                 voidConverter(),
                 Duration.ofMinutes(1));
 
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new IdentifyInternalComponentsActivity(),
                 voidConverter(),
                 voidConverter(),
                 Duration.ofMinutes(30));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new ImportBomActivity(
                         fileStorage,
                         engine,
@@ -242,55 +247,64 @@ public final class DexEngineInitializer implements ServletContextListener {
                 protoConverter(ImportBomArg.class),
                 voidConverter(),
                 Duration.ofMinutes(5));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new ImportVexActivity(fileStorage),
                 protoConverter(ImportVexArg.class),
                 voidConverter(),
                 Duration.ofMinutes(5));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new DeleteFilesActivity(fileStorage),
                 protoConverter(DeleteFilesArgument.class),
                 voidConverter(),
                 Duration.ofMinutes(1));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new EvalProjectPoliciesActivity(new CelPolicyEngine()),
                 protoConverter(EvalProjectPoliciesArg.class),
                 voidConverter(),
-                Duration.ofMinutes(5),
-                activityExecutionTimeout(config, "eval-project-policies").orElse(null));
-        engine.registerActivity(
+                Duration.ofMinutes(5));
+        registerActivity(
+                engine,
                 new FetchPackageMetadataResolutionCandidatesActivity(pluginManager),
                 voidConverter(),
                 protoConverter(FetchPackageMetadataResolutionCandidatesRes.class),
                 Duration.ofMinutes(1));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new FetchProjectMetricsUpdateCandidatesActivity(),
                 voidConverter(),
                 protoConverter(FetchProjectMetricsUpdateCandidatesRes.class),
                 Duration.ofMinutes(1));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new InvokeVulnAnalyzerActivity(fileStorage, pluginManager),
                 protoConverter(InvokeVulnAnalyzerArg.class),
                 protoConverter(InvokeVulnAnalyzerRes.class),
                 Duration.ofMinutes(5));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new MirrorVulnDataSourceActivity(pluginManager),
                 protoConverter(MirrorVulnDataSourceArg.class),
                 voidConverter(),
                 // NB: Account for slow downloads, mainly of sources relying on data dumps.
                 // Activities can't heartbeat while blocked on I/O.
                 Duration.ofMinutes(15));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new MirrorKevDataSourceActivity(pluginManager),
                 protoConverter(MirrorKevDataSourceArg.class),
                 voidConverter(),
                 Duration.ofMinutes(5));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new PrepareVulnAnalysisActivity(fileStorage, pluginManager),
                 protoConverter(PrepareVulnAnalysisArg.class),
                 protoConverter(PrepareVulnAnalysisRes.class),
                 Duration.ofMinutes(5));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new ProcessScheduledNotificationRuleActivity(
                         engine,
                         fileStorage,
@@ -298,7 +312,8 @@ public final class DexEngineInitializer implements ServletContextListener {
                 protoConverter(ProcessScheduledNotificationRuleArg.class),
                 voidConverter(),
                 Duration.ofMinutes(5));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new PublishNotificationActivity(
                         pluginManager,
                         fileStorage,
@@ -307,7 +322,8 @@ public final class DexEngineInitializer implements ServletContextListener {
                 protoConverter(PublishNotificationActivityArg.class),
                 voidConverter(),
                 Duration.ofMinutes(1));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new ReconcileVulnAnalysisResultsActivity(
                         fileStorage,
                         pluginManager,
@@ -315,27 +331,32 @@ public final class DexEngineInitializer implements ServletContextListener {
                 protoConverter(ReconcileVulnAnalysisResultsArg.class),
                 voidConverter(),
                 Duration.ofMinutes(5));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new RefreshGlobalPortfolioMetricsActivity(),
                 voidConverter(),
                 voidConverter(),
                 Duration.ofMinutes(5));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new RefreshVulnerabilityMetricsActivity(),
                 voidConverter(),
                 voidConverter(),
                 Duration.ofMinutes(5));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new ResolvePackageMetadataActivity(pluginManager, secretManager),
                 protoConverter(ResolvePackageMetadataActivityArg.class),
                 voidConverter(),
                 Duration.ofMinutes(10));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new SyncVulnPolicyBundleActivity(config, HttpClient.INSTANCE),
                 protoConverter(SyncVulnPolicyBundleArg.class),
                 voidConverter(),
                 Duration.ofMinutes(5));
-        engine.registerActivity(
+        registerActivity(
+                engine,
                 new UpdateProjectMetricsActivity(),
                 protoConverter(UpdateProjectMetricsArg.class),
                 voidConverter(),
@@ -416,6 +437,10 @@ public final class DexEngineInitializer implements ServletContextListener {
         config.getOptionalValue("dt.dex-engine.query-timeout-ms", long.class)
                 .map(Duration::ofMillis)
                 .ifPresent(engineConfig::setQueryTimeout);
+
+        config.getOptionalValue("dt.dex-engine.activity.execution-timeout-ms", long.class)
+                .map(Duration::ofMillis)
+                .ifPresent(engineConfig::setDefaultActivityExecutionTimeout);
 
         // Leader election.
         config.getOptionalValue("dt.dex-engine.leader-election.enabled", boolean.class)
@@ -594,11 +619,22 @@ public final class DexEngineInitializer implements ServletContextListener {
         return Optional.of(backoffFunction);
     }
 
-    private static Optional<Duration> activityExecutionTimeout(Config config, String activityName) {
-        return config.getOptionalValue(
-                "dt.dex.engine.activity.%s.execution-timeout-ms".formatted(activityName),
-                long.class)
-                .map(Duration::ofMillis);
+    private <A, R> void registerActivity(
+            DexEngine engine,
+            Activity<A, R> activity,
+            PayloadConverter<A> argumentConverter,
+            PayloadConverter<R> resultConverter,
+            Duration lockTimeout) {
+        final var activitySpec = activity.getClass().getAnnotation(ActivitySpec.class);
+        requireNonNull(activitySpec, "Activity class must be annotated with @" + ActivitySpec.class.getSimpleName());
+
+        final Duration executionTimeout = config.getOptionalValue(
+                        "dt.dex-engine.activity.%s.execution-timeout-ms".formatted(activitySpec.name()),
+                        long.class)
+                .map(Duration::ofMillis)
+                .orElse(null);
+
+        engine.registerActivity(activity, argumentConverter, resultConverter, lockTimeout, executionTimeout);
     }
 
 }

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -933,15 +933,6 @@ dt.vuln-policy-bundle.auth.username=
 # @type:     string
 dt.vuln-policy-bundle.auth.bearer-token=
 
-# Upper bound on wall-clock runtime for the eval-project-policies Dex activity.
-# Prevents a single policy evaluation from running indefinitely (for example due to
-# expensive or malicious policies). When exceeded, the activity is cancelled and may
-# be retried according to its retry policy.
-#
-# @category: Durable Execution
-# @type:     integer
-dt.dex.engine.activity.eval-project-policies.execution-timeout-ms=600000
-
 # Whether to execute initialization tasks on startup.
 #
 # @category: General
@@ -1248,6 +1239,20 @@ dt.dex-engine.datasource.name=default
 # @category: Durable Execution
 # @type:     integer
 # dt.dex-engine.query-timeout-ms=10000
+
+# Defines the maximum duration in milliseconds a single activity execution attempt may take.
+# <br/><br/>
+# Applies to all activities that do not define their own `dt.dex-engine.activity.<name>.execution-timeout-ms`.
+#
+# @category: Durable Execution
+# @type:     integer
+# dt.dex-engine.activity.execution-timeout-ms=3600000
+
+# Defines the maximum duration in milliseconds a single project policies evaluation may take.
+#
+# @category: Durable Execution
+# @type:     integer
+dt.dex-engine.activity.eval-project-policies.execution-timeout-ms=600000
 
 # Whether leader election in the durable execution engine should be enabled.
 # <br/><br/>

--- a/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngine.java
+++ b/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngine.java
@@ -96,14 +96,14 @@ public interface DexEngine extends Closeable {
      * <p>
      * The executor's class <strong>must</strong> be annotated with {@link ActivitySpec}.
      *
-     * @param executor             The {@link Activity} of the activity.
-     * @param argumentConverter    The {@link PayloadConverter} to use for arguments.
-     * @param resultConverter      The {@link PayloadConverter} to use for results.
-     * @param lockTimeout          How instances of this activity shall be locked for execution.
-     * @param executionTimeout     Maximum time the activity may execute before it is cancelled.
-     *                             {@code null} means no execution timeout.
-     * @param <A>                  Type of the activity's argument.
-     * @param <R>                  Type of the activity's result.
+     * @param executor          The {@link Activity} of the activity.
+     * @param argumentConverter The {@link PayloadConverter} to use for arguments.
+     * @param resultConverter   The {@link PayloadConverter} to use for results.
+     * @param lockTimeout       How instances of this activity shall be locked for execution.
+     * @param executionTimeout  Maximum time the activity may execute before it is cancelled.
+     *                          When {@code null}, {@link DexEngineConfig#defaultActivityExecutionTimeout()} is assumed.
+     * @param <A>               Type of the activity's argument.
+     * @param <R>               Type of the activity's result.
      * @throws IllegalStateException When the engine was already started.
      */
     <A, R> void registerActivity(

--- a/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngineConfig.java
+++ b/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngineConfig.java
@@ -357,6 +357,7 @@ public class DexEngineConfig {
     private final TaskSchedulerConfig activityTaskSchedulerConfig = new TaskSchedulerConfig();
 
     private Duration queryTimeout = Duration.ofSeconds(10);
+    private Duration defaultActivityExecutionTimeout = Duration.ofHours(1);
     private PageTokenEncoder pageTokenEncoder = new SimplePageTokenEncoder();
 
     public DexEngineConfig(DataSource dataSource) {
@@ -441,6 +442,21 @@ public class DexEngineConfig {
         this.queryTimeout = queryTimeout;
     }
 
+    /**
+     * @return Execution timeout applied to activities registered without an explicit one.
+     */
+    public Duration defaultActivityExecutionTimeout() {
+        return defaultActivityExecutionTimeout;
+    }
+
+    public void setDefaultActivityExecutionTimeout(Duration defaultActivityExecutionTimeout) {
+        requireNonNull(defaultActivityExecutionTimeout, "defaultActivityExecutionTimeout must not be null");
+        if (!defaultActivityExecutionTimeout.isPositive()) {
+            throw new IllegalArgumentException("defaultActivityExecutionTimeout must not be negative or zero");
+        }
+        this.defaultActivityExecutionTimeout = defaultActivityExecutionTimeout;
+    }
+
     public PageTokenEncoder pageTokenEncoder() {
         return pageTokenEncoder;
     }
@@ -464,6 +480,7 @@ public class DexEngineConfig {
                 .add("workflowTaskSchedulerConfig=" + workflowTaskSchedulerConfig)
                 .add("activityTaskSchedulerConfig=" + activityTaskSchedulerConfig)
                 .add("queryTimeout=" + queryTimeout)
+                .add("defaultActivityExecutionTimeout=" + defaultActivityExecutionTimeout)
                 .add("pageTokenEncoder=" + pageTokenEncoder)
                 .toString();
     }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityMetadata.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityMetadata.java
@@ -20,7 +20,6 @@ package org.dependencytrack.dex.engine;
 
 import org.dependencytrack.dex.api.Activity;
 import org.dependencytrack.dex.api.payload.PayloadConverter;
-import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
 
@@ -31,5 +30,5 @@ record ActivityMetadata<A, R>(
         PayloadConverter<R> resultConverter,
         String defaultTaskQueueName,
         Duration lockTimeout,
-        @Nullable Duration executionTimeout) {
+        Duration executionTimeout) {
 }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
@@ -35,6 +35,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -112,20 +113,25 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
                 return;
             }
 
-            final Future<Object> future;
+            final var executionStoppedLatch = new CountDownLatch(1);
+            final Future<Object> executionFuture;
             try {
-                future = executionExecutor.submit(
-                        () -> activityMetadata.executor().execute(ctx, arg));
+                executionFuture = executionExecutor.submit(() -> {
+                    try {
+                        return activityMetadata.executor().execute(ctx, arg);
+                    } finally {
+                        executionStoppedLatch.countDown();
+                    }
+                });
             } catch (RejectedExecutionException e) {
                 logger.debug("Execution executor is shut down; Abandoning task");
                 abandon(task);
                 return;
             }
+
             final Duration executionTimeout = activityMetadata.executionTimeout();
             try {
-                final Object activityResult = executionTimeout != null
-                        ? future.get(executionTimeout.toMillis(), TimeUnit.MILLISECONDS)
-                        : future.get();
+                final Object activityResult = executionFuture.get(executionTimeout.toMillis(), TimeUnit.MILLISECONDS);
                 final Payload result;
                 try {
                     result = activityMetadata.resultConverter().convertToPayload(activityResult);
@@ -140,10 +146,27 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
                 }
                 engine.onTaskEvent(new ActivityTaskCompletedEvent(task, result));
             } catch (TimeoutException e) {
-                future.cancel(/* interruptIfRunning */ true);
+                executionFuture.cancel(/* interruptIfRunning */ true);
+
+                // Wait a short moment for the activity task to terminate before moving on.
+                //
+                // NB: Calling Future#get after cancellation returns immediately even
+                // when the backing task is still executing. Hence, using a latch instead.
+                try {
+                    if (!executionStoppedLatch.await(5, TimeUnit.SECONDS)) {
+                        logger.warn("""
+                                Activity did not complete within 5s after cancellation; \
+                                the next attempt may run concurrently with it""");
+                    }
+                } catch (InterruptedException _) {
+                    logger.debug("Interrupted while waiting for cancelled task execution to complete");
+                }
+
                 final var cause = new TimeoutException(
-                        "Activity execution exceeded timeout of %s".formatted(executionTimeout));
+                        "Activity execution exceeded timeout of %s".formatted(
+                                executionTimeout));
                 cause.initCause(e);
+
                 final Instant retryAt = computeRetryAt(task, cause);
                 if (retryAt == null) {
                     logger.warn(
@@ -181,7 +204,7 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
                 }
             } catch (InterruptedException e) {
                 logger.debug("Interrupted while waiting for activity execution to complete; Abandoning task");
-                future.cancel(true);
+                executionFuture.cancel(true);
                 abandon(task);
                 Thread.currentThread().interrupt();
             }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -155,7 +155,7 @@ final class DexEngineImpl implements DexEngine {
     private final DexEngineConfig config;
     private final Jdbi jdbi;
     private final ReentrantLock statusLock = new ReentrantLock();
-    private final MetadataRegistry metadataRegistry = new MetadataRegistry();
+    private final MetadataRegistry metadataRegistry;
     private final Map<String, TaskWorker> taskWorkerByName = new HashMap<>();
     private final Map<String, TaskWorker> workflowWorkerByQueue = new HashMap<>();
     private final Map<String, TaskWorker> activityWorkerByQueue = new HashMap<>();
@@ -178,6 +178,7 @@ final class DexEngineImpl implements DexEngine {
 
     DexEngineImpl(DexEngineConfig config) {
         this.config = requireNonNull(config);
+        this.metadataRegistry = new MetadataRegistry(config.defaultActivityExecutionTimeout());
         this.jdbi = JdbiFactory.create(config.dataSource(), config.queryTimeout(), config.pageTokenEncoder());
         this.runsCreatedCounter = Counter
                 .builder("dt.dex.engine.runs.created")

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/MetadataRegistry.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/MetadataRegistry.java
@@ -39,6 +39,7 @@ final class MetadataRegistry {
 
     private static final Pattern WORKFLOW_NAME_PATTERN = Pattern.compile("^[\\w-]+");
     private static final Pattern ACTIVITY_NAME_PATTERN = WORKFLOW_NAME_PATTERN;
+    private final Duration defaultActivityExecutionTimeout;
 
     @SuppressWarnings("rawtypes")
     private final Map<Class<? extends Workflow>, String> workflowNameByExecutorClass = new ConcurrentHashMap<>();
@@ -51,6 +52,12 @@ final class MetadataRegistry {
 
     @SuppressWarnings("rawtypes")
     private final Map<String, ActivityMetadata> activityMetadataByName = new HashMap<>();
+
+    MetadataRegistry(Duration defaultActivityExecutionTimeout) {
+        this.defaultActivityExecutionTimeout = requireNonNull(
+                defaultActivityExecutionTimeout,
+                "defaultActivityExecutionTimeout must not be null");
+    }
 
     <A, R> void registerWorkflow(
             Workflow<A, R> workflow,
@@ -167,8 +174,13 @@ final class MetadataRegistry {
         requireNonNull(resultConverter, "resultConverter must not be null");
         requireValidTaskQueueName(defaultTaskQueueName);
         requireValidLockTimeout(lockTimeout);
-        requireValidExecutionTimeout(executionTimeout);
         requireNonNull(activity, "activity must not be null");
+
+        final Duration effectiveExecutionTimeout =
+                executionTimeout == null
+                        ? defaultActivityExecutionTimeout
+                        : executionTimeout;
+        requireValidExecutionTimeout(effectiveExecutionTimeout);
 
         if (activityNameByExecutorClass.containsKey(activity.getClass())) {
             throw new IllegalArgumentException(
@@ -187,7 +199,7 @@ final class MetadataRegistry {
                 resultConverter,
                 defaultTaskQueueName,
                 lockTimeout,
-                executionTimeout);
+                effectiveExecutionTimeout);
         activityNameByExecutorClass.put(activity.getClass(), name);
         activityMetadataByName.put(name, metadata);
     }
@@ -305,9 +317,9 @@ final class MetadataRegistry {
         }
     }
 
-    private static void requireValidExecutionTimeout(@Nullable Duration executionTimeout) {
-        if (executionTimeout != null && !executionTimeout.isPositive()) {
-            throw new IllegalArgumentException("executionTimeout must be positive when set");
+    private static void requireValidExecutionTimeout(Duration executionTimeout) {
+        if (!executionTimeout.isPositive()) {
+            throw new IllegalArgumentException("executionTimeout must be positive");
         }
     }
 

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/MetadataRegistryTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/MetadataRegistryTest.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.dex.engine;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.dependencytrack.dex.api.payload.PayloadConverters.voidConverter;
+
+class MetadataRegistryTest {
+
+    private static final Duration DEFAULT_EXECUTION_TIMEOUT = Duration.ofHours(1);
+
+    private MetadataRegistry metadataRegistry;
+
+    @BeforeEach
+    void beforeEach() {
+        metadataRegistry = new MetadataRegistry(DEFAULT_EXECUTION_TIMEOUT);
+    }
+
+    @Test
+    void shouldApplyDefaultExecutionTimeoutWhenNoneIsProvided() {
+        registerActivity("test", Duration.ofMinutes(1), /* executionTimeout */ null);
+
+        assertThat(metadataRegistry.getActivityMetadata("test").executionTimeout())
+                .isEqualTo(DEFAULT_EXECUTION_TIMEOUT);
+    }
+
+    @Test
+    void shouldPreferProvidedExecutionTimeoutOverDefault() {
+        registerActivity("test", Duration.ofMinutes(30), Duration.ofMinutes(45));
+
+        assertThat(metadataRegistry.getActivityMetadata("test").executionTimeout())
+                .isEqualTo(Duration.ofMinutes(45));
+    }
+
+    @Test
+    void shouldRejectNonPositiveExecutionTimeout() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> registerActivity("test", Duration.ofMinutes(1), Duration.ZERO))
+                .withMessageContaining("executionTimeout must be positive");
+    }
+
+    private void registerActivity(String name, Duration lockTimeout, @Nullable Duration executionTimeout) {
+        metadataRegistry.registerActivity(
+                name,
+                voidConverter(),
+                voidConverter(),
+                "default",
+                lockTimeout,
+                executionTimeout,
+                (_, _) -> null);
+    }
+
+}


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

dex: define default activity execution timeout.

Ensures that all activities have an execution timeout by defining a conservative default of 1h, which can be overwritten on a per-activity basis.

Also adds a short wait after an activity execution got canceled, to reduce the risk of duplicate executions, should the canceled activity not respect the thread interruption immediately.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #6741 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
