### PR TITLE
Support AWS-managed credentials for S3 storage

### DIFF
--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -1138,10 +1138,15 @@ dt.file-storage.local.directory=${dt.data-directory}/storage
 # `dt.file-storage.s3.secret-key` are used. When both are missing, requests are performed
 # anonymously. When only one of the two is set, startup fails.
 # <br/><br/>
-# When set to `aws`, credentials are resolved from the AWS credential chain. This supports
-# ECS task roles, IRSA / web identity tokens, and the EC2 instance metadata service, and
-# does not require static keys to be configured. `dt.file-storage.s3.access-key` and
-# `dt.file-storage.s3.secret-key` are ignored in this mode.
+# When set to `aws`, credentials are resolved from the environment, mirroring the credential
+# provider chain of the AWS SDK: `AWS_*` environment variables, the shared AWS config file
+# (~/.aws/credentials), ECS task roles, EKS IRSA / web identity tokens, and the EC2 instance
+# metadata service, in that order. Static keys are not required and are ignored in this mode.
+# Startup fails if no credentials can be resolved.
+# <br/><br/>
+# EKS Pod Identity is not supported: the S3 client does not read
+# AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE and rejects the non-loopback Pod Identity Agent
+# endpoint. Use IRSA instead.
 #
 # @category:     Storage
 # @default:      static

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -1132,13 +1132,32 @@ dt.file-storage.local.directory=${dt.data-directory}/storage
 # @type:     string
 # dt.file-storage.s3.bucket=
 
+# Defines the source of the credentials used to authenticate against the S3 endpoint.
+# <br/><br/>
+# When set to `static`, the statically configured `dt.file-storage.s3.access-key` and
+# `dt.file-storage.s3.secret-key` are used. When both are missing, requests are performed
+# anonymously. When only one of the two is set, startup fails.
+# <br/><br/>
+# When set to `aws`, credentials are resolved from the AWS credential chain. This supports
+# ECS task roles, IRSA / web identity tokens, and the EC2 instance metadata service, and
+# does not require static keys to be configured. `dt.file-storage.s3.access-key` and
+# `dt.file-storage.s3.secret-key` are ignored in this mode.
+#
+# @category:     Storage
+# @default:      static
+# @type:         enum
+# @valid-values: [static, aws]
+# dt.file-storage.s3.credentials-source=static
+
 # Defines the S3 access key / username.
+# Has no effect when dt.file-storage.s3.credentials-source is `aws`.
 #
 # @category: Storage
 # @type:     string
 # dt.file-storage.s3.access-key=
 
 # Defines the S3 secret key / password.
+# Has no effect when dt.file-storage.s3.credentials-source is `aws`.
 #
 # @category: Storage
 # @type:     string

--- a/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorageProvider.java
+++ b/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorageProvider.java
@@ -21,6 +21,9 @@ package org.dependencytrack.filestorage.s3;
 import com.github.luben.zstd.Zstd;
 import io.minio.BucketExistsArgs;
 import io.minio.MinioClient;
+import io.minio.credentials.AwsConfigProvider;
+import io.minio.credentials.AwsEnvironmentProvider;
+import io.minio.credentials.ChainedProvider;
 import io.minio.credentials.IamAwsProvider;
 import io.minio.credentials.Provider;
 import io.minio.credentials.StaticProvider;
@@ -116,7 +119,22 @@ public final class S3FileStorageProvider implements FileStorageProvider {
                 }
                 yield Optional.empty();
             }
