### PR TITLE
Backport: Fix failure to emit notification when vulnerability description is empty

### DIFF
--- a/notification/api/src/main/java/org/dependencytrack/notification/api/NotificationFactory.java
+++ b/notification/api/src/main/java/org/dependencytrack/notification/api/NotificationFactory.java
@@ -247,18 +247,9 @@ public final class NotificationFactory {
         }
         title += "]";
 
-        final String content;
-        if (vulnerability.hasDescription()) {
-            content = vulnerability.getDescription();
-        } else {
-            content = vulnerability.hasTitle()
-                    ? "%s: %s".formatted(vulnerability.getVulnId(), vulnerability.getTitle())
-                    : vulnerability.getVulnId();
-        }
-
         return newNotificationBuilder(SCOPE_PORTFOLIO, GROUP_VULNERABILITY_RETRACTED, LEVEL_INFORMATIONAL)
                 .setTitle(title)
-                .setContent(content)
+                .setContent(contentFor(vulnerability))
                 .setSubject(Any.pack(
                         VulnerabilityRetractedSubject.newBuilder()
                                 .setProject(project)
@@ -294,18 +285,9 @@ public final class NotificationFactory {
         }
         title += "]";
 
-        final String content;
-        if (vulnerability.hasDescription()) {
-            content = vulnerability.getDescription();
-        } else {
-            content = vulnerability.hasTitle()
-                    ? "%s: %s".formatted(vulnerability.getVulnId(), vulnerability.getTitle())
-                    : vulnerability.getVulnId();
-        }
-
         return newNotificationBuilder(SCOPE_PORTFOLIO, GROUP_NEW_VULNERABILITY, LEVEL_INFORMATIONAL)
                 .setTitle(title)
-                .setContent(content)
+                .setContent(contentFor(vulnerability))
                 .setSubject(Any.pack(
                         NewVulnerabilitySubject.newBuilder()
                                 .setProject(project)
@@ -603,6 +585,17 @@ public final class NotificationFactory {
                 .setScope(scope)
                 .setGroup(group)
                 .setLevel(level);
+    }
+
+    private static String contentFor(Vulnerability vulnerability) {
+        if (!vulnerability.getDescription().isBlank()) {
+            return vulnerability.getDescription();
+        }
+        if (!vulnerability.getTitle().isBlank()) {
+            return "%s: %s".formatted(vulnerability.getVulnId(), vulnerability.getTitle());
+        }
+
+        return vulnerability.getVulnId();
     }
 
 }

--- a/notification/api/src/test/java/org/dependencytrack/notification/api/NotificationFactoryTest.java
+++ b/notification/api/src/test/java/org/dependencytrack/notification/api/NotificationFactoryTest.java
@@ -18,11 +18,23 @@
  */
 package org.dependencytrack.notification.api;
 
+import org.dependencytrack.notification.proto.v1.AnalysisTrigger;
+import org.dependencytrack.notification.proto.v1.Component;
 import org.dependencytrack.notification.proto.v1.Notification;
+import org.dependencytrack.notification.proto.v1.Project;
+import org.dependencytrack.notification.proto.v1.Vulnerability;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.dependencytrack.notification.api.NotificationFactory.createNewVulnerabilityNotification;
+import static org.dependencytrack.notification.api.NotificationFactory.createVulnerabilityRetractedNotification;
 import static org.dependencytrack.notification.api.NotificationFactory.newNotificationBuilder;
 import static org.dependencytrack.notification.proto.v1.Group.GROUP_BOM_CONSUMED;
 import static org.dependencytrack.notification.proto.v1.Group.GROUP_UNSPECIFIED;
@@ -30,6 +42,7 @@ import static org.dependencytrack.notification.proto.v1.Level.LEVEL_INFORMATIONA
 import static org.dependencytrack.notification.proto.v1.Level.LEVEL_UNSPECIFIED;
 import static org.dependencytrack.notification.proto.v1.Scope.SCOPE_PORTFOLIO;
 import static org.dependencytrack.notification.proto.v1.Scope.SCOPE_UNSPECIFIED;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class NotificationFactoryTest {
 
@@ -90,6 +103,58 @@ class NotificationFactoryTest {
                 .isThrownBy(() -> newNotificationBuilder(
                         SCOPE_PORTFOLIO, GROUP_BOM_CONSUMED, LEVEL_UNSPECIFIED))
                 .withMessage("Invalid level: LEVEL_UNSPECIFIED");
+    }
+
+    @ParameterizedTest
+    @MethodSource("vulnerabilityContentArguments")
+    void createNewVulnerabilityNotificationShouldPopulateContent(
+            Vulnerability vulnerability,
+            String expectedContent) {
+        final Notification notification =
+                createNewVulnerabilityNotification(
+                        Project.newBuilder().setName("acme-app").build(),
+                        Component.newBuilder().setName("acme-lib").build(),
+                        vulnerability,
+                        AnalysisTrigger.ANALYSIS_TRIGGER_BOM_UPLOAD);
+        assertThat(notification.getContent()).isEqualTo(expectedContent);
+    }
+
+    @ParameterizedTest
+    @MethodSource("vulnerabilityContentArguments")
+    void createVulnerabilityRetractedNotificationShouldPopulateContent(
+            Vulnerability vulnerability,
+            String expectedContent) {
+        final Notification notification =
+                createVulnerabilityRetractedNotification(
+                        Project.newBuilder().setName("acme-app").build(),
+                        Component.newBuilder().setName("acme-lib").build(),
+                        vulnerability);
+        assertThat(notification.getContent()).isEqualTo(expectedContent);
+    }
+
+    private static Stream<Arguments> vulnerabilityContentArguments() {
+        final Supplier<Vulnerability.Builder> vulnBuilder =
+                () -> Vulnerability.newBuilder().setVulnId("CVE-123").setSource("NVD");
+
+        return Stream.of(
+                arguments(
+                        vulnBuilder.get().setDescription("Some description").setTitle("Some title").build(),
+                        "Some description"),
+                arguments(
+                        vulnBuilder.get().setDescription("").setTitle("Some title").build(),
+                        "CVE-123: Some title"),
+                arguments(
+                        vulnBuilder.get().setTitle("Some title").build(),
+                        "CVE-123: Some title"),
+                arguments(
+                        vulnBuilder.get().setDescription("").setTitle("").build(),
+                        "CVE-123"),
+                arguments(
+                        vulnBuilder.get().setDescription("   ").build(),
+                        "CVE-123"),
+                arguments(
+                        vulnBuilder.get().build(),
+                        "CVE-123"));
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes failure to emit notification when vulnerability description is empty.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6826
Backports #6844

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
