### PR TITLE
Fix notification rule test to work regardless of rule level

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/NotificationPublisherResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/NotificationPublisherResource.java
@@ -429,23 +429,15 @@ public class NotificationPublisherResource extends AbstractApiResource {
     }
 
     private @Nullable Notification buildTestNotification(Scope scope, Group group, Level ruleLevel) {
-        final List<Level> levelsToTry = switch (ruleLevel) {
-            case LEVEL_INFORMATIONAL -> List.of(Level.LEVEL_INFORMATIONAL, Level.LEVEL_WARNING, Level.LEVEL_ERROR);
-            case LEVEL_WARNING -> List.of(Level.LEVEL_WARNING, Level.LEVEL_ERROR);
-            case LEVEL_ERROR -> List.of(Level.LEVEL_ERROR);
-            default -> List.of();
-        };
-
-        for (final Level level : levelsToTry) {
-            final Notification notification = createTestNotification(scope, group, level);
-            if (notification != null) {
-                return notification.toBuilder()
-                        .setTitle("[TEST] " + notification.getTitle())
-                        .build();
-            }
+        final Notification notification = createTestNotification(scope, group);
+        if (notification == null) {
+            return null;
         }
 
-        return null;
+        return notification.toBuilder()
+                .setLevel(ruleLevel)
+                .setTitle("[TEST] " + notification.getTitle())
+                .build();
     }
 
 }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
@@ -38,6 +38,7 @@ import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationLevel;
 import org.dependencytrack.notification.NotificationScope;
 import org.dependencytrack.notification.publishing.DefaultNotificationPublishersPlugin;
+import org.dependencytrack.notification.proto.v1.Level;
 import org.dependencytrack.persistence.jdbi.JdbiFactory;
 import org.dependencytrack.plugin.runtime.PluginManager;
 import org.dependencytrack.proto.internal.workflow.v1.PublishNotificationWorkflowArg;
@@ -557,6 +558,37 @@ class NotificationPublisherResourceTest extends ResourceTest {
             assertThat(arg.getNotificationRuleNamesList()).containsExactly("Scheduled Rule");
             assertThat(arg.getNotification().getTitle()).startsWith("[TEST] ");
             assertThat(arg.getRuleTest()).isTrue();
+        });
+    }
+
+    @Test
+    void shouldDispatchTestNotificationForErrorLevelRule() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION);
+
+        new DefaultNotificationPublisherInitializer().seedDefaultPublishers(pluginManager);
+
+        final NotificationPublisher slackPublisher = qm.getNotificationPublisher("Slack");
+        final NotificationRule rule = qm.createNotificationRule(
+                "Error Rule",
+                NotificationScope.PORTFOLIO,
+                NotificationLevel.ERROR,
+                slackPublisher);
+        rule.setNotifyOn(Set.of(NotificationGroup.NEW_VULNERABILITY));
+        rule.setPublisherConfig("{\"destination\":\"https://example.com/webhook\"}");
+
+        final Response response = jersey
+                .target(V1_NOTIFICATION_PUBLISHER + "/test/" + rule.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.entity("", MediaType.APPLICATION_FORM_URLENCODED_TYPE));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        final Collection<? extends CreateWorkflowRunRequest<?>> requests = captureBatchedCreateRunRequests();
+        assertThat(requests).singleElement().satisfies(request -> {
+            final var arg = (PublishNotificationWorkflowArg) request.argument();
+            assertThat(arg.getNotification().getLevel()).isEqualTo(Level.LEVEL_ERROR);
+            assertThat(arg.getNotification().getTitle()).startsWith("[TEST] ");
         });
     }
 

--- a/notification/api/src/main/java/org/dependencytrack/notification/api/TestNotificationFactory.java
+++ b/notification/api/src/main/java/org/dependencytrack/notification/api/TestNotificationFactory.java
@@ -174,6 +174,24 @@ public final class TestNotificationFactory {
         return null;
     }
 
+    /**
+     * Returns a test notification for the given scope and group, regardless of level.
+     * Used by notification rule tests where the rule's configured level is applied separately.
+     */
+    public static @Nullable Notification createTestNotification(Scope scope, Group group) {
+        requireNonNull(scope, "scope must not be null");
+        requireNonNull(group, "group must not be null");
+
+        for (final var entry : SUPPLIER_MATRIX.entrySet()) {
+            final SupplierMatrixKey key = entry.getKey();
+            if (key.scope() == scope && key.group() == group) {
+                return entry.getValue().get();
+            }
+        }
+
+        return null;
+    }
+
     public static Notification createAnalyzerErrorTestNotification() {
         return createAnalyzerErrorNotification("failure");
     }


### PR DESCRIPTION
Today I lost a lot time debugging email alerts not working. The "Perform Test" button confirmed to me that a test email was submitted to the queue succesfully. But it didn't arrive. Turns out no e-mail was queued after all. The reason is that my alert has level "Error" and the test button only has an "Informational" template to use. So it didn't find a suitable template and didn't send a test e-mail. This PR simplifies the template/supplier matrix to always generate an event regardless of the chosen level.

## Summary
- Fixes the notification rule test endpoint silently succeeding without dispatching when a rule is configured at Error level but the selected event group only has Informational test templates.
- Looks up test notifications by scope and group only, then applies the rule's level to the dummy notification so publisher delivery can be verified independently of production routing semantics.
- Adds a regression test for Error-level rules with `NEW_VULNERABILITY`.
