### PR TITLE
Fix teams being logged as object references instead of names

### DIFF
--- a/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
+++ b/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
@@ -421,7 +421,7 @@ public class AlpineQueryManager extends AbstractAlpineQueryManager {
             }
             for (final String groupDN: groupDNs) {
                 for (final MappedLdapGroup mappedLdapGroup: getMappedLdapGroups(groupDN)) {
-                    LOGGER.debug("Adding user: {} to team: {}", user.getUsername(), mappedLdapGroup.getTeam());
+                    LOGGER.debug("Adding user: {} to team: {}", user.getUsername(), mappedLdapGroup.getTeam().getName());
                     addUserToTeam(user, mappedLdapGroup.getTeam());
                 }
             }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -582,7 +582,7 @@ public class ProjectResource extends AbstractApiResource {
                                 .entity("""
                                         accessTeams must either specify a UUID or a name,\
                                         but the team %s has neither.\
-                                        """.formatted(chosenTeam))
+                                        """.formatted(chosenTeam.getName()))
                                 .build());
                     }
                 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/UserResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/UserResource.java
@@ -852,7 +852,7 @@ public class UserResource extends AbstractApiResource {
                 principal.setTeams(requestedTeams);
                 qm.persist(principal);
                 super.logSecurityEvent(LOGGER, SecurityMarkers.SECURITY_AUDIT,
-                        "Added team membership for: " + principal.getUsername() + " / team: " + requestedTeams.toString());
+                        "Added team membership for: " + principal.getUsername() + " / team: " + requestedTeams.stream().map(Team::getName).toList());
                 return Response.ok(principal).build();
             });
         }


### PR DESCRIPTION
### Description
Resolve team names via getName() in log and error messages so teams no longer appear as object references.

### Addressed Issue
Fixes #6915 

### Additional Details
-

### Checklist
- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

