### PR TITLE
Set `format: binary` in OpenAPI for multipart BOM upload

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -584,7 +584,7 @@ public class BomResource extends AbstractApiResource {
             @FormDataParam("parentUUID") String parentUUID,
             @DefaultValue("false") @FormDataParam("isLatest") boolean isLatest,
             @FormDataParam("isActive") Boolean isActive,
-            @Parameter(schema = @Schema(type = "string")) @FormDataParam("bom") final List<FormDataBodyPart> artifactParts
+            @Parameter(schema = @Schema(type = "string", format = "binary")) @FormDataParam("bom") final List<FormDataBodyPart> artifactParts
     ) {
         if (artifactParts == null || artifactParts.isEmpty()) {
             throw new WebApplicationException(Response


### PR DESCRIPTION
### Description

Add `format: binary` in the type specification for the bom field.
This provides more semantic information for users.

### Addressed Issue

https://github.com/DependencyTrack/dependency-track/issues/6955 (partially)

### Additional Details

According to:
https://swagger.io/docs/specification/v3_0/describing-request-body/multipart-requests/

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and ~~I have provided tests to verify that it works as intended~~ **tested manually**, see below
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

### Manual testing

```sh
make build # necessary to build openapi resource
make api-server-dev
curl http://localhost:8080/api/openapi.yaml
# check that `format: binary` appears in the spec
```

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
