### PR TITLE
dex: reduce metrics collection footprint

### DIFF
--- a/dev/monitoring/grafana/dashboards/apiserver-dex.json
+++ b/dev/monitoring/grafana/dashboards/apiserver-dex.json
@@ -38,7 +38,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "Current workflow run counts grouped by lifecycle status.",
+      "description": "Current non-terminal workflow run counts grouped by lifecycle status.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/dev/monitoring/grafana/dashboards/apiserver-overview.json
+++ b/dev/monitoring/grafana/dashboards/apiserver-overview.json
@@ -900,7 +900,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "Snapshot of workflow run counts by lifecycle status.",
+      "description": "Snapshot of non-terminal workflow run counts by lifecycle status.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration/V0.1.9__AddWorkflowRunStatusMetricsIndex.sql
+++ b/dex/engine-migration/src/main/resources/org/dependencytrack/dex/engine/migration/V0.1.9__AddWorkflowRunStatusMetricsIndex.sql
@@ -1,0 +1,3 @@
+create index concurrently if not exists dex_workflow_run_status_metrics_idx
+    on dex_workflow_run (workflow_name, status)
+ where status in ('CREATED', 'RUNNING', 'SUSPENDED');

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -242,6 +242,7 @@ final class DexEngineImpl implements DexEngine {
             LOGGER.debug("Starting metrics collector");
             metricsCollector = new DexEngineMetricsCollector(
                     jdbi,
+                    () -> leaderElection == null || leaderElection.isLeader(),
                     config.metrics().collectorInitialDelay(),
                     config.metrics().collectorInterval(),
                     config.metrics().meterRegistry());

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineMetricsCollector.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineMetricsCollector.java
@@ -36,6 +36,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 final class DexEngineMetricsCollector implements Closeable {
 
@@ -43,6 +44,7 @@ final class DexEngineMetricsCollector implements Closeable {
     private static final int ACTIVITY_TASK_QUEUE_BACKLOG_COUNT_CAP = 10_000;
 
     private final Jdbi jdbi;
+    private final Supplier<Boolean> leadershipSupplier;
     private final Duration initialDelay;
     private final Duration interval;
     private final MultiGauge runCountGauge;
@@ -55,13 +57,19 @@ final class DexEngineMetricsCollector implements Closeable {
     private final AtomicBoolean running = new AtomicBoolean(false);
     private @Nullable ScheduledExecutorService executor;
 
-    DexEngineMetricsCollector(Jdbi jdbi, Duration initialDelay, Duration interval, MeterRegistry meterRegistry) {
+    DexEngineMetricsCollector(
+            Jdbi jdbi,
+            Supplier<Boolean> leadershipSupplier,
+            Duration initialDelay,
+            Duration interval,
+            MeterRegistry meterRegistry) {
         this.jdbi = jdbi;
+        this.leadershipSupplier = leadershipSupplier;
         this.initialDelay = initialDelay;
         this.interval = interval;
         this.runCountGauge = MultiGauge
                 .builder("dt.dex.engine.workflow.runs.current")
-                .description("Current number of workflow runs by name and status")
+                .description("Current number of workflow runs by name and status (non-terminal only)")
                 .register(meterRegistry);
         this.workflowTaskQueueCapacityGauge = MultiGauge
                 .builder("dt.dex.engine.workflow.task.queue.capacity")
@@ -133,6 +141,18 @@ final class DexEngineMetricsCollector implements Closeable {
     }
 
     private void collectMetrics() {
+        if (!leadershipSupplier.get()) {
+            LOGGER.debug("Not the leader; Skipping collection");
+            runCountGauge.register(List.of(), /* overwrite */ true);
+            workflowTaskQueueCapacityGauge.register(List.of(), /* overwrite */ true);
+            workflowTaskQueueDepthGauge.register(List.of(), /* overwrite */ true);
+            activityTaskQueueCapacityGauge.register(List.of(), /* overwrite */ true);
+            activityTaskQueueDepthGauge.register(List.of(), /* overwrite */ true);
+            activityTaskQueueBacklogGauge.register(List.of(), /* overwrite */ true);
+            activityTaskQueueBacklogAgeGauge.register(List.of(), /* overwrite */ true);
+            return;
+        }
+
         collectRunMetrics();
         collectWorkflowTaskQueueMetrics();
         collectActivityTaskQueueMetrics();
@@ -147,6 +167,7 @@ final class DexEngineMetricsCollector implements Closeable {
                                      , status
                                      , count(*)
                                   from dex_workflow_run
+                                 where status in ('CREATED', 'RUNNING', 'SUSPENDED')
                                  group by workflow_name
                                         , status
                                 """)

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineMetricsCollectorTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineMetricsCollectorTest.java
@@ -31,6 +31,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
@@ -68,13 +69,14 @@ class DexEngineMetricsCollectorTest {
                     values ('a0000000-0000-0000-0000-000000000001', 'wf-a', 1, 'default', 'RUNNING', now())
                          , ('a0000000-0000-0000-0000-000000000002', 'wf-a', 1, 'default', 'RUNNING', now())
                          , ('a0000000-0000-0000-0000-000000000003', 'wf-a', 1, 'default', 'CREATED', now())
+                         , ('a0000000-0000-0000-0000-000000000004', 'wf-a', 1, 'default', 'SUSPENDED', now())
                          , ('b0000000-0000-0000-0000-000000000001', 'wf-b', 1, 'default', 'COMPLETED', now())
                          , ('b0000000-0000-0000-0000-000000000002', 'wf-b', 1, 'default', 'FAILED', now())
                     """);
         });
 
         try (final var collector = new DexEngineMetricsCollector(
-                jdbi, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
+                jdbi, () -> true, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
             collector.start();
 
             await("Collection")
@@ -88,11 +90,11 @@ class DexEngineMetricsCollectorTest {
                                 .tag("workflowName", "wf-a").tag("status", "created")
                                 .gauge().value()).isEqualTo(1.0);
                         assertThat(meterRegistry.get("dt.dex.engine.workflow.runs.current")
-                                .tag("workflowName", "wf-b").tag("status", "completed")
+                                .tag("workflowName", "wf-a").tag("status", "suspended")
                                 .gauge().value()).isEqualTo(1.0);
-                        assertThat(meterRegistry.get("dt.dex.engine.workflow.runs.current")
-                                .tag("workflowName", "wf-b").tag("status", "failed")
-                                .gauge().value()).isEqualTo(1.0);
+
+                        assertThat(meterRegistry.get("dt.dex.engine.workflow.runs.current").gauges())
+                                .noneSatisfy(gauge -> assertThat(gauge.getId().getTag("workflowName")).isEqualTo("wf-b"));
                     });
         }
     }
@@ -109,7 +111,7 @@ class DexEngineMetricsCollectorTest {
         });
 
         try (final var collector = new DexEngineMetricsCollector(
-                jdbi, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
+                jdbi, () -> true, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
             collector.start();
 
             await("First Collection")
@@ -124,7 +126,7 @@ class DexEngineMetricsCollectorTest {
                             .isEqualTo(2.0));
 
             jdbi.useHandle(handle -> handle.execute("""
-                    update dex_workflow_run set status = 'COMPLETED', completed_at = now()
+                    update dex_workflow_run set status = 'RUNNING', started_at = now()
                     """));
 
             await("Second Collection")
@@ -134,7 +136,7 @@ class DexEngineMetricsCollectorTest {
                         assertThat(meterRegistry
                                 .get("dt.dex.engine.workflow.runs.current")
                                 .tag("workflowName", "wf-a")
-                                .tag("status", "completed")
+                                .tag("status", "running")
                                 .gauge()
                                 .value())
                                 .isEqualTo(2.0);
@@ -146,6 +148,44 @@ class DexEngineMetricsCollectorTest {
                                 .gauge())
                                 .isNull();
                     });
+        }
+    }
+
+    @Test
+    void shouldNotCollectWhenNotLeader() {
+        jdbi.useHandle(handle -> {
+            handle.execute("select dex_create_workflow_task_queue('default', cast(100 as smallint))");
+            handle.execute("""
+                    insert into dex_workflow_run(id, workflow_name, workflow_version, task_queue_name, status, created_at)
+                    values ('a0000000-0000-0000-0000-000000000001', 'wf-a', 1, 'default', 'CREATED', now())
+                    """);
+        });
+
+        final var leader = new AtomicBoolean(true);
+
+        try (final var collector = new DexEngineMetricsCollector(
+                jdbi, leader::get, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
+            collector.start();
+
+            await("Collection While Leader")
+                    .atMost(Duration.ofSeconds(5))
+                    .ignoreException(MeterNotFoundException.class)
+                    .untilAsserted(() -> assertThat(meterRegistry
+                            .get("dt.dex.engine.workflow.runs.current")
+                            .tag("workflowName", "wf-a")
+                            .tag("status", "created")
+                            .gauge()
+                            .value())
+                            .isEqualTo(1.0));
+
+            leader.set(false);
+
+            await("Gauges cleared after losing leadership")
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> assertThat(meterRegistry
+                            .find("dt.dex.engine.workflow.runs.current")
+                            .gauges())
+                            .isEmpty());
         }
     }
 
@@ -171,7 +211,7 @@ class DexEngineMetricsCollectorTest {
         });
 
         try (final var collector = new DexEngineMetricsCollector(
-                jdbi, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
+                jdbi, () -> true, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
             collector.start();
 
             await("Collection")
@@ -218,7 +258,7 @@ class DexEngineMetricsCollectorTest {
         });
 
         try (final var collector = new DexEngineMetricsCollector(
-                jdbi, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
+                jdbi, () -> true, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
             collector.start();
 
             await("Collection")
@@ -255,7 +295,7 @@ class DexEngineMetricsCollectorTest {
                     values ('a0000000-0000-0000-0000-000000000001', 'wf-a', 1, 'default', 'RUNNING', now())
                          , ('a0000000-0000-0000-0000-000000000002', 'wf-a', 1, 'default', 'RUNNING', now())
                     """);
-            
+
             handle.execute("""
                     insert into dex_activity_task(queue_name, workflow_run_id, created_event_id, activity_name, priority, retry_policy, status, visible_from, created_at)
                     values ('act-queue-a', 'a0000000-0000-0000-0000-000000000001', 1, 'act-a', 0, ''::bytea, 'CREATED', now() - interval '1 second', now())
@@ -267,7 +307,7 @@ class DexEngineMetricsCollectorTest {
         });
 
         try (final var collector = new DexEngineMetricsCollector(
-                jdbi, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
+                jdbi, () -> true, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
             collector.start();
 
             await("Collection")
@@ -308,7 +348,7 @@ class DexEngineMetricsCollectorTest {
         });
 
         try (final var collector = new DexEngineMetricsCollector(
-                jdbi, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
+                jdbi, () -> true, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
             collector.start();
 
             await("Collection")
@@ -328,7 +368,7 @@ class DexEngineMetricsCollectorTest {
     @Test
     void shouldHandleEmptyDatabase() {
         try (final var collector = new DexEngineMetricsCollector(
-                jdbi, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
+                jdbi, () -> true, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
             collector.start();
 
             await("Collection")


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

dex: reduce metrics collection footprint.

Addresses an issue observed in production where calculating the `dt.dex.engine.workflow.runs.current` gauge caused excessive disk reads, because the backing query is not supported by any index.

Only runs the asynchronous metrics collector on the leader node. Node point in having it run on all nodes in the cluster.

Only reports the counts of non-terminal runs. Terminal runs and their statuses are already covered by `dt.dex.engine.runs.completed`.

Adds a partial index over non-terminal runs to support metrics calculation. Allows the query to become an index-only scan. Incurs a slight write overhead but repeated full table scans are arguably worse.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