-            case AWS -> Optional.of(new IamAwsProvider(null, httpClient));
+            case AWS -> {
+                final var accessKey = config
+                        .getOptionalValue("dt.file-storage.s3.access-key", String.class).orElse(null);
+                final var secretKey = config
+                        .getOptionalValue("dt.file-storage.s3.secret-key", String.class).orElse(null);
+                if (Objects.nonNull(accessKey) || Objects.nonNull(secretKey)) {
+                    throw new IllegalStateException(
+                            "Conflicting credentials configuration: dt.file-storage.s3.credentials-source is aws, "
+                                    + "but dt.file-storage.s3.access-key or dt.file-storage.s3.secret-key is also configured");
+                }
+                yield Optional.of(new ChainedProvider(
+                        new AwsEnvironmentProvider(),
+                        new AwsConfigProvider(/* filename */ null, /* profile */ null),
+                        new IamAwsProvider(/* customEndpoint */ null, httpClient)
+                ));
+            }
         };
     }
 

--- a/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorageProvider.java
+++ b/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorageProvider.java
@@ -21,6 +21,9 @@ package org.dependencytrack.filestorage.s3;
 import com.github.luben.zstd.Zstd;
 import io.minio.BucketExistsArgs;
 import io.minio.MinioClient;
+import io.minio.credentials.IamAwsProvider;
+import io.minio.credentials.Provider;
+import io.minio.credentials.StaticProvider;
 import okhttp3.OkHttpClient;
 import org.dependencytrack.filestorage.api.FileStorage;
 import org.dependencytrack.filestorage.api.FileStorageProvider;
@@ -30,6 +33,9 @@ import org.slf4j.LoggerFactory;
 
 import java.net.ProxySelector;
 import java.time.Duration;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * @since 5.0.0
@@ -38,6 +44,8 @@ public final class S3FileStorageProvider implements FileStorageProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(S3FileStorageProvider.class);
     static final String NAME = "s3";
