### PR TITLE
Don't assemble expensive notifications when no subscribing rule exists

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -49,6 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SequencedCollection;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -59,6 +60,14 @@ import java.util.stream.Collectors;
         @RegisterRowMapper(NotificationVulnerabilityRowMapper.class)
 })
 public interface NotificationSubjectDao extends SqlObject {
+
+    /// @since 5.1.0
+    @SqlQuery("""
+            SELECT DISTINCT UNNEST("NOTIFY_ON")
+              FROM "NOTIFICATIONRULE"
+             WHERE "ENABLED"
+            """)
+    Set<String> getSubscribedNotificationGroups();
 
     @SqlQuery("""
             SELECT c."UUID" AS "componentUuid"

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyEngine.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyEngine.java
@@ -31,6 +31,7 @@ import org.dependencytrack.model.PolicyCondition;
 import org.dependencytrack.model.PolicyCondition.Subject;
 import org.dependencytrack.model.PolicyViolation;
 import org.dependencytrack.notification.JdbiNotificationEmitter;
+import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.persistence.jdbi.NotificationSubjectDao;
 import org.dependencytrack.persistence.jdbi.ProjectDao;
 import org.dependencytrack.policy.cel.CelPolicyCompiler.CacheMode;
@@ -284,13 +285,25 @@ public final class CelPolicyEngine {
         LOGGER.info("Identified {} new violations", newViolationIds.size());
 
         if (!newViolationIds.isEmpty()) {
-            useJdbiTransaction(handle -> new JdbiNotificationEmitter(handle).emitAll(
-                    handle.attach(NotificationSubjectDao.class)
-                            .getForNewPolicyViolations(newViolationIds)
-                            .stream()
-                            .map(subject -> createPolicyViolationNotification(
-                                    subject.getProject(), subject.getComponent(), subject.getPolicyViolation()))
-                            .toList()));
+            useJdbiTransaction(handle -> {
+                final var notificationSubjectDao = handle.attach(NotificationSubjectDao.class);
+
+                // Assembling notification subjects is expensive. Skip it for groups that no
+                // enabled rule subscribes to. The emitter would discard those notifications anyway.
+                if (!notificationSubjectDao
+                        .getSubscribedNotificationGroups()
+                        .contains(NotificationGroup.POLICY_VIOLATION.name())) {
+                    return;
+                }
+
+                new JdbiNotificationEmitter(handle).emitAll(
+                        notificationSubjectDao
+                                .getForNewPolicyViolations(newViolationIds)
+                                .stream()
+                                .map(subject -> createPolicyViolationNotification(
+                                        subject.getProject(), subject.getComponent(), subject.getPolicyViolation()))
+                                .toList());
+            });
         }
     }
 

--- a/apiserver/src/main/java/org/dependencytrack/vulnanalysis/ReconcileVulnAnalysisResultsActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulnanalysis/ReconcileVulnAnalysisResultsActivity.java
@@ -33,6 +33,7 @@ import org.dependencytrack.model.FindingKey;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityKey;
 import org.dependencytrack.notification.JdbiNotificationEmitter;
+import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.proto.v1.Notification;
 import org.dependencytrack.notification.proto.v1.VulnerabilityAnalysisDecisionChangeSubject;
 import org.dependencytrack.parser.dependencytrack.BovModelConverter;
@@ -514,6 +515,10 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
             final var notificationSubjectDao = handle.attach(NotificationSubjectDao.class);
             final var findingDao = new FindingDao(handle);
 
+            // Assembling notification subjects is expensive. Skip it for groups that no
+            // enabled rule subscribes to. The emitter would discard those notifications anyway.
+            final Set<String> subscribedGroups = notificationSubjectDao.getSubscribedNotificationGroups();
+
             final List<FindingKey> createdFindingKeys = findingDao.createFindings(findingsToCreate);
             LOGGER.debug("Created {} new finding(s)", createdFindingKeys.size());
 
@@ -531,13 +536,19 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
             LOGGER.debug("Removed {} stale attribution(s)", attributionsDeleted);
 
             final List<Notification> auditChangeNotifications =
-                    applyVulnPolicyResults(handle, projectId, policyResults, vulnDbIdsByComponentId);
+                    applyVulnPolicyResults(
+                            handle,
+                            projectId,
+                            policyResults,
+                            vulnDbIdsByComponentId,
+                            subscribedGroups);
 
             final var notifications = new ArrayList<>(auditChangeNotifications);
             notifications.addAll(createAnalyzerErrorNotifications(projectUuid, failedAnalyzers));
             notifications.addAll(
                     createNewVulnerabilityNotifications(
                             notificationSubjectDao,
+                            subscribedGroups,
                             Stream
                                     .concat(createdFindingKeys.stream(), reactivatedFindingKeys.stream())
                                     .collect(Collectors.toSet()),
@@ -545,8 +556,10 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
             notifications.addAll(
                     createVulnerabilityRetractedNotifications(
                             notificationSubjectDao,
+                            subscribedGroups,
                             inactiveFindingKeys));
-            if (arg.hasContextFileMetadata()) {
+            if (arg.hasContextFileMetadata()
+                    && subscribedGroups.contains(NotificationGroup.NEW_VULNERABLE_DEPENDENCY.name())) {
                 final List<Long> newComponentIds = readNewComponentIds(arg.getContextFileMetadata());
                 if (!newComponentIds.isEmpty()) {
                     notificationSubjectDao
@@ -673,7 +686,8 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
             Handle handle,
             long projectId,
             Map<Long, Map<Long, VulnerabilityPolicy>> policyResults,
-            Map<Long, Set<Long>> activeFindings) {
+            Map<Long, Set<Long>> activeFindings,
+            Set<String> subscribedGroups) {
         final var analysisDao = new AnalysisDao(handle);
         final var reconcileResults = new ArrayList<AnalysisReconciler.Result>();
 
@@ -760,6 +774,10 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
         final int commentsCreated = analysisDao.createComments(createCommentCommands);
         LOGGER.debug("Created {} analysis comment(s)", commentsCreated);
 
+        if (!subscribedGroups.contains(NotificationGroup.PROJECT_AUDIT_CHANGE.name())) {
+            return List.of();
+        }
+
         // Build notifications for analyses where state or suppression changed.
         final List<AnalysisReconciler.Result> auditChangeResults =
                 reconcileResults.stream()
@@ -814,9 +832,11 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
 
     private List<Notification> createNewVulnerabilityNotifications(
             NotificationSubjectDao dao,
+            Set<String> subscribedGroups,
             Collection<FindingKey> findingKeys,
             AnalysisTrigger analysisTrigger) {
-        if (findingKeys.isEmpty()) {
+        if (findingKeys.isEmpty()
+                || !subscribedGroups.contains(NotificationGroup.NEW_VULNERABILITY.name())) {
             return List.of();
         }
 
@@ -841,8 +861,10 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
 
     private List<Notification> createVulnerabilityRetractedNotifications(
             NotificationSubjectDao dao,
+            Set<String> subscribedGroups,
             Collection<FindingKey> findingKeys) {
-        if (findingKeys.isEmpty()) {
+        if (findingKeys.isEmpty()
+                || !subscribedGroups.contains(NotificationGroup.VULNERABILITY_RETRACTED.name())) {
             return List.of();
         }
 

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
@@ -24,6 +24,8 @@ import org.dependencytrack.kevdatasource.api.KevAssertion;
 import org.dependencytrack.model.Analysis;
 import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.Component;
+import org.dependencytrack.model.NotificationPublisher;
+import org.dependencytrack.model.NotificationRule;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition.Operator;
 import org.dependencytrack.model.PolicyCondition.Subject;
@@ -33,6 +35,9 @@ import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.ViolationAnalysisState;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityKey;
+import org.dependencytrack.notification.NotificationGroup;
+import org.dependencytrack.notification.NotificationLevel;
+import org.dependencytrack.notification.NotificationScope;
 import org.dependencytrack.notification.proto.v1.NewVulnerabilitySubject;
 import org.dependencytrack.notification.proto.v1.NewVulnerableDependencySubject;
 import org.dependencytrack.notification.proto.v1.PolicyViolationSubject;
@@ -54,6 +59,49 @@ import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 import static org.hamcrest.Matchers.equalTo;
 
 public class NotificationSubjectDaoTest extends PersistenceCapableTest {
+
+    @Test
+    public void testGetSubscribedNotificationGroups() {
+        final NotificationPublisher publisher =
+                qm.createNotificationPublisher(
+                        "publisher",
+                        "description",
+                        "extensionName",
+                        "templateContent",
+                        "templateMimeType",
+                        /* isDefault */ false);
+
+        final NotificationRule enabledRule =
+                qm.createNotificationRule(
+                        "enabled",
+                        NotificationScope.PORTFOLIO,
+                        NotificationLevel.INFORMATIONAL,
+                        publisher);
+        enabledRule.setNotifyOn(Set.of(
+                NotificationGroup.NEW_VULNERABILITY,
+                NotificationGroup.NEW_VULNERABLE_DEPENDENCY));
+
+        final NotificationRule disabledRule =
+                qm.createNotificationRule(
+                        "disabled",
+                        NotificationScope.PORTFOLIO,
+                        NotificationLevel.INFORMATIONAL,
+                        publisher);
+        disabledRule.setNotifyOn(Set.of(NotificationGroup.POLICY_VIOLATION));
+        disabledRule.setEnabled(false);
+
+        qm.persist(enabledRule);
+        qm.persist(disabledRule);
+
+        final Set<String> subscribedGroups = withJdbiHandle(
+                handle -> handle
+                        .attach(NotificationSubjectDao.class)
+                        .getSubscribedNotificationGroups());
+
+        assertThat(subscribedGroups).containsExactlyInAnyOrder(
+                NotificationGroup.NEW_VULNERABILITY.name(),
+                NotificationGroup.NEW_VULNERABLE_DEPENDENCY.name());
+    }
 
     @Test
     public void testGetForNewVulnerabilities() {


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Don't assemble expensive notifications when no subscribing rule exists.

The notification emitter already discards notifications for which no rule exists, but the payload is still generated, which can be expensive. Adds a simple group-based pre-check so instances without matching rules don't pay the penalty.

This mostly affects the `NEW_VULNERABILITY`, `NEW_VULNERABLE_DEPENDENCY`, and `POLICY_VIOLATION` notifications.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
