### PR TITLE
Backport: dex: enforce execution timeout for activities

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/dex/DexEngineInitializer.java
+++ b/apiserver/src/main/java/org/dependencytrack/dex/DexEngineInitializer.java
@@ -247,7 +247,8 @@ public final class DexEngineInitializer implements ServletContextListener {
                 new EvalProjectPoliciesActivity(new CelPolicyEngine()),
                 protoConverter(EvalProjectPoliciesArg.class),
                 voidConverter(),
-                Duration.ofMinutes(5));
+                Duration.ofMinutes(5),
+                activityExecutionTimeout(config, "eval-project-policies").orElse(null));
         engine.registerActivity(
                 new FetchPackageMetadataResolutionCandidatesActivity(pluginManager),
                 voidConverter(),
@@ -575,6 +576,13 @@ public final class DexEngineInitializer implements ServletContextListener {
                 maxDelayMillis.get());
 
         return Optional.of(backoffFunction);
+    }
+
+    private static Optional<Duration> activityExecutionTimeout(Config config, String activityName) {
+        return config.getOptionalValue(
+                "dt.dex.engine.activity.%s.execution-timeout-ms".formatted(activityName),
+                long.class)
+                .map(Duration::ofMillis);
     }
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/policy/EvalProjectPoliciesActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/EvalProjectPoliciesActivity.java
@@ -29,6 +29,7 @@ import org.slf4j.MDC;
 
 import java.util.UUID;
 
+import static java.util.Objects.requireNonNull;
 import static org.dependencytrack.common.MdcKeys.MDC_PROJECT_UUID;
 
 /**
@@ -40,7 +41,7 @@ public final class EvalProjectPoliciesActivity implements Activity<EvalProjectPo
     private final CelPolicyEngine policyEngine;
 
     public EvalProjectPoliciesActivity(CelPolicyEngine policyEngine) {
-        this.policyEngine = policyEngine;
+        this.policyEngine = requireNonNull(policyEngine, "policyEngine must not be null");
     }
 
     @Override

--- a/apiserver/src/main/java/org/dependencytrack/policy/vulnerability/VulnerabilityPolicyEvaluator.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/vulnerability/VulnerabilityPolicyEvaluator.java
@@ -34,6 +34,8 @@ public interface VulnerabilityPolicyEvaluator {
      * @return A nested {@link Map} keyed by component ID, then vulnerability ID,
      * containing matched {@link VulnerabilityPolicy}s.
      */
-    Map<Long, Map<Long, VulnerabilityPolicy>> evaluateAll(long projectId, Map<Long, Set<Long>> vulnIdsByComponentId);
+    Map<Long, Map<Long, VulnerabilityPolicy>> evaluateAll(
+            long projectId,
+            Map<Long, Set<Long>> vulnIdsByComponentId);
 
 }

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -925,6 +925,15 @@ dt.vuln-policy-bundle.auth.username=
 # @type:     string
 dt.vuln-policy-bundle.auth.bearer-token=
 
+# Upper bound on wall-clock runtime for the eval-project-policies Dex activity.
+# Prevents a single policy evaluation from running indefinitely (for example due to
+# expensive or malicious policies). When exceeded, the activity is cancelled and may
+# be retried according to its retry policy.
+#
+# @category: Durable Execution
+# @type:     integer
+dt.dex.engine.activity.eval-project-policies.execution-timeout-ms=600000
+
 # Whether to execute initialization tasks on startup.
 #
 # @category: General

--- a/apiserver/src/test/java/org/dependencytrack/dex/DexEngineInitializerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/dex/DexEngineInitializerTest.java
@@ -34,6 +34,7 @@ import org.dependencytrack.persistence.jdbi.JdbiFactory;
 import org.dependencytrack.plugin.runtime.PluginManager;
 import org.dependencytrack.secret.TestSecretManager;
 import org.dependencytrack.secret.management.SecretManager;