+    static final String CREDENTIALS_SOURCE_STATIC = "static";
+    static final String CREDENTIALS_SOURCE_AWS = "aws";
 
     @Override
     public String name() {
@@ -63,11 +71,7 @@ public final class S3FileStorageProvider implements FileStorageProvider {
                 .httpClient(httpClient, /* close */ true)
                 .endpoint(config.getValue("dt.file-storage.s3.endpoint", String.class));
 
-        final var accessKey = config.getOptionalValue("dt.file-storage.s3.access-key", String.class).orElse(null);
-        final var secretKey = config.getOptionalValue("dt.file-storage.s3.secret-key", String.class).orElse(null);
-        if (accessKey != null && secretKey != null) {
-            clientBuilder.credentials(accessKey, secretKey);
-        }
+        resolveCredentialsProvider(config, httpClient).ifPresent(clientBuilder::credentialsProvider);
 
         config.getOptionalValue("dt.file-storage.s3.region", String.class).ifPresent(clientBuilder::region);
         final MinioClient s3Client = clientBuilder.build();
@@ -88,6 +92,56 @@ public final class S3FileStorageProvider implements FileStorageProvider {
         }
 
         return new S3FileStorage(s3Client, bucketName, compressionLevel);
+    }
+
+    /**
+     * Resolves the {@link Provider} used to authenticate against the S3 endpoint.
+     * <p>
+     * The credentials source is selected via {@code dt.file-storage.s3.credentials-source}:
+     * <ul>
+     *     <li>{@code static} (default): Use the statically configured {@code access-key} and
+     *     {@code secret-key}. When both are missing, no credentials are configured and requests
+     *     are performed anonymously (unchanged legacy behavior). When only one key is configured,
+     *     initialization fails.</li>
+     *     <li>{@code aws}: Resolve credentials from the workload's AWS identity via
+     *     {@link IamAwsProvider}. This supports IRSA / web identity
+     *     ({@code AWS_WEB_IDENTITY_TOKEN_FILE}), ECS task roles
+     *     ({@code AWS_CONTAINER_CREDENTIALS_RELATIVE_URI} / {@code AWS_CONTAINER_CREDENTIALS_FULL_URI}),
+     *     and the EC2 instance metadata service, in that order of precedence. No static keys are
+     *     required. Note that this is not the full AWS default credential provider chain:
+     *     {@code AWS_ACCESS_KEY_ID} / {@code AWS_SECRET_ACCESS_KEY} environment variables and
+     *     {@code ~/.aws/credentials} profiles are not consulted; use {@code static} for those.</li>
+     * </ul>
+     *
+     * @return The resolved {@link Provider}, if one should be configured.
+     */
+    static Optional<Provider> resolveCredentialsProvider(Config config, OkHttpClient httpClient) {
+        final String credentialsSource = config
+                .getOptionalValue("dt.file-storage.s3.credentials-source", String.class)
+                .map(String::trim)
+                .map(value -> value.toLowerCase(Locale.ROOT))
+                .orElse(CREDENTIALS_SOURCE_STATIC);
+
+        return switch (credentialsSource) {
+            case CREDENTIALS_SOURCE_STATIC -> {
+                final var accessKey = config
+                        .getOptionalValue("dt.file-storage.s3.access-key", String.class).orElse(null);
+                final var secretKey = config
+                        .getOptionalValue("dt.file-storage.s3.secret-key", String.class).orElse(null);
+                if (Objects.nonNull(accessKey) && Objects.nonNull(secretKey)) {
+                    yield Optional.of(new StaticProvider(accessKey, secretKey, null));
+                }
+                if (Objects.nonNull(accessKey) || Objects.nonNull(secretKey)) {
+                    throw new IllegalStateException(
+                            "Both dt.file-storage.s3.access-key and dt.file-storage.s3.secret-key must be set when using static credentials");
+                }
+                yield Optional.empty();
+            }
+            case CREDENTIALS_SOURCE_AWS -> Optional.of(new IamAwsProvider(null, httpClient));
+            default -> throw new IllegalStateException(
+                    "Invalid value for dt.file-storage.s3.credentials-source: '%s' (valid values: [%s, %s])".formatted(
+                            credentialsSource, CREDENTIALS_SOURCE_STATIC, CREDENTIALS_SOURCE_AWS));
+        };
     }
 
     private static void requireBucketExists(MinioClient s3Client, String bucketName) {

--- a/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorageProvider.java
+++ b/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorageProvider.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.ProxySelector;
 import java.time.Duration;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -44,8 +43,11 @@ public final class S3FileStorageProvider implements FileStorageProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(S3FileStorageProvider.class);
     static final String NAME = "s3";
-    static final String CREDENTIALS_SOURCE_STATIC = "static";
-    static final String CREDENTIALS_SOURCE_AWS = "aws";
+
+    enum CredentialsSource {
+        STATIC,
+        AWS
+    }
 
     @Override
     public String name() {
@@ -94,36 +96,13 @@ public final class S3FileStorageProvider implements FileStorageProvider {
         return new S3FileStorage(s3Client, bucketName, compressionLevel);
     }
 
-    /**
-     * Resolves the {@link Provider} used to authenticate against the S3 endpoint.
-     * <p>
-     * The credentials source is selected via {@code dt.file-storage.s3.credentials-source}:
-     * <ul>
-     *     <li>{@code static} (default): Use the statically configured {@code access-key} and
-     *     {@code secret-key}. When both are missing, no credentials are configured and requests
-     *     are performed anonymously (unchanged legacy behavior). When only one key is configured,
-     *     initialization fails.</li>
-     *     <li>{@code aws}: Resolve credentials from the workload's AWS identity via
-     *     {@link IamAwsProvider}. This supports IRSA / web identity
-     *     ({@code AWS_WEB_IDENTITY_TOKEN_FILE}), ECS task roles
-     *     ({@code AWS_CONTAINER_CREDENTIALS_RELATIVE_URI} / {@code AWS_CONTAINER_CREDENTIALS_FULL_URI}),
-     *     and the EC2 instance metadata service, in that order of precedence. No static keys are
-     *     required. Note that this is not the full AWS default credential provider chain:
-     *     {@code AWS_ACCESS_KEY_ID} / {@code AWS_SECRET_ACCESS_KEY} environment variables and
-     *     {@code ~/.aws/credentials} profiles are not consulted; use {@code static} for those.</li>
-     * </ul>
-     *
-     * @return The resolved {@link Provider}, if one should be configured.
-     */
     static Optional<Provider> resolveCredentialsProvider(Config config, OkHttpClient httpClient) {
-        final String credentialsSource = config
-                .getOptionalValue("dt.file-storage.s3.credentials-source", String.class)
-                .map(String::trim)
-                .map(value -> value.toLowerCase(Locale.ROOT))
-                .orElse(CREDENTIALS_SOURCE_STATIC);
+        final CredentialsSource credentialsSource = config
+                .getOptionalValue("dt.file-storage.s3.credentials-source", CredentialsSource.class)
+                .orElse(CredentialsSource.STATIC);
 
         return switch (credentialsSource) {
-            case CREDENTIALS_SOURCE_STATIC -> {
+            case STATIC -> {
                 final var accessKey = config
                         .getOptionalValue("dt.file-storage.s3.access-key", String.class).orElse(null);
                 final var secretKey = config
@@ -137,10 +116,7 @@ public final class S3FileStorageProvider implements FileStorageProvider {
                 }
                 yield Optional.empty();
             }
-            case CREDENTIALS_SOURCE_AWS -> Optional.of(new IamAwsProvider(null, httpClient));
-            default -> throw new IllegalStateException(
-                    "Invalid value for dt.file-storage.s3.credentials-source: '%s' (valid values: [%s, %s])".formatted(
-                            credentialsSource, CREDENTIALS_SOURCE_STATIC, CREDENTIALS_SOURCE_AWS));
+            case AWS -> Optional.of(new IamAwsProvider(null, httpClient));
         };
     }
 

--- a/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageProviderTest.java
+++ b/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageProviderTest.java
@@ -1,0 +1,154 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.filestorage.s3;
+
+import io.minio.credentials.ChainedProvider;
+import io.minio.credentials.StaticProvider;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import okhttp3.OkHttpClient;
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class S3FileStorageProviderTest {
+
+    @Test
+    void shouldHaveNameS3() {
+        final var provider = new S3FileStorageProvider();
+        assertThat(provider.name()).isEqualTo("s3");
+    }
+
+    @Test
+    void resolveCredentialsProviderShouldReturnStaticProviderByDefault() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.access-key", "foo"),
+                Map.entry("dt.file-storage.s3.secret-key", "bar")));
+
+        assertThat(S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
+                .hasValueSatisfying(provider -> assertThat(provider).isInstanceOf(StaticProvider.class));
+    }
+
+    @Test
+    void resolveCredentialsProviderShouldReturnStaticProviderWhenSourceIsStatic() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.credentials-source", "static"),
+                Map.entry("dt.file-storage.s3.access-key", "foo"),
+                Map.entry("dt.file-storage.s3.secret-key", "bar")));
+
+        assertThat(S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
+                .hasValueSatisfying(provider -> assertThat(provider).isInstanceOf(StaticProvider.class));
+    }
+
+    @Test
+    void resolveCredentialsProviderShouldReturnEmptyWhenStaticKeysAreMissing() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.credentials-source", "static")));
+
+        assertThat(S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient())).isEmpty();
+    }
+
+    @Test
+    void resolveCredentialsProviderShouldThrowWhenOnlyAccessKeyIsConfigured() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.credentials-source", "static"),
+                Map.entry("dt.file-storage.s3.access-key", "foo")));
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
+                .withMessage("Both dt.file-storage.s3.access-key and dt.file-storage.s3.secret-key "
+                        + "must be set when using static credentials");
+    }
+
+    @Test
+    void resolveCredentialsProviderShouldThrowWhenOnlySecretKeyIsConfigured() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.credentials-source", "static"),
+                Map.entry("dt.file-storage.s3.secret-key", "bar")));
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
+                .withMessage("Both dt.file-storage.s3.access-key and dt.file-storage.s3.secret-key "
+                        + "must be set when using static credentials");
+    }
+
+    @Test
+    void resolveCredentialsProviderShouldReturnChainedProviderWhenSourceIsAws() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.credentials-source", "aws")));
+
+        assertThat(S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
+                .hasValueSatisfying(provider -> assertThat(provider).isInstanceOf(ChainedProvider.class));
+    }
+
+    @Test
+    void resolveCredentialsProviderShouldThrowWhenAwsSourceIsCombinedWithStaticCredentials() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.credentials-source", "aws"),
+                Map.entry("dt.file-storage.s3.access-key", "foo"),
+                Map.entry("dt.file-storage.s3.secret-key", "bar")));
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
+                .withMessageContaining("Conflicting credentials configuration");
+    }
+
+    /**
+     * {@link io.minio.credentials.EnvironmentProvider} reads system properties before environment
+     * variables, which is what allows this test to drive the chain without a real AWS environment.
+     */
+    @Test
+    void resolveCredentialsProviderShouldConsultAwsEnvironmentWhenSourceIsAws() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.credentials-source", "aws")));
+
+        System.setProperty("AWS_ACCESS_KEY_ID", "foo");
+        System.setProperty("AWS_SECRET_ACCESS_KEY", "bar");
+        try {
+            assertThat(S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
+                    .hasValueSatisfying(provider -> assertThat(provider.fetch())
+                            .satisfies(credentials -> {
+                                assertThat(credentials.accessKey()).isEqualTo("foo");
+                                assertThat(credentials.secretKey()).isEqualTo("bar");
+                            }));
+        } finally {
+            System.clearProperty("AWS_ACCESS_KEY_ID");
+            System.clearProperty("AWS_SECRET_ACCESS_KEY");
+        }
+    }
+
+    @Test
+    void resolveCredentialsProviderShouldThrowWhenSourceIsInvalid() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.credentials-source", "bogus")));
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()));
+    }
+
+    private static Config configOf(Map<String, String> configValues) {
+        return new SmallRyeConfigBuilder()
+                .withDefaultValues(configValues)
+                .build();
+    }
+
+}

