### PR TITLE
Set `format: bytes` in OpenAPI for base64 BOM upload

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/BomSubmitRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/BomSubmitRequest.java
@@ -165,6 +165,7 @@ public final class BomSubmitRequest {
     @Schema(
             description = "Base64 encoded BOM",
             requiredMode = Schema.RequiredMode.REQUIRED,
+            format = "bytes",
             example = """
                     ewogICJib21Gb3JtYXQiOiAiQ3ljbG9uZURYIiwKICAic3BlY1ZlcnNpb24iOiAi\
                     MS40IiwKICAiY29tcG9uZW50cyI6IFsKICAgIHsKICAgICAgInR5cGUiOiAibGli\


### PR DESCRIPTION
### Description

Add `format: bytes` in the type specification for the bom field.
This provides more semantic information for users.

### Addressed Issue

https://github.com/DependencyTrack/dependency-track/issues/6955 (partially)

### Additional Details

According to:
https://swagger.io/docs/specification/v3_0/data-models/data-types/#files

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and ~~I have provided tests to verify that it works as intended~~ **tested manually**, see below
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

### Manual testing

```sh
make build # necessary to build openapi resource
make api-server-dev
curl http://localhost:8080/api/openapi.yaml
# check that `format: bytes` appears in the spec
```

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
