### PR TITLE
S3 ambient aws credentials

### DIFF
--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -1134,12 +1134,12 @@ dt.file-storage.local.directory=${dt.data-directory}/storage
 
 # Defines the S3 access key / username.
 #
-# When both this and dt.file-storage.s3.secret-key are omitted, credentials are
-# instead resolved from the environment, mirroring the credential provider chain
-# of the AWS SDK: AWS_* environment variables, the shared AWS config file
-# (~/.aws/credentials), ECS task roles, EKS IRSA, and EC2 instance profiles.
-# Startup fails if no credentials can be resolved. Prefer omitting static
-# credentials on AWS.
+# Must be configured together with dt.file-storage.s3.secret-key.
+# When both are omitted, credentials are instead resolved from the environment,
+# mirroring the credential provider chain of the AWS SDK: AWS_* environment
+# variables, the shared AWS config file (~/.aws/credentials), ECS task roles,
+# EKS IRSA, and EC2 instance profiles. Startup fails if no credentials can be
+# resolved. Prefer omitting static credentials on AWS.
 #
 # EKS Pod Identity is not supported: the S3 client does not read
 # AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE and rejects the non-loopback
@@ -1151,6 +1151,7 @@ dt.file-storage.local.directory=${dt.data-directory}/storage
 
 # Defines the S3 secret key / password.
 #
+# Must be configured together with dt.file-storage.s3.access-key.
 # See dt.file-storage.s3.access-key for how credentials are resolved when both are omitted.
 #
 # @category: Storage

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -1132,18 +1132,34 @@ dt.file-storage.local.directory=${dt.data-directory}/storage
 # @type:     string
 # dt.file-storage.s3.bucket=
 
-# Defines the S3 access key / username.
+# Defines the source of S3 credentials.
 #
-# Must be configured together with dt.file-storage.s3.secret-key.
-# When both are omitted, credentials are instead resolved from the environment,
-# mirroring the credential provider chain of the AWS SDK: AWS_* environment
-# variables, the shared AWS config file (~/.aws/credentials), ECS task roles,
-# EKS IRSA, and EC2 instance profiles. Startup fails if no credentials can be
-# resolved. Prefer omitting static credentials on AWS.
+# With the default of static, credentials are taken from dt.file-storage.s3.access-key
+# and dt.file-storage.s3.secret-key. When both are omitted, requests are sent unsigned
+# (anonymous access), intended for S3-compatible endpoints (e.g. MinIO, Ceph) that
+# allow it.
+#
+# With aws, credentials are resolved from the environment instead, mirroring the
+# credential provider chain of the AWS SDK: AWS_* environment variables, the shared
+# AWS config file (~/.aws/credentials), ECS task roles, EKS IRSA, and EC2 instance
+# profiles. Startup fails if no credentials can be resolved, or if static credentials
+# are also configured.
 #
 # EKS Pod Identity is not supported: the S3 client does not read
 # AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE and rejects the non-loopback
 # Pod Identity Agent endpoint. Use IRSA instead.
+#
+# @category:     Storage
+# @default:      static
+# @type:         enum
+# @valid-values: [static, aws]
+# dt.file-storage.s3.credentials-source=
+
+# Defines the S3 access key / username.
+#
+# Must be configured together with dt.file-storage.s3.secret-key.
+# See dt.file-storage.s3.credentials-source for how credentials are resolved
+# when both are omitted.
 #
 # @category: Storage
 # @type:     string
@@ -1152,7 +1168,8 @@ dt.file-storage.local.directory=${dt.data-directory}/storage
 # Defines the S3 secret key / password.
 #
 # Must be configured together with dt.file-storage.s3.access-key.
-# See dt.file-storage.s3.access-key for how credentials are resolved when both are omitted.
+# See dt.file-storage.s3.credentials-source for how credentials are resolved
+# when both are omitted.
 #
 # @category: Storage
 # @type:     string

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -1137,7 +1137,8 @@ dt.file-storage.local.directory=${dt.data-directory}/storage
 # With the default of static, credentials are taken from dt.file-storage.s3.access-key
 # and dt.file-storage.s3.secret-key. When both are omitted, requests are sent unsigned
 # (anonymous access), intended for S3-compatible endpoints (e.g. MinIO, Ceph) that
