### PR TITLE
Backport: Improve responsiveness to thread interruptions

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/pkgmetadata/ResolvePackageMetadataActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/pkgmetadata/ResolvePackageMetadataActivity.java
@@ -155,8 +155,17 @@ public final class ResolvePackageMetadataActivity implements Activity<ResolvePac
                         throw e;
                     } catch (RetryableResolutionException e) {
                         resultBuffer.flush();
+                        if (Thread.interrupted()) {
+                            throw new InterruptedException("Interrupted before all PURLs could be resolved");
+                        }
+
                         throw new ApplicationFailureException(e.getMessage(), e, e.retryAfter());
                     } catch (Exception e) {
+                        if (Thread.interrupted()) {
+                            resultBuffer.flush();
+                            throw new InterruptedException("Interrupted before all PURLs could be resolved");
+                        }
+
                         LOGGER.warn("Failed to resolve metadata; persisting empty result", e);
                         resultBuffer.addEmptyResult(purlStr);
                     } finally {

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyEngine.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyEngine.java
@@ -113,7 +113,7 @@ public final class CelPolicyEngine {
         this.scriptHost = scriptHost;
     }
 
-    public void evaluateProject(UUID uuid) {
+    public void evaluateProject(UUID uuid) throws InterruptedException {
         // TODO: Should this entire procedure run in a single DB transaction?
         //   Would be better for atomicity, but could block DB connections for prolonged
         //   period of time for larger projects with many violations.
@@ -243,6 +243,10 @@ public final class CelPolicyEngine {
         final Timestamp protoNow = Timestamps.now();
 
         for (final Map.Entry<Long, Component> entry : componentsById.entrySet()) {
+            if (Thread.interrupted()) {
+                throw new InterruptedException("Interrupted before policies could be evaluated for all components");
+            }
+
             final long componentId = entry.getKey();
             final Component protoComponent = entry.getValue();
 

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelVulnerabilityPolicyEvaluator.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelVulnerabilityPolicyEvaluator.java
@@ -72,7 +72,7 @@ public final class CelVulnerabilityPolicyEvaluator implements VulnerabilityPolic
     @Override
     public Map<Long, Map<Long, VulnerabilityPolicy>> evaluateAll(
             long projectId,
-            Map<Long, Set<Long>> vulnIdsByComponentId) {
+            Map<Long, Set<Long>> vulnIdsByComponentId) throws InterruptedException {
         final Timer.Sample timerSample = Timer.start();
         try {
             return evaluateAllInternal(projectId, vulnIdsByComponentId);
@@ -85,7 +85,7 @@ public final class CelVulnerabilityPolicyEvaluator implements VulnerabilityPolic
 
     private Map<Long, Map<Long, VulnerabilityPolicy>> evaluateAllInternal(
             final long projectId,
-            final Map<Long, Set<Long>> vulnIdsByComponentId) {
+            final Map<Long, Set<Long>> vulnIdsByComponentId) throws InterruptedException {
         requireNonNull(vulnIdsByComponentId, "vulnIdsByComponentId must not be null");
 
         if (vulnIdsByComponentId.isEmpty()) {
@@ -171,6 +171,11 @@ public final class CelVulnerabilityPolicyEvaluator implements VulnerabilityPolic
         final Timestamp protoNow = Timestamps.now();
 
         for (final var entry : vulnIdsByComponentId.entrySet()) {
+            if (Thread.interrupted()) {
+                throw new InterruptedException(
+                        "Interrupted before vulnerability policies could be evaluated for all components");
+            }
+
             final long componentId = entry.getKey();
             final Collection<Long> vulnIds = entry.getValue();
             if (vulnIds.isEmpty()) {

--- a/apiserver/src/main/java/org/dependencytrack/policy/vulnerability/VulnerabilityPolicyEvaluator.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/vulnerability/VulnerabilityPolicyEvaluator.java
@@ -33,9 +33,10 @@ public interface VulnerabilityPolicyEvaluator {
      * @param vulnIdsByComponentId A mapping of component IDs to their associated vulnerability IDs.
      * @return A nested {@link Map} keyed by component ID, then vulnerability ID,
      * containing matched {@link VulnerabilityPolicy}s.
+     * @throws InterruptedException When the calling thread was interrupted during evaluation.
      */
     Map<Long, Map<Long, VulnerabilityPolicy>> evaluateAll(
             long projectId,
-            Map<Long, Set<Long>> vulnIdsByComponentId);
+            Map<Long, Set<Long>> vulnIdsByComponentId) throws InterruptedException;
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
@@ -71,6 +71,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -179,7 +180,7 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
         return null;
     }
 
-    private void processEvent(final ProcessingContext ctx, final byte[] cdxBomBytes) {
+    private void processEvent(final ProcessingContext ctx, final byte[] cdxBomBytes) throws InterruptedException {
         final ConsumedBom consumedBom;
         try {
             final Parser parser = BomParserFactory.createParser(cdxBomBytes);
@@ -201,6 +202,10 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
             throw new TerminalApplicationFailureException("Failed to consume BOM", e);
         }
 
+        if (Thread.interrupted()) {
+            throw new InterruptedException("Interrupted before the BOM could be processed");
+        }
+
         dispatchBomConsumedNotification(ctx);
 
         final ProcessedBom processedBom;
@@ -210,6 +215,10 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
              var _ = MDC.putCloseable(MDC_BOM_VERSION, String.valueOf(ctx.bomVersion))) {
             try {
                 processedBom = processBom(ctx, consumedBom);
+            } catch (CancellationException e) {
+                final var interruptedException = new InterruptedException("BOM processing was interrupted");
+                interruptedException.initCause(e);
+                throw interruptedException;
             } catch (Throwable e) {
                 LOGGER.error("Failed to process BOM", e);
                 try (final var qm = new QueryManager()) {
@@ -490,6 +499,10 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
                 .collect(Collectors.toSet());
 
         for (final Component component : components) {
+            if (Thread.currentThread().isInterrupted()) {
+                throw new CancellationException("Interrupted before all components could be processed");
+            }
+
             component.setInternal(internalComponentIdentifier.isInternal(component));
             resolveAndApplyLicense(qm, component, licenseCache, customLicenseCache);
 
@@ -602,6 +615,10 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
                 .collect(Collectors.toSet());
 
         for (final ServiceComponent service : services) {
+            if (Thread.currentThread().isInterrupted()) {
+                throw new CancellationException("Interrupted before all services could be processed");
+            }
+
             final var componentIdentity = new ComponentIdentity(service);
             ServiceComponent persistentService = persistentServiceByIdentity.get(componentIdentity);
             if (persistentService == null) {
@@ -690,6 +707,11 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
         }
 
         for (final Component component : componentsByIdentity.values()) {
+            if (Thread.currentThread().isInterrupted()) {
+                throw new CancellationException(
+                        "Interrupted before the dependency graph could be processed for all components");
+            }
+
             assertPersistent(component, "Component must be persistent");
             final String mergedDirectDependenciesJson = resolveMergedDirectDependenciesJson(
                     component, dependencyGraph, identitiesByBomRef, bomRefsByIdentity);

--- a/apiserver/src/main/java/org/dependencytrack/vulnanalysis/ReconcileVulnAnalysisResultsActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulnanalysis/ReconcileVulnAnalysisResultsActivity.java
@@ -628,7 +628,7 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
 
     private Map<Long, Map<Long, VulnerabilityPolicy>> evaluateVulnPolicies(
             long projectId,
-            Map<Long, Set<Long>> vulnIdsByComponentId) {
+            Map<Long, Set<Long>> vulnIdsByComponentId) throws InterruptedException {
         if (vulnIdsByComponentId.isEmpty()) {
             return Map.of();
         }

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
@@ -405,7 +405,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithPolicyOperatorAnyAndAllConditionsMatching() {
+    void testEvaluateProjectWithPolicyOperatorAnyAndAllConditionsMatching() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 project.name == "acme-app"
@@ -833,7 +833,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithPolicyOperatorAnyAndNotAllConditionsMatching() {
+    void testEvaluateProjectWithPolicyOperatorAnyAndNotAllConditionsMatching() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 project.name == "acme-app"
@@ -856,7 +856,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithPolicyOperatorAnyAndNoConditionsMatching() {
+    void testEvaluateProjectWithPolicyOperatorAnyAndNoConditionsMatching() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 project.name == "someOtherProjectThatIsNotAcmeApp"
@@ -879,7 +879,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithPolicyOperatorAllAndAllConditionsMatching() {
+    void testEvaluateProjectWithPolicyOperatorAllAndAllConditionsMatching() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ALL, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 project.name == "acme-app"
@@ -902,7 +902,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithPolicyOperatorAllAndNotAllConditionsMatching() {
+    void testEvaluateProjectWithPolicyOperatorAllAndNotAllConditionsMatching() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ALL, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 project.name == "acme-app"
@@ -925,7 +925,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithPolicyOperatorAllAndNoConditionsMatching() {
+    void testEvaluateProjectWithPolicyOperatorAllAndNoConditionsMatching() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ALL, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 project.name == "someOtherProjectThatIsNotAcmeApp"
@@ -948,7 +948,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithPolicyAssignedToProject() {
+    void testEvaluateProjectWithPolicyAssignedToProject() throws Exception {
         final var policyA = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policyA, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 component.name.startsWith("acme-lib")
@@ -985,7 +985,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithPolicyAssignedToProjectParent() {
+    void testEvaluateProjectWithPolicyAssignedToProjectParent() throws Exception {
         final var policyA = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policyA, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 component.name.startsWith("acme-lib")
@@ -1028,7 +1028,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithPolicyAssignedToTag() {
+    void testEvaluateProjectWithPolicyAssignedToTag() throws Exception {
         final Tag tag = qm.createTag("foo");
 
         final var policyA = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
@@ -1068,7 +1068,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithInvalidScript() {
+    void testEvaluateProjectWithInvalidScript() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 component.doesNotExist == "foo"
@@ -1094,7 +1094,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithScriptExecutionException() {
+    void testEvaluateProjectWithScriptExecutionException() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 project.last_bom_import == timestamp("invalid")
@@ -1120,7 +1120,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithFuncProjectDependsOnComponent() {
+    void testEvaluateProjectWithFuncProjectDependsOnComponent() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 project.depends_on(v1.Component{name: "acme-lib-a"})
@@ -1153,7 +1153,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithFuncProjectDependsOnComponentWithRegexAndVers() {
+    void testEvaluateProjectWithFuncProjectDependsOnComponentWithRegexAndVers() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 project.depends_on(v1.Component{name: "re:^acme-lib-.*$", version: "vers:generic/>1|<2.0"})
@@ -1188,7 +1188,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithFuncComponentIsDependencyOfComponent() {
+    void testEvaluateProjectWithFuncComponentIsDependencyOfComponent() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 component.is_dependency_of(v1.Component{name: "acme-lib-a"})
@@ -1220,7 +1220,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithFuncComponentIsDependencyOfComponentWithRegex() {
+    void testEvaluateProjectWithFuncComponentIsDependencyOfComponentWithRegex() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 component.is_dependency_of(v1.Component{name: "re:.*-lib-.*"})
@@ -1252,7 +1252,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithFuncComponentIsDependencyOfComponentWithVersRange() {
+    void testEvaluateProjectWithFuncComponentIsDependencyOfComponentWithVersRange() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 component.is_dependency_of(v1.Component{
@@ -1288,7 +1288,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithFuncComponentIsDependencyOfExclusiveComponentWithSinglePath() {
+    void testEvaluateProjectWithFuncComponentIsDependencyOfExclusiveComponentWithSinglePath() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -1372,7 +1372,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithFuncComponentIsDependencyOfExclusiveComponentWithMultiplePaths() {
+    void testEvaluateProjectWithFuncComponentIsDependencyOfExclusiveComponentWithMultiplePaths() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -1458,7 +1458,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithFuncComponentIsDependencyOfExclusiveComponentWithMultiplePaths2() {
+    void testEvaluateProjectWithFuncComponentIsDependencyOfExclusiveComponentWithMultiplePaths2() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -1534,7 +1534,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithFuncComponentIsDependencyOfExclusiveComponentWithMultiplePaths3() {
+    void testEvaluateProjectWithFuncComponentIsDependencyOfExclusiveComponentWithMultiplePaths3() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -1622,7 +1622,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithFuncComponentIsDependencyOfExclusiveComponentWithMultiplePaths4() {
+    void testEvaluateProjectWithFuncComponentIsDependencyOfExclusiveComponentWithMultiplePaths4() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -1805,7 +1805,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithFuncComponentIsDependencyOfExclusiveComponentWithMultiplePaths5() {
+    void testEvaluateProjectWithFuncComponentIsDependencyOfExclusiveComponentWithMultiplePaths5() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -1853,7 +1853,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithFuncMatchesRange() {
+    void testEvaluateProjectWithFuncMatchesRange() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 project.matches_range("vers:generic/<1")
@@ -1883,7 +1883,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithFuncMatchesRangeWithInvalidRange() {
+    void testEvaluateProjectWithFuncMatchesRangeWithInvalidRange() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 project.matches_range("foo")
@@ -1913,7 +1913,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithToolMetadata() {
+    void testEvaluateProjectWithToolMetadata() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 project.metadata.tools.components.exists(tool,
@@ -1950,12 +1950,12 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWhenProjectDoesNotExist() {
+    void testEvaluateProjectWhenProjectDoesNotExist() throws Exception {
         assertThatNoException().isThrownBy(() -> new CelPolicyEngine().evaluateProject(UUID.randomUUID()));
     }
 
     @Test
-    void issue1924() {
+    void issue1924() throws Exception {
         Policy policy = qm.createPolicy("Policy 1924", Policy.Operator.ALL, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.SEVERITY, PolicyCondition.Operator.IS, Severity.CRITICAL.name());
         qm.createPolicyCondition(policy, PolicyCondition.Subject.PACKAGE_URL, PolicyCondition.Operator.NO_MATCH, "pkg:deb");
@@ -2029,7 +2029,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void issue2455() {
+    void issue2455() throws Exception {
         Policy policy = qm.createPolicy("Policy 1924", Policy.Operator.ALL, Policy.ViolationState.INFO);
 
         License license = new License();
@@ -2086,7 +2086,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithNoLongerApplicableViolationWithAnalysis() {
+    void testEvaluateProjectWithNoLongerApplicableViolationWithAnalysis() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         project.setVersion("1.0.0");
@@ -2128,7 +2128,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithFuncComponentIsDirectDependencyOfComponent() {
+    void testEvaluateProjectWithFuncComponentIsDirectDependencyOfComponent() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -2173,7 +2173,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithFuncComponentIsDirectDependencyOfExclusiveComponent() {
+    void testEvaluateProjectWithFuncComponentIsDirectDependencyOfExclusiveComponent() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -2245,7 +2245,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithFuncComponentIsDirectDependencyOfComponentWithInMemoryFilter() {
+    void testEvaluateProjectWithFuncComponentIsDirectDependencyOfComponentWithInMemoryFilter() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         project.setVersion("1.0");
@@ -2297,7 +2297,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithPropertiesSize() {
+    void testEvaluateProjectWithPropertiesSize() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -2320,7 +2320,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void shouldEvaluateComponentPropertyFields() {
+    void shouldEvaluateComponentPropertyFields() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -2348,7 +2348,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void shouldEvaluateComponentPropertiesSize() {
+    void shouldEvaluateComponentPropertiesSize() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -2373,7 +2373,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void testEvaluateProjectWithLicenseGroupsSize() {
+    void testEvaluateProjectWithLicenseGroupsSize() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -2422,7 +2422,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     void shouldEvaluateSpdxExprFunctionOnLicenseExpression(
             String celExpression,
             String licenseExpression,
-            boolean expectViolation) {
+            boolean expectViolation) throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION,
                 PolicyCondition.Operator.MATCHES, celExpression, PolicyViolation.Type.LICENSE);
@@ -2446,7 +2446,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void shouldEvaluateSpdxExprFunctionOnResolvedLicenseId() {
+    void shouldEvaluateSpdxExprFunctionOnResolvedLicenseId() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 has(component.resolved_license)
@@ -2474,7 +2474,7 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
     }
 
     @Test
-    void shouldNotEvaluateSuppressedVulnerabilities() {
+    void shouldNotEvaluateSuppressedVulnerabilities() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
                 vulns.exists(v, v.id == "CVE-001")

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/CelVulnerabilityPolicyEvaluatorTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/CelVulnerabilityPolicyEvaluatorTest.java
@@ -54,7 +54,7 @@ public class CelVulnerabilityPolicyEvaluatorTest extends PersistenceCapableTest 
     }
 
     @Test
-    public void testEvaluateAllWithNoApplicablePolicies() {
+    public void testEvaluateAllWithNoApplicablePolicies() throws Exception {
         final var project = new org.dependencytrack.model.Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -73,7 +73,7 @@ public class CelVulnerabilityPolicyEvaluatorTest extends PersistenceCapableTest 
     }
 
     @Test
-    public void testEvaluateAllWithNoMatchingPolicies() {
+    public void testEvaluateAllWithNoMatchingPolicies() throws Exception {
         final var project = new org.dependencytrack.model.Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -96,7 +96,7 @@ public class CelVulnerabilityPolicyEvaluatorTest extends PersistenceCapableTest 
     }
 
     @Test
-    public void testEvaluateAllWithMultipleMatchingPolicies() {
+    public void testEvaluateAllWithMultipleMatchingPolicies() throws Exception {
         final var project = new org.dependencytrack.model.Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -126,7 +126,7 @@ public class CelVulnerabilityPolicyEvaluatorTest extends PersistenceCapableTest 
     }
 
     @Test
-    public void testEvaluateAllWithMultipleComponents() {
+    public void testEvaluateAllWithMultipleComponents() throws Exception {
         final var project = new org.dependencytrack.model.Project();
         project.setName("acme-app");
         qm.persist(project);
@@ -168,7 +168,7 @@ public class CelVulnerabilityPolicyEvaluatorTest extends PersistenceCapableTest 
     }
 
     @Test
-    public void testEvaluateAllWithEmptyInput() {
+    public void testEvaluateAllWithEmptyInput() throws Exception {
         final var project = new org.dependencytrack.model.Project();
         project.setName("acme-app");
         qm.persist(project);

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/CpeConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/CpeConditionTest.java
@@ -53,7 +53,7 @@ public class CpeConditionTest extends PersistenceCapableTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void testCondition(final Operator operator, final String conditionCpe, final String componentCpe, final boolean expectViolation) {
+    public void testCondition(final Operator operator, final String conditionCpe, final String componentCpe, final boolean expectViolation) throws Exception {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.CPE, operator, conditionCpe);
 

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/CweConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/CweConditionTest.java
@@ -49,7 +49,7 @@ public class CweConditionTest extends PersistenceCapableTest {
     @MethodSource("parameters")
     public void testSingleCwe(Policy.Operator policyOperator, Policy.ViolationState violationState,
                               PolicyCondition.Operator conditionOperator, String inputConditionCwe, int inputCweId, int inputCweId2,
-                              boolean expectViolation, PolicyViolation.Type actualType, Policy.ViolationState actualViolationState) {
+                              boolean expectViolation, PolicyViolation.Type actualType, Policy.ViolationState actualViolationState) throws Exception {
         Policy policy = qm.createPolicy("Test Policy", policyOperator, violationState);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.CWE, conditionOperator, inputConditionCwe);
         final var project = new Project();

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/EpssConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/EpssConditionTest.java
@@ -97,7 +97,7 @@ public class EpssConditionTest extends PersistenceCapableTest {
             final String conditionValue,
             final Double vulnEpssScore,
             final boolean expectViolation
-    ) {
+    ) throws Exception {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EPSS, operator, conditionValue);
 

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/HashConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/HashConditionTest.java
@@ -66,7 +66,7 @@ public class HashConditionTest extends PersistenceCapableTest {
     @MethodSource("parameters")
     public void testCondition(Policy.Operator policyOperator, final Operator condition, final String conditionHash,
                               final String actualHash, final boolean expectViolation, ViolationState violationState,
-                              Type actualType, ViolationState actualViolationState) {
+                              Type actualType, ViolationState actualViolationState) throws Exception {
         final Policy policy = qm.createPolicy("policy", policyOperator, violationState);
         qm.createPolicyCondition(policy, Subject.COMPONENT_HASH, condition, conditionHash);
 
@@ -93,7 +93,7 @@ public class HashConditionTest extends PersistenceCapableTest {
 
 
     @Test
-    public void testWithNullPolicyCondition() {
+    public void testWithNullPolicyCondition() throws Exception {
 
         final var project = new Project();
         project.setName("acme-app");

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/InternalStatusConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/InternalStatusConditionTest.java
@@ -56,7 +56,7 @@ class InternalStatusConditionTest extends PersistenceCapableTest {
             Operator operator,
             String conditionValue,
             boolean componentInternal,
-            boolean expectViolation) {
+            boolean expectViolation) throws Exception {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, ViolationState.INFO);
         qm.createPolicyCondition(policy, Subject.IS_INTERNAL, operator, conditionValue);
 

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/LicenseConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/LicenseConditionTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class LicenseConditionTest extends PersistenceCapableTest {
 
     @Test
-    public void hasMatch() {
+    public void hasMatch() throws Exception {
         License license = new License();
         license.setName("Apache 2.0");
         license.setUuid(UUID.randomUUID());
@@ -57,7 +57,7 @@ public class LicenseConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void noMatch() {
+    public void noMatch() throws Exception {
         License license = new License();
         license.setName("Apache 2.0");
         license.setUuid(UUID.randomUUID());
@@ -81,7 +81,7 @@ public class LicenseConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void wrongOperator() {
+    public void wrongOperator() throws Exception {
         License license = new License();
         license.setName("Apache 2.0");
         license.setUuid(UUID.randomUUID());
@@ -104,7 +104,7 @@ public class LicenseConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    void shouldMatchByLicenseExpression() {
+    void shouldMatchByLicenseExpression() throws Exception {
         final var license = new License();
         license.setName("MIT License");
         license.setLicenseId("MIT");
@@ -129,7 +129,7 @@ public class LicenseConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    void shouldMatchByLicenseName() {
+    void shouldMatchByLicenseName() throws Exception {
         final var license = new License();
         license.setName("MIT License");
         license.setLicenseId("MIT");
@@ -154,7 +154,7 @@ public class LicenseConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    void shouldNotViolateIsNotWhenOrExpressionPermitsLicense() {
+    void shouldNotViolateIsNotWhenOrExpressionPermitsLicense() throws Exception {
         final var mit = new License();
         mit.setName("MIT License");
         mit.setLicenseId("MIT");
@@ -179,7 +179,7 @@ public class LicenseConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    void shouldViolateIsWhenAndExpressionContainsForbiddenLicense() {
+    void shouldViolateIsWhenAndExpressionContainsForbiddenLicense() throws Exception {
         final var gpl = new License();
         gpl.setName("GNU General Public License v2.0");
         gpl.setLicenseId("GPL-2.0");
@@ -204,7 +204,7 @@ public class LicenseConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    void shouldViolateIsNotUnresolvedWhenLicenseExpressionIsSet() {
+    void shouldViolateIsNotUnresolvedWhenLicenseExpressionIsSet() throws Exception {
         final Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.LICENSE, PolicyCondition.Operator.IS_NOT, "unresolved");
 
@@ -223,7 +223,7 @@ public class LicenseConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    void shouldMatchCustomLicenseByUuid() {
+    void shouldMatchCustomLicenseByUuid() throws Exception {
         final var custom = new License();
         custom.setName("Acme Proprietary");
         custom.setUuid(UUID.randomUUID());
@@ -247,7 +247,7 @@ public class LicenseConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void valueIsUnresolved() {
+    public void valueIsUnresolved() throws Exception {
         License license = new License();
         license.setName("Apache 2.0");
         license.setUuid(UUID.randomUUID());

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/LicenseGroupConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/LicenseGroupConditionTest.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class LicenseGroupConditionTest extends PersistenceCapableTest {
 
     @Test
-    public void hasMatch() {
+    public void hasMatch() throws Exception {
         License license = new License();
         license.setName("Apache 2.0");
         license.setUuid(UUID.randomUUID());
@@ -66,7 +66,7 @@ public class LicenseGroupConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void noMatch() {
+    public void noMatch() throws Exception {
         License license = new License();
         license.setName("Apache 2.0");
         license.setUuid(UUID.randomUUID());
@@ -94,7 +94,7 @@ public class LicenseGroupConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void unknownLicenseViolateWhitelist() {
+    public void unknownLicenseViolateWhitelist() throws Exception {
         LicenseGroup lg = qm.createLicenseGroup("Test License Group");
         lg = qm.persist(lg);
         lg = qm.detach(LicenseGroup.class, lg.getId());
@@ -118,7 +118,7 @@ public class LicenseGroupConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void wrongOperator() {
+    public void wrongOperator() throws Exception {
         License license = new License();
         license.setName("Apache 2.0");
         license.setLicenseId("Apache-2.0");
@@ -144,7 +144,7 @@ public class LicenseGroupConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    void shouldMatchLicenseGroupByLicenseExpression() {
+    void shouldMatchLicenseGroupByLicenseExpression() throws Exception {
         final var mit = new License();
         mit.setName("MIT License");
         mit.setLicenseId("MIT");
@@ -172,7 +172,7 @@ public class LicenseGroupConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    void shouldMatchLicenseGroupByLicenseName() {
+    void shouldMatchLicenseGroupByLicenseName() throws Exception {
         final var mit = new License();
         mit.setName("MIT License");
         mit.setLicenseId("MIT");
@@ -200,7 +200,7 @@ public class LicenseGroupConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    void shouldNotViolateIsNotWhenOrExpressionPermitsGroupMember() {
+    void shouldNotViolateIsNotWhenOrExpressionPermitsGroupMember() throws Exception {
         final var mit = new License();
         mit.setName("MIT License");
         mit.setLicenseId("MIT");
@@ -228,7 +228,7 @@ public class LicenseGroupConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    void shouldViolateIsWhenAndExpressionContainsGroupMember() {
+    void shouldViolateIsWhenAndExpressionContainsGroupMember() throws Exception {
         final var gpl = new License();
         gpl.setName("GNU General Public License v2.0");
         gpl.setLicenseId("GPL-2.0");
@@ -256,7 +256,7 @@ public class LicenseGroupConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void licenseGroupDoesNotExist() {
+    public void licenseGroupDoesNotExist() throws Exception {
         License license = new License();
         license.setName("Apache 2.0");
         license.setLicenseId("Apache-2.0");

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/SeverityConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/SeverityConditionTest.java
@@ -58,7 +58,7 @@ public class SeverityConditionTest extends PersistenceCapableTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void testCondition(final Operator operator, final String conditionSeverity, final String actualSeverity, final boolean expectViolation) {
+    public void testCondition(final Operator operator, final String conditionSeverity, final String actualSeverity, final boolean expectViolation) throws Exception {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, ViolationState.INFO);
         qm.createPolicyCondition(policy, Subject.SEVERITY, operator, conditionSeverity);
 
@@ -94,7 +94,7 @@ public class SeverityConditionTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testSeverityCalculation() {
+    public void testSeverityCalculation() throws Exception {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, ViolationState.FAIL);
         qm.createPolicyCondition(policy, Subject.SEVERITY, Operator.IS, Severity.CRITICAL.name(), Type.SECURITY);
 

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/SwidTagIdConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/SwidTagIdConditionTest.java
@@ -51,7 +51,7 @@ public class SwidTagIdConditionTest extends PersistenceCapableTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void testCondition(final Operator operator, final String conditionSwidTagId, final String componentSwidTagId, final boolean expectViolation) {
+    public void testCondition(final Operator operator, final String conditionSwidTagId, final String componentSwidTagId, final boolean expectViolation) throws Exception {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.SWID_TAGID, operator, conditionSwidTagId);
 

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/VersionConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/VersionConditionTest.java
@@ -53,7 +53,7 @@ public class VersionConditionTest extends PersistenceCapableTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void testCondition(final PolicyCondition.Operator operator, final String conditionVersion, final String componentVersion, final boolean expectViolation) {
+    public void testCondition(final PolicyCondition.Operator operator, final String conditionVersion, final String componentVersion, final boolean expectViolation) throws Exception {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.VERSION, operator, conditionVersion);
 

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/VulnerabilityIdConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/VulnerabilityIdConditionTest.java
@@ -51,7 +51,7 @@ public class VulnerabilityIdConditionTest extends PersistenceCapableTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void testCondition(final PolicyCondition.Operator operator, final String conditionVulnId, final String actualVulnId, final boolean expectViolation) {
+    public void testCondition(final PolicyCondition.Operator operator, final String conditionVulnId, final String actualVulnId, final boolean expectViolation) throws Exception {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.VULNERABILITY_ID, operator, conditionVulnId);
 

--- a/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorage.java
+++ b/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorage.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.UncheckedIOException;
@@ -147,8 +148,16 @@ final class S3FileStorage implements FileStorage {
                             /* objectSize */ -1L,
                             /* partSize */ 10485760L /* (10MiB) */)
                     .build());
+            compressionFuture.get();
+        } catch (InterruptedException e) {
+            compressionFuture.cancel(/* mayInterruptIfRunning */ true);
+            Thread.currentThread().interrupt();
 
-            compressionFuture.join();
+            final var interruptedException =
+                    new InterruptedIOException(
+                            "Interrupted before the file could be stored");
+            interruptedException.initCause(e);
+            throw interruptedException;
         } catch (Exception e) {
             compressionFuture.cancel(true);
 


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds interrupt checks and propagation to code that can potentially run for a long-ish time.

dex will interrupt activities that exceed their execution timeout, but that only takes effect if the code being executed is receptive to interruption.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #6837 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