--- a/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
+++ b/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
@@ -19,7 +19,10 @@
 package org.dependencytrack.filestorage.s3;
 
 import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
+import io.minio.credentials.IamAwsProvider;
+import io.minio.credentials.StaticProvider;
 import io.smallrye.config.SmallRyeConfigBuilder;
+import okhttp3.OkHttpClient;
 import org.dependencytrack.filestorage.api.FileStorage;
 import org.dependencytrack.filestorage.proto.v1.FileMetadata;
 import org.eclipse.microprofile.config.Config;
@@ -58,24 +61,110 @@ class S3FileStorageTest {
     @Test
     void shouldThrowWhenBucketDoesNotExist() {
         assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(() -> createStorage(Map.ofEntries(
-                        Map.entry("dt.file-storage.s3.endpoint", s3MockContainer.getHttpEndpoint()),
-                        Map.entry("dt.file-storage.s3.access-key", "foo"),
-                        Map.entry("dt.file-storage.s3.secret-key", "bar"),
-                        Map.entry("dt.file-storage.s3.bucket", "does-not-exist"))))
+                .isThrownBy(() -> {
+                    try (final FileStorage ignored = createStorage(Map.ofEntries(
+                            Map.entry("dt.file-storage.s3.endpoint", s3MockContainer.getHttpEndpoint()),
+                            Map.entry("dt.file-storage.s3.access-key", "foo"),
+                            Map.entry("dt.file-storage.s3.secret-key", "bar"),
+                            Map.entry("dt.file-storage.s3.bucket", "does-not-exist")))) {}
+                })
                 .withMessage("Bucket does-not-exist does not exist");
     }
 
     @Test
     void shouldThrowWhenBucketExistenceCheckFailed() {
         assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(() -> createStorage(Map.ofEntries(
-                        Map.entry("dt.file-storage.s3.endpoint", "http://localhost:1"),
-                        Map.entry("dt.file-storage.s3.access-key", "foo"),
-                        Map.entry("dt.file-storage.s3.secret-key", "bar"),
-                        Map.entry("dt.file-storage.s3.bucket", "does-not-exist"),
-                        Map.entry("dt.file-storage.s3.connect-timeout-ms", "500"))))
+                .isThrownBy(() -> {
+                    try (final FileStorage ignored = createStorage(Map.ofEntries(
+                            Map.entry("dt.file-storage.s3.endpoint", "http://localhost:1"),
+                            Map.entry("dt.file-storage.s3.access-key", "foo"),
+                            Map.entry("dt.file-storage.s3.secret-key", "bar"),
+                            Map.entry("dt.file-storage.s3.bucket", "does-not-exist"),
+                            Map.entry("dt.file-storage.s3.connect-timeout-ms", "500")))) {}
+                })
                 .withMessage("Failed to determine if bucket does-not-exist exists");
+    }
+
+    @Test
+    void resolveCredentialsProviderShouldReturnStaticProviderByDefault() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.access-key", "foo"),
+                Map.entry("dt.file-storage.s3.secret-key", "bar")));
+
+        assertThat(S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
+                .hasValueSatisfying(provider -> assertThat(provider).isInstanceOf(StaticProvider.class));
+    }
+
+    @Test
+    void resolveCredentialsProviderShouldReturnStaticProviderWhenSourceIsStatic() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.credentials-source", "static"),
+                Map.entry("dt.file-storage.s3.access-key", "foo"),
+                Map.entry("dt.file-storage.s3.secret-key", "bar")));
+
+        assertThat(S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
+                .hasValueSatisfying(provider -> assertThat(provider).isInstanceOf(StaticProvider.class));
+    }
+
+    @Test
+    void resolveCredentialsProviderShouldReturnEmptyWhenStaticKeysAreMissing() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.credentials-source", "static")));
+
+        assertThat(S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient())).isEmpty();
+    }
+
+    @Test
+    void resolveCredentialsProviderShouldThrowWhenOnlyAccessKeyIsConfigured() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.credentials-source", "static"),
+                Map.entry("dt.file-storage.s3.access-key", "foo")));
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
+                .withMessage("Both dt.file-storage.s3.access-key and dt.file-storage.s3.secret-key "
+                        + "must be set when using static credentials");
+    }
+
+    @Test
+    void resolveCredentialsProviderShouldThrowWhenOnlySecretKeyIsConfigured() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.credentials-source", "static"),
+                Map.entry("dt.file-storage.s3.secret-key", "bar")));
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
+                .withMessage("Both dt.file-storage.s3.access-key and dt.file-storage.s3.secret-key "
+                        + "must be set when using static credentials");
+    }
+
+    @Test
+    void resolveCredentialsProviderShouldReturnIamAwsProviderWhenSourceIsAws() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.credentials-source", "aws")));
+
+        assertThat(S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
+                .hasValueSatisfying(provider -> assertThat(provider).isInstanceOf(IamAwsProvider.class));
+    }
+
+    @Test
+    void resolveCredentialsProviderShouldIgnoreCaseAndWhitespaceForSource() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.credentials-source", "  AWS  ")));
+
+        assertThat(S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
+                .hasValueSatisfying(provider -> assertThat(provider).isInstanceOf(IamAwsProvider.class));
+    }
+
+    @Test
+    void resolveCredentialsProviderShouldThrowWhenSourceIsInvalid() {
+        final Config config = configOf(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.credentials-source", "bogus")));
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
+                .withMessage("Invalid value for dt.file-storage.s3.credentials-source: "
+                        + "'bogus' (valid values: [static, aws])");
     }
 
     @Test
@@ -206,6 +295,12 @@ class S3FileStorageTest {
                 .withDefaultValues(configValues)
                 .build();
         return new S3FileStorageProvider().create(config, ProxySelector.getDefault());
+    }
+
+    private static Config configOf(Map<String, String> configValues) {
+        return new SmallRyeConfigBuilder()
+                .withDefaultValues(configValues)
+                .build();
     }
 
 }

