### PR TITLE
Replace Maven UUID generator plugin with build helper plugin

### DIFF
--- a/alpine/pom.xml
+++ b/alpine/pom.xml
@@ -71,7 +71,6 @@
         <!-- Maven Plugin Versions -->
         <maven.dependency.plugin.version>3.8.1</maven.dependency.plugin.version>
         <maven.shade.plugin.version>3.6.1</maven.shade.plugin.version>
-        <maven.uuidgenerator.plugin.version>1.0.1</maven.uuidgenerator.plugin.version>
 
         <!-- Dependency Versions -->
         <lib.bcrypt.version>0.4</lib.bcrypt.version>
@@ -166,16 +165,22 @@
             </plugin>
 
             <plugin>
-                <groupId>us.springett</groupId>
-                <artifactId>maven-uuid-generator</artifactId>
-                <version>${maven.uuidgenerator.plugin.version}</version>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>generate-uuid</id>
+                        <id>generate-build-uuid</id>
                         <phase>initialize</phase>
                         <goals>
-                            <goal>generate</goal>
+                            <goal>bsh-property</goal>
                         </goals>
+                        <configuration>
+                            <source>
+                                project.getProperties().setProperty(
+                                    "project.build.uuid",
+                                    java.util.UUID.randomUUID().toString());
+                            </source>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -557,16 +557,22 @@
 
         <plugins>
             <plugin>
-                <groupId>us.springett</groupId>
-                <artifactId>maven-uuid-generator</artifactId>
-                <version>1.0.1</version>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>generate-uuid</id>
+                        <id>generate-build-uuid</id>
                         <phase>initialize</phase>
                         <goals>
-                            <goal>generate</goal>
+                            <goal>bsh-property</goal>
                         </goals>
+                        <configuration>
+                            <source>
+                                project.getProperties().setProperty(
+                                    "project.build.uuid",
+                                    java.util.UUID.randomUUID().toString());
+                            </source>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/plugin/config/pom.xml
+++ b/plugin/config/pom.xml
@@ -111,7 +111,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <id>add-test-source</id>

--- a/pom.xml
+++ b/pom.xml
@@ -642,6 +642,12 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.6.1</version>
+                </plugin>
+
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.15.0</version>


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Replaces Maven UUID generator plugin with build helper plugin.

The UUID generator plugin is unmaintained and causes build warnings because it's not marked as thread safe. We already use the build helper plugin, and it covers the UUID generation via the `bsh-property` goal.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
