### PR TITLE
Backport: Exclude project from components loaded during ImportBomActivity

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
@@ -55,6 +55,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
+import javax.jdo.FetchGroup;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import java.io.ByteArrayInputStream;
@@ -861,6 +862,25 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
 
     private static List<Component> getAllComponents(final QueryManager qm, final Project project) {
         final Query<Component> query = qm.getPersistenceManager().newQuery(Component.class);
+
+        // Every component contains a reference to its parent project, which also contains the set of direct references
+        // it has. For large BOM uploads, this results in massively duplicated data being fetched that we don't
+        // actually need. Unfortunately, a lot of other code relies on the project being part of the default fetch
+        // group, so it can't just be removed everywhere just yet. Instead, we'll selectively remove it here.
+        final var trimmedFetchGroup = qm.getPersistenceManager().getFetchGroup(Component.class, "DEFAULT_TRIMMED");
+        if (!trimmedFetchGroup.isUnmodifiable()) {
+            final var defaultFetchGroup = qm.getPersistenceManager().getFetchGroup(Component.class, FetchGroup.DEFAULT);
+            for (final var member : defaultFetchGroup.getMembers()) {
+                trimmedFetchGroup.addMembers(member.toString());
+            }
+
+            trimmedFetchGroup.removeMember("project");
+            trimmedFetchGroup.setUnmodifiable();
+        }
+
+        query.getFetchPlan().removeGroup(FetchGroup.DEFAULT);
+        query.getFetchPlan().addGroup("DEFAULT_TRIMMED");
+
         query.getFetchPlan().addGroup(Component.FetchGroup.BOM_UPLOAD_PROCESSING.name());
         query.getFetchPlan().setFetchSize(FETCH_SIZE_GREEDY);
         query.setFilter("project.id == :projectId");
@@ -875,6 +895,22 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
 
     private static List<ServiceComponent> getAllServices(final QueryManager qm, final Project project) {
         final Query<ServiceComponent> query = qm.getPersistenceManager().newQuery(ServiceComponent.class);
+
+        // Every service component contains a reference to its parent project, which also contains the set of direct
+        // references it has. For large BOM uploads, this results in massively duplicated data being fetched that we don't
+        // actually need. Unfortunately, a lot of other code relies on the project being part of the default fetch
+        // group, so it can't just be removed everywhere just yet. Instead, we'll selectively remove it here.
+        final var trimmedFetchGroup = qm.getPersistenceManager().getFetchGroup(ServiceComponent.class, "DEFAULT_TRIMMED");
+        if (!trimmedFetchGroup.isUnmodifiable()) {
+            final var defaultFetchGroup = qm.getPersistenceManager().getFetchGroup(ServiceComponent.class, FetchGroup.DEFAULT);
+            for (final var member : defaultFetchGroup.getMembers()) {
+                trimmedFetchGroup.addMembers(member.toString());
+            }
+
+            trimmedFetchGroup.removeMember("project");
+            trimmedFetchGroup.setUnmodifiable();
+        }
+
         query.getFetchPlan().setFetchSize(FETCH_SIZE_GREEDY);
         query.setFilter("project.id == :projectId");
         query.setParameters(project.getId());


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Excludes project from components loaded during ImportBomActivity.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6810
Backports #6824 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