+import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,7 @@ import org.testcontainers.utility.DockerImageName;
 import java.net.http.HttpClient;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -60,12 +62,13 @@ class DexEngineInitializerTest {
     @Container
     private final PostgreSQLContainer postgresContainer =
             new PostgreSQLContainer(DockerImageName.parse("postgres:14-alpine"));
+    private PGSimpleDataSource dataSource;
     private DataSourceRegistry dataSourceRegistry;
     private DexEngineInitializer initializer;
 
     @BeforeEach
     void beforeEach() {
-        final var dataSource = new PGSimpleDataSource();
+        dataSource = new PGSimpleDataSource();
         dataSource.setUrl(postgresContainer.getJdbcUrl());
         dataSource.setUser(postgresContainer.getUsername());
         dataSource.setPassword(postgresContainer.getPassword());
@@ -85,12 +88,11 @@ class DexEngineInitializerTest {
     @Test
     void shouldStartEngine() throws Exception {
         final var config = new SmallRyeConfigBuilder()
-                .withDefaultValues(Map.ofEntries(
-                        Map.entry("dt.dex-engine.datasource.name", "foo"),
-                        Map.entry("dt.datasource.foo.url", postgresContainer.getJdbcUrl()),
-                        Map.entry("dt.datasource.foo.username", postgresContainer.getUsername()),
-                        Map.entry("dt.datasource.foo.password", postgresContainer.getPassword()),
-                        Map.entry("dt.notification.outbox-relay.large-notification-threshold-bytes", "65536")))
+                .addDefaultSources()
+                .withSources(configSource(Map.of(
+                        "dt.datasource.default.url", postgresContainer.getJdbcUrl(),
+                        "dt.datasource.default.username", postgresContainer.getUsername(),
+                        "dt.datasource.default.password", postgresContainer.getPassword())))
                 .build();
 
         dataSourceRegistry = new DataSourceRegistry(config);
@@ -104,7 +106,7 @@ class DexEngineInitializerTest {
         doReturn(new MemoryFileStorage())
                 .when(servletContextMock).getAttribute(eq(FileStorage.class.getName()));
         doReturn(new PluginManager(config, cacheManager, secretManager::getSecretValue,
-                JdbiFactory.createJdbi(),
+                JdbiFactory.createLocalJdbi(dataSource),
                 HttpClient.newHttpClient(), Collections.emptyList()))
                 .when(servletContextMock).getAttribute(eq(PluginManager.class.getName()));
         doReturn(secretManager)
@@ -124,6 +126,35 @@ class DexEngineInitializerTest {
         final DexEngine engine = engineCaptor.getValue();
         assertThat(engine).isNotNull();
         engine.close();
+    }
+
+    private static ConfigSource configSource(Map<String, String> properties) {
+        return new ConfigSource() {
+            @Override
+            public Map<String, String> getProperties() {
+                return properties;
+            }
+
+            @Override
+            public Set<String> getPropertyNames() {
+                return properties.keySet();
+            }
+
+            @Override
+            public String getValue(String propertyName) {
+                return properties.get(propertyName);
+            }
+
+            @Override
+            public String getName() {
+                return DexEngineInitializerTest.class.getSimpleName();
+            }
+
+            @Override
+            public int getOrdinal() {
+                return 500;
+            }
+        };
     }
 
 }

--- a/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngine.java
+++ b/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngine.java
@@ -83,11 +83,35 @@ public interface DexEngine extends Closeable {
      * @param <R>               Type of the activity's result.
      * @throws IllegalStateException When the engine was already started.
      */
+    default <A, R> void registerActivity(
+            Activity<A, R> executor,
+            PayloadConverter<A> argumentConverter,
+            PayloadConverter<R> resultConverter,
+            Duration lockTimeout) {
+        registerActivity(executor, argumentConverter, resultConverter, lockTimeout, null);
+    }
+
+    /**
+     * Register an activity.
+     * <p>
+     * The executor's class <strong>must</strong> be annotated with {@link ActivitySpec}.
+     *
+     * @param executor             The {@link Activity} of the activity.
+     * @param argumentConverter    The {@link PayloadConverter} to use for arguments.
+     * @param resultConverter      The {@link PayloadConverter} to use for results.
+     * @param lockTimeout          How instances of this activity shall be locked for execution.
+     * @param executionTimeout     Maximum time the activity may execute before it is cancelled.
+     *                             {@code null} means no execution timeout.
+     * @param <A>                  Type of the activity's argument.
+     * @param <R>                  Type of the activity's result.
+     * @throws IllegalStateException When the engine was already started.
+     */
     <A, R> void registerActivity(
             Activity<A, R> executor,
             PayloadConverter<A> argumentConverter,
             PayloadConverter<R> resultConverter,
-            Duration lockTimeout);
+            Duration lockTimeout,
+            @Nullable Duration executionTimeout);
 
     /**
      * Register a task worker.

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityMetadata.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityMetadata.java
@@ -20,6 +20,7 @@ package org.dependencytrack.dex.engine;
 
 import org.dependencytrack.dex.api.Activity;
 import org.dependencytrack.dex.api.payload.PayloadConverter;
+import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
 
@@ -29,5 +30,6 @@ record ActivityMetadata<A, R>(
         PayloadConverter<A> argumentConverter,
         PayloadConverter<R> resultConverter,
         String defaultTaskQueueName,
-        Duration lockTimeout) {
+        Duration lockTimeout,
+        @Nullable Duration executionTimeout) {
 }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
@@ -41,6 +41,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
 
 import static java.util.Objects.requireNonNull;
@@ -120,9 +121,11 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
                 abandon(task);
                 return;
             }
-
+            final Duration executionTimeout = activityMetadata.executionTimeout();
             try {
-                final Object activityResult = future.get();
+                final Object activityResult = executionTimeout != null
+                        ? future.get(executionTimeout.toMillis(), TimeUnit.MILLISECONDS)
+                        : future.get();
                 final Payload result;
                 try {
                     result = activityMetadata.resultConverter().convertToPayload(activityResult);
@@ -136,6 +139,25 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
                     return;
                 }
                 engine.onTaskEvent(new ActivityTaskCompletedEvent(task, result));
+            } catch (TimeoutException e) {
+                future.cancel(/* interruptIfRunning */ true);
+                final var cause = new TimeoutException(
+                        "Activity execution exceeded timeout of %s".formatted(executionTimeout));
+                cause.initCause(e);
+                final Instant retryAt = computeRetryAt(task, cause);
+                if (retryAt == null) {
+                    logger.warn(
+                            "Activity execution exceeded timeout of {}; Failing task terminally",
+                            executionTimeout);
+                } else {
+                    logger.warn(
+                            "Activity execution exceeded timeout of {}; Next retry due at {} (attempt {}/{})",
+                            executionTimeout,
+                            retryAt,
+                            task.attempt() + 1,
+                            task.retryPolicy().maxAttempts());
+                }
+                engine.onTaskEvent(new ActivityTaskFailedEvent(task, cause, retryAt));
             } catch (ExecutionException e) {
                 final Throwable cause = e.getCause();
                 if (cause instanceof InterruptedException || executionExecutor.isShutdown()) {

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -514,9 +514,11 @@ final class DexEngineImpl implements DexEngine {
             Activity<A, R> activity,
             PayloadConverter<A> argumentConverter,
             PayloadConverter<R> resultConverter,
-            Duration lockTimeout) {
+            Duration lockTimeout,
+            @Nullable Duration executionTimeout) {
         requireStatusAnyOf(Status.CREATED, Status.STOPPED);
-        metadataRegistry.registerActivity(activity, argumentConverter, resultConverter, lockTimeout);
+        metadataRegistry.registerActivity(
+                activity, argumentConverter, resultConverter, lockTimeout, executionTimeout);
     }
 
     <A, R> void registerActivityInternal(
@@ -526,6 +528,24 @@ final class DexEngineImpl implements DexEngine {
             String defaultTaskQueueName,
             Duration lockTimeout,
             Activity<A, R> activity) {
+        registerActivityInternal(
+                activityName,
+                argumentConverter,
+                resultConverter,
+                defaultTaskQueueName,
+                lockTimeout,
+                null,
+                activity);
+    }
+
+    <A, R> void registerActivityInternal(
+            String activityName,
+            PayloadConverter<A> argumentConverter,
+            PayloadConverter<R> resultConverter,
+            String defaultTaskQueueName,
+            Duration lockTimeout,
+            @Nullable Duration executionTimeout,
+            Activity<A, R> activity) {
         requireStatusAnyOf(Status.CREATED, Status.STOPPED);
         metadataRegistry.registerActivity(
                 activityName,
@@ -533,6 +553,7 @@ final class DexEngineImpl implements DexEngine {
                 resultConverter,
                 defaultTaskQueueName,
                 lockTimeout,
+                executionTimeout,
                 activity);
     }
 

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/MetadataRegistry.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/MetadataRegistry.java
@@ -114,6 +114,15 @@ final class MetadataRegistry {
             PayloadConverter<A> argumentConverter,
             PayloadConverter<R> resultConverter,
             Duration lockTimeout) {
+        registerActivity(activity, argumentConverter, resultConverter, lockTimeout, null);
+    }
+
+    <A, R> void registerActivity(
+            Activity<A, R> activity,
+            PayloadConverter<A> argumentConverter,
+            PayloadConverter<R> resultConverter,
+            Duration lockTimeout,
+            @Nullable Duration executionTimeout) {
         requireNonNull(activity, "activity must not be null");
 
         final ActivitySpec activitySpec = requireActivitySpec(activity.getClass());
@@ -124,6 +133,7 @@ final class MetadataRegistry {
                 resultConverter,
                 activitySpec.defaultTaskQueue(),
                 lockTimeout,
+                executionTimeout,
                 activity);
     }
 
@@ -134,11 +144,30 @@ final class MetadataRegistry {
             String defaultTaskQueueName,
             Duration lockTimeout,
             Activity<A, R> activity) {
+        registerActivity(
+                name,
+                argumentConverter,
+                resultConverter,
+                defaultTaskQueueName,
+                lockTimeout,
+                null,
+                activity);
+    }
+
+    <A, R> void registerActivity(
+            String name,
+            PayloadConverter<A> argumentConverter,
+            PayloadConverter<R> resultConverter,
+            String defaultTaskQueueName,
+            Duration lockTimeout,
+            @Nullable Duration executionTimeout,
+            Activity<A, R> activity) {
         requireValidActivityName(name);
         requireNonNull(argumentConverter, "argumentConverter must not be null");
         requireNonNull(resultConverter, "resultConverter must not be null");
         requireValidTaskQueueName(defaultTaskQueueName);
         requireValidLockTimeout(lockTimeout);
+        requireValidExecutionTimeout(executionTimeout);
         requireNonNull(activity, "activity must not be null");
 
         if (activityNameByExecutorClass.containsKey(activity.getClass())) {
@@ -157,7 +186,8 @@ final class MetadataRegistry {
                 argumentConverter,
                 resultConverter,
                 defaultTaskQueueName,
-                lockTimeout);
+                lockTimeout,
+                executionTimeout);
         activityNameByExecutorClass.put(activity.getClass(), name);
         activityMetadataByName.put(name, metadata);
     }
@@ -272,6 +302,12 @@ final class MetadataRegistry {
         requireNonNull(lockTimeout, "lockTimeout must not be null");
         if (!lockTimeout.isPositive()) {
             throw new IllegalArgumentException("lockTimeout must positive");
+        }
+    }
+
+    private static void requireValidExecutionTimeout(@Nullable Duration executionTimeout) {
+        if (executionTimeout != null && !executionTimeout.isPositive()) {
+            throw new IllegalArgumentException("executionTimeout must be positive when set");
         }
     }
 

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
@@ -1465,6 +1465,57 @@ class DexEngineImplTest {
     }
 
     @Test
+    void shouldCancelAndRetryActivityWhenExecutionTimeoutIsExceeded() {
+        final var invocations = new AtomicInteger();
+        final var interruptions = new AtomicInteger();
+        final RetryPolicy retryPolicy = RetryPolicy.ofDefault()
+                .withInitialDelay(Duration.ofMillis(10))
+                .withMaxDelay(Duration.ofMillis(10))
+                .withMaxAttempts(2);
+
+        registerWorkflow("test", (ctx, _) -> {
+            ctx.callActivity(
+                    "test",
+                    ACTIVITY_TASK_QUEUE,
+                    null,
+                    voidConverter(),
+                    voidConverter(),
+                    retryPolicy)
+                    .await();
+            return null;
+        });
+        engine.registerActivityInternal(
+                "test",
+                voidConverter(),
+                voidConverter(),
+                ACTIVITY_TASK_QUEUE,
+                Duration.ofSeconds(5),
+                Duration.ofMillis(100),
+                (_, _) -> {
+                    invocations.incrementAndGet();
+                    try {
+                        Thread.sleep(Duration.ofMinutes(1));
+                    } catch (InterruptedException e) {
+                        interruptions.incrementAndGet();
+                        throw e;
+                    }
+                    return null;
+                });
+        registerWorkflowWorker("workflow-worker", 1);
+        registerTaskWorker("activity-worker", 1);
+        engine.start();
+
+        final UUID runId = engine.createRun(new CreateWorkflowRunRequest<>("test", 1));
+
+        awaitRunStatus(runId, WorkflowRunStatus.FAILED);
+        await("Activity executions to be interrupted")
+                .untilAsserted(() -> {
+                    assertThat(invocations).hasValue(2);
+                    assertThat(interruptions).hasValue(2);
+                });
+    }
+
+    @Test
     void shouldCancelActivitiesDuringGracefulShutdown() throws Exception {
         final var activityStarted = new AtomicBoolean(false);
         final var activityInterrupted = new AtomicBoolean(false);


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

dex: enforce execution timeout for activities.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #6740
Backports #6741

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
