### PR TITLE
Fix KafkaNotificationPublisherTest flakiness

### DIFF
--- a/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/kafka/KafkaNotificationPublisherTest.java
+++ b/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/kafka/KafkaNotificationPublisherTest.java
@@ -32,7 +32,6 @@ import org.dependencytrack.notification.proto.v1.Notification;
 import org.dependencytrack.notification.proto.v1.Scope;
 import org.dependencytrack.notification.publishing.AbstractNotificationPublisherTest;
 import org.dependencytrack.plugin.api.config.RuntimeConfig;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -57,6 +56,8 @@ class KafkaNotificationPublisherTest extends AbstractNotificationPublisherTest {
     @Container
     private static final KafkaContainer kafkaContainer = new KafkaContainer("apache/kafka:4.1.1");
 
+    private String topicName;
+
     @Override
     protected NotificationPublisherFactory createPublisherFactory() {
         return new KafkaNotificationPublisherFactory();
@@ -77,22 +78,19 @@ class KafkaNotificationPublisherTest extends AbstractNotificationPublisherTest {
     @BeforeEach
     @Override
     protected void beforeEach() throws Exception {
+        topicName = "dependencytrack-notifications-" + UUID.randomUUID();
+
         try (final var adminClient = AdminClient.create(Map.of(
                 BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers()))) {
-            adminClient.createTopics(List.of(new NewTopic("dependencytrack-notifications", 1, (short) 1))).all().get();
+            adminClient.createTopics(List.of(new NewTopic(topicName, 1, (short) 1))).all().get();
         }
 
         super.beforeEach();
     }
 
-    @AfterEach
-    protected void afterEach() {
-        try (final var adminClient = AdminClient.create(Map.of(
-                BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers()))) {
-            adminClient.deleteTopics(List.of("dependencytrack-notifications"));
-        }
-
-        super.afterEach();
+    @Override
+    protected void customizeRuleConfig(RuntimeConfig ruleConfig) {
+        ((KafkaNotificationPublisherRuleConfigV1) ruleConfig).setTopicName(topicName);
     }
 
     @Override
@@ -122,7 +120,7 @@ class KafkaNotificationPublisherTest extends AbstractNotificationPublisherTest {
                 Map.entry(AUTO_OFFSET_RESET_CONFIG, "earliest"),
                 Map.entry(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName()),
                 Map.entry(VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName())))) {
-            consumer.subscribe(List.of("dependencytrack-notifications"));
+            consumer.subscribe(List.of(topicName));
 
             final ConsumerRecords<String, byte[]> records = consumer.poll(Duration.ofSeconds(1));
             assertThat(records).hasSize(1);


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes `KafkaNotificationPublisherTest` flakiness.

Topic deletion is asynchronous so a topic of the previous test could still exist when the next already started. Creating a separate topic per test resolves that.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
