### PR TITLE
Enable NullAway for dex modules

### DIFF
--- a/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/WorkflowRun.java
+++ b/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/WorkflowRun.java
@@ -33,7 +33,7 @@ public record WorkflowRun(
         @Nullable UUID parentId,
         String workflowName,
         int workflowVersion,
-        String workflowInstanceId,
+        @Nullable String workflowInstanceId,
         WorkflowRunStatus status,
         @Nullable String customStatus,
         int priority,

--- a/dex/engine/pom.xml
+++ b/dex/engine/pom.xml
@@ -32,9 +32,6 @@
 
     <properties>
         <project.parentBaseDir>${project.basedir}/../..</project.parentBaseDir>
-
-        <!-- TODO: Remove after fixing all existing findings. -->
-        <nullaway.severity>OFF</nullaway.severity>
     </properties>
 
     <dependencies>

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/AbstractTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/AbstractTaskWorker.java
@@ -25,9 +25,9 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter.MeterProvider;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,21 +57,20 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
     private final IntervalFunction pollBackoffFunction;
     private final int maxConcurrency;
     private final Semaphore semaphore;
-    private final MeterRegistry meterRegistry;
     private final BooleanSupplier downstreamAcceptsWork;
     private final Lock statusLock;
+    private final Thread pollThread;
+    private final ExecutorService taskExecutor;
+    private final Timer pollLatencyTimer;
+    private final Counter pollsCounter;
+    private final Counter backpressureSkipsCounter;
+    private final MeterProvider<DistributionSummary> polledTasksDistribution;
+    private final MeterProvider<Counter> processedCounter;
+    private final MeterProvider<Timer> processLatencyTimer;
     final Logger logger;
 
     private volatile Status status = Status.CREATED;
     private volatile boolean nudged = false;
-    private @Nullable Thread pollThread;
-    private @Nullable ExecutorService taskExecutor;
-    private @Nullable Timer pollLatencyTimer;
-    private @Nullable Counter pollsCounter;
-    private @Nullable Counter backpressureSkipsCounter;
-    private @Nullable MeterProvider<DistributionSummary> polledTasksDistribution;
-    private @Nullable MeterProvider<Counter> processedCounter;
-    private @Nullable MeterProvider<Timer> processLatencyTimer;
 
     AbstractTaskWorker(
             final String name,
@@ -83,58 +82,46 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
         this.name = name;
         this.minPollIntervalMillis = requireNonNull(minPollInterval, "minPollInterval must not be null").toMillis();
         this.pollBackoffFunction = requireNonNull(pollBackoffFunction, "pollBackoffFunction must not be null");
-        this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry must not be null");
+        requireNonNull(meterRegistry, "meterRegistry must not be null");
         this.downstreamAcceptsWork = requireNonNull(downstreamAcceptsWork, "downstreamAcceptsWork must not be null");
         this.statusLock = new ReentrantLock();
         this.maxConcurrency = maxConcurrency;
         this.semaphore = new Semaphore(maxConcurrency);
         this.logger = LoggerFactory.getLogger(getClass());
-    }
 
-    abstract List<T> poll(int limit);
-
-    abstract void process(T task);
-
-    abstract void abandon(T task);
-
-    @Override
-    public void start() {
-        setStatus(Status.STARTING);
-
-        pollThread = Thread.ofPlatform()
+        this.pollThread = Thread.ofPlatform()
                 .name("%s-Poller-".formatted(getClass().getSimpleName()), 0)
                 .unstarted(this::pollAndDispatch);
 
         final var taskExecutorName = "%s-%s-Executor".formatted(getClass().getSimpleName(), name);
-        taskExecutor = Executors.newThreadPerTaskExecutor(
+        this.taskExecutor = Executors.newThreadPerTaskExecutor(
                 Thread.ofVirtual()
                         .name(taskExecutorName + "-", 0)
                         .factory());
-
-        new ExecutorServiceMetrics(taskExecutor, taskExecutorName, null).bindTo(meterRegistry);
+        new ExecutorServiceMetrics(taskExecutor, taskExecutorName, Tags.empty()).bindTo(meterRegistry);
 
         final var commonMeterTags = List.of(Tag.of("workerType", getClass().getSimpleName()));
-        pollLatencyTimer = Timer
+        this.pollLatencyTimer = Timer
                 .builder("dt.dex.engine.task.worker.poll.latency")
                 .tags(commonMeterTags)
                 .register(meterRegistry);
-        pollsCounter = Counter
+        this.pollsCounter = Counter
                 .builder("dt.dex.engine.task.worker.polls")
                 .tags(commonMeterTags)
                 .register(meterRegistry);
-        backpressureSkipsCounter = Counter
+        this.backpressureSkipsCounter = Counter
                 .builder("dt.dex.engine.task.worker.poll.skipped.backpressure")
                 .tags(commonMeterTags)
                 .register(meterRegistry);
-        polledTasksDistribution = DistributionSummary
+        this.polledTasksDistribution = DistributionSummary
                 .builder("dt.dex.engine.task.worker.tasks.polled")
                 .tags(commonMeterTags)
                 .withRegistry(meterRegistry);
-        processedCounter = Counter
+        this.processedCounter = Counter
                 .builder("dt.dex.engine.task.worker.tasks.processed")
                 .tags(commonMeterTags)
                 .withRegistry(meterRegistry);
-        processLatencyTimer = Timer
+        this.processLatencyTimer = Timer
                 .builder("dt.dex.engine.task.worker.process.latency")
                 .tags(commonMeterTags)
                 .withRegistry(meterRegistry);
@@ -147,6 +134,17 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
                 .tags(commonMeterTags)
                 .tag("name", name)
                 .register(meterRegistry);
+    }
+
+    abstract List<T> poll(int limit);
+
+    abstract void process(T task);
+
+    abstract void abandon(T task);
+
+    @Override
+    public void start() {
+        setStatus(Status.STARTING);
 
         pollThread.start();
 
@@ -162,7 +160,7 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
     public void close() {
         setStatus(Status.STOPPING);
 
-        if (pollThread != null && pollThread.isAlive()) {
+        if (pollThread.isAlive()) {
             LockSupport.unpark(pollThread);
             logger.debug("Waiting for poll thread to stop");
             try {
@@ -177,23 +175,20 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
                 pollThread.interrupt();
             }
         }
-        if (taskExecutor != null) {
-            logger.debug("Waiting for task executor to stop");
-            taskExecutor.shutdown();
+        logger.debug("Waiting for task executor to stop");
+        taskExecutor.shutdown();
 
-            try {
-                final boolean terminated = taskExecutor.awaitTermination(30, TimeUnit.SECONDS);
-                if (!terminated) {
-                    logger.warn("Task executor did not stop in time; Interrupting it");
-                    taskExecutor.shutdownNow();
-                }
-            } catch (InterruptedException e) {
-                logger.warn("Interrupted while waiting for task executor to stop", e);
-                Thread.currentThread().interrupt();
+        try {
+            final boolean terminated = taskExecutor.awaitTermination(30, TimeUnit.SECONDS);
+            if (!terminated) {
+                logger.warn("Task executor did not stop in time; Interrupting it");
                 taskExecutor.shutdownNow();
             }
+        } catch (InterruptedException e) {
+            logger.warn("Interrupted while waiting for task executor to stop", e);
+            Thread.currentThread().interrupt();
+            taskExecutor.shutdownNow();
         }
-
 
         setStatus(Status.STOPPED);
     }
@@ -201,9 +196,7 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
     @Override
     public void nudge() {
         nudged = true;
-        if (pollThread != null) {
-            LockSupport.unpark(pollThread);
-        }
+        LockSupport.unpark(pollThread);
     }
 
     private void pollAndDispatch() {

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskScheduler.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskScheduler.java
@@ -28,7 +28,6 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.Query;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.Update;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -51,16 +50,15 @@ final class ActivityTaskScheduler implements Closeable {
 
     private final Jdbi jdbi;
     private final Supplier<Boolean> leadershipSupplier;
-    private final MeterRegistry meterRegistry;
     private final long pollIntervalMillis;
     private final IntervalFunction pollBackoffFunction;
     private final Consumer<String> onTasksScheduledCallback;
     private final Thread pollThread;
+    private final Counter pollsCounter;
+    private final MeterProvider<Timer> taskSchedulingLatencyTimer;
+    private final MeterProvider<Counter> tasksScheduledCounter;
     private volatile boolean stopped = false;
     private volatile boolean nudged = false;
-    private @Nullable Counter pollsCounter;
-    private @Nullable MeterProvider<Timer> taskSchedulingLatencyTimer;
-    private @Nullable MeterProvider<Counter> tasksScheduledCounter;
 
     ActivityTaskScheduler(
             Jdbi jdbi,
@@ -71,26 +69,24 @@ final class ActivityTaskScheduler implements Closeable {
             Consumer<String> onTasksScheduledCallback) {
         this.jdbi = jdbi;
         this.leadershipSupplier = leadershipSupplier;
-        this.meterRegistry = meterRegistry;
         this.pollIntervalMillis = pollIntervalMillis.toMillis();
         this.pollBackoffFunction = pollBackoffFunction;
         this.onTasksScheduledCallback = onTasksScheduledCallback;
         this.pollThread = Thread.ofPlatform()
                 .name(ActivityTaskScheduler.class.getSimpleName())
                 .unstarted(this::pollLoop);
+        this.pollsCounter = Counter
+                .builder("dt.dex.engine.activity.task.scheduler.polls")
+                .register(meterRegistry);
+        this.taskSchedulingLatencyTimer = Timer
+                .builder("dt.dex.engine.activity.task.scheduling.latency")
+                .withRegistry(meterRegistry);
+        this.tasksScheduledCounter = Counter
+                .builder("dt.dex.engine.activity.tasks.scheduled")
+                .withRegistry(meterRegistry);
     }
 
     void start() {
-        pollsCounter = Counter
-                .builder("dt.dex.engine.activity.task.scheduler.polls")
-                .register(meterRegistry);
-        taskSchedulingLatencyTimer = Timer
-                .builder("dt.dex.engine.activity.task.scheduling.latency")
-                .withRegistry(meterRegistry);
-        tasksScheduledCounter = Counter
-                .builder("dt.dex.engine.activity.tasks.scheduled")
-                .withRegistry(meterRegistry);
-
         pollThread.start();
     }
 

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
@@ -47,6 +47,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 import static org.dependencytrack.dex.engine.MdcKeys.MDC_ACTIVITY_NAME;
 import static org.dependencytrack.dex.engine.MdcKeys.MDC_ACTIVITY_TASK_ATTEMPT;
 import static org.dependencytrack.dex.engine.MdcKeys.MDC_ACTIVITY_TASK_EXECUTION_ID;
@@ -161,7 +162,7 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
                     logger.debug("Activity was interrupted or worker is shutting down; abandoning task");
                     abandon(task);
                 } else {
-                    fail(task, "Activity failed", cause);
+                    fail(task, "Activity failed", requireNonNullElse(cause, e));
                 }
                 return;
             } catch (InterruptedException e) {

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ConcurrencyKeyMaintenanceWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ConcurrencyKeyMaintenanceWorker.java
@@ -45,10 +45,9 @@ final class ConcurrencyKeyMaintenanceWorker implements Closeable {
 
     private final Jdbi jdbi;
     private final Supplier<Boolean> leadershipSupplier;
-    private final MeterRegistry meterRegistry;
     private final long repairIntervalMillis;
     private final Runnable onWakeupsRepaired;
-    private @Nullable Counter repairedWakeupsCounter;
+    private final Counter repairedWakeupsCounter;
     private @Nullable ScheduledExecutorService executor;
     private volatile boolean stopped = false;
     private boolean wasLeader = false;
@@ -61,15 +60,14 @@ final class ConcurrencyKeyMaintenanceWorker implements Closeable {
             Runnable onWakeupsRepaired) {
         this.jdbi = jdbi;
         this.leadershipSupplier = leadershipSupplier;
-        this.meterRegistry = meterRegistry;
         this.repairIntervalMillis = repairInterval.toMillis();
         this.onWakeupsRepaired = onWakeupsRepaired;
+        this.repairedWakeupsCounter = Counter
+                .builder("dt.dex.engine.workflow.concurrency.key.wakeups.repaired")
+                .register(meterRegistry);
     }
 
     void start() {
-        repairedWakeupsCounter = Counter
-                .builder("dt.dex.engine.workflow.concurrency.key.wakeups.repaired")
-                .register(meterRegistry);
         executor = Executors.newSingleThreadScheduledExecutor(
                 Thread.ofPlatform()
                         .name(getClass().getSimpleName())

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -29,6 +29,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter.MeterProvider;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
 import org.dependencytrack.common.pagination.Page;
 import org.dependencytrack.common.pagination.PageIterator;
@@ -212,7 +213,7 @@ final class DexEngineImpl implements DexEngine {
             runHistoryCacheBuilder.expireAfterAccess(config.runHistoryCache().evictAfterAccess());
         }
         runHistoryCache = runHistoryCacheBuilder.build();
-        new CaffeineCacheMetrics<>(runHistoryCache, "DexEngine-RunHistoryCache", null)
+        new CaffeineCacheMetrics<>(runHistoryCache, "DexEngine-RunHistoryCache", Tags.empty())
                 .bindTo(config.metrics().meterRegistry());
 
         LOGGER.debug("Registering default event listeners");
@@ -242,7 +243,7 @@ final class DexEngineImpl implements DexEngine {
             LOGGER.debug("Starting metrics collector");
             metricsCollector = new DexEngineMetricsCollector(
                     jdbi,
-                    () -> leaderElection == null || leaderElection.isLeader(),
+                    this::isLeader,
                     config.metrics().collectorInitialDelay(),
                     config.metrics().collectorInterval(),
                     config.metrics().meterRegistry());
@@ -255,7 +256,7 @@ final class DexEngineImpl implements DexEngine {
             LOGGER.debug("Starting workflow task scheduler");
             workflowTaskScheduler = new WorkflowTaskScheduler(
                     jdbi,
-                    leaderElection::isLeader,
+                    this::isLeader,
                     config.metrics().meterRegistry(),
                     config.workflowTaskScheduler().pollInterval(),
                     config.workflowTaskScheduler().pollBackoffFunction(),
@@ -271,7 +272,7 @@ final class DexEngineImpl implements DexEngine {
             LOGGER.debug("Starting activity task scheduler");
             activityTaskScheduler = new ActivityTaskScheduler(
                     jdbi,
-                    leaderElection::isLeader,
+                    this::isLeader,
                     config.metrics().meterRegistry(),
                     config.activityTaskScheduler().pollInterval(),
                     config.activityTaskScheduler().pollBackoffFunction(),
@@ -365,7 +366,7 @@ final class DexEngineImpl implements DexEngine {
             LOGGER.debug("Starting maintenance worker");
             maintenanceWorker = new MaintenanceWorker(
                     jdbi,
-                    leaderElection::isLeader,
+                    this::isLeader,
                     config.maintenance().runRetentionDuration(),
                     config.maintenance().runDeletionBatchSize(),
                     config.maintenance().runDeletionMaxBatchesPerCycle(),
@@ -598,6 +599,8 @@ final class DexEngineImpl implements DexEngine {
             throw new IllegalStateException("Activity task queue %s does not exist".formatted(options.queueName()));
         }
 
+        requireUnregisteredTaskWorker("activity/" + options.name(), options.queueName(), activityWorkerByQueue);
+
         final var worker = new ActivityTaskWorker(
                 options.name(),
                 this,
@@ -610,14 +613,8 @@ final class DexEngineImpl implements DexEngine {
                 () -> (taskEventBuffer == null || taskEventBuffer.acceptsWork())
                         && (activityTaskHeartbeatBuffer == null || activityTaskHeartbeatBuffer.acceptsWork()));
 
-        if (taskWorkerByName.putIfAbsent("activity/" + options.name(), worker) != null) {
-            throw new IllegalStateException(
-                    "An task worker with name %s was already registered".formatted(options.name()));
-        }
-        if (activityWorkerByQueue.putIfAbsent(options.queueName(), worker) != null) {
-            throw new IllegalStateException(
-                    "An activity task worker for queue %s was already registered".formatted(options.queueName()));
-        }
+        taskWorkerByName.put("activity/" + options.name(), worker);
+        activityWorkerByQueue.put(options.queueName(), worker);
     }
 
     private void registerWorkflowTaskWorker(TaskWorkerOptions options) {
@@ -626,6 +623,8 @@ final class DexEngineImpl implements DexEngine {
         if (!queueExists) {
             throw new IllegalStateException("Workflow task queue %s does not exist".formatted(options.queueName()));
         }
+
+        requireUnregisteredTaskWorker("workflow/" + options.name(), options.queueName(), workflowWorkerByQueue);
 
         final var worker = new WorkflowTaskWorker(
                 options.name(),
@@ -638,14 +637,8 @@ final class DexEngineImpl implements DexEngine {
                 config.metrics().meterRegistry(),
                 () -> taskEventBuffer == null || taskEventBuffer.acceptsWork());
 
-        if (taskWorkerByName.putIfAbsent("workflow/" + options.name(), worker) != null) {
-            throw new IllegalStateException(
-                    "A task worker with name %s was already registered".formatted(options.name()));
-        }
-        if (workflowWorkerByQueue.putIfAbsent(options.queueName(), worker) != null) {
-            throw new IllegalStateException(
-                    "A workflow task worker for queue %s was already registered".formatted(options.queueName()));
-        }
+        taskWorkerByName.put("workflow/" + options.name(), worker);
+        workflowWorkerByQueue.put(options.queueName(), worker);
     }
 
     @Override
@@ -709,7 +702,10 @@ final class DexEngineImpl implements DexEngine {
                 } else {
                     argumentPayload = workflowMetadata.argumentConverter().convertToPayload(request.argument());
                 }
-                runCreatedBuilder.setArgument(argumentPayload);
+                runCreatedBuilder.setArgument(
+                        requireNonNull(
+                                argumentPayload,
+                                "argumentPayload must not be null"));
             }
 
             messagesToCreate.add(
@@ -960,7 +956,7 @@ final class DexEngineImpl implements DexEngine {
         requireStatusAnyOf(Status.RUNNING);
 
         try {
-            return externalEventBuffer.add(externalEvent);
+            return requireStarted(externalEventBuffer, "externalEventBuffer").add(externalEvent);
         } catch (InterruptedException | TimeoutException e) {
             throw new RuntimeException(e);
         }
@@ -993,7 +989,7 @@ final class DexEngineImpl implements DexEngine {
     void onTaskEvent(TaskEvent taskEvent) {
         final CompletableFuture<Void> future;
         try {
-            future = taskEventBuffer.add(taskEvent);
+            future = requireStarted(taskEventBuffer, "taskEventBuffer").add(taskEvent);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IllegalStateException(
@@ -1056,6 +1052,9 @@ final class DexEngineImpl implements DexEngine {
             String queueName,
             Collection<PollWorkflowTaskCommand> commands,
             int limit) {
+        final Cache<WorkflowRunHistoryCacheKey, CachedWorkflowRunHistory> runHistoryCache =
+                requireStarted(this.runHistoryCache, "runHistoryCache");
+
         return jdbi.inTransaction(handle -> {
             final var dao = new WorkflowDao(handle);
 
@@ -1086,7 +1085,9 @@ final class DexEngineImpl implements DexEngine {
 
             return polledTaskByRunId.values().stream()
                     .map(polledTask -> {
-                        final PolledWorkflowEvents polledEvents = polledEventsByRunId.get(polledTask.runId());
+                        final PolledWorkflowEvents polledEvents = requireNonNull(
+                                polledEventsByRunId.get(polledTask.runId()),
+                                "polledEvents must not be null for workflow run %s".formatted(polledTask.runId()));
                         final CachedWorkflowRunHistory cachedHistory = cachedHistoryByRunId.get(polledTask.runId());
                         final List<WorkflowEvent> cachedHistoryEvents = cachedHistory != null
                                 ? cachedHistory.events()
@@ -1313,14 +1314,18 @@ final class DexEngineImpl implements DexEngine {
                 runHistoryCacheKeysToInvalidate.add(
                         new WorkflowRunHistoryCacheKey(
                                 run.id(),
-                                continuedAsNewGenerationByRunId.get(run.id())));
+                                requireNonNull(
+                                        continuedAsNewGenerationByRunId.get(run.id()),
+                                        () -> "continuedAsNewGeneration must not be null for workflow run %s"
+                                                .formatted(run.id()))));
             }
         }
 
         if (!continuedAsNewRunIds.isEmpty()) {
             workflowDao.truncateRunHistories(continuedAsNewRunIds);
             workflowDao.getJdbiHandle().afterCommit(
-                    () -> runHistoryCache.invalidateAll(runHistoryCacheKeysToInvalidate));
+                    () -> requireStarted(runHistoryCache, "runHistoryCache")
+                            .invalidateAll(runHistoryCacheKeysToInvalidate));
         }
 
         if (!createHistoryEntryCommands.isEmpty()) {
@@ -1855,6 +1860,38 @@ final class DexEngineImpl implements DexEngine {
 
             runsCompletedCounter.withTags(tags).increment();
         }
+    }
+
+    private void requireUnregisteredTaskWorker(
+            String workerName,
+            String queueName,
+            Map<String, TaskWorker> workerByQueue) {
+        if (taskWorkerByName.containsKey(workerName)) {
+            throw new IllegalStateException(
+                    "A task worker with name %s was already registered".formatted(workerName));
+        }
+        if (workerByQueue.containsKey(queueName)) {
+            throw new IllegalStateException(
+                    "A task worker for queue %s was already registered".formatted(queueName));
+        }
+    }
+
+    private boolean isLeader() {
+        // Every instance acts as leader when leader election is disabled.
+        // A null leaderElection with leader election enabled means the engine
+        // is shutting down, in which case leadership must not be assumed.
+        return leaderElection != null
+                ? leaderElection.isLeader()
+                : !config.leaderElection().isEnabled();
+    }
+
+    private <T> T requireStarted(final @Nullable T component, final String name) {
+        if (component == null) {
+            throw new IllegalStateException(
+                    "%s is not initialized; Engine is in status %s".formatted(name, this.status));
+        }
+
+        return component;
     }
 
     private void setStatus(Status newStatus) {

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineLeaderElection.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineLeaderElection.java
@@ -42,11 +42,10 @@ final class DexEngineLeaderElection implements Closeable {
     private final Jdbi jdbi;
     private final Duration leaseDuration;
     private final Duration checkInterval;
-    private final MeterRegistry meterRegistry;
+    private final Counter leadershipAcquiredCounter;
+    private final Counter leadershipLostCounter;
 
     private @Nullable ScheduledExecutorService executor;
-    private @Nullable Counter leadershipAcquiredCounter;
-    private @Nullable Counter leadershipLostCounter;
     private volatile boolean isLeader;
 
     DexEngineLeaderElection(
@@ -59,22 +58,18 @@ final class DexEngineLeaderElection implements Closeable {
         this.jdbi = jdbi;
         this.leaseDuration = leaseDuration;
         this.checkInterval = checkInterval;
-        this.meterRegistry = meterRegistry;
-    }
-
-    void start() {
+        this.leadershipAcquiredCounter = Counter
+                .builder("dt.dex.engine.leadership.acquired")
+                .register(meterRegistry);
+        this.leadershipLostCounter = Counter
+                .builder("dt.dex.engine.leadership.lost")
+                .register(meterRegistry);
         Gauge
                 .builder("dt.dex.engine.leadership.status", this, it -> it.isLeader ? 1 : 0)
                 .register(meterRegistry);
+    }
 
-        leadershipAcquiredCounter = Counter
-                .builder("dt.dex.engine.leadership.acquired")
-                .register(meterRegistry);
-
-        leadershipLostCounter = Counter
-                .builder("dt.dex.engine.leadership.lost")
-                .register(meterRegistry);
-
+    void start() {
         executor = Executors.newSingleThreadScheduledExecutor(
                 Thread.ofPlatform()
                         .name(getClass().getSimpleName())

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/FailureConverter.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/FailureConverter.java
@@ -166,8 +166,9 @@ final class FailureConverter {
             }
         }
 
-        if (throwable.getStackTrace() != null && throwable.getStackTrace().length > 0) {
-            failureBuilder.setStackTrace(serializeStackTrace(throwable.getStackTrace()));
+        final String stackTrace = serializeStackTrace(throwable.getStackTrace());
+        if (stackTrace != null) {
+            failureBuilder.setStackTrace(stackTrace);
         }
 
         if (throwable.getCause() != null) {

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/TaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/TaskWorker.java
@@ -29,7 +29,7 @@ interface TaskWorker extends Closeable {
         STARTING(2),   // 1
         RUNNING(3),    // 2
         STOPPING(4),   // 3
-        STOPPED(1);    // 4
+        STOPPED;       // 4
 
         private final Set<Integer> allowedTransitions;
 

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowContextImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowContextImpl.java
@@ -274,7 +274,7 @@ final class WorkflowContextImpl<A, R> implements WorkflowContext<A> {
         final int eventId = currentEventId++;
         final int elapsedEventId = currentEventId++;
         pendingCommandByEventId.put(eventId, new CreateTimerCommand(
-                eventId, elapsedEventId, name, currentTime.plus(delay)));
+                eventId, elapsedEventId, name, currentTime().plus(delay)));
 
         final var awaitable = new AwaitableImpl<>(this, voidConverter());
         pendingAwaitableByEventId.put(elapsedEventId, awaitable);
@@ -399,7 +399,7 @@ final class WorkflowContextImpl<A, R> implements WorkflowContext<A> {
                 LOGGER.trace("Blocked");
             }
         } catch (WorkflowRunCanceledError e) {
-            cancel(e.getMessage());
+            cancel(requireNonNullElse(e.getMessage(), "Workflow run was canceled"));
         } catch (WorkflowRunContinuedAsNewError e) {
             continueAsNew(e.getArgument());
         } catch (WorkflowRunDeterminismError | Exception e) {

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowRunState.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowRunState.java
@@ -54,6 +54,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static com.fasterxml.uuid.Generators.timeBasedEpochRandomGenerator;
+import static java.util.Objects.requireNonNull;
 import static org.dependencytrack.dex.engine.support.ProtobufUtil.toInstant;
 import static org.dependencytrack.dex.engine.support.ProtobufUtil.toProtoTimestamp;
 
@@ -124,14 +125,12 @@ final class WorkflowRunState {
         return parentId;
     }
 
-    @Nullable
     String workflowName() {
-        return workflowName;
+        return requireNonNull(workflowName, "workflowName is not set because no RunCreated event was applied");
     }
 
-    @Nullable
-    Integer workflowVersion() {
-        return workflowVersion;
+    int workflowVersion() {
+        return requireNonNull(workflowVersion, "workflowVersion is not set because no RunCreated event was applied");
     }
 
     @Nullable
@@ -139,9 +138,8 @@ final class WorkflowRunState {
         return workflowInstanceId;
     }
 
-    @Nullable
     String taskQueueName() {
-        return taskQueueName;
+        return requireNonNull(taskQueueName, "taskQueueName is not set because no RunCreated event was applied");
     }
 
     @Nullable
@@ -189,9 +187,12 @@ final class WorkflowRunState {
         return pendingTimerCreatedEventIds;
     }
 
-    @Nullable
+    boolean isCreated() {
+        return createdEvent != null;
+    }
+
     WorkflowRunStatus status() {
-        return status;
+        return requireNonNull(status, "status is not set because no RunCreated event was applied");
     }
 
     @Nullable
@@ -203,9 +204,8 @@ final class WorkflowRunState {
         this.customStatus = customStatus;
     }
 
-    @Nullable
-    Integer priority() {
-        return priority;
+    int priority() {
+        return requireNonNull(priority, "priority is not set because no RunCreated event was applied");
     }
 
     @Nullable
@@ -228,9 +228,8 @@ final class WorkflowRunState {
         return failure;
     }
 
-    @Nullable
     Instant createdAt() {
-        return createdAt;
+        return requireNonNull(createdAt, "createdAt is not set because no RunCreated event was applied");
     }
 
     @Nullable
@@ -391,6 +390,7 @@ final class WorkflowRunState {
 
     private void processCompleteRunCommand(final CompleteRunCommand command) {
         // If this is a sub-workflow run, ensure the parent run is informed about the outcome.
+        final WorkflowEvent createdEvent = createdEvent();
         if (createdEvent.getRunCreated().hasParentRun()) {
             final RunCreated.ParentRun parentRun = createdEvent.getRunCreated().getParentRun();
             final var parentRunId = UUID.fromString(parentRun.getId());
@@ -444,10 +444,10 @@ final class WorkflowRunState {
 
     private void processContinueAsNewCommand(final ContinueRunAsNewCommand command) {
         final var newRunCreatedBuilder = RunCreated.newBuilder()
-                .setWorkflowName(this.workflowName)
-                .setWorkflowVersion(this.workflowVersion)
-                .setTaskQueueName(this.taskQueueName)
-                .setPriority(this.priority);
+                .setWorkflowName(workflowName())
+                .setWorkflowVersion(workflowVersion())
+                .setTaskQueueName(taskQueueName())
+                .setPriority(priority());
         if (command.argument() != null) {
             newRunCreatedBuilder.setArgument(command.argument());
         }
@@ -460,8 +460,9 @@ final class WorkflowRunState {
         if (this.labels != null && !this.labels.isEmpty()) {
             newRunCreatedBuilder.putAllLabels(this.labels);
         }
-        if (this.createdEvent.getRunCreated().hasParentRun()) {
-            newRunCreatedBuilder.setParentRun(this.createdEvent.getRunCreated().getParentRun());
+        final WorkflowEvent createdEvent = createdEvent();
+        if (createdEvent.getRunCreated().hasParentRun()) {
+            newRunCreatedBuilder.setParentRun(createdEvent.getRunCreated().getParentRun());
         }
 
         this.continuedAsNew = true;
@@ -548,8 +549,8 @@ final class WorkflowRunState {
         final var parentRunBuilder = RunCreated.ParentRun.newBuilder()
                 .setChildRunCreatedEventId(command.eventId())
                 .setId(this.id.toString())
-                .setWorkflowName(this.workflowName)
-                .setWorkflowVersion(this.workflowVersion);
+                .setWorkflowName(workflowName())
+                .setWorkflowVersion(workflowVersion());
         if (this.workflowInstanceId != null) {
             parentRunBuilder.setWorkflowInstanceId(this.workflowInstanceId);
         }
@@ -599,6 +600,10 @@ final class WorkflowRunState {
                                                 .build())
                                 .build(),
                         command.elapseAt()));
+    }
+
+    private WorkflowEvent createdEvent() {
+        return requireNonNull(createdEvent, "createdEvent is not set because no RunCreated event was applied");
     }
 
     private void setStatus(final WorkflowRunStatus newStatus) {

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskScheduler.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskScheduler.java
@@ -27,7 +27,6 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.Query;
 import org.jdbi.v3.core.statement.StatementContext;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -52,17 +51,16 @@ final class WorkflowTaskScheduler implements Closeable {
 
     private final Jdbi jdbi;
     private final Supplier<Boolean> leadershipSupplier;
-    private final MeterRegistry meterRegistry;
     private final long pollIntervalMillis;
     private final IntervalFunction pollBackoffFunction;
     private final Consumer<String> onTasksScheduled;
     private final ConcurrencyKeyMaintenanceWorker concurrencyKeyMaintenanceWorker;
     private final Thread pollThread;
+    private final Counter pollsCounter;
+    private final MeterProvider<Timer> taskSchedulingLatencyTimer;
+    private final MeterProvider<Counter> tasksScheduledCounter;
     private volatile boolean stopped = false;
     private volatile boolean nudged = false;
-    private @Nullable Counter pollsCounter;
-    private @Nullable MeterProvider<Timer> taskSchedulingLatencyTimer;
-    private @Nullable MeterProvider<Counter> tasksScheduledCounter;
     private boolean wasLeader = false;
 
     WorkflowTaskScheduler(
@@ -75,7 +73,6 @@ final class WorkflowTaskScheduler implements Closeable {
             Consumer<String> onTasksScheduled) {
         this.jdbi = jdbi;
         this.leadershipSupplier = leadershipSupplier;
-        this.meterRegistry = meterRegistry;
         this.pollIntervalMillis = pollInterval.toMillis();
         this.pollBackoffFunction = pollBackoffFunction;
         this.onTasksScheduled = onTasksScheduled;
@@ -89,18 +86,18 @@ final class WorkflowTaskScheduler implements Closeable {
         this.pollThread = Thread.ofPlatform()
                 .name(getClass().getSimpleName())
                 .unstarted(this::pollLoop);
+        this.pollsCounter = Counter
+                .builder("dt.dex.engine.workflow.task.scheduler.polls")
+                .register(meterRegistry);
+        this.taskSchedulingLatencyTimer = Timer
+                .builder("dt.dex.engine.workflow.task.scheduling.latency")
+                .withRegistry(meterRegistry);
+        this.tasksScheduledCounter = Counter
+                .builder("dt.dex.engine.workflow.tasks.scheduled")
+                .withRegistry(meterRegistry);
     }
 
     void start() {
-        pollsCounter = Counter
-                .builder("dt.dex.engine.workflow.task.scheduler.polls")
-                .register(meterRegistry);
-        taskSchedulingLatencyTimer = Timer
-                .builder("dt.dex.engine.workflow.task.scheduling.latency")
-                .withRegistry(meterRegistry);
-        tasksScheduledCounter = Counter
-                .builder("dt.dex.engine.workflow.tasks.scheduled")
-                .withRegistry(meterRegistry);
         concurrencyKeyMaintenanceWorker.start();
         pollThread.start();
     }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskWorker.java
@@ -88,7 +88,7 @@ final class WorkflowTaskWorker extends AbstractTaskWorker<WorkflowTask> {
 
             // Hydrate workflow run state from the history.
             final var workflowRunState = new WorkflowRunState(task.workflowRunId(), task.history());
-            if (workflowRunState.status() != null && workflowRunState.status().isTerminal()) {
+            if (workflowRunState.isCreated() && workflowRunState.status().isTerminal()) {
                 logger.warn("""
                         Task was scheduled despite the workflow run already being in terminal state {}. \
                         Discarding {} events in the run's inbox.""", workflowRunState.status(), task.inbox().size());
@@ -132,6 +132,14 @@ final class WorkflowTaskWorker extends AbstractTaskWorker<WorkflowTask> {
                 logger.warn("No new events; Abandoning task");
                 abandon(task);
                 return;
+            }
+
+            // All actions after this require state that only the RunCreated event provides,
+            // so a run without it can not make progress. Fail here rather than when task events
+            // are flushed, where the failure would take down the entire batch.
+            if (!workflowRunState.isCreated()) {
+                throw new IllegalStateException(
+                        "Run has no RunCreated event in its history or inbox and can not make progress");
             }
 
             final var ctx = new WorkflowContextImpl<>(

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/support/Buffer.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/support/Buffer.java
@@ -50,11 +50,10 @@ public final class Buffer<T> implements Closeable {
 
     public enum Status {
 
-        CREATED(1, 3), // 0
-        STARTING(2),   // 1
-        RUNNING(3),    // 2
-        STOPPING(4),   // 3
-        STOPPED;       // 4
+        CREATED(1, 2), // 0
+        RUNNING(2),    // 1
+        STOPPING(3),   // 2
+        STOPPED;       // 3
 
         private final Set<Integer> allowedTransitions;
 
@@ -87,13 +86,12 @@ public final class Buffer<T> implements Closeable {
     private final Duration flushInterval;
     private final ReentrantLock flushLock;
     private final ReentrantLock statusLock;
-    private final MeterRegistry meterRegistry;
     private final CircuitBreaker circuitBreaker;
+    private final DistributionSummary batchSizeDistribution;
+    private final Timer itemWaitLatencyTimer;
+    private final Counter flushCounter;
+    private final Timer flushLatencyTimer;
     private volatile Status status = Status.CREATED;
-    private @Nullable DistributionSummary batchSizeDistribution;
-    private @Nullable Timer itemWaitLatencyTimer;
-    private @Nullable Counter flushCounter;
-    private @Nullable Timer flushLatencyTimer;
 
     public Buffer(
             String name,
@@ -133,8 +131,30 @@ public final class Buffer<T> implements Closeable {
         this.flushInterval = flushInterval;
         this.flushLock = new ReentrantLock();
         this.statusLock = new ReentrantLock();
-        this.meterRegistry = meterRegistry;
         this.circuitBreaker = circuitBreakerRegistry.circuitBreaker("dt.dex.engine.buffer." + name);
+
+        final List<Tag> commonMeterTags = List.of(Tag.of("buffer", name));
+        this.batchSizeDistribution = DistributionSummary
+                .builder("dt.dex.engine.buffer.flush.batch.size")
+                .publishPercentileHistogram()
+                .tags(commonMeterTags)
+                .register(meterRegistry);
+        this.itemWaitLatencyTimer = Timer
+                .builder("dt.dex.engine.buffer.item.wait.latency")
+                .tags(commonMeterTags)
+                .register(meterRegistry);
+        this.flushCounter = Counter
+                .builder("dt.dex.engine.buffer.flushes")
+                .tags(commonMeterTags)
+                .register(meterRegistry);
+        this.flushLatencyTimer = Timer
+                .builder("dt.dex.engine.buffer.flush.latency")
+                .tags(commonMeterTags)
+                .register(meterRegistry);
+        Gauge
+                .builder("dt.dex.engine.buffer.items.queued", itemsQueue::size)
+                .tags(commonMeterTags)
+                .register(meterRegistry);
     }
 
     public String name() {
@@ -154,31 +174,6 @@ public final class Buffer<T> implements Closeable {
     }
 
     public void start() {
-        setStatus(Status.STARTING);
-
-        final List<Tag> commonMeterTags = List.of(Tag.of("buffer", name));
-        batchSizeDistribution = DistributionSummary
-                .builder("dt.dex.engine.buffer.flush.batch.size")
-                .publishPercentileHistogram()
-                .tags(commonMeterTags)
-                .register(meterRegistry);
-        Gauge
-                .builder("dt.dex.engine.buffer.items.queued", itemsQueue::size)
-                .tags(commonMeterTags)
-                .register(meterRegistry);
-        itemWaitLatencyTimer = Timer
-                .builder("dt.dex.engine.buffer.item.wait.latency")
-                .tags(commonMeterTags)
-                .register(meterRegistry);
-        flushCounter = Counter
-                .builder("dt.dex.engine.buffer.flushes")
-                .tags(commonMeterTags)
-                .register(meterRegistry);
-        flushLatencyTimer = Timer
-                .builder("dt.dex.engine.buffer.flush.latency")
-                .tags(commonMeterTags)
-                .register(meterRegistry);
-
         setStatus(Status.RUNNING);
 
         flushThread.start();

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/WorkflowRunStateTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/WorkflowRunStateTest.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.dex.engine;
+
+import com.google.protobuf.util.Timestamps;
+import org.dependencytrack.dex.engine.api.WorkflowRunStatus;
+import org.dependencytrack.dex.proto.event.v1.RunCreated;
+import org.dependencytrack.dex.proto.event.v1.WorkflowEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+
+import static com.fasterxml.uuid.Generators.timeBasedEpochRandomGenerator;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class WorkflowRunStateTest {
+
+    @Test
+    void shouldNotBeCreatedWhenHistoryIsEmpty() {
+        final var runState = new WorkflowRunState(timeBasedEpochRandomGenerator().generate(), List.of());
+
+        assertThat(runState.isCreated()).isFalse();
+    }
+
+    @Test
+    void shouldBeCreatedAfterApplyingRunCreatedEvent() {
+        final UUID runId = timeBasedEpochRandomGenerator().generate();
+        final var runState = new WorkflowRunState(runId, List.of(runCreatedEvent()));
+
+        assertThat(runState.isCreated()).isTrue();
+        assertThat(runState.workflowName()).isEqualTo("foo");
+        assertThat(runState.workflowVersion()).isEqualTo(1);
+        assertThat(runState.taskQueueName()).isEqualTo("default");
+        assertThat(runState.priority()).isEqualTo(5);
+        assertThat(runState.status()).isEqualTo(WorkflowRunStatus.CREATED);
+        assertThat(runState.createdAt()).isNotNull();
+    }
+
+    @Test
+    void shouldThrowWhenAccessingRunCreatedFieldsBeforeRunWasCreated() {
+        final var runState = new WorkflowRunState(timeBasedEpochRandomGenerator().generate(), List.of());
+
+        record Accessor(String field, Function<WorkflowRunState, Object> get) {
+        }
+
+        final List<Accessor> accessors = List.of(
+                new Accessor("workflowName", WorkflowRunState::workflowName),
+                new Accessor("workflowVersion", WorkflowRunState::workflowVersion),
+                new Accessor("taskQueueName", WorkflowRunState::taskQueueName),
+                new Accessor("priority", WorkflowRunState::priority),
+                new Accessor("status", WorkflowRunState::status),
+                new Accessor("createdAt", WorkflowRunState::createdAt));
+
+        for (final Accessor accessor : accessors) {
+            assertThatExceptionOfType(NullPointerException.class)
+                    .as("accessor %s", accessor.field())
+                    .isThrownBy(() -> accessor.get().apply(runState))
+                    .withMessage("%s is not set because no RunCreated event was applied"
+                            .formatted(accessor.field()));
+        }
+    }
+
+    private static WorkflowEvent runCreatedEvent() {
+        return WorkflowEvent.newBuilder()
+                .setId(-1)
+                .setTimestamp(Timestamps.now())
+                .setRunCreated(RunCreated.newBuilder()
+                        .setWorkflowName("foo")
+                        .setWorkflowVersion(1)
+                        .setTaskQueueName("default")
+                        .setPriority(5)
+                        .build())
+                .build();
+    }
+
+}


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Enables NullAway for dex modules:

Enforces nullability checks at compile-time for dex modules, which were previously excluded.

Restructures code where necessary to reduce friction, caused by e.g. late initialization of threads, executors, and Micrometer Meter fields.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
