### PR TITLE
Backport: Strip trailing `/` from `baseUrl` notification template variable

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/dex/DexEngineInitializer.java
+++ b/apiserver/src/main/java/org/dependencytrack/dex/DexEngineInitializer.java
@@ -51,6 +51,7 @@ import org.dependencytrack.notification.ProcessScheduledNotificationRuleActivity
 import org.dependencytrack.notification.ProcessScheduledNotificationsWorkflow;
 import org.dependencytrack.notification.PublishNotificationActivity;
 import org.dependencytrack.notification.PublishNotificationWorkflow;
+import org.dependencytrack.notification.api.templating.NotificationTemplateVariables;
 import org.dependencytrack.notification.templating.pebble.PebbleNotificationTemplateRendererFactory;
 import org.dependencytrack.persistence.jdbi.ConfigPropertyDao;
 import org.dependencytrack.pkgmetadata.FetchPackageMetadataResolutionCandidatesActivity;
@@ -158,7 +159,7 @@ public final class DexEngineInitializer implements ServletContextListener {
         requireNonNull(secretManager, "secretManager has not been initialized");
 
         final var templateRendererFactory = new PebbleNotificationTemplateRendererFactory(
-                Map.of("baseUrl", () -> withJdbiHandle(
+                Map.of(NotificationTemplateVariables.BASE_URL, () -> withJdbiHandle(
                         handle -> handle
                                 .attach(ConfigPropertyDao.class)
                                 .getOptionalValue(GENERAL_BASE_URL)

--- a/apiserver/src/test/java/org/dependencytrack/notification/PublishNotificationWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/notification/PublishNotificationWorkflowTest.java
@@ -38,6 +38,7 @@ import org.dependencytrack.filestorage.proto.v1.FileMetadata;
 import org.dependencytrack.model.NotificationRule;
 import org.dependencytrack.model.NotificationTriggerType;
 import org.dependencytrack.notification.api.publishing.NotificationPublisher;
+import org.dependencytrack.notification.api.templating.NotificationTemplateVariables;
 import org.dependencytrack.notification.proto.v1.Notification;
 import org.dependencytrack.notification.publishing.DefaultNotificationPublishersPlugin;
 import org.dependencytrack.notification.templating.pebble.PebbleNotificationTemplateRendererFactory;
@@ -291,7 +292,7 @@ class PublishNotificationWorkflowTest extends PersistenceCapableTest {
         final var publisher = new org.dependencytrack.model.NotificationPublisher();
         publisher.setName("Test Publisher");
         publisher.setExtensionName(publisherExtensionName);
-        publisher.setTemplate("{{ notification.subject.project.name }}");
+        publisher.setTemplate("{{ %s.subject.project.name }}".formatted(NotificationTemplateVariables.NOTIFICATION));
         publisher.setTemplateMimeType("text/plain");
         qm.persist(publisher);
 

--- a/notification/api/src/main/java/org/dependencytrack/notification/api/templating/NotificationTemplateVariables.java
+++ b/notification/api/src/main/java/org/dependencytrack/notification/api/templating/NotificationTemplateVariables.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.notification.api.templating;
+
+/**
+ * Names of variables available in the notification template context.
+ * <p>
+ * Consumers that supply or reference template context values should use these
+ * constants rather than a concrete template-engine implementation.
+ *
+ * @since 5.0.0
+ */
+public final class NotificationTemplateVariables {
+
+    /**
+     * Application base URL used to construct frontend links.
+     */
+    public static final String BASE_URL = "baseUrl";
+
+    /**
+     * Notification timestamp as epoch seconds.
+     */
+    public static final String TIMESTAMP_EPOCH_SECONDS = "timestampEpochSeconds";
+
+    /**
+     * Notification timestamp as a formatted string.
+     */
+    public static final String TIMESTAMP = "timestamp";
+
+    /**
+     * The notification protobuf message.
+     */
+    public static final String NOTIFICATION = "notification";
+
+    /**
+     * Unpacked notification subject (when present).
+     */
+    public static final String SUBJECT = "subject";
+
+    /**
+     * Notification subject serialized as JSON (when present).
+     */
+    public static final String SUBJECT_JSON = "subjectJson";
+
+    private NotificationTemplateVariables() {
+    }
+
+}

--- a/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/AbstractNotificationPublisherTest.java
+++ b/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/AbstractNotificationPublisherTest.java
@@ -25,6 +25,7 @@ import org.dependencytrack.notification.api.publishing.NotificationPublishContex
 import org.dependencytrack.notification.api.publishing.NotificationPublisher;
 import org.dependencytrack.notification.api.publishing.NotificationPublisherFactory;
 import org.dependencytrack.notification.api.templating.NotificationTemplateRenderer;
+import org.dependencytrack.notification.api.templating.NotificationTemplateVariables;
 import org.dependencytrack.notification.proto.v1.Group;
 import org.dependencytrack.notification.proto.v1.Level;
 import org.dependencytrack.notification.proto.v1.Notification;
@@ -101,7 +102,7 @@ public abstract class AbstractNotificationPublisherTest {
 
         final var templateRendererFactory =
                 new PebbleNotificationTemplateRendererFactory(
-                        Map.of("baseUrl", () -> "https://example.com"));
+                        Map.of(NotificationTemplateVariables.BASE_URL, () -> "https://example.com"));
         final NotificationTemplateRenderer templateRenderer =
                 templateRendererFactory.createRenderer(
                         publisherFactory.defaultTemplate());

--- a/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/email/EmailNotificationPublisherTest.java
+++ b/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/email/EmailNotificationPublisherTest.java
@@ -27,6 +27,7 @@ import org.dependencytrack.notification.api.publishing.NotificationPublishContex
 import org.dependencytrack.notification.api.publishing.NotificationPublisherFactory;
 import org.dependencytrack.notification.api.templating.NotificationTemplate;
 import org.dependencytrack.notification.api.templating.NotificationTemplateRenderer;
+import org.dependencytrack.notification.api.templating.NotificationTemplateVariables;
 import org.dependencytrack.notification.proto.v1.Notification;
 import org.dependencytrack.notification.publishing.AbstractNotificationPublisherTest;
 import org.dependencytrack.notification.templating.pebble.PebbleNotificationTemplateRendererFactory;
@@ -351,12 +352,12 @@ class EmailNotificationPublisherTest extends AbstractNotificationPublisherTest {
     @Test
     void shouldSendHtmlBodyWhenTemplateMimeTypeIsHtml() throws Exception {
         final var htmlTemplate = new NotificationTemplate(/* language=HTML */ """
-                <html><body><p>{{ notification.title }}</p></body></html>\
-                """,
+                <html><body><p>{{ %s.title }}</p></body></html>\
+                """.formatted(NotificationTemplateVariables.NOTIFICATION),
                 "text/html; charset=utf-8");
         final NotificationTemplateRenderer htmlRenderer =
                 new PebbleNotificationTemplateRendererFactory(
-                        Map.of("baseUrl", () -> "https://example.com"))
+                        Map.of(NotificationTemplateVariables.BASE_URL, () -> "https://example.com"))
                         .createRenderer(htmlTemplate);
         final var publishCtx =
                 new NotificationPublishContext(

--- a/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/email/EmailNotificationPublisherTlsTest.java
+++ b/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/email/EmailNotificationPublisherTlsTest.java
@@ -25,6 +25,7 @@ import org.dependencytrack.notification.api.TestNotificationFactory;
 import org.dependencytrack.notification.api.publishing.NotificationPublishContext;
 import org.dependencytrack.notification.api.publishing.NotificationPublisher;
 import org.dependencytrack.notification.api.templating.NotificationTemplateRenderer;
+import org.dependencytrack.notification.api.templating.NotificationTemplateVariables;
 import org.dependencytrack.notification.proto.v1.Notification;
 import org.dependencytrack.notification.templating.pebble.PebbleNotificationTemplateRendererFactory;
 import org.dependencytrack.plugin.api.MutableServiceRegistry;
@@ -82,7 +83,7 @@ class EmailNotificationPublisherTlsTest {
 
         final var templateRendererFactory =
                 new PebbleNotificationTemplateRendererFactory(
-                        Map.of("baseUrl", () -> "https://example.com"));
+                        Map.of(NotificationTemplateVariables.BASE_URL, () -> "https://example.com"));
         final NotificationTemplateRenderer templateRenderer =
                 templateRendererFactory.createRenderer(
                         publisherFactory.defaultTemplate());

--- a/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/webhook/WebhookNotificationPublisherTest.java
+++ b/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/webhook/WebhookNotificationPublisherTest.java
@@ -25,6 +25,7 @@ import org.dependencytrack.notification.api.publishing.NotificationPublishContex
 import org.dependencytrack.notification.api.publishing.NotificationPublisherFactory;
 import org.dependencytrack.notification.api.publishing.RetryablePublishException;
 import org.dependencytrack.notification.api.templating.NotificationTemplateRenderer;
+import org.dependencytrack.notification.api.templating.NotificationTemplateVariables;
 import org.dependencytrack.notification.proto.v1.Notification;
 import org.dependencytrack.notification.publishing.AbstractNotificationPublisherTest;
 import org.dependencytrack.notification.templating.pebble.PebbleNotificationTemplateRendererFactory;
@@ -425,7 +426,7 @@ class WebhookNotificationPublisherTest extends AbstractNotificationPublisherTest
 
                 final var templateRendererFactory =
                         new PebbleNotificationTemplateRendererFactory(
-                                Map.of("baseUrl", () -> "https://example.com"));
+                                Map.of(NotificationTemplateVariables.BASE_URL, () -> "https://example.com"));
                 final NotificationTemplateRenderer templateRenderer =
                         templateRendererFactory.createRenderer(factory.defaultTemplate());
 

--- a/notification/templating/pom.xml
+++ b/notification/templating/pom.xml
@@ -61,6 +61,18 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/notification/templating/src/main/java/org/dependencytrack/notification/templating/pebble/PebbleNotificationTemplateRenderer.java
+++ b/notification/templating/src/main/java/org/dependencytrack/notification/templating/pebble/PebbleNotificationTemplateRenderer.java
@@ -54,6 +54,12 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
+import static org.dependencytrack.notification.api.templating.NotificationTemplateVariables.BASE_URL;
+import static org.dependencytrack.notification.api.templating.NotificationTemplateVariables.NOTIFICATION;
+import static org.dependencytrack.notification.api.templating.NotificationTemplateVariables.SUBJECT;
+import static org.dependencytrack.notification.api.templating.NotificationTemplateVariables.SUBJECT_JSON;
+import static org.dependencytrack.notification.api.templating.NotificationTemplateVariables.TIMESTAMP;
+import static org.dependencytrack.notification.api.templating.NotificationTemplateVariables.TIMESTAMP_EPOCH_SECONDS;
 
 /**
  * A {@link NotificationTemplateRenderer} powered by Pebble.
@@ -93,10 +99,11 @@ final class PebbleNotificationTemplateRenderer implements NotificationTemplateRe
         if (additionalContext != null) {
             templateCtx.putAll(additionalContext);
         }
-        templateCtx.put("baseUrl", contextVariableSuppliers.getOrDefault("baseUrl", NULL_SUPPLIER).get());
-        templateCtx.put("timestampEpochSeconds", Timestamps.toSeconds(notification.getTimestamp()));
-        templateCtx.put("timestamp", format(notification.getTimestamp()));
-        templateCtx.put("notification", notification);
+        templateCtx.put(BASE_URL, normalizeBaseUrl(
+                contextVariableSuppliers.getOrDefault(BASE_URL, NULL_SUPPLIER).get()));
+        templateCtx.put(TIMESTAMP_EPOCH_SECONDS, Timestamps.toSeconds(notification.getTimestamp()));
+        templateCtx.put(TIMESTAMP, format(notification.getTimestamp()));
+        templateCtx.put(NOTIFICATION, notification);
 
         final Message subject;
         try {
@@ -106,10 +113,10 @@ final class PebbleNotificationTemplateRenderer implements NotificationTemplateRe
         }
 
         if (subject != null) {
-            templateCtx.put("subject", subject);
+            templateCtx.put(SUBJECT, subject);
 
             try {
-                templateCtx.put("subjectJson", JsonFormat.printer().print(subject));
+                templateCtx.put(SUBJECT_JSON, JsonFormat.printer().print(subject));
             } catch (IOException e) {
                 throw new UncheckedIOException("Failed to serialize subject as JSON", e);
             }
@@ -131,6 +138,28 @@ final class PebbleNotificationTemplateRenderer implements NotificationTemplateRe
 
     private static String format(Timestamp protoTimestamp) {
         return TIMESTAMP_FORMATTER.format(Instant.ofEpochMilli(Timestamps.toMillis(protoTimestamp)));
+    }
+
+    /**
+     * Notification templates concatenate
+     * {@link org.dependencytrack.notification.api.templating.NotificationTemplateVariables#BASE_URL}
+     * with path segments that already start with {@code /}
+     * (e.g. {@code {{ baseUrl }}/projects/...} and {@code {{ baseUrl }}{{ frontendUri }}}).
+     * Configured base URLs commonly include a trailing slash; strip trailing slashes
+     * so rendered links never contain redundant {@code //}, which breaks the frontend router.
+     *
+     * @see <a href="https://github.com/DependencyTrack/dependency-track/issues/6786">#6786</a>
+     */
+    private static @Nullable Object normalizeBaseUrl(@Nullable Object baseUrl) {
+        if (!(baseUrl instanceof String value)) {
+            return baseUrl;
+        }
+
+        int end = value.length();
+        while (end > 0 && value.charAt(end - 1) == '/') {
+            end--;
+        }
+        return end == value.length() ? value : value.substring(0, end);
     }
 
     private static @Nullable Message extractSubject(Notification notification) throws IOException {

--- a/notification/templating/src/test/java/org/dependencytrack/notification/templating/pebble/PebbleNotificationTemplateRendererTest.java
+++ b/notification/templating/src/test/java/org/dependencytrack/notification/templating/pebble/PebbleNotificationTemplateRendererTest.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.notification.templating.pebble;
+
+import com.google.protobuf.util.Timestamps;
+import org.dependencytrack.notification.api.templating.NotificationTemplate;
+import org.dependencytrack.notification.api.templating.NotificationTemplateRenderer;
+import org.dependencytrack.notification.api.templating.RenderedNotificationTemplate;
+import org.dependencytrack.notification.proto.v1.Notification;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.notification.api.templating.NotificationTemplateVariables.BASE_URL;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+/**
+ * @see <a href="https://github.com/DependencyTrack/dependency-track/issues/6786">#6786</a>
+ */
+class PebbleNotificationTemplateRendererTest {
+
+    @ParameterizedTest
+    @MethodSource("baseUrlNormalizationArguments")
+    void shouldNormalizeBaseUrlTrailingSlashes(String configuredBaseUrl, String expectedBaseUrl) {
+        final RenderedNotificationTemplate rendered = render(
+                configuredBaseUrl,
+                """
+                        Vulnerability URL: {{ %1$s }}/vulnerability/?source=GITHUB&vulnId=GHSA-45gg-vh54-h5m9
+                        Component URL:     {{ %1$s }}/component/?uuid=a0f76ff1-4f7b-4c97-af53-a39629a4d18c
+                        Project URL:       {{ %1$s }}/projects/24593709-c6f4-4341-b8b4-852b8379a61e
+                        Other affected projects: {{ %1$s }}{{ frontendUri }}\
+                        """.formatted(BASE_URL),
+                Map.of("frontendUri", "/vulnerabilities/GITHUB/GHSA-45gg-vh54-h5m9/affectedProjects"));
+
+        assertThat(rendered.content()).isEqualTo("""
+                Vulnerability URL: %s/vulnerability/?source=GITHUB&vulnId=GHSA-45gg-vh54-h5m9
+                Component URL:     %s/component/?uuid=a0f76ff1-4f7b-4c97-af53-a39629a4d18c
+                Project URL:       %s/projects/24593709-c6f4-4341-b8b4-852b8379a61e
+                Other affected projects: %s/vulnerabilities/GITHUB/GHSA-45gg-vh54-h5m9/affectedProjects\
+                """.formatted(expectedBaseUrl, expectedBaseUrl, expectedBaseUrl, expectedBaseUrl));
+    }
+
+    private static Stream<Arguments> baseUrlNormalizationArguments() {
+        return Stream.of(
+                arguments("https://example.com", "https://example.com"),
+                arguments("https://example.com/", "https://example.com"),
+                arguments("https://example.com///", "https://example.com"),
+                arguments("https://example.com/dependency-track", "https://example.com/dependency-track"),
+                arguments("https://example.com/dependency-track/", "https://example.com/dependency-track"));
+    }
+
+    @Test
+    void shouldLeaveNullBaseUrlAsNull() {
+        final RenderedNotificationTemplate rendered = render(
+                null,
+                "%1$s=[{{ %1$s }}]".formatted(BASE_URL),
+                Map.of());
+
+        // Pebble renders null variables as empty strings.
+        assertThat(rendered.content()).isEqualTo("%s=[]".formatted(BASE_URL));
+    }
+
+    @Test
+    void shouldLeaveEmptyBaseUrlEmpty() {
+        final RenderedNotificationTemplate rendered = render(
+                "",
+                "%1$s=[{{ %1$s }}]".formatted(BASE_URL),
+                Map.of());
+
+        assertThat(rendered.content()).isEqualTo("%s=[]".formatted(BASE_URL));
+    }
+
+    private static RenderedNotificationTemplate render(
+            String baseUrl,
+            String templateContent,
+            Map<String, Object> additionalContext) {
+        final NotificationTemplateRenderer renderer =
+                new PebbleNotificationTemplateRendererFactory(
+                        Map.of(BASE_URL, () -> baseUrl))
+                        .createRenderer(new NotificationTemplate(templateContent, "text/plain"));
+
+        final RenderedNotificationTemplate rendered = renderer.render(
+                Notification.newBuilder()
+                        .setTimestamp(Timestamps.fromMillis(0L))
+                        .build(),
+                additionalContext);
+
+        assertThat(rendered).isNotNull();
+        return rendered;
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Strips trailing `/` from `baseUrl` notification template variable.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6786
Backports #6799

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