-# allow it.
+# allow it. Anonymous uploads are spooled to a temporary file before being uploaded
+# in a single part, and are limited to 5GiB per file.
 #
 # With aws, credentials are resolved from the environment instead, mirroring the
 # credential provider chain of the AWS SDK: AWS_* environment variables, the shared

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -1134,11 +1134,24 @@ dt.file-storage.local.directory=${dt.data-directory}/storage
 
 # Defines the S3 access key / username.
 #
+# When both this and dt.file-storage.s3.secret-key are omitted, credentials are
+# instead resolved from the environment, mirroring the credential provider chain
+# of the AWS SDK: AWS_* environment variables, the shared AWS config file
+# (~/.aws/credentials), ECS task roles, EKS IRSA, and EC2 instance profiles.
+# Startup fails if no credentials can be resolved. Prefer omitting static
+# credentials on AWS.
+#
+# EKS Pod Identity is not supported: the S3 client does not read
+# AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE and rejects the non-loopback
+# Pod Identity Agent endpoint. Use IRSA instead.
+#
 # @category: Storage
 # @type:     string
 # dt.file-storage.s3.access-key=
 
 # Defines the S3 secret key / password.
+#
+# See dt.file-storage.s3.access-key for how credentials are resolved when both are omitted.
 #
 # @category: Storage
 # @type:     string

--- a/docs/adr/004-file-storage-plugin.md
+++ b/docs/adr/004-file-storage-plugin.md
@@ -262,19 +262,18 @@ This made the provider hard to use on AWS. There, the usual way to grant access 
 IAM role attached to the workload, not a long-lived key pair. Many organizations do not allow
 static keys at all.
 
-We adjusted the default. When both keys are omitted, the provider now resolves credentials from its
-environment. It tries environment variables, the shared AWS configuration file, IAM Roles for
-Service Accounts (IRSA) on EKS, task roles on ECS, and instance profiles on EC2, in that order.
-Static keys still take precedence when they are configured, so existing deployments keep working.
+We added a credentials source option. It defaults to static, which keeps the original behavior:
+configured keys are used, and when both are left empty, requests are sent unsigned. This keeps
+anonymous access to S3-compatible endpoints working without any configuration change. Setting the
+source to aws instead resolves credentials from the environment. It tries environment variables,
+the shared AWS configuration file, IAM Roles for Service Accounts (IRSA) on EKS, task roles on
+ECS, and instance profiles on EC2, in that order. Resolution happens on the first request, which
+is the bucket check during startup, so a deployment without resolvable credentials fails to start.
+Combining the aws source with static keys fails at startup, because the two contradict each other.
 
 The S3 client library we already depend on ships these resolvers, so this added no new dependency.
 We looked at the AWS SDK as an alternative and decided against it. It would add roughly 4 MB of
 dependencies, and its synchronous S3 client cannot stream uploads the way our current client does.
-
-Anonymous access is no longer reachable by leaving both keys empty. The provider resolves
-credentials on its first request, which is the bucket check during startup. A deployment without
-usable credentials now fails to start instead of sending unsigned requests. We consider this the
-better default, because anonymous writes would require a publicly writable bucket.
 
 EKS Pod Identity is not covered. The client library does not read the token file that the Pod
 Identity Agent provides, and it rejects the agent's endpoint because that address is not a loopback

