### PR TITLE
Add contributor docs for interruptibility constraints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ If Maven needs to be invoked directly, only do so from the repository root.
 * Favor strong cohesion, loose coupling.
 * Prefer raw SQL + JDBI for new persistence code. JDO/DataNucleus is legacy; avoid touching unless necessary.
 * Legacy `apiserver` reuses persistence models as REST DTOs. New endpoints must separate API from persistence.
+* Long-running work must be interruptible. Check for interruption at batch boundaries, never swallow `InterruptedException`. See [`docs/INTERRUPTIBILITY.md`](docs/INTERRUPTIBILITY.md).
 * Nullability is declared with JSpecify and enforced by NullAway. Every new package must have a `package-info.java` annotated with `@NullMarked`. See [`docs/NULLABILITY.md`](docs/NULLABILITY.md).
 * Substantial changes need an ADR under `docs/adr/` (*Accepted* before merge). See `CONTRIBUTING.md#architecture-decision-records` for the trigger criteria and `docs/adr/README.md` for the format and writing style. Start from `docs/adr/000-template.md`.
 

--- a/docs/INTERRUPTIBILITY.md
+++ b/docs/INTERRUPTIBILITY.md
@@ -1,0 +1,52 @@
+# Interruptibility
+
+The durable execution engine (dex) cancels a running activity by interrupting its thread.
+It does so when the execution timeout of an attempt is exceeded, when the activity task lock
+was lost to another worker, or when the application is shutting down. In all cases the result
+of the execution can no longer be committed, so work that continues past the interrupt is wasted.
+Long-running code must therefore react to interrupts. This practice was introduced via [ADR 034].
+
+## Rules
+
+* Never swallow `InterruptedException`. Either let it propagate, or restore the flag with
+  `Thread.currentThread().interrupt()` and return.
+* Let `InterruptedException` propagate out of `Activity#execute`. The worker abandons the task
+  without consuming a retry. Any other exception is treated as a failed attempt.
+* Check for interruption at batch boundaries, for example once per page or batch, not once per row.
+  A batch should be short enough for cancellation to take effect within seconds.
+* Use `Thread.interrupted()` when you throw right away, since it clears the flag you are about to
+  represent as an exception. Use `Thread.currentThread().isInterrupted()` when callers above you
+  still need the flag.
+* Keep database work paginated. The PostgreSQL JDBC driver cancels the running query on interrupt,
+  but a single large statement still has to be rolled back before the activity can stop.
+* Where interrupts do not reach, use a timeout instead. CPU-bound loops without a check,
+  work submitted to a `ForkJoinPool` or parallel stream, and most third-party I/O libraries
+  are not interruptible.
+
+## Example
+
+```java
+@Override
+public @Nullable Void execute(ActivityContext ctx, @Nullable Void argument) throws InterruptedException {
+    List<Component> components = fetchNextComponentsPage(null);
+    while (!components.isEmpty()) {
+        if (Thread.interrupted()) {
+            throw new InterruptedException("Interrupted before all components could be processed");
+        }
+
+        process(components);
+        components = fetchNextComponentsPage(components.getLast());
+    }
+
+    return null;
+}
+```
+
+## References
+
+* [`Thread#interrupt`] javadoc
+* [Java Tutorials: Interrupts]
+
+[ADR 034]: adr/034-auto-heartbeat-activity-locks.md
+[Java Tutorials: Interrupts]: https://docs.oracle.com/javase/tutorial/essential/concurrency/interrupt.html
+[`Thread#interrupt`]: https://docs.oracle.com/en/java/javase/25/docs//api/java.base/java/lang/Thread.html#interrupt()


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds contributor docs for interruptibility constraints.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