--- a/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
+++ b/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
@@ -19,10 +19,7 @@
 package org.dependencytrack.filestorage.s3;
 
 import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
-import io.minio.credentials.IamAwsProvider;
-import io.minio.credentials.StaticProvider;
 import io.smallrye.config.SmallRyeConfigBuilder;
-import okhttp3.OkHttpClient;
 import org.dependencytrack.filestorage.api.FileStorage;
 import org.dependencytrack.filestorage.proto.v1.FileMetadata;
 import org.eclipse.microprofile.config.Config;
@@ -53,12 +50,6 @@ class S3FileStorageTest {
                     .withInitialBuckets("test");
 
     @Test
-    void shouldHaveNameS3() {
-        final var provider = new S3FileStorageProvider();
-        assertThat(provider.name()).isEqualTo("s3");
-    }
-
-    @Test
     void shouldThrowWhenBucketDoesNotExist() {
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> {
@@ -83,77 +74,6 @@ class S3FileStorageTest {
                             Map.entry("dt.file-storage.s3.connect-timeout-ms", "500")))) {}
                 })
                 .withMessage("Failed to determine if bucket does-not-exist exists");
-    }
-
-    @Test
-    void resolveCredentialsProviderShouldReturnStaticProviderByDefault() {
-        final Config config = configOf(Map.ofEntries(
-                Map.entry("dt.file-storage.s3.access-key", "foo"),
-                Map.entry("dt.file-storage.s3.secret-key", "bar")));
-
-        assertThat(S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
-                .hasValueSatisfying(provider -> assertThat(provider).isInstanceOf(StaticProvider.class));
-    }
-
-    @Test
-    void resolveCredentialsProviderShouldReturnStaticProviderWhenSourceIsStatic() {
-        final Config config = configOf(Map.ofEntries(
-                Map.entry("dt.file-storage.s3.credentials-source", "static"),
-                Map.entry("dt.file-storage.s3.access-key", "foo"),
-                Map.entry("dt.file-storage.s3.secret-key", "bar")));
-
-        assertThat(S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
-                .hasValueSatisfying(provider -> assertThat(provider).isInstanceOf(StaticProvider.class));
-    }
-
-    @Test
-    void resolveCredentialsProviderShouldReturnEmptyWhenStaticKeysAreMissing() {
-        final Config config = configOf(Map.ofEntries(
-                Map.entry("dt.file-storage.s3.credentials-source", "static")));
-
-        assertThat(S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient())).isEmpty();
-    }
-
-    @Test
-    void resolveCredentialsProviderShouldThrowWhenOnlyAccessKeyIsConfigured() {
-        final Config config = configOf(Map.ofEntries(
-                Map.entry("dt.file-storage.s3.credentials-source", "static"),
-                Map.entry("dt.file-storage.s3.access-key", "foo")));
-
-        assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(() -> S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
-                .withMessage("Both dt.file-storage.s3.access-key and dt.file-storage.s3.secret-key "
-                        + "must be set when using static credentials");
-    }
-
-    @Test
-    void resolveCredentialsProviderShouldThrowWhenOnlySecretKeyIsConfigured() {
-        final Config config = configOf(Map.ofEntries(
-                Map.entry("dt.file-storage.s3.credentials-source", "static"),
-                Map.entry("dt.file-storage.s3.secret-key", "bar")));
-
-        assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(() -> S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
-                .withMessage("Both dt.file-storage.s3.access-key and dt.file-storage.s3.secret-key "
-                        + "must be set when using static credentials");
-    }
-
-    @Test
-    void resolveCredentialsProviderShouldReturnIamAwsProviderWhenSourceIsAws() {
-        final Config config = configOf(Map.ofEntries(
-                Map.entry("dt.file-storage.s3.credentials-source", "aws")));
-
-        assertThat(S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
-                .hasValueSatisfying(provider -> assertThat(provider).isInstanceOf(IamAwsProvider.class));
-    }
-
-    @Test
-    void resolveCredentialsProviderShouldThrowWhenSourceIsInvalid() {
-        final Config config = configOf(Map.ofEntries(
-                Map.entry("dt.file-storage.s3.credentials-source", "bogus")));
-
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()));
     }
 
     @Test
@@ -284,12 +204,6 @@ class S3FileStorageTest {
                 .withDefaultValues(configValues)
                 .build();
         return new S3FileStorageProvider().create(config, ProxySelector.getDefault());
-    }
-
-    private static Config configOf(Map<String, String> configValues) {
-        return new SmallRyeConfigBuilder()
-                .withDefaultValues(configValues)
-                .build();
     }
 
 }

--- a/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
+++ b/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
@@ -148,23 +148,12 @@ class S3FileStorageTest {
     }
 
     @Test
-    void resolveCredentialsProviderShouldIgnoreCaseAndWhitespaceForSource() {
-        final Config config = configOf(Map.ofEntries(
-                Map.entry("dt.file-storage.s3.credentials-source", "  AWS  ")));
-
-        assertThat(S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
-                .hasValueSatisfying(provider -> assertThat(provider).isInstanceOf(IamAwsProvider.class));
-    }
-
-    @Test
     void resolveCredentialsProviderShouldThrowWhenSourceIsInvalid() {
         final Config config = configOf(Map.ofEntries(
                 Map.entry("dt.file-storage.s3.credentials-source", "bogus")));
 
-        assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(() -> S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()))
-                .withMessage("Invalid value for dt.file-storage.s3.credentials-source: "
-                        + "'bogus' (valid values: [static, aws])");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> S3FileStorageProvider.resolveCredentialsProvider(config, new OkHttpClient()));
     }
 
     @Test


