### PR TITLE
Backport: dex: Make query timeout configurable

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/dex/DexEngineInitializer.java
+++ b/apiserver/src/main/java/org/dependencytrack/dex/DexEngineInitializer.java
@@ -398,6 +398,10 @@ public final class DexEngineInitializer implements ServletContextListener {
         final var engineConfig = new DexEngineConfig(dataSource);
         engineConfig.setPageTokenEncoder(new SimplePageTokenEncoder());
 
+        config.getOptionalValue("dt.dex-engine.query-timeout-ms", long.class)
+                .map(Duration::ofMillis)
+                .ifPresent(engineConfig::setQueryTimeout);
+
         // Leader election.
         config.getOptionalValue("dt.dex-engine.leader-election.enabled", boolean.class)
                 .ifPresent(engineConfig.leaderElection()::setEnabled);

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -1204,6 +1204,18 @@ dt.dex-engine.datasource.name=default
 # @type:     string
 # dt.dex-engine.migration.datasource.name=
 
+# Defines the timeout in milliseconds enforced for all database queries made by the durable execution engine.
+# <br/><br/>
+# Should not be modified unless repeated timeouts are experienced. The default timeout is generous for the
+# engine's workload. Query timeouts being exceeded usually points at deeper issues, such as slow I/O,
+# lagging autovacuum, the planner choosing suboptimal query plans, or queries themselves being inefficient.
+# If you find yourself having to increase this, report an issue about performance degradation so the underlying
+# issue can be resolved.
+#
+# @category: Durable Execution
+# @type:     integer
+# dt.dex-engine.query-timeout-ms=10000
+
 # Whether leader election in the durable execution engine should be enabled.
 # <br/><br/>
 # Disabling leader election also disables the workflow task scheduler,

--- a/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngineConfig.java
+++ b/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngineConfig.java
@@ -327,6 +327,7 @@ public class DexEngineConfig {
     private final TaskSchedulerConfig workflowTaskSchedulerConfig = new TaskSchedulerConfig();
     private final TaskSchedulerConfig activityTaskSchedulerConfig = new TaskSchedulerConfig();
 
+    private Duration queryTimeout = Duration.ofSeconds(10);
     private PageTokenEncoder pageTokenEncoder = new SimplePageTokenEncoder();
 
     public DexEngineConfig(DataSource dataSource) {
@@ -396,6 +397,21 @@ public class DexEngineConfig {
         return activityTaskSchedulerConfig;
     }
 
+    /**
+     * @return Timeout for database queries.
+     */
+    public Duration queryTimeout() {
+        return queryTimeout;
+    }
+
+    public void setQueryTimeout(Duration queryTimeout) {
+        requireNonNull(queryTimeout, "queryTimeout must not be null");
+        if (!queryTimeout.isPositive()) {
+            throw new IllegalArgumentException("queryTimeout must not be negative or zero");
+        }
+        this.queryTimeout = queryTimeout;
+    }
+
     public PageTokenEncoder pageTokenEncoder() {
         return pageTokenEncoder;
     }
@@ -418,6 +434,7 @@ public class DexEngineConfig {
                 .add("metricsConfig=" + metricsConfig)
                 .add("workflowTaskSchedulerConfig=" + workflowTaskSchedulerConfig)
                 .add("activityTaskSchedulerConfig=" + activityTaskSchedulerConfig)
+                .add("queryTimeout=" + queryTimeout)
                 .add("pageTokenEncoder=" + pageTokenEncoder)
                 .toString();
     }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -175,7 +175,7 @@ final class DexEngineImpl implements DexEngine {
 
     DexEngineImpl(DexEngineConfig config) {
         this.config = requireNonNull(config);
-        this.jdbi = JdbiFactory.create(config.dataSource(), config.pageTokenEncoder());
+        this.jdbi = JdbiFactory.create(config.dataSource(), config.queryTimeout(), config.pageTokenEncoder());
         this.runsCreatedCounter = Counter
                 .builder("dt.dex.engine.runs.created")
                 .withRegistry(config.metrics().meterRegistry());

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/jdbi/JdbiFactory.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/jdbi/JdbiFactory.java
@@ -48,8 +48,10 @@ public final class JdbiFactory {
 
     public static Jdbi create(
             final DataSource dataSource,
+            final Duration queryTimeout,
             final PageTokenEncoder pageTokenEncoder) {
         requireNonNull(dataSource, "dataSource must not be null");
+        requireNonNull(queryTimeout, "queryTimeout must not be null");
         requireNonNull(pageTokenEncoder, "pageTokenEncoder must not be null");
 
         return Jdbi
@@ -57,8 +59,10 @@ public final class JdbiFactory {
                 .installPlugin(new Jackson2Plugin())
                 .installPlugin(new PostgresPlugin())
                 .setTemplateEngine(FreemarkerEngine.instance())
-                .configure(PaginationConfig.class, config -> config.setPageTokenEncoder(pageTokenEncoder))
-                .configure(SqlStatements.class, statementsCfg -> statementsCfg.setQueryTimeout(10))
+                .configure(PaginationConfig.class, cfg -> cfg.setPageTokenEncoder(pageTokenEncoder))
+                .configure(
+                        SqlStatements.class,
+                        cfg -> cfg.setQueryTimeout(Math.toIntExact(queryTimeout.toSeconds())))
                 // Ensure all required mappings are registered *once*
                 // on startup. Defining these on a per-query basis imposes
                 // additional overhead that is worth avoiding given how

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineMetricsCollectorTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineMetricsCollectorTest.java
@@ -55,7 +55,7 @@ class DexEngineMetricsCollectorTest {
         dataSource.setPassword(postgresContainer.getPassword());
         dataSource.setDatabaseName(postgresContainer.getDatabaseName());
 
-        jdbi = JdbiFactory.create(dataSource, new SimplePageTokenEncoder());
+        jdbi = JdbiFactory.create(dataSource, Duration.ofSeconds(10), new SimplePageTokenEncoder());
         meterRegistry = new SimpleMeterRegistry();
     }
 

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/MaintenanceWorkerTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/MaintenanceWorkerTest.java
@@ -51,7 +51,7 @@ class MaintenanceWorkerTest {
         dataSource.setPassword(postgresContainer.getPassword());
         dataSource.setDatabaseName(postgresContainer.getDatabaseName());
 
-        jdbi = JdbiFactory.create(dataSource, new SimplePageTokenEncoder());
+        jdbi = JdbiFactory.create(dataSource, Duration.ofSeconds(10), new SimplePageTokenEncoder());
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

dex: Make query timeout configurable.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #6806 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