--- a/docs/adr/004-file-storage-plugin.md
+++ b/docs/adr/004-file-storage-plugin.md
@@ -252,7 +252,38 @@ class Foo {
   deal with missing files, and perform compensating actions accordingly. Since file storage is not the
   primary system of record, files existing without the application knowing about them is not an issue.
 
+## Follow-up (2026-07-31)
+
+The `s3` provider originally supported static credentials only. When both the access key and the
+secret key were left empty, the provider installed no credentials at all and sent unsigned requests.
+It did not fall back to the credentials that a cloud platform offers on its own.
+
+This made the provider hard to use on AWS. There, the usual way to grant access to a bucket is an
+IAM role attached to the workload, not a long-lived key pair. Many organizations do not allow
+static keys at all.
+
+We adjusted the default. When both keys are omitted, the provider now resolves credentials from its
+environment. It tries environment variables, the shared AWS configuration file, IAM Roles for
+Service Accounts (IRSA) on EKS, task roles on ECS, and instance profiles on EC2, in that order.
+Static keys still take precedence when they are configured, so existing deployments keep working.
+
+The S3 client library we already depend on ships these resolvers, so this added no new dependency.
+We looked at the AWS SDK as an alternative and decided against it. It would add roughly 4 MB of
+dependencies, and its synchronous S3 client cannot stream uploads the way our current client does.
+
+Anonymous access is no longer reachable by leaving both keys empty. The provider resolves
+credentials on its first request, which is the bucket check during startup. A deployment without
+usable credentials now fails to start instead of sending unsigned requests. We consider this the
+better default, because anonymous writes would require a publicly writable bucket.
+
+EKS Pod Identity is not covered. The client library does not read the token file that the Pod
+Identity Agent provides, and it rejects the agent's endpoint because that address is not a loopback
+address. IRSA is the supported option on EKS.
+
+See [dependency-track/#6851].
+
 [ADR-001]: 001-drop-kafka-dependency.md
 [ADR-002]: 002-workflow-orchestration.md
 
 [hyades-apiserver/#805]: https://github.com/DependencyTrack/hyades-apiserver/pull/805
+[dependency-track/#6851]: https://github.com/DependencyTrack/dependency-track/issues/6851

--- a/docs/adr/004-file-storage-plugin.md
+++ b/docs/adr/004-file-storage-plugin.md
@@ -275,6 +275,12 @@ The S3 client library we already depend on ships these resolvers, so this added 
 We looked at the AWS SDK as an alternative and decided against it. It would add roughly 4 MB of
 dependencies, and its synchronous S3 client cannot stream uploads the way our current client does.
 
+Anonymous uploads take a different path than credentialed ones. The client library refuses to
+send an unsigned request body without its MD5 hash, which cannot be known for a stream that is
+still being compressed, and cannot be provided for each part of a multipart upload. Uploads are
+therefore spooled to a temporary file first and sent in a single part, which caps anonymous
+uploads at 5GiB per file. Credentialed uploads keep streaming without touching disk.
+
 EKS Pod Identity is not covered. The client library does not read the token file that the Pod
 Identity Agent provides, and it rejects the agent's endpoint because that address is not a loopback
 address. IRSA is the supported option on EKS.

--- a/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorage.java
+++ b/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorage.java
@@ -23,8 +23,10 @@ import com.github.luben.zstd.ZstdOutputStream;
 import io.minio.GetObjectArgs;
 import io.minio.GetObjectResponse;
 import io.minio.MinioClient;
+import io.minio.ObjectWriteArgs;
 import io.minio.PutObjectArgs;
 import io.minio.RemoveObjectArgs;
+import io.minio.UploadObjectArgs;
 import io.minio.errors.ErrorResponseException;
 import org.dependencytrack.filestorage.api.FileStorage;
 import org.dependencytrack.filestorage.proto.v1.FileMetadata;
@@ -38,11 +40,15 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import java.util.HexFormat;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.Objects.requireNonNull;
@@ -58,14 +64,17 @@ final class S3FileStorage implements FileStorage {
     private final MinioClient s3Client;
     private final String bucketName;
     private final int compressionLevel;
+    private final boolean anonymousAccess;
 
     S3FileStorage(
             MinioClient s3Client,
             String bucketName,
-            int compressionLevel) {
+            int compressionLevel,
+            boolean anonymousAccess) {
         this.s3Client = s3Client;
         this.bucketName = bucketName;
         this.compressionLevel = compressionLevel;
+        this.anonymousAccess = anonymousAccess;
     }
 
     @Override
@@ -126,6 +135,24 @@ final class S3FileStorage implements FileStorage {
             throw new IllegalStateException(e);
         }
 
+        if (anonymousAccess) {
+            storeAnonymously(fileLocation, contentStream, messageDigest);
+        } else {
+            storeStreaming(fileLocation, contentStream, messageDigest);
+        }
+
+        return FileMetadata.newBuilder()
+                .setProviderName(S3FileStorageProvider.NAME)
+                .setLocation(locationUri.toString())
+                .setMediaType(mediaType)
+                .setSha256Digest(HexFormat.of().formatHex(messageDigest.digest()))
+                .build();
+    }
+
+    private void storeStreaming(
+            S3FileLocation fileLocation,
+            InputStream contentStream,
+            MessageDigest messageDigest) throws IOException {
         final var pipedOutputStream = new PipedOutputStream();
         final var pipedInputStream = new PipedInputStream(pipedOutputStream, 65536 /* (64KiB) */);
 
@@ -169,13 +196,51 @@ final class S3FileStorage implements FileStorage {
         } finally {
             pipedInputStream.close();
         }
+    }
 
-        return FileMetadata.newBuilder()
-                .setProviderName(S3FileStorageProvider.NAME)
-                .setLocation(locationUri.toString())
-                .setMediaType(mediaType)
-                .setSha256Digest(HexFormat.of().formatHex(messageDigest.digest()))
-                .build();
+    /**
+     * The S3 client rejects unsigned request bodies that carry no Content-MD5 header.
+     * That hash cannot be computed for a stream of unknown length, and cannot be provided
+     * per part of a multipart upload. Spool the compressed content to a temporary file to
+     * compute its MD5 hash first, then upload the file in a single part. This limits
+     * anonymous uploads to the maximum size of a single part (5GiB).
+     */
+    private void storeAnonymously(
+            S3FileLocation fileLocation,
+            InputStream contentStream,
+            MessageDigest messageDigest) throws IOException {
+        final MessageDigest md5Digest;
+        try {
+            md5Digest = MessageDigest.getInstance("MD5");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+
+        final Path tempFile = Files.createTempFile("dt-file-storage-s3", null);
+        try {
+            try (final var md5OutputStream = new DigestOutputStream(
+                    Files.newOutputStream(tempFile), md5Digest);
+                 final var digestOutputStream = new DigestOutputStream(md5OutputStream, messageDigest);
+                 final var zstdOutputStream = new ZstdOutputStream(digestOutputStream, compressionLevel)) {
+                contentStream.transferTo(zstdOutputStream);
+            }
+
+            final long objectSize = Files.size(tempFile);
+            final long partSize = Math.max(objectSize, ObjectWriteArgs.MIN_MULTIPART_SIZE);
+            final String contentMd5 = Base64.getEncoder().encodeToString(md5Digest.digest());
+            s3Client.uploadObject(UploadObjectArgs.builder()
+                    .bucket(fileLocation.bucket())
+                    .object(fileLocation.object())
+                    .filename(tempFile.toString(), partSize)
+                    .headers(Map.of("Content-MD5", contentMd5))
+                    .build());
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException(e);
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
     }
 
     @Override

--- a/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorageProvider.java
+++ b/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorageProvider.java
@@ -69,24 +69,43 @@ public final class S3FileStorageProvider implements FileStorageProvider {
 
         final var accessKey = config.getOptionalValue("dt.file-storage.s3.access-key", String.class).orElse(null);
         final var secretKey = config.getOptionalValue("dt.file-storage.s3.secret-key", String.class).orElse(null);
-        if (accessKey != null && secretKey != null) {
-            clientBuilder.credentials(accessKey, secretKey);
-        } else if (accessKey != null || secretKey != null) {
-            throw new IllegalStateException(
-                    "Incomplete static credentials: dt.file-storage.s3.access-key and dt.file-storage.s3.secret-key "
-                    + "must either both be configured, or both be omitted to resolve credentials from the environment");
-        } else {
-            // No static credentials. Resolve them from the environment instead, mirroring the
-            // credential provider chain of the AWS SDK. This covers AWS_* environment variables,
-            // the shared AWS config file, ECS task roles, EKS IRSA, and EC2 instance profiles.
-            // Resolution is lazy: the chain is consulted on the first request, and throws
-            // java.security.ProviderException when no provider yields credentials. The bucket
-            // existence check below is that first request, so unresolvable credentials fail startup.
-            LOGGER.debug("No static credentials configured; resolving credentials from the environment");
-            clientBuilder.credentialsProvider(new ChainedProvider(
-                    new AwsEnvironmentProvider(),
-                    new AwsConfigProvider(/* filename */ null, /* profile */ null),
-                    new IamAwsProvider(/* customEndpoint */ null, httpClient)));
+        final var credentialsSource = config
+                .getOptionalValue("dt.file-storage.s3.credentials-source", String.class)
+                .orElse("static");
+        switch (credentialsSource) {
+            case "aws" -> {
+                if (accessKey != null || secretKey != null) {
+                    throw new IllegalStateException(
+                            "Conflicting credentials configuration: dt.file-storage.s3.credentials-source is aws, "
+                            + "but dt.file-storage.s3.access-key or dt.file-storage.s3.secret-key is also configured");
+                }
+                // Resolve credentials from the environment, mirroring the credential provider
+                // chain of the AWS SDK. This covers AWS_* environment variables, the shared AWS
+                // config file, ECS task roles, EKS IRSA, and EC2 instance profiles.
+                // Resolution is lazy: the chain is consulted on the first request, and throws
+                // java.security.ProviderException when no provider yields credentials. The bucket
+                // existence check below is that first request, so unresolvable credentials fail startup.
+                LOGGER.debug("Resolving credentials from the environment");
+                clientBuilder.credentialsProvider(new ChainedProvider(
+                        new AwsEnvironmentProvider(),
+                        new AwsConfigProvider(/* filename */ null, /* profile */ null),
+                        new IamAwsProvider(/* customEndpoint */ null, httpClient)));
+            }
+            case "static" -> {
+                if (accessKey != null && secretKey != null) {
+                    clientBuilder.credentials(accessKey, secretKey);
+                } else if (accessKey != null || secretKey != null) {
+                    throw new IllegalStateException(
+                            "Incomplete static credentials: dt.file-storage.s3.access-key and "
+                            + "dt.file-storage.s3.secret-key must either both be configured, or both be omitted");
+                } else {
+                    // Installing no credentials provider makes the client send unsigned requests.
+                    // Intended for S3-compatible endpoints that allow anonymous access.
+                    LOGGER.debug("No static credentials configured; requests will be unsigned");
+                }
+            }
+            default -> throw new IllegalStateException(
+                    "Invalid credentials source: must be static or aws, but is " + credentialsSource);
         }
 
         config.getOptionalValue("dt.file-storage.s3.region", String.class).ifPresent(clientBuilder::region);

--- a/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorageProvider.java
+++ b/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorageProvider.java
@@ -71,6 +71,10 @@ public final class S3FileStorageProvider implements FileStorageProvider {
         final var secretKey = config.getOptionalValue("dt.file-storage.s3.secret-key", String.class).orElse(null);
         if (accessKey != null && secretKey != null) {
             clientBuilder.credentials(accessKey, secretKey);
+        } else if (accessKey != null || secretKey != null) {
+            throw new IllegalStateException(
+                    "Incomplete static credentials: dt.file-storage.s3.access-key and dt.file-storage.s3.secret-key "
+                    + "must either both be configured, or both be omitted to resolve credentials from the environment");
         } else {
             // No static credentials. Resolve them from the environment instead, mirroring the
             // credential provider chain of the AWS SDK. This covers AWS_* environment variables,

--- a/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorageProvider.java
+++ b/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorageProvider.java
@@ -72,6 +72,7 @@ public final class S3FileStorageProvider implements FileStorageProvider {
         final var credentialsSource = config
                 .getOptionalValue("dt.file-storage.s3.credentials-source", String.class)
                 .orElse("static");
+        var anonymousAccess = false;
         switch (credentialsSource) {
             case "aws" -> {
                 if (accessKey != null || secretKey != null) {
@@ -102,6 +103,7 @@ public final class S3FileStorageProvider implements FileStorageProvider {
                     // Installing no credentials provider makes the client send unsigned requests.
                     // Intended for S3-compatible endpoints that allow anonymous access.
                     LOGGER.debug("No static credentials configured; requests will be unsigned");
+                    anonymousAccess = true;
                 }
             }
             default -> throw new IllegalStateException(
@@ -126,7 +128,7 @@ public final class S3FileStorageProvider implements FileStorageProvider {
                             compressionLevel));
         }
 
-        return new S3FileStorage(s3Client, bucketName, compressionLevel);
+        return new S3FileStorage(s3Client, bucketName, compressionLevel, anonymousAccess);
     }
 
     private static void requireBucketExists(MinioClient s3Client, String bucketName) {

--- a/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorageProvider.java
+++ b/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorageProvider.java
@@ -21,6 +21,10 @@ package org.dependencytrack.filestorage.s3;
 import com.github.luben.zstd.Zstd;
 import io.minio.BucketExistsArgs;
 import io.minio.MinioClient;
+import io.minio.credentials.AwsConfigProvider;
+import io.minio.credentials.AwsEnvironmentProvider;
+import io.minio.credentials.ChainedProvider;
+import io.minio.credentials.IamAwsProvider;
 import okhttp3.OkHttpClient;
 import org.dependencytrack.filestorage.api.FileStorage;
 import org.dependencytrack.filestorage.api.FileStorageProvider;
@@ -67,6 +71,18 @@ public final class S3FileStorageProvider implements FileStorageProvider {
         final var secretKey = config.getOptionalValue("dt.file-storage.s3.secret-key", String.class).orElse(null);
         if (accessKey != null && secretKey != null) {
             clientBuilder.credentials(accessKey, secretKey);
+        } else {
+            // No static credentials. Resolve them from the environment instead, mirroring the
+            // credential provider chain of the AWS SDK. This covers AWS_* environment variables,
+            // the shared AWS config file, ECS task roles, EKS IRSA, and EC2 instance profiles.
+            // Resolution is lazy: the chain is consulted on the first request, and throws
+            // java.security.ProviderException when no provider yields credentials. The bucket
+            // existence check below is that first request, so unresolvable credentials fail startup.
+            LOGGER.debug("No static credentials configured; resolving credentials from the environment");
+            clientBuilder.credentialsProvider(new ChainedProvider(
+                    new AwsEnvironmentProvider(),
+                    new AwsConfigProvider(/* filename */ null, /* profile */ null),
+                    new IamAwsProvider(/* customEndpoint */ null, httpClient)));
         }
 
         config.getOptionalValue("dt.file-storage.s3.region", String.class).ifPresent(clientBuilder::region);

--- a/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
+++ b/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
@@ -98,18 +98,41 @@ class S3FileStorageTest {
                 .withMessageContaining("Incomplete static credentials");
     }
 
+    @Test
+    void shouldThrowWhenAwsCredentialsSourceIsCombinedWithStaticCredentials() {
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> createStorage(Map.ofEntries(
+                        Map.entry("dt.file-storage.s3.endpoint", s3MockContainer.getHttpEndpoint()),
+                        Map.entry("dt.file-storage.s3.credentials-source", "aws"),
+                        Map.entry("dt.file-storage.s3.access-key", "foo"),
+                        Map.entry("dt.file-storage.s3.secret-key", "bar"),
+                        Map.entry("dt.file-storage.s3.bucket", "test"))))
+                .withMessageContaining("Conflicting credentials configuration");
+    }
+
+    @Test
+    void shouldThrowWhenCredentialsSourceIsInvalid() {
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> createStorage(Map.ofEntries(
+                        Map.entry("dt.file-storage.s3.endpoint", s3MockContainer.getHttpEndpoint()),
+                        Map.entry("dt.file-storage.s3.credentials-source", "foo"),
+                        Map.entry("dt.file-storage.s3.bucket", "test"))))
+                .withMessage("Invalid credentials source: must be static or aws, but is foo");
+    }
+
     /**
-     * Without static credentials, the client must resolve them from the environment
-     * rather than falling back to unsigned (anonymous) requests.
+     * With the aws credentials source, the client must resolve credentials from the
+     * environment rather than falling back to unsigned (anonymous) requests.
      * {@link io.minio.credentials.EnvironmentProvider} reads system properties before
      * environment variables, which is what lets this test drive the chain.
      */
     @Test
-    void shouldResolveCredentialsFromEnvironmentWhenStaticCredentialsAreAbsent() throws Exception {
+    void shouldResolveCredentialsFromEnvironmentWhenCredentialsSourceIsAws() throws Exception {
         System.setProperty("AWS_ACCESS_KEY_ID", "foo");
         System.setProperty("AWS_SECRET_ACCESS_KEY", "bar");
         try (final FileStorage storage = createStorage(Map.ofEntries(
                 Map.entry("dt.file-storage.s3.endpoint", s3MockContainer.getHttpEndpoint()),
+                Map.entry("dt.file-storage.s3.credentials-source", "aws"),
                 Map.entry("dt.file-storage.s3.bucket", "test")))) {
             final FileMetadata fileMetadata = storage.store(
                     "ambient/foo", new ByteArrayInputStream("baz".getBytes()));

--- a/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
+++ b/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
@@ -78,6 +78,26 @@ class S3FileStorageTest {
                 .withMessage("Failed to determine if bucket does-not-exist exists");
     }
 
+    @Test
+    void shouldThrowWhenOnlyAccessKeyIsConfigured() {
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> createStorage(Map.ofEntries(
+                        Map.entry("dt.file-storage.s3.endpoint", s3MockContainer.getHttpEndpoint()),
+                        Map.entry("dt.file-storage.s3.access-key", "foo"),
+                        Map.entry("dt.file-storage.s3.bucket", "test"))))
+                .withMessageContaining("Incomplete static credentials");
+    }
+
+    @Test
+    void shouldThrowWhenOnlySecretKeyIsConfigured() {
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> createStorage(Map.ofEntries(
+                        Map.entry("dt.file-storage.s3.endpoint", s3MockContainer.getHttpEndpoint()),
+                        Map.entry("dt.file-storage.s3.secret-key", "bar"),
+                        Map.entry("dt.file-storage.s3.bucket", "test"))))
+                .withMessageContaining("Incomplete static credentials");
+    }
+
     /**
      * Without static credentials, the client must resolve them from the environment
      * rather than falling back to unsigned (anonymous) requests.

--- a/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
+++ b/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
@@ -37,6 +37,7 @@ import java.net.ConnectException;
 import java.net.ProxySelector;
 import java.nio.file.NoSuchFileException;
 import java.util.Map;
+import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -118,6 +119,39 @@ class S3FileStorageTest {
                         Map.entry("dt.file-storage.s3.credentials-source", "foo"),
                         Map.entry("dt.file-storage.s3.bucket", "test"))))
                 .withMessage("Invalid credentials source: must be static or aws, but is foo");
+    }
+
+    @Test
+    void shouldSendUnsignedRequestsWhenNoCredentialsAreConfigured() throws Exception {
+        try (final FileStorage storage = createStorage(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.endpoint", s3MockContainer.getHttpEndpoint()),
+                Map.entry("dt.file-storage.s3.bucket", "test")))) {
+            final FileMetadata fileMetadata = storage.store(
+                    "anonymous/foo", new ByteArrayInputStream("baz".getBytes()));
+            assertThat(storage.get(fileMetadata).readAllBytes()).asString().isEqualTo("baz");
+            assertThat(storage.delete(fileMetadata)).isTrue();
+        }
+    }
+
+    /**
+     * Anonymous uploads must stay single-part regardless of size, because the whole-file
+     * Content-MD5 header cannot be provided per part of a multipart upload. Random data is
+     * incompressible, so 12MiB of it exceeds both the 10MiB part size of the credentialed
+     * path and the 5MiB minimum part size, exercising the part sizing of the anonymous path.
+     */
+    @Test
+    void shouldStoreLargeFileWhenNoCredentialsAreConfigured() throws Exception {
+        final var content = new byte[12 * 1024 * 1024];
+        new Random(6889).nextBytes(content);
+
+        try (final FileStorage storage = createStorage(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.endpoint", s3MockContainer.getHttpEndpoint()),
+                Map.entry("dt.file-storage.s3.bucket", "test")))) {
+            final FileMetadata fileMetadata = storage.store(
+                    "anonymous/large", new ByteArrayInputStream(content));
+            assertThat(storage.get(fileMetadata).readAllBytes()).isEqualTo(content);
+            assertThat(storage.delete(fileMetadata)).isTrue();
+        }
     }
 
     /**

--- a/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
+++ b/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
@@ -78,6 +78,29 @@ class S3FileStorageTest {
                 .withMessage("Failed to determine if bucket does-not-exist exists");
     }
 
+    /**
+     * Without static credentials, the client must resolve them from the environment
+     * rather than falling back to unsigned (anonymous) requests.
+     * {@link io.minio.credentials.EnvironmentProvider} reads system properties before
+     * environment variables, which is what lets this test drive the chain.
+     */
+    @Test
+    void shouldResolveCredentialsFromEnvironmentWhenStaticCredentialsAreAbsent() throws Exception {
+        System.setProperty("AWS_ACCESS_KEY_ID", "foo");
+        System.setProperty("AWS_SECRET_ACCESS_KEY", "bar");
+        try (final FileStorage storage = createStorage(Map.ofEntries(
+                Map.entry("dt.file-storage.s3.endpoint", s3MockContainer.getHttpEndpoint()),
+                Map.entry("dt.file-storage.s3.bucket", "test")))) {
+            final FileMetadata fileMetadata = storage.store(
+                    "ambient/foo", new ByteArrayInputStream("baz".getBytes()));
+            assertThat(storage.get(fileMetadata).readAllBytes()).asString().isEqualTo("baz");
+            assertThat(storage.delete(fileMetadata)).isTrue();
+        } finally {
+            System.clearProperty("AWS_ACCESS_KEY_ID");
+            System.clearProperty("AWS_SECRET_ACCESS_KEY");
+        }
+    }
+
     @Test
     void shouldStoreAndGetAndDeleteFile() throws Exception {
         try (final FileStorage storage = createStorage()) {


### PR DESCRIPTION
### Description

The `s3` file storage provider only supported static credentials. When `dt.file-storage.s3.access-key` and `secret-key` were both absent, no credentials provider was installed at all, so the client sent unsigned (anonymous) requests with no fallback to ambient credential resolution. Task-based roles and IRSA are a common (and often org-mandated) way to grant S3 access.

When no static credentials are configured, the provider now resolves them from the environment instead, covering `AWS_*` environment variables, the shared AWS config file, ECS task roles, EKS IRSA, and EC2 instance profiles. Static credentials continue to work exactly as before, so this is backwards compatible for every configuration that sets them.

A second commit closes a related gap: configuring only one of `access-key` / `secret-key` used to be silently ignored, and now fails at startup naming both properties.

### Addressed Issue

Closes #6851

### Additional Details

**No new dependencies.** This uses the credential providers already bundled in `minio-java` (`io.minio.credentials`), chained in AWS-SDK-like order:

```java
clientBuilder.credentialsProvider(new ChainedProvider(
        new AwsEnvironmentProvider(),
        new AwsConfigProvider(null, null),
        new IamAwsProvider(null, httpClient)));
```

Switching to the AWS SDK v2 was considered and rejected, per @nscuro's own evaluation in DependencyTrack/helm-charts#384: roughly 4 MB of additional dependencies, and the synchronous S3 client lacks the streaming uploads `minio-java` provides.

**On the open question in the issue thread** (@nscuro: *"we'd need to verify how well Minio handles the case where no static creds are provided and it cannot resolve AWS creds dynamically. IIRC it fails loudly and the AWS S3 SDK doesn't"*). Verified against `minio-java` 9.0.3: `ChainedProvider.fetch()` throws `java.security.ProviderException("All providers fail to fetch credentials")` when every provider fails. So it does fail loudly. Resolution is lazy, consulted on the first request, and the existing bucket-existence check at startup is that first consumer, so unresolvable credentials fail startup rather than surfacing later at runtime.

**Behavior change worth calling out.** Truly anonymous (unsigned) access is no longer reachable via "configure no credentials". Anyone relying on that today would now fail at startup. I judged this acceptable because it requires a publicly writable bucket, and the Helm chart already refuses to render without credentials, so no chart user can be in that state. The issue floated keeping anonymous access behind an explicit opt-in flag. Happy to add one if you'd prefer that over the loud failure.

**EKS Pod Identity is not covered**, despite being requested in DependencyTrack/helm-charts#384. Two concrete blockers in `minio-java` 9.0.3's `IamAwsProvider`: it reads `AWS_CONTAINER_AUTHORIZATION_TOKEN` but not the `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` variant that the Pod Identity Agent injects, and `checkLoopbackHost()` rejects the agent's non-loopback endpoint (`169.254.170.23`). IRSA, ECS task roles, and IMDS all work. This limitation is documented in `application.properties`.

**Documentation.** `apiserver/src/main/resources/application.properties` is updated for both properties, including the Pod Identity caveat, so the generated property reference will pick it up. The hand-written file-storage page in DependencyTrack/docs is not generated, so it needs its own change: a companion PR there adds an "Authentication" section covering both credential modes, the resolution order, and the Pod Identity exclusion.

**ADR.** No new ADR. Per the criteria in `CONTRIBUTING.md`, this introduces no module or extension point, no schema or migration change, no REST contract change, no new runtime dependency or external integration, and no change to concurrency or consistency characteristics. It alters credential resolution inside an existing provider. It does adjust a default of an accepted ADR, though, so per the convention in `docs/adr/README.md` I added a `## Follow-up (2026-07-31)` section to [ADR-004](docs/adr/004-file-storage-plugin.md) instead. Happy to promote that to a full ADR if you read the criteria differently.

**Companion changes:**

* DependencyTrack/helm-charts#384 adds a `fileStorage.s3.authentication.type: auto` mode that stops injecting credentials so this resolution path can take over.
* A PR against DependencyTrack/docs documents the new behavior on the file-storage reference page.

**Testing notes.** Three tests added (ambient resolution via the environment; both half-configured-credential cases). Verified locally with JDK 25 + Docker: `file-storage/provider-s3` goes from 11 to 14 tests with my three passing. Two pre-existing failures in the `WhenHostIsUnavailable` nested class fail identically on an unmodified `main` in my environment. They assert `ConnectException` but a VM-based Docker runtime (colima) returns `SocketException: Connection reset`. They are unrelated to this change and should pass on CI's native Docker.

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