### PR DESCRIPTION
### Description

The S3 file storage provider only authenticated when static access and secret keys were configured, and otherwise issued anonymous requests. This prevented the use of AWS-managed credentials (IRSA, ECS task roles, EC2 instance profiles), which are the recommended way to grant access on AWS and avoid long-lived static keys.

This PR adds a `dt.file-storage.s3.credentials-source` option, defaulting to `static` to preserve existing behavior. When set to `aws`, credentials are resolved from the workload's AWS identity, so no static keys need to be configured.

### Addressed Issue

Closes #6851

### Additional Details

When `credentials-source=aws`, credentials are resolved via MinIO's `ChainedProvider`, composed of `AwsEnvironmentProvider` (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`), `AwsConfigProvider` (`~/.aws/credentials`), and `IamAwsProvider`, which itself supports web identity tokens (IRSA), ECS container credentials (`AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` `AWS_CONTAINER_CREDENTIALS_FULL_URI`) and the EC2 instance metadata service, in that order of precedence.

Note that this is close to, but not exactly, the AWS default credential provider chain: the AWS SDK consults web identity tokens before `~/.aws/credentials`, whereas the chain above is evaluated in the order listed.

Behavior change worth highlighting: configuring only one of the two static keys now fails at startup instead of silently falling back to anonymous requests. Such a configuration could never authenticate, since SigV4 requires both an access key and a secret key, so this only surfaces already-broken setups. Setting static keys together with `credentials-source=aws` fails at startup as well, so a leftover key cannot silently shadow the intended source.

The credential resolution logic is covered by `S3FileStorageProviderTest`, which deliberately does not use Testcontainers so it runs without Docker.

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations