### PR TITLE
Add durable component license curation: component analyses, policies, and read-only imported components

### DIFF
--- a/api/src/main/openapi/openapi.yaml
+++ b/api/src/main/openapi/openapi.yaml
@@ -185,6 +185,8 @@ servers:
 tags:
 - name: Component Analyses
   description: Endpoints related to component analyses (license curation)
+- name: Component Policies
+  description: Endpoints related to component policies (automated license curation)
 - name: Components
   description: Endpoints related to components
 - name: Extensions
@@ -225,6 +227,10 @@ paths:
     $ref: "./resources/projects/project-components.yaml"
   /component-analyses:
     $ref: "./resources/component-analyses/component-analyses.yaml"
+  /component-policies:
+    $ref: "./resources/component-policies/component-policies.yaml"
+  /component-policies/{id}:
+    $ref: "./resources/component-policies/component-policy.yaml"
   /component-analyses/{id}:
     $ref: "./resources/component-analyses/component-analysis.yaml"
   /component-analyses/{id}/comments:

--- a/api/src/main/openapi/openapi.yaml
+++ b/api/src/main/openapi/openapi.yaml
@@ -183,6 +183,8 @@ security:
 servers:
 - url: /api/v2
 tags:
+- name: Component Analyses
+  description: Endpoints related to component analyses (license curation)
 - name: Components
   description: Endpoints related to components
 - name: Extensions
@@ -221,6 +223,12 @@ paths:
     $ref: "./resources/projects/project-clone.yaml"
   /projects/{uuid}/components:
     $ref: "./resources/projects/project-components.yaml"
+  /component-analyses:
+    $ref: "./resources/component-analyses/component-analyses.yaml"
+  /component-analyses/{id}:
+    $ref: "./resources/component-analyses/component-analysis.yaml"
+  /component-analyses/{id}/comments:
+    $ref: "./resources/component-analyses/component-analysis-comments.yaml"
   /secrets:
     $ref: "./resources/secrets/secrets.yaml"
   /secrets/{name}:

--- a/api/src/main/openapi/resources/component-analyses/component-analyses.yaml
+++ b/api/src/main/openapi/resources/component-analyses/component-analyses.yaml
@@ -1,0 +1,86 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+get:
+  operationId: listComponentAnalyses
+  summary: List component analyses of a project
+  description: |-
+    Returns all component analyses (durable license curations) of a project.
+
+    Requires permission `VIEW_PORTFOLIO`.
+  tags:
+    - Component Analyses
+  parameters:
+    - name: project
+      in: query
+      description: UUID of the project
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    "200":
+      description: Component analyses of the project
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/list-component-analyses-response.yaml"
+    "401":
+      $ref: "../../shared/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../../shared/responses/generic-forbidden-error.yaml"
+    "404":
+      $ref: "../../shared/responses/generic-not-found-error.yaml"
+    default:
+      $ref: "../../shared/responses/generic-error.yaml"
+put:
+  operationId: updateComponentAnalysis
+  summary: Create or update a component analysis
+  description: |-
+    Creates or updates the analysis of the component identified by
+    purl or group/name/version within the project given as project_uuid.
+    The license override is an SPDX license ID or custom license name;
+    changes are recorded in the analysis audit trail. The curation is
+    re-applied on every BOM ingest.
+
+    Requires permission `POLICY_MANAGEMENT`.
+  tags:
+    - Component Analyses
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "./schemas/upsert-component-analysis-request.yaml"
+  responses:
+    "204":
+      description: Component analysis created or updated
+    "400":
+      description: Bad Request
+      content:
+        application/problem+json:
+          schema:
+            anyOf:
+              - $ref: "../../shared/schemas/invalid-request-problem-details.yaml"
+              - $ref: "../../shared/schemas/problem-details.yaml"
+    "401":
+      $ref: "../../shared/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../../shared/responses/generic-forbidden-error.yaml"
+    "404":
+      $ref: "../../shared/responses/generic-not-found-error.yaml"
+    default:
+      $ref: "../../shared/responses/generic-error.yaml"

--- a/api/src/main/openapi/resources/component-analyses/component-analysis-comments.yaml
+++ b/api/src/main/openapi/resources/component-analyses/component-analysis-comments.yaml
@@ -1,0 +1,84 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+parameters:
+  - name: id
+    in: path
+    description: ID of the component analysis
+    required: true
+    schema:
+      type: integer
+      format: int64
+get:
+  operationId: listComponentAnalysisComments
+  summary: List the audit trail of a component analysis
+  description: |-
+    Requires permission `VIEW_PORTFOLIO`.
+  tags:
+    - Component Analyses
+  responses:
+    "200":
+      description: Audit-trail comments, oldest first
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/list-component-analysis-comments-response.yaml"
+    "401":
+      $ref: "../../shared/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../../shared/responses/generic-forbidden-error.yaml"
+    "404":
+      $ref: "../../shared/responses/generic-not-found-error.yaml"
+    default:
+      $ref: "../../shared/responses/generic-error.yaml"
+post:
+  operationId: createComponentAnalysisComment
+  summary: Add a comment to a component analysis
+  description: |-
+    Requires permission `POLICY_MANAGEMENT`.
+  tags:
+    - Component Analyses
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "./schemas/create-component-analysis-comment-request.yaml"
+  responses:
+    "201":
+      description: Comment created
+      headers:
+        Location:
+          description: URL of the audit trail the comment was appended to
+          schema:
+            type: string
+            format: uri
+    "400":
+      description: Bad Request
+      content:
+        application/problem+json:
+          schema:
+            anyOf:
+              - $ref: "../../shared/schemas/invalid-request-problem-details.yaml"
+              - $ref: "../../shared/schemas/problem-details.yaml"
+    "401":
+      $ref: "../../shared/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../../shared/responses/generic-forbidden-error.yaml"
+    "404":
+      $ref: "../../shared/responses/generic-not-found-error.yaml"
+    default:
+      $ref: "../../shared/responses/generic-error.yaml"

--- a/api/src/main/openapi/resources/component-analyses/component-analysis.yaml
+++ b/api/src/main/openapi/resources/component-analyses/component-analysis.yaml
@@ -1,0 +1,45 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+parameters:
+  - name: id
+    in: path
+    description: ID of the component analysis
+    required: true
+    schema:
+      type: integer
+      format: int64
+delete:
+  operationId: deleteComponentAnalysis
+  summary: Delete a component analysis
+  description: |-
+    Deletes a component analysis and its audit trail. The component's
+    license reverts to the BOM-declared state on the next upload.
+
+    Requires permission `POLICY_MANAGEMENT`.
+  tags:
+    - Component Analyses
+  responses:
+    "204":
+      description: Analysis deleted
+    "401":
+      $ref: "../../shared/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../../shared/responses/generic-forbidden-error.yaml"
+    "404":
+      $ref: "../../shared/responses/generic-not-found-error.yaml"
+    default:
+      $ref: "../../shared/responses/generic-error.yaml"

--- a/api/src/main/openapi/resources/component-analyses/schemas/component-analysis-comment.yaml
+++ b/api/src/main/openapi/resources/component-analyses/schemas/component-analysis-comment.yaml
@@ -1,0 +1,27 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  timestamp:
+    $ref: "../../../shared/schemas/timestamp.yaml"
+  commenter:
+    type: string
+  comment:
+    type: string
+required:
+  - timestamp
+  - comment

--- a/api/src/main/openapi/resources/component-analyses/schemas/component-analysis.yaml
+++ b/api/src/main/openapi/resources/component-analyses/schemas/component-analysis.yaml
@@ -1,0 +1,40 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  id:
+    type: integer
+    format: int64
+  purl:
+    type: string
+  group:
+    type: string
+  name:
+    type: string
+  version:
+    type: string
+  license:
+    type: string
+    description: SPDX license ID or custom license name of the override
+  declared_license:
+    type: string
+    description: The BOM-declared license the override replaced (snapshot from the last upload)
+  details:
+    type: string
+required:
+  - id
+  - name

--- a/api/src/main/openapi/resources/component-analyses/schemas/create-component-analysis-comment-request.yaml
+++ b/api/src/main/openapi/resources/component-analyses/schemas/create-component-analysis-comment-request.yaml
@@ -1,0 +1,23 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  comment:
+    type: string
+    minLength: 1
+required:
+  - comment

--- a/api/src/main/openapi/resources/component-analyses/schemas/list-component-analyses-response.yaml
+++ b/api/src/main/openapi/resources/component-analyses/schemas/list-component-analyses-response.yaml
@@ -1,0 +1,24 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  analyses:
+    type: array
+    items:
+      $ref: "./component-analysis.yaml"
+required:
+  - analyses

--- a/api/src/main/openapi/resources/component-analyses/schemas/list-component-analysis-comments-response.yaml
+++ b/api/src/main/openapi/resources/component-analyses/schemas/list-component-analysis-comments-response.yaml
@@ -1,0 +1,24 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  comments:
+    type: array
+    items:
+      $ref: "./component-analysis-comment.yaml"
+required:
+  - comments

--- a/api/src/main/openapi/resources/component-analyses/schemas/upsert-component-analysis-request.yaml
+++ b/api/src/main/openapi/resources/component-analyses/schemas/upsert-component-analysis-request.yaml
@@ -1,0 +1,40 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  project_uuid:
+    type: string
+    format: uuid
+    description: UUID of the project the component belongs to
+  purl:
+    type: string
+    description: Canonical package URL identifying the component
+  group:
+    type: string
+  name:
+    type: string
+  version:
+    type: string
+  license:
+    type: string
+    description: SPDX license ID or custom license name
+  details:
+    type: string
+    description: Free-text curation note, written onto the component
+required:
+  - project_uuid
+  - name

--- a/api/src/main/openapi/resources/component-policies/component-policies.yaml
+++ b/api/src/main/openapi/resources/component-policies/component-policies.yaml
@@ -1,0 +1,83 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+get:
+  operationId: listComponentPolicies
+  summary: List component policies
+  description: |-
+    Returns all component policies in evaluation order
+    'priority ascending, name ascending'.
+
+    Requires permission `POLICY_MANAGEMENT`.
+  tags:
+    - Component Policies
+  responses:
+    "200":
+      description: Component policies
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/list-component-policies-response.yaml"
+    "401":
+      $ref: "../../shared/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../../shared/responses/generic-forbidden-error.yaml"
+    default:
+      $ref: "../../shared/responses/generic-error.yaml"
+post:
+  operationId: createComponentPolicy
+  summary: Create a component policy
+  description: |-
+    The CEL condition is compiled server-side; compilation failures are
+    rejected with a 400 response. The policy applies to every BOM ingest,
+    portfolio-wide: components matching the condition get a license
+    curation with the given license and details. Manual curations always
+    win over policies.
+
+    Requires permission `POLICY_MANAGEMENT`.
+  tags:
+    - Component Policies
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "./schemas/upsert-component-policy-request.yaml"
+  responses:
+    "201":
+      description: Policy created
+      headers:
+        Location:
+          description: URL of the created policy
+          schema:
+            type: string
+            format: uri
+    "400":
+      description: Bad Request
+      content:
+        application/problem+json:
+          schema:
+            anyOf:
+              - $ref: "../../shared/schemas/invalid-request-problem-details.yaml"
+              - $ref: "../../shared/schemas/problem-details.yaml"
+    "401":
+      $ref: "../../shared/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../../shared/responses/generic-forbidden-error.yaml"
+    "409":
+      $ref: "../../shared/responses/generic-conflict-error.yaml"
+    default:
+      $ref: "../../shared/responses/generic-error.yaml"

--- a/api/src/main/openapi/resources/component-policies/component-policy.yaml
+++ b/api/src/main/openapi/resources/component-policies/component-policy.yaml
@@ -1,0 +1,77 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+parameters:
+  - name: id
+    in: path
+    description: ID of the component policy
+    required: true
+    schema:
+      type: integer
+      format: int64
+put:
+  operationId: updateComponentPolicy
+  summary: Update a component policy
+  description: |-
+    Requires permission `POLICY_MANAGEMENT`.
+  tags:
+    - Component Policies
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "./schemas/upsert-component-policy-request.yaml"
+  responses:
+    "204":
+      description: Policy updated
+    "400":
+      description: Bad Request
+      content:
+        application/problem+json:
+          schema:
+            anyOf:
+              - $ref: "../../shared/schemas/invalid-request-problem-details.yaml"
+              - $ref: "../../shared/schemas/problem-details.yaml"
+    "401":
+      $ref: "../../shared/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../../shared/responses/generic-forbidden-error.yaml"
+    "404":
+      $ref: "../../shared/responses/generic-not-found-error.yaml"
+    default:
+      $ref: "../../shared/responses/generic-error.yaml"
+delete:
+  operationId: deleteComponentPolicy
+  summary: Delete a component policy
+  description: |-
+    Analyses applied by the policy are kept, including their audit
+    trails; they become manual analyses.
+
+    Requires permission `POLICY_MANAGEMENT`.
+  tags:
+    - Component Policies
+  responses:
+    "204":
+      description: Policy deleted
+    "401":
+      $ref: "../../shared/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../../shared/responses/generic-forbidden-error.yaml"
+    "404":
+      $ref: "../../shared/responses/generic-not-found-error.yaml"
+    default:
+      $ref: "../../shared/responses/generic-error.yaml"

--- a/api/src/main/openapi/resources/component-policies/schemas/component-policy.yaml
+++ b/api/src/main/openapi/resources/component-policies/schemas/component-policy.yaml
@@ -1,0 +1,55 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  id:
+    type: integer
+    format: int64
+  name:
+    type: string
+  description:
+    type: string
+  author:
+    type: string
+  enabled:
+    type: boolean
+  priority:
+    type: integer
+    format: int32
+    description: Evaluation order, ascending; first matching policy wins
+  condition:
+    type: string
+    description: CEL expression over component, project, now
+  license:
+    type: string
+    description: SPDX license ID or custom license name applied on match
+  details:
+    type: string
+  valid_from:
+    type: string
+    format: date-time
+    description: Policy applies only from this time on
+  valid_until:
+    type: string
+    format: date-time
+    description: Policy applies only until this time
+required:
+  - id
+  - name
+  - enabled
+  - priority
+  - condition

--- a/api/src/main/openapi/resources/component-policies/schemas/list-component-policies-response.yaml
+++ b/api/src/main/openapi/resources/component-policies/schemas/list-component-policies-response.yaml
@@ -1,0 +1,24 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  policies:
+    type: array
+    items:
+      $ref: "./component-policy.yaml"
+required:
+  - policies

--- a/api/src/main/openapi/resources/component-policies/schemas/upsert-component-policy-request.yaml
+++ b/api/src/main/openapi/resources/component-policies/schemas/upsert-component-policy-request.yaml
@@ -1,0 +1,51 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  name:
+    type: string
+    minLength: 1
+  description:
+    type: string
+  enabled:
+    type: boolean
+    default: true
+  priority:
+    type: integer
+    format: int32
+    default: 0
+  condition:
+    type: string
+    minLength: 1
+    description: CEL expression over component, project, now
+  license:
+    type: string
+    description: SPDX license ID or custom license name applied on match
+  details:
+    type: string
+    description: Free-text note written onto matched components
+  valid_from:
+    type: string
+    format: date-time
+    description: Policy applies only from this time on
+  valid_until:
+    type: string
+    format: date-time
+    description: Policy applies only until this time
+required:
+  - name
+  - condition

--- a/api/src/main/openapi/resources/components/components.yaml
+++ b/api/src/main/openapi/resources/components/components.yaml
@@ -17,7 +17,12 @@
 post:
   operationId: createComponent
   summary: Creates a new component for the project
-  description: Requires permission `PORTFOLIO_MANAGEMENT` or `PORTFOLIO_MANAGEMENT_UPDATE`
+  description: |-
+    The created component is flagged as manually created: it stays editable
+    and survives BOM synchronization. Components imported from BOM uploads
+    are read-only and curated via component analyses or component policies.
+
+    Requires permission `PORTFOLIO_MANAGEMENT` or `PORTFOLIO_MANAGEMENT_UPDATE`
   tags:
     - Components
   requestBody:

--- a/apiserver/src/main/java/org/dependencytrack/componentanalysis/ComponentAnalysisApplier.java
+++ b/apiserver/src/main/java/org/dependencytrack/componentanalysis/ComponentAnalysisApplier.java
@@ -1,0 +1,130 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.componentanalysis;
+
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.License;
+import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.persistence.jdbi.ComponentAnalysisDao;
+import org.dependencytrack.persistence.jdbi.ComponentAnalysisDao.ComponentAnalysis;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
+
+/**
+ * Re-applies durable component analyses (license curation) onto a project's
+ * components during BOM ingest.
+ * <p>
+ * BOM ingest overwrites component license fields with whatever the uploaded
+ * BOM declares; analyses are identity-keyed records that survive uploads and
+ * are re-applied here on every ingest — after the BOM's own license
+ * resolution and before policy evaluation, so LICENSE policy violations are
+ * evaluated against the curated license.
+ */
+public final class ComponentAnalysisApplier {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ComponentAnalysisApplier.class);
+
+    private final QueryManager qm;
+    private final Map<IdentityKey, ComponentAnalysis> analysesByIdentity;
+    private final Map<Long, License> licenseCache = new HashMap<>();
+    private int appliedCount;
+
+    private ComponentAnalysisApplier(final QueryManager qm, final Map<IdentityKey, ComponentAnalysis> analysesByIdentity) {
+        this.qm = qm;
+        this.analysesByIdentity = analysesByIdentity;
+    }
+
+    public static ComponentAnalysisApplier forProject(final QueryManager qm, final long projectId) {
+        final List<ComponentAnalysis> analyses = withJdbiHandle(
+                handle -> new ComponentAnalysisDao(handle).getAllByProject(projectId));
+        return new ComponentAnalysisApplier(qm, analyses.stream()
+                .collect(Collectors.toMap(
+                        analysis -> new IdentityKey(analysis.purl(), analysis.group(), analysis.name(), analysis.version()),
+                        Function.identity(),
+                        (previous, duplicate) -> previous)));
+    }
+
+    /**
+     * Applies the component's analysis, if one exists. Must be called on the
+     * persistent component AFTER field synchronization from the BOM — the
+     * override must win over the BOM-declared license.
+     */
+    public void apply(final Component component) {
+        if (analysesByIdentity.isEmpty()) {
+            return;
+        }
+        final ComponentAnalysis analysis = analysesByIdentity.get(new IdentityKey(
+                component.getPurl() != null ? component.getPurl().canonicalize() : null,
+                component.getGroup(), component.getName(), component.getVersion()));
+        if (analysis == null) {
+            return;
+        }
+        if (analysis.licenseId() != null) {
+            final License license = licenseCache.computeIfAbsent(
+                    analysis.licenseId(), id -> qm.getObjectById(License.class, id));
+            if (license != null) {
+                // refresh the declared snapshot from what this upload brought,
+                // BEFORE overriding — clearing the override restores it
+                withJdbiHandle(handle -> {
+                    new ComponentAnalysisDao(handle).updateDeclaredSnapshot(
+                            analysis.id(),
+                            component.getResolvedLicense() != null
+                                    ? component.getResolvedLicense().getId() : null,
+                            component.getLicense(),
+                            component.getLicenseExpression());
+                    return null;
+                });
+                component.setResolvedLicense(license);
+                component.setLicenseExpression(null);
+            } else {
+                LOGGER.warn("Component analysis {} references a license that no longer exists; skipping license override", analysis.id());
+            }
+        }
+        if (analysis.details() != null) {
+            component.setNotes(analysis.details());
+        }
+        appliedCount++;
+    }
+
+    public int appliedCount() {
+        return appliedCount;
+    }
+
+    /**
+     * Identity used for matching, null-normalized so it behaves identically
+     * to the COALESCE-based unique index on COMPONENT_ANALYSIS.
+     */
+    private record IdentityKey(String purl, String group, String name, String version) {
+        private IdentityKey {
+            purl = Objects.requireNonNullElse(purl, "");
+            group = Objects.requireNonNullElse(group, "");
+            name = Objects.requireNonNullElse(name, "");
+            version = Objects.requireNonNullElse(version, "");
+        }
+    }
+}

--- a/apiserver/src/main/java/org/dependencytrack/model/Component.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/Component.java
@@ -336,6 +336,15 @@ public class Component implements Serializable {
     @JsonProperty("isInternal")
     private Boolean internal;
 
+    // True only for components created by hand through the REST API; BOM
+    // imports leave it false. Manual components stay editable and are never
+    // deleted by BOM synchronization. When a BOM component matches a manual
+    // component's identity, the BOM takes ownership: the flag clears and the
+    // component becomes read-only.
+    @Persistent
+    @Column(name = "MANUALLY_CREATED", allowsNull = "true")
+    private Boolean manuallyCreated;
+
     @Persistent
     @Column(name = "DESCRIPTION", jdbcType = "VARCHAR", length = 1024)
     @Size(max = 1024)
@@ -736,6 +745,17 @@ public class Component implements Serializable {
 
     public void setInternal(boolean internal) {
         this.internal = internal;
+    }
+
+    public boolean isManuallyCreated() {
+        if (manuallyCreated == null) {
+            return false;
+        }
+        return manuallyCreated;
+    }
+
+    public void setManuallyCreated(boolean manuallyCreated) {
+        this.manuallyCreated = manuallyCreated;
     }
 
     public String getDescription() {

--- a/apiserver/src/main/java/org/dependencytrack/model/sqlmapping/ComponentProjection.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/sqlmapping/ComponentProjection.java
@@ -73,6 +73,8 @@ public class ComponentProjection {
 
     public Boolean internal;
 
+    public Boolean manuallyCreated;
+
     public Double lastInheritedRiskScore;
 
     public String md5;
@@ -181,6 +183,9 @@ public class ComponentProjection {
         componentPersistent.setId(result.id);
         if (result.internal != null) {
             componentPersistent.setInternal(result.internal);
+        }
+        if (result.manuallyCreated != null) {
+            componentPersistent.setManuallyCreated(result.manuallyCreated);
         }
         componentPersistent.setScope(result.scope != null ? Scope.valueOf(result.scope) : null);
         componentPersistent.setNotes(result.text);

--- a/apiserver/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -138,6 +138,7 @@ final class ComponentQueryManager extends QueryManager {
                         "A0"."FILENAME" AS "filename",
                         "A0"."GROUP" AS "group",
                         "A0"."INTERNAL" AS "internal",
+                        "A0"."MANUALLY_CREATED" AS "manuallyCreated",
                         "A0"."LAST_RISKSCORE" AS "lastInheritedRiskScore",
                         "A0"."LICENSE" AS "componentLicenseName",
                         "A0"."LICENSE_EXPRESSION" AS "licenseExpression",

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ComponentAnalysisDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ComponentAnalysisDao.java
@@ -1,0 +1,381 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.jdbi;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Access to durable, identity-keyed component analyses (license curation).
+ * <p>
+ * Component records are deleted and recreated across BOM uploads; a component
+ * analysis is therefore keyed by the component's identity (purl, or
+ * group/name/version) within a project, and re-applied on every ingest by
+ * {@code ImportBomActivity}.
+ */
+public final class ComponentAnalysisDao {
+
+    private final Handle handle;
+
+    public ComponentAnalysisDao(final Handle handle) {
+        this.handle = handle;
+    }
+
+    public record ComponentAnalysis(
+            long id,
+            long projectId,
+            @Nullable String purl,
+            @Nullable String group,
+            String name,
+            @Nullable String version,
+            @Nullable Long licenseId,
+            @Nullable Long declaredLicenseId,
+            @Nullable String declaredLicenseName,
+            @Nullable String declaredLicenseExpression,
+            @Nullable String details,
+            @Nullable Long policyId) {
+    }
+
+    public record ComponentAnalysisComment(
+            long id,
+            Instant timestamp,
+            @Nullable String commenter,
+            String comment) {
+    }
+
+    private static final RowMapper<ComponentAnalysis> ANALYSIS_ROW_MAPPER = (rs, ctx) -> new ComponentAnalysis(
+            rs.getLong("ID"),
+            rs.getLong("PROJECT_ID"),
+            rs.getString("PURL"),
+            rs.getString("GROUP"),
+            rs.getString("NAME"),
+            rs.getString("VERSION"),
+            rs.getObject("LICENSE_ID", Long.class),
+            rs.getObject("DECLARED_LICENSE_ID", Long.class),
+            rs.getString("DECLARED_LICENSE_NAME"),
+            rs.getString("DECLARED_LICENSE_EXPRESSION"),
+            rs.getString("DETAILS"),
+            rs.getObject("POLICY_ID", Long.class));
+
+    private static final RowMapper<ComponentAnalysisComment> COMMENT_ROW_MAPPER = (rs, ctx) -> new ComponentAnalysisComment(
+            rs.getLong("ID"),
+            rs.getTimestamp("TIMESTAMP").toInstant(),
+            rs.getString("COMMENTER"),
+            rs.getString("COMMENT"));
+
+    /**
+     * All analyses of one project, for bulk matching during BOM ingest.
+     */
+    public List<ComponentAnalysis> getAllByProject(final long projectId) {
+        return handle.createQuery("""
+                        SELECT "ID", "PROJECT_ID", "PURL", "GROUP", "NAME", "VERSION",
+                               "LICENSE_ID", "DECLARED_LICENSE_ID", "DECLARED_LICENSE_NAME",
+                               "DECLARED_LICENSE_EXPRESSION", "DETAILS", "POLICY_ID"
+                          FROM "COMPONENT_ANALYSIS"
+                         WHERE "PROJECT_ID" = :projectId
+                        """)
+                .bind("projectId", projectId)
+                .map(ANALYSIS_ROW_MAPPER)
+                .list();
+    }
+
+    public Optional<ComponentAnalysis> getByIdentity(
+            final long projectId,
+            @Nullable final String purl,
+            @Nullable final String group,
+            final String name,
+            @Nullable final String version) {
+        return handle.createQuery("""
+                        SELECT "ID", "PROJECT_ID", "PURL", "GROUP", "NAME", "VERSION",
+                               "LICENSE_ID", "DECLARED_LICENSE_ID", "DECLARED_LICENSE_NAME",
+                               "DECLARED_LICENSE_EXPRESSION", "DETAILS", "POLICY_ID"
+                          FROM "COMPONENT_ANALYSIS"
+                         WHERE "PROJECT_ID" = :projectId
+                           AND COALESCE("PURL", '') = COALESCE(:purl, '')
+                           AND COALESCE("GROUP", '') = COALESCE(:group, '')
+                           AND "NAME" = :name
+                           AND COALESCE("VERSION", '') = COALESCE(:version, '')
+                        """)
+                .bind("projectId", projectId)
+                .bind("purl", purl)
+                .bind("group", group)
+                .bind("name", name)
+                .bind("version", version)
+                .map(ANALYSIS_ROW_MAPPER)
+                .findOne();
+    }
+
+    /**
+     * Create-or-update keyed by the identity unique index; returns the row id.
+     */
+    public long upsert(
+            final long projectId,
+            @Nullable final String purl,
+            @Nullable final String group,
+            final String name,
+            @Nullable final String version,
+            @Nullable final Long licenseId,
+            @Nullable final String details) {
+        return handle.createQuery("""
+                        INSERT INTO "COMPONENT_ANALYSIS"
+                          ("PROJECT_ID", "PURL", "GROUP", "NAME", "VERSION",
+                           "LICENSE_ID", "DETAILS")
+                        VALUES
+                          (:projectId, :purl, :group, :name, :version,
+                           :licenseId, :details)
+                        ON CONFLICT ("PROJECT_ID", COALESCE("PURL", ''), COALESCE("GROUP", ''),
+                                     "NAME", COALESCE("VERSION", ''))
+                        DO UPDATE
+                           SET "LICENSE_ID" = EXCLUDED."LICENSE_ID"
+                             , "DETAILS" = EXCLUDED."DETAILS"
+                             , "POLICY_ID" = NULL
+                             , "UPDATED_AT" = NOW()
+                        RETURNING "ID"
+                        """)
+                .bind("projectId", projectId)
+                .bind("purl", purl)
+                .bind("group", group)
+                .bind("name", name)
+                .bind("version", version)
+                .bind("licenseId", licenseId)
+                .bind("details", details)
+                .mapTo(Long.class)
+                .one();
+    }
+
+    /**
+     * Applies an analysis to the project's currently matching component rows
+     * (the ingest hook does the same on every later BOM upload). Details are
+     * written to the component notes; a license override also clears a
+     * BOM-declared multi-license expression.
+     */
+    public int applyToComponents(
+            final long projectId,
+            @Nullable final String purl,
+            @Nullable final String group,
+            final String name,
+            @Nullable final String version,
+            @Nullable final Long licenseId,
+            @Nullable final String details) {
+        return handle.createUpdate("""
+                        UPDATE "COMPONENT"
+                           SET "LICENSE_ID" = COALESCE(:licenseId, "LICENSE_ID")
+                             , "LICENSE_EXPRESSION" = CASE WHEN :licenseId IS NULL
+                                                           THEN "LICENSE_EXPRESSION" ELSE NULL END
+                             , "TEXT" = COALESCE(:details, "TEXT")
+                         WHERE "PROJECT_ID" = :projectId
+                           AND COALESCE("PURL", '') = COALESCE(:purl, '')
+                           AND COALESCE("GROUP", '') = COALESCE(:group, '')
+                           AND "NAME" = :name
+                           AND COALESCE("VERSION", '') = COALESCE(:version, '')
+                        """)
+                .bind("projectId", projectId)
+                .bind("purl", purl)
+                .bind("group", group)
+                .bind("name", name)
+                .bind("version", version)
+                .bind("licenseId", licenseId)
+                .bind("details", details)
+                .execute();
+    }
+
+    /**
+     * Stores the BOM-declared license snapshot on an analysis; used to
+     * restore the uploaded value when the override is cleared.
+     */
+    public void updateDeclaredSnapshot(
+            final long analysisId,
+            @Nullable final Long declaredLicenseId,
+            @Nullable final String declaredLicenseName,
+            @Nullable final String declaredLicenseExpression) {
+        handle.createUpdate("""
+                        UPDATE "COMPONENT_ANALYSIS"
+                           SET "DECLARED_LICENSE_ID" = :declaredLicenseId
+                             , "DECLARED_LICENSE_NAME" = :declaredLicenseName
+                             , "DECLARED_LICENSE_EXPRESSION" = :declaredLicenseExpression
+                         WHERE "ID" = :analysisId
+                        """)
+                .bind("analysisId", analysisId)
+                .bind("declaredLicenseId", declaredLicenseId)
+                .bind("declaredLicenseName", declaredLicenseName)
+                .bind("declaredLicenseExpression", declaredLicenseExpression)
+                .execute();
+    }
+
+    /**
+     * Restores the declared-license snapshot onto the project's currently
+     * matching component rows — the instant part of clearing an override.
+     */
+    public int restoreDeclaredLicense(
+            final long projectId,
+            @Nullable final String purl,
+            @Nullable final String group,
+            final String name,
+            @Nullable final String version,
+            @Nullable final Long declaredLicenseId,
+            @Nullable final String declaredLicenseName,
+            @Nullable final String declaredLicenseExpression) {
+        return handle.createUpdate("""
+                        UPDATE "COMPONENT"
+                           SET "LICENSE_ID" = :declaredLicenseId
+                             , "LICENSE" = :declaredLicenseName
+                             , "LICENSE_EXPRESSION" = :declaredLicenseExpression
+                         WHERE "PROJECT_ID" = :projectId
+                           AND COALESCE("PURL", '') = COALESCE(:purl, '')
+                           AND COALESCE("GROUP", '') = COALESCE(:group, '')
+                           AND "NAME" = :name
+                           AND COALESCE("VERSION", '') = COALESCE(:version, '')
+                        """)
+                .bind("projectId", projectId)
+                .bind("purl", purl)
+                .bind("group", group)
+                .bind("name", name)
+                .bind("version", version)
+                .bind("declaredLicenseId", declaredLicenseId)
+                .bind("declaredLicenseName", declaredLicenseName)
+                .bind("declaredLicenseExpression", declaredLicenseExpression)
+                .execute();
+    }
+
+    public record ComponentLicenseRow(
+            @Nullable Long licenseId,
+            @Nullable String licenseName,
+            @Nullable String licenseExpression) {
+    }
+
+    /**
+     * Current license fields of the first component matching the identity —
+     * the values captured as the declared snapshot when an override is set.
+     */
+    public Optional<ComponentLicenseRow> getComponentLicense(
+            final long projectId,
+            @Nullable final String purl,
+            @Nullable final String group,
+            final String name,
+            @Nullable final String version) {
+        return handle.createQuery("""
+                        SELECT "LICENSE_ID", "LICENSE", "LICENSE_EXPRESSION"
+                          FROM "COMPONENT"
+                         WHERE "PROJECT_ID" = :projectId
+                           AND COALESCE("PURL", '') = COALESCE(:purl, '')
+                           AND COALESCE("GROUP", '') = COALESCE(:group, '')
+                           AND "NAME" = :name
+                           AND COALESCE("VERSION", '') = COALESCE(:version, '')
+                         LIMIT 1
+                        """)
+                .bind("projectId", projectId)
+                .bind("purl", purl)
+                .bind("group", group)
+                .bind("name", name)
+                .bind("version", version)
+                .map((rs, ctx) -> new ComponentLicenseRow(
+                        rs.getObject("LICENSE_ID", Long.class),
+                        rs.getString("LICENSE"),
+                        rs.getString("LICENSE_EXPRESSION")))
+                .findOne();
+    }
+
+    /**
+     * Create-or-update by a component policy. Manual analyses
+     * (POLICY_ID IS NULL) are never modified — the empty Optional says the
+     * policy lost to a manual decision.
+     */
+    public Optional<Long> upsertPolicyAnalysis(
+            final long projectId,
+            @Nullable final String purl,
+            @Nullable final String group,
+            final String name,
+            @Nullable final String version,
+            @Nullable final Long licenseId,
+            @Nullable final String details,
+            final long policyId) {
+        return handle.createQuery("""
+                        INSERT INTO "COMPONENT_ANALYSIS"
+                          ("PROJECT_ID", "PURL", "GROUP", "NAME", "VERSION",
+                           "LICENSE_ID", "DETAILS", "POLICY_ID")
+                        VALUES
+                          (:projectId, :purl, :group, :name, :version,
+                           :licenseId, :details, :policyId)
+                        ON CONFLICT ("PROJECT_ID", COALESCE("PURL", ''), COALESCE("GROUP", ''),
+                                     "NAME", COALESCE("VERSION", ''))
+                        DO UPDATE
+                           SET "LICENSE_ID" = EXCLUDED."LICENSE_ID"
+                             , "DETAILS" = EXCLUDED."DETAILS"
+                             , "POLICY_ID" = EXCLUDED."POLICY_ID"
+                             , "UPDATED_AT" = NOW()
+                         WHERE "COMPONENT_ANALYSIS"."POLICY_ID" IS NOT NULL
+                        RETURNING "ID"
+                        """)
+                .bind("projectId", projectId)
+                .bind("purl", purl)
+                .bind("group", group)
+                .bind("name", name)
+                .bind("version", version)
+                .bind("licenseId", licenseId)
+                .bind("details", details)
+                .bind("policyId", policyId)
+                .mapTo(Long.class)
+                .findOne();
+    }
+
+    public boolean delete(final long analysisId) {
+        return handle.createUpdate("""
+                        DELETE FROM "COMPONENT_ANALYSIS" WHERE "ID" = :id
+                        """)
+                .bind("id", analysisId)
+                .execute() > 0;
+    }
+
+    public record CreateCommentCommand(long componentAnalysisId, @Nullable String commenter, String comment) {
+    }
+
+    public int createComments(final Collection<CreateCommentCommand> commands) {
+        final var batch = handle.prepareBatch("""
+                INSERT INTO "COMPONENT_ANALYSIS_COMMENT"
+                  ("COMPONENT_ANALYSIS_ID", "COMMENTER", "COMMENT")
+                VALUES
+                  (:componentAnalysisId, :commenter, :comment)
+                """);
+        for (final CreateCommentCommand command : commands) {
+            batch.bind("componentAnalysisId", command.componentAnalysisId())
+                    .bind("commenter", command.commenter())
+                    .bind("comment", command.comment())
+                    .add();
+        }
+        return batch.execute().length;
+    }
+
+    public List<ComponentAnalysisComment> getComments(final long componentAnalysisId) {
+        return handle.createQuery("""
+                        SELECT "ID", "TIMESTAMP", "COMMENTER", "COMMENT"
+                          FROM "COMPONENT_ANALYSIS_COMMENT"
+                         WHERE "COMPONENT_ANALYSIS_ID" = :componentAnalysisId
+                         ORDER BY "TIMESTAMP", "ID"
+                        """)
+                .bind("componentAnalysisId", componentAnalysisId)
+                .map(COMMENT_ROW_MAPPER)
+                .list();
+    }
+}

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ComponentPolicyDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ComponentPolicyDao.java
@@ -1,0 +1,184 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.jdbi;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Access to component policies (automated license curation rules).
+ */
+public final class ComponentPolicyDao {
+
+    private final Handle handle;
+
+    public ComponentPolicyDao(final Handle handle) {
+        this.handle = handle;
+    }
+
+    public record ComponentPolicy(
+            long id,
+            String name,
+            @Nullable String description,
+            @Nullable String author,
+            boolean enabled,
+            int priority,
+            String condition,
+            @Nullable Long licenseId,
+            @Nullable String details,
+            @Nullable Instant validFrom,
+            @Nullable Instant validUntil) {
+    }
+
+    private static final RowMapper<ComponentPolicy> ROW_MAPPER = (rs, ctx) -> new ComponentPolicy(
+            rs.getLong("ID"),
+            rs.getString("NAME"),
+            rs.getString("DESCRIPTION"),
+            rs.getString("AUTHOR"),
+            rs.getBoolean("ENABLED"),
+            rs.getInt("PRIORITY"),
+            rs.getString("CONDITION"),
+            rs.getObject("LICENSE_ID", Long.class),
+            rs.getString("DETAILS"),
+            rs.getTimestamp("VALID_FROM") != null ? rs.getTimestamp("VALID_FROM").toInstant() : null,
+            rs.getTimestamp("VALID_UNTIL") != null ? rs.getTimestamp("VALID_UNTIL").toInstant() : null);
+
+    private static final String SELECT = """
+            SELECT "ID", "NAME", "DESCRIPTION", "AUTHOR", "ENABLED",
+                   "PRIORITY", "CONDITION", "LICENSE_ID", "DETAILS",
+                   "VALID_FROM", "VALID_UNTIL"
+              FROM "COMPONENT_POLICY"
+            """;
+
+    /**
+     * All policies, evaluation order: priority ascending, then name.
+     */
+    public List<ComponentPolicy> getAll() {
+        return handle.createQuery(SELECT + " ORDER BY \"PRIORITY\", \"NAME\"")
+                .map(ROW_MAPPER)
+                .list();
+    }
+
+    /**
+     * Enabled policies whose validity window (when set) contains now.
+     */
+    public List<ComponentPolicy> getAllEnabled() {
+        return handle.createQuery(SELECT
+                        + " WHERE \"ENABLED\""
+                        + " AND (\"VALID_FROM\" IS NULL OR \"VALID_FROM\" <= NOW())"
+                        + " AND (\"VALID_UNTIL\" IS NULL OR \"VALID_UNTIL\" >= NOW())"
+                        + " ORDER BY \"PRIORITY\", \"NAME\"")
+                .map(ROW_MAPPER)
+                .list();
+    }
+
+    public Optional<ComponentPolicy> getById(final long id) {
+        return handle.createQuery(SELECT + " WHERE \"ID\" = :id")
+                .bind("id", id)
+                .map(ROW_MAPPER)
+                .findOne();
+    }
+
+    public long create(
+            final String name,
+            @Nullable final String description,
+            @Nullable final String author,
+            final boolean enabled,
+            final int priority,
+            final String condition,
+            @Nullable final Long licenseId,
+            @Nullable final String details,
+            @Nullable final Instant validFrom,
+            @Nullable final Instant validUntil) {
+        return handle.createQuery("""
+                        INSERT INTO "COMPONENT_POLICY"
+                          ("NAME", "DESCRIPTION", "AUTHOR", "ENABLED",
+                           "PRIORITY", "CONDITION", "LICENSE_ID", "DETAILS",
+                           "VALID_FROM", "VALID_UNTIL")
+                        VALUES
+                          (:name, :description, :author, :enabled,
+                           :priority, :condition, :licenseId, :details,
+                           :validFrom, :validUntil)
+                        RETURNING "ID"
+                        """)
+                .bind("name", name)
+                .bind("description", description)
+                .bind("author", author)
+                .bind("enabled", enabled)
+                .bind("priority", priority)
+                .bind("condition", condition)
+                .bind("licenseId", licenseId)
+                .bind("details", details)
+                .bind("validFrom", validFrom)
+                .bind("validUntil", validUntil)
+                .mapTo(Long.class)
+                .one();
+    }
+
+    public boolean update(
+            final long id,
+            final String name,
+            @Nullable final String description,
+            final boolean enabled,
+            final int priority,
+            final String condition,
+            @Nullable final Long licenseId,
+            @Nullable final String details,
+            @Nullable final Instant validFrom,
+            @Nullable final Instant validUntil) {
+        return handle.createUpdate("""
+                        UPDATE "COMPONENT_POLICY"
+                           SET "NAME" = :name
+                             , "DESCRIPTION" = :description
+                             , "ENABLED" = :enabled
+                             , "PRIORITY" = :priority
+                             , "CONDITION" = :condition
+                             , "LICENSE_ID" = :licenseId
+                             , "DETAILS" = :details
+                             , "VALID_FROM" = :validFrom
+                             , "VALID_UNTIL" = :validUntil
+                             , "UPDATED_AT" = NOW()
+                         WHERE "ID" = :id
+                        """)
+                .bind("id", id)
+                .bind("name", name)
+                .bind("description", description)
+                .bind("enabled", enabled)
+                .bind("priority", priority)
+                .bind("condition", condition)
+                .bind("licenseId", licenseId)
+                .bind("details", details)
+                .bind("validFrom", validFrom)
+                .bind("validUntil", validUntil)
+                .execute() > 0;
+    }
+
+    public boolean delete(final long id) {
+        return handle.createUpdate("""
+                        DELETE FROM "COMPONENT_POLICY" WHERE "ID" = :id
+                        """)
+                .bind("id", id)
+                .execute() > 0;
+    }
+}

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelComponentPolicyApplier.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelComponentPolicyApplier.java
@@ -1,0 +1,316 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.policy.cel;
+
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import dev.cel.common.CelValidationException;
+import dev.cel.runtime.CelEvaluationException;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.License;
+import org.dependencytrack.persistence.jdbi.ComponentAnalysisDao;
+import org.dependencytrack.persistence.jdbi.ComponentAnalysisDao.CreateCommentCommand;
+import org.dependencytrack.persistence.jdbi.ComponentPolicyDao;
+import org.dependencytrack.persistence.jdbi.ComponentPolicyDao.ComponentPolicy;
+import org.dependencytrack.proto.policy.v1.Project;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.inJdbiTransaction;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
+
+/**
+ * Evaluates component policies (automated license curation rules) against a
+ * project's components during BOM ingest, maintaining the policy-owned
+ * component analyses. The first matching policy by priority wins; manual
+ * analyses are never touched.
+ */
+public final class CelComponentPolicyApplier {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CelComponentPolicyApplier.class);
+
+    private CelComponentPolicyApplier() {
+    }
+
+    public static void applyPolicies(final org.dependencytrack.model.Project project, final Collection<Component> components) {
+        final long projectId = project.getId();
+        if (components.isEmpty()) {
+            return;
+        }
+        final List<ComponentPolicy> policies = withJdbiHandle(
+                handle -> new ComponentPolicyDao(handle).getAllEnabled());
+        if (policies.isEmpty()) {
+            return;
+        }
+
+        // Compile conditions, preserving priority order.
+        final var compiler = CelPolicyCompiler.getInstance(CelPolicyType.COMPONENT);
+        final var programsByPolicyId = new LinkedHashMap<Long, CelPolicyProgram>();
+        final var policiesById = new LinkedHashMap<Long, ComponentPolicy>();
+        for (final ComponentPolicy policy : policies) {
+            try {
+                programsByPolicyId.put(policy.id(), compiler.compile(
+                        policy.condition(), CelPolicyCompiler.CacheMode.CACHE));
+                policiesById.put(policy.id(), policy);
+            } catch (CelValidationException e) {
+                LOGGER.warn("Failed to compile condition of component policy {}; skipping", policy.name(), e);
+            }
+        }
+        if (programsByPolicyId.isEmpty()) {
+            return;
+        }
+
+        // Protos are built from the in-flight JDO objects: at first upload the
+        // project and its components are not committed yet, so reading them
+        // back via JDBI would see nothing.
+        final Project.Builder projectBuilder = Project.newBuilder()
+                .setName(Objects.requireNonNullElse(project.getName(), ""))
+                .setVersion(Objects.requireNonNullElse(project.getVersion(), ""));
+        if (project.getUuid() != null) {
+            projectBuilder.setUuid(project.getUuid().toString());
+        }
+        final Project scriptArgProject = projectBuilder.build();
+
+        final var protoComponentsById = new java.util.HashMap<Long, org.dependencytrack.proto.policy.v1.Component>();
+        for (final Component component : components) {
+            final var builder = org.dependencytrack.proto.policy.v1.Component.newBuilder()
+                    .setName(Objects.requireNonNullElse(component.getName(), ""));
+            if (component.getUuid() != null) {
+                builder.setUuid(component.getUuid().toString());
+            }
+            if (component.getGroup() != null) {
+                builder.setGroup(component.getGroup());
+            }
+            if (component.getVersion() != null) {
+                builder.setVersion(component.getVersion());
+            }
+            if (component.getPurl() != null) {
+                builder.setPurl(component.getPurl().canonicalize());
+            }
+            if (component.getCpe() != null) {
+                builder.setCpe(component.getCpe());
+            }
+            if (component.getSwidTagId() != null) {
+                builder.setSwidTagId(component.getSwidTagId());
+            }
+            builder.setIsInternal(component.isInternal());
+            if (component.getLicense() != null) {
+                builder.setLicenseName(component.getLicense());
+            }
+            if (component.getLicenseExpression() != null) {
+                builder.setLicenseExpression(component.getLicenseExpression());
+            }
+            final License resolvedLicense = component.getResolvedLicense();
+            if (resolvedLicense != null) {
+                final var licenseBuilder = org.dependencytrack.proto.policy.v1.License.newBuilder();
+                if (resolvedLicense.getUuid() != null) {
+                    licenseBuilder.setUuid(resolvedLicense.getUuid().toString());
+                }
+                if (resolvedLicense.getLicenseId() != null) {
+                    licenseBuilder.setId(resolvedLicense.getLicenseId());
+                }
+                if (resolvedLicense.getName() != null) {
+                    licenseBuilder.setName(resolvedLicense.getName());
+                }
+                builder.setResolvedLicense(licenseBuilder);
+            }
+            protoComponentsById.put(component.getId(), builder.build());
+        }
+
+        final Timestamp protoNow = Timestamps.now();
+        int applied = 0;
+        final var matchedComponentIds = new java.util.HashSet<Long>();
+        for (final Component component : components) {
+            final var protoComponent = protoComponentsById.getOrDefault(
+                    component.getId(), org.dependencytrack.proto.policy.v1.Component.getDefaultInstance());
+            for (final var entry : programsByPolicyId.entrySet()) {
+                final ComponentPolicy policy = policiesById.get(entry.getKey());
+                final Map<String, Object> arguments = Map.ofEntries(
+                        Map.entry(CelPolicyVariable.COMPONENT.variableName(), protoComponent),
+                        Map.entry(CelPolicyVariable.PROJECT.variableName(), scriptArgProject),
+                        Map.entry(CelPolicyVariable.VULNS.variableName(), List.of()),
+                        Map.entry(CelPolicyVariable.NOW.variableName(), protoNow));
+                try {
+                    if (entry.getValue().execute(arguments)) {
+                        maintainAnalysis(projectId, component, policy);
+                        matchedComponentIds.add(component.getId());
+                        applied++;
+                        break;    // first match by priority wins
+                    }
+                } catch (CelEvaluationException e) {
+                    LOGGER.warn("Failed to evaluate condition of component policy {} for component {}",
+                            policy.name(), component.getName(), e);
+                    break;
+                }
+            }
+        }
+        if (applied > 0) {
+            LOGGER.info("Component policies matched {} component(s) of project {}", applied, projectId);
+        }
+
+        retractStaleAnalyses(projectId, components, matchedComponentIds, policiesById);
+    }
+
+    /**
+     * Clears policy-owned analyses of components no policy matches anymore
+     * (e.g. the component is now imported WITH a license): the BOM-declared
+     * state applies again. The analysis row and its audit trail are kept;
+     * manual analyses are never touched.
+     */
+    private static void retractStaleAnalyses(
+            final long projectId,
+            final Collection<Component> components,
+            final java.util.Set<Long> matchedComponentIds,
+            final Map<Long, ComponentPolicy> policiesById) {
+        final var unmatchedKeys = new java.util.HashMap<String, Component>();
+        for (final Component component : components) {
+            if (!matchedComponentIds.contains(component.getId())) {
+                unmatchedKeys.put(identityKey(
+                        component.getPurl() != null ? component.getPurl().canonicalize() : null,
+                        component.getGroup(), component.getName(), component.getVersion()), component);
+            }
+        }
+        if (unmatchedKeys.isEmpty()) {
+            return;
+        }
+        inJdbiTransaction(handle -> {
+            final var dao = new ComponentAnalysisDao(handle);
+            for (final ComponentAnalysisDao.ComponentAnalysis analysis : dao.getAllByProject(projectId)) {
+                if (analysis.policyId() == null
+                        || (analysis.licenseId() == null && analysis.details() == null)) {
+                    continue;
+                }
+                final String key = identityKey(analysis.purl(), analysis.group(),
+                        analysis.name(), analysis.version());
+                if (!unmatchedKeys.containsKey(key)) {
+                    continue;
+                }
+                dao.upsertPolicyAnalysis(
+                        projectId, analysis.purl(), analysis.group(),
+                        analysis.name(), analysis.version(),
+                        null, null, analysis.policyId());
+                final ComponentPolicy policy = policiesById.get(analysis.policyId());
+                final String commenter = policy != null
+                        ? policyCommenter(policy)
+                        : "[ComponentPolicy{Id=%d}]".formatted(analysis.policyId());
+                final var comments = new java.util.ArrayList<CreateCommentCommand>();
+                comments.add(new CreateCommentCommand(analysis.id(), commenter,
+                        "Retracted: condition no longer matches; the imported license applies"));
+                if (analysis.licenseId() != null) {
+                    comments.add(new CreateCommentCommand(analysis.id(), commenter,
+                            "License override: %s → not set".formatted(
+                                    licenseLabel(handle, analysis.licenseId()))));
+                }
+                if (analysis.details() != null) {
+                    comments.add(new CreateCommentCommand(analysis.id(), commenter,
+                            "Details: %s → not set".formatted(analysis.details())));
+                }
+                dao.createComments(comments);
+                LOGGER.info("Retracted component-policy analysis {} of project {}", analysis.id(), projectId);
+            }
+            return null;
+        });
+    }
+
+    private static String policyCommenter(final ComponentPolicy policy) {
+        return "[ComponentPolicy{Name=%s, Author=%s}]".formatted(
+                policy.name(), Objects.requireNonNullElse(policy.author(), "?"));
+    }
+
+    /**
+     * Display label of a license: its SPDX ID, or the name for custom ones.
+     */
+    private static String licenseLabel(final org.jdbi.v3.core.Handle handle, final Long licenseId) {
+        if (licenseId == null) {
+            return "not set";
+        }
+        return handle.createQuery("""
+                        SELECT COALESCE("LICENSEID", "NAME") FROM "LICENSE" WHERE "ID" = :id
+                        """)
+                .bind("id", licenseId)
+                .mapTo(String.class)
+                .findOne()
+                .orElse("unknown");
+    }
+
+    private static String identityKey(final String purl, final String group,
+                                      final String name, final String version) {
+        return String.join("|",
+                Objects.requireNonNullElse(purl, ""),
+                Objects.requireNonNullElse(group, ""),
+                Objects.requireNonNullElse(name, ""),
+                Objects.requireNonNullElse(version, ""));
+    }
+
+    /**
+     * Creates or converges the policy-owned analysis of a matched component,
+     * with audit comments on every effective change. Manual analyses win.
+     */
+    private static void maintainAnalysis(final long projectId, final Component component, final ComponentPolicy policy) {
+        final String purl = component.getPurl() != null ? component.getPurl().canonicalize() : null;
+        inJdbiTransaction(handle -> {
+            final var dao = new ComponentAnalysisDao(handle);
+            final ComponentAnalysisDao.ComponentAnalysis existing = dao.getByIdentity(
+                    projectId, purl, component.getGroup(),
+                    component.getName(), component.getVersion()).orElse(null);
+            if (existing != null && existing.policyId() == null) {
+                return null;    // manual analysis wins
+            }
+            if (existing != null
+                    && Objects.equals(existing.licenseId(), policy.licenseId())
+                    && Objects.equals(existing.details(), policy.details())
+                    && Objects.equals(existing.policyId(), policy.id())) {
+                return null;    // already converged, keep the audit trail quiet
+            }
+            final Long analysisId = dao.upsertPolicyAnalysis(
+                    projectId, purl, component.getGroup(),
+                    component.getName(), component.getVersion(),
+                    policy.licenseId(), policy.details(), policy.id()).orElse(null);
+            if (analysisId == null) {
+                return null;    // raced by a manual analysis
+            }
+            final String commenter = policyCommenter(policy);
+            final var comments = new java.util.ArrayList<CreateCommentCommand>();
+            comments.add(new CreateCommentCommand(analysisId, commenter,
+                    "Matched on condition: " + policy.condition()));
+            final Long oldLicenseId = existing != null ? existing.licenseId() : null;
+            if (!Objects.equals(oldLicenseId, policy.licenseId())) {
+                comments.add(new CreateCommentCommand(analysisId, commenter,
+                        "License override: %s → %s".formatted(
+                                licenseLabel(handle, oldLicenseId),
+                                licenseLabel(handle, policy.licenseId()))));
+            }
+            final String oldDetails = existing != null ? existing.details() : null;
+            if (!Objects.equals(oldDetails, policy.details())) {
+                comments.add(new CreateCommentCommand(analysisId, commenter,
+                        "Details: %s → %s".formatted(
+                                Objects.requireNonNullElse(oldDetails, "not set"),
+                                Objects.requireNonNullElse(policy.details(), "not set"))));
+            }
+            dao.createComments(comments);
+            return null;
+        });
+    }
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ComponentPropertyResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ComponentPropertyResource.java
@@ -128,7 +128,8 @@ public class ComponentPropertyResource extends AbstractConfigPropertyResource {
                     description = "Access to the requested project is forbidden",
                     content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The component could not be found"),
-            @ApiResponse(responseCode = "409", description = "A property with the specified component/group/name combination already exists")
+            @ApiResponse(responseCode = "409", description = "A property with the specified component/group/name combination already exists"),
+            @ApiResponse(responseCode = "405", description = "The component was imported from a BOM and is read-only; only manually created components can be modified")
     })
     @PermissionRequired({
             Permissions.Constants.PORTFOLIO_MANAGEMENT,
@@ -155,6 +156,9 @@ public class ComponentPropertyResource extends AbstractConfigPropertyResource {
                             .build();
                 }
                 requireAccess(qm, component.getProject());
+                if (!component.isManuallyCreated()) {
+                    return importedComponentsAreReadOnly();
+                }
 
                 final List<ComponentProperty> existingProperties = qm.getComponentProperties(
                         component, request.groupName(), request.propertyName());
@@ -206,6 +210,7 @@ public class ComponentPropertyResource extends AbstractConfigPropertyResource {
                     description = "Access to the requested project is forbidden",
                     content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The component or component property could not be found"),
+            @ApiResponse(responseCode = "405", description = "The component was imported from a BOM and is read-only; only manually created components can be modified")
     })
     @PermissionRequired({
             Permissions.Constants.PORTFOLIO_MANAGEMENT,
@@ -221,6 +226,9 @@ public class ComponentPropertyResource extends AbstractConfigPropertyResource {
                 final Component component = qm.getObjectByUuid(Component.class, componentUuid);
                 if (component != null) {
                     requireAccess(qm, component.getProject());
+                    if (!component.isManuallyCreated()) {
+                        return importedComponentsAreReadOnly();
+                    }
                     final long propertiesDeleted = qm.deleteComponentPropertyByUuid(
                             component, UUID.fromString(propertyUuid));
                     if (propertiesDeleted > 0) {
@@ -243,4 +251,15 @@ public class ComponentPropertyResource extends AbstractConfigPropertyResource {
         }
     }
 
+    /**
+     * Imported components are managed exclusively by SBOM uploads; license
+     * curation happens via component analyses and component policies. Only
+     * components that were created manually through the REST API may be
+     * modified or deleted.
+     */
+    private static Response importedComponentsAreReadOnly() {
+        return Response.status(Response.Status.METHOD_NOT_ALLOWED)
+                .entity("Imported components are read-only: they are managed by SBOM uploads and curated via component analyses or component policies. Only manually created components can be modified.")
+                .build();
+    }
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -418,6 +418,7 @@ public class ComponentResource extends AbstractApiResource {
                 }
                 component.setParent(parent);
                 component.setNotes(StringUtils.trimToNull(jsonComponent.getNotes()));
+                component.setManuallyCreated(true);
 
                 qm.createComponent(component, true);
 
@@ -445,6 +446,7 @@ public class ComponentResource extends AbstractApiResource {
                     description = "Access to the requested project is forbidden",
                     content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The UUID of the component could not be found"),
+            @ApiResponse(responseCode = "405", description = "The component was imported from a BOM and is read-only; only manually created components can be modified"),
     })
     @PermissionRequired({Permissions.Constants.PORTFOLIO_MANAGEMENT, Permissions.Constants.PORTFOLIO_MANAGEMENT_UPDATE})
     public Response updateComponent(Component jsonComponent) {
@@ -483,6 +485,9 @@ public class ComponentResource extends AbstractApiResource {
                 final Component component = qm.getObjectByUuid(Component.class, jsonComponent.getUuid());
                 if (component != null) {
                     requireAccess(qm, component.getProject());
+                    if (!component.isManuallyCreated()) {
+                        return importedComponentsAreReadOnly();
+                    }
                     // Name cannot be empty or null - prevent it
                     final String name = StringUtils.trimToNull(jsonComponent.getName());
                     if (name != null) {
@@ -566,7 +571,8 @@ public class ComponentResource extends AbstractApiResource {
                     responseCode = "403",
                     description = "Access to the requested project is forbidden",
                     content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
-            @ApiResponse(responseCode = "404", description = "The UUID of the component could not be found")
+            @ApiResponse(responseCode = "404", description = "The UUID of the component could not be found"),
+            @ApiResponse(responseCode = "405", description = "The component was imported from a BOM and is read-only; only manually created components can be modified"),
     })
     @PermissionRequired({Permissions.Constants.PORTFOLIO_MANAGEMENT, Permissions.Constants.PORTFOLIO_MANAGEMENT_DELETE})
     public Response deleteComponent(
@@ -577,6 +583,9 @@ public class ComponentResource extends AbstractApiResource {
                 final Component component = qm.getObjectByUuid(Component.class, uuid, Component.FetchGroup.ALL.name());
                 if (component != null) {
                     requireAccess(qm, component.getProject());
+                    if (!component.isManuallyCreated()) {
+                        return importedComponentsAreReadOnly();
+                    }
                     try (final Handle jdbiHandle = openJdbiHandle()) {
                         final var componentDao = jdbiHandle.attach(ComponentDao.class);
                         componentDao.deleteComponent(component.getUuid());
@@ -692,4 +701,15 @@ public class ComponentResource extends AbstractApiResource {
         return Response.ok(occurrences).header(TOTAL_COUNT_HEADER, totalCount).build();
     }
 
+    /**
+     * Imported components are managed exclusively by SBOM uploads; license
+     * curation happens via component analyses and component policies. Only
+     * components that were created manually through the REST API may be
+     * modified or deleted.
+     */
+    private static Response importedComponentsAreReadOnly() {
+        return Response.status(Response.Status.METHOD_NOT_ALLOWED)
+                .entity("Imported components are read-only: they are managed by SBOM uploads and curated via component analyses or component policies. Only manually created components can be modified.")
+                .build();
+    }
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/ComponentAnalysesResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/ComponentAnalysesResource.java
@@ -1,0 +1,254 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v2;
+
+import alpine.server.auth.PermissionRequired;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.Provider;
+import org.dependencytrack.api.v2.ComponentAnalysesApi;
+import org.dependencytrack.api.v2.model.ComponentAnalysisComment;
+import org.dependencytrack.api.v2.model.CreateComponentAnalysisCommentRequest;
+import org.dependencytrack.api.v2.model.ListComponentAnalysesResponse;
+import org.dependencytrack.api.v2.model.ListComponentAnalysisCommentsResponse;
+import org.dependencytrack.api.v2.model.UpsertComponentAnalysisRequest;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.License;
+import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.resources.AbstractApiResource;
+import org.dependencytrack.persistence.jdbi.ComponentAnalysisDao;
+import org.dependencytrack.persistence.jdbi.ComponentAnalysisDao.ComponentAnalysis;
+import org.dependencytrack.persistence.jdbi.ComponentAnalysisDao.CreateCommentCommand;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.inJdbiTransaction;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
+
+/**
+ * REST resource for component analyses (durable license curation).
+ */
+@Provider
+public final class ComponentAnalysesResource extends AbstractApiResource implements ComponentAnalysesApi {
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Override
+    @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
+    public Response listComponentAnalyses(final UUID project) {
+        final long projectId = requireProjectId(project);
+        final List<ComponentAnalysis> analyses = withJdbiHandle(
+                handle -> new ComponentAnalysisDao(handle).getAllByProject(projectId));
+        final var items = new ArrayList<org.dependencytrack.api.v2.model.ComponentAnalysis>(analyses.size());
+        try (final var qm = new QueryManager()) {
+            for (final ComponentAnalysis analysis : analyses) {
+                items.add(mapAnalysis(qm, analysis));
+            }
+        }
+        return Response.ok(ListComponentAnalysesResponse.builder().analyses(items).build()).build();
+    }
+
+    @Override
+    @PermissionRequired(Permissions.Constants.POLICY_MANAGEMENT)
+    public Response updateComponentAnalysis(final UpsertComponentAnalysisRequest request) {
+        final long projectId = requireProjectId(request.getProjectUuid());
+
+        try (final var qm = new QueryManager()) {
+            final Long licenseId;
+            if (request.getLicense() != null) {
+                licenseId = resolveLicense(qm, request.getLicense()).getId();
+            } else {
+                licenseId = null;
+            }
+
+            final String commenter = getPrincipal().getName();
+            inJdbiTransaction(handle -> {
+                final var dao = new ComponentAnalysisDao(handle);
+                final ComponentAnalysis existing = dao.getByIdentity(
+                        projectId, request.getPurl(), request.getGroup(),
+                        request.getName(), request.getVersion()).orElse(null);
+                final long id = dao.upsert(
+                        projectId, request.getPurl(), request.getGroup(),
+                        request.getName(), request.getVersion(),
+                        licenseId, request.getDetails());
+                final var comments = new ArrayList<CreateCommentCommand>();
+                final Long oldLicenseId = existing != null ? existing.licenseId() : null;
+                if (!Objects.equals(oldLicenseId, licenseId)) {
+                    comments.add(new CreateCommentCommand(id, commenter,
+                            "License override: %s → %s".formatted(
+                                    oldLicenseId != null ? licenseLabel(qm, oldLicenseId) : "not set",
+                                    request.getLicense() != null ? request.getLicense() : "not set")));
+                }
+                final String oldDetails = existing != null ? existing.details() : null;
+                if (!Objects.equals(oldDetails, request.getDetails())) {
+                    comments.add(new CreateCommentCommand(id, commenter,
+                            "Details: %s → %s".formatted(
+                                    Objects.requireNonNullElse(oldDetails, "not set"),
+                                    Objects.requireNonNullElse(request.getDetails(), "not set"))));
+                }
+                if (!comments.isEmpty()) {
+                    dao.createComments(comments);
+                }
+                if (licenseId != null) {
+                    // first override on this component: snapshot the uploaded
+                    // license so clearing can restore it instantly
+                    if (existing == null || existing.licenseId() == null) {
+                        dao.getComponentLicense(
+                                projectId, request.getPurl(), request.getGroup(),
+                                request.getName(), request.getVersion())
+                            .ifPresent(row -> dao.updateDeclaredSnapshot(
+                                    id, row.licenseId(), row.licenseName(),
+                                    row.licenseExpression()));
+                    }
+                    dao.applyToComponents(
+                            projectId, request.getPurl(), request.getGroup(),
+                            request.getName(), request.getVersion(),
+                            licenseId, request.getDetails());
+                } else {
+                    if (existing != null && existing.licenseId() != null) {
+                        dao.restoreDeclaredLicense(
+                                projectId, request.getPurl(), request.getGroup(),
+                                request.getName(), request.getVersion(),
+                                existing.declaredLicenseId(),
+                                existing.declaredLicenseName(),
+                                existing.declaredLicenseExpression());
+                    }
+                    dao.applyToComponents(
+                            projectId, request.getPurl(), request.getGroup(),
+                            request.getName(), request.getVersion(),
+                            /* licenseId */ null, request.getDetails());
+                }
+                return null;
+            });
+            return Response.noContent().build();
+        }
+    }
+
+    @Override
+    @PermissionRequired(Permissions.Constants.POLICY_MANAGEMENT)
+    public Response deleteComponentAnalysis(final Long id) {
+        final boolean deleted = inJdbiTransaction(
+                handle -> new ComponentAnalysisDao(handle).delete(id));
+        if (!deleted) {
+            throw new NotFoundException();
+        }
+        return Response.noContent().build();
+    }
+
+    @Override
+    @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
+    public Response listComponentAnalysisComments(final Long id) {
+        final List<ComponentAnalysisDao.ComponentAnalysisComment> comments = withJdbiHandle(
+                handle -> new ComponentAnalysisDao(handle).getComments(id));
+        return Response.ok(ListComponentAnalysisCommentsResponse.builder()
+                .comments(comments.stream()
+                        .<ComponentAnalysisComment>map(comment -> ComponentAnalysisComment.builder()
+                                .timestamp(comment.timestamp().toEpochMilli())
+                                .commenter(comment.commenter())
+                                .comment(comment.comment())
+                                .build())
+                        .toList())
+                .build()).build();
+    }
+
+    @Override
+    @PermissionRequired(Permissions.Constants.POLICY_MANAGEMENT)
+    public Response createComponentAnalysisComment(final Long id, final CreateComponentAnalysisCommentRequest request) {
+        final String commenter = getPrincipal().getName();
+        inJdbiTransaction(handle -> new ComponentAnalysisDao(handle)
+                .createComments(List.of(new CreateCommentCommand(id, commenter, request.getComment()))));
+        return Response.created(uriInfo.getBaseUriBuilder()
+                        .path("/component-analyses")
+                        .path(String.valueOf(id))
+                        .path("/comments")
+                        .build())
+                .build();
+    }
+
+    private static long requireProjectId(final UUID uuid) {
+        final Long projectId = withJdbiHandle(handle -> handle
+                .createQuery("SELECT \"ID\" FROM \"PROJECT\" WHERE \"UUID\" = :uuid")
+                .bind("uuid", uuid)
+                .mapTo(Long.class)
+                .findOne()
+                .orElse(null));
+        if (projectId == null) {
+            throw new NotFoundException();
+        }
+        return projectId;
+    }
+
+    /**
+     * Resolves an SPDX license ID or (custom) license name; 400 when unknown —
+     * overrides must reference licenses DT can attach to components.
+     */
+    private static License resolveLicense(final QueryManager qm, final String licenseIdOrName) {
+        final License license = qm.getLicenseByIdOrName(licenseIdOrName);
+        if (license != null && license != License.UNRESOLVED) {
+            return license;
+        }
+        final License customLicense = qm.getCustomLicenseByName(licenseIdOrName);
+        if (customLicense != null && customLicense != License.UNRESOLVED) {
+            return customLicense;
+        }
+        throw new BadRequestException("License %s is not known; create it as a custom license first".formatted(licenseIdOrName));
+    }
+
+    /**
+     * Display label of a license: its SPDX ID, or the name for custom licenses.
+     */
+    private static String licenseLabel(final QueryManager qm, final long licenseId) {
+        final License license = qm.getObjectById(License.class, licenseId);
+        if (license == null) {
+            return "unknown";
+        }
+        return license.getLicenseId() != null ? license.getLicenseId() : license.getName();
+    }
+
+    private static org.dependencytrack.api.v2.model.ComponentAnalysis mapAnalysis(
+            final QueryManager qm, final ComponentAnalysis analysis) {
+        final String licenseIdOrName = analysis.licenseId() != null
+                ? licenseLabel(qm, analysis.licenseId())
+                : null;
+        String declaredLicense = analysis.declaredLicenseExpression();
+        if (declaredLicense == null && analysis.declaredLicenseId() != null) {
+            declaredLicense = licenseLabel(qm, analysis.declaredLicenseId());
+        }
+        if (declaredLicense == null) {
+            declaredLicense = analysis.declaredLicenseName();
+        }
+        return org.dependencytrack.api.v2.model.ComponentAnalysis.builder()
+                .id(analysis.id())
+                .purl(analysis.purl())
+                .group(analysis.group())
+                .name(analysis.name())
+                .version(analysis.version())
+                .license(licenseIdOrName)
+                .declaredLicense(declaredLicense)
+                .details(analysis.details())
+                .build();
+    }
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/ComponentPoliciesResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/ComponentPoliciesResource.java
@@ -1,0 +1,170 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v2;
+
+import alpine.server.auth.PermissionRequired;
+import dev.cel.common.CelValidationException;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.Provider;
+import org.dependencytrack.api.v2.ComponentPoliciesApi;
+import org.dependencytrack.api.v2.model.ComponentPolicy;
+import org.dependencytrack.api.v2.model.ListComponentPoliciesResponse;
+import org.dependencytrack.api.v2.model.UpsertComponentPolicyRequest;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.License;
+import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.persistence.jdbi.ComponentPolicyDao;
+import org.dependencytrack.resources.AbstractApiResource;
+import org.dependencytrack.policy.cel.CelPolicyCompiler;
+import org.dependencytrack.policy.cel.CelPolicyType;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.inJdbiTransaction;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
+
+/**
+ * REST resource for component policies (automated license curation rules).
+ */
+@Provider
+public final class ComponentPoliciesResource extends AbstractApiResource implements ComponentPoliciesApi {
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Override
+    @PermissionRequired(Permissions.Constants.POLICY_MANAGEMENT)
+    public Response listComponentPolicies() {
+        final List<ComponentPolicyDao.ComponentPolicy> policies = withJdbiHandle(
+                handle -> new ComponentPolicyDao(handle).getAll());
+        try (final var qm = new QueryManager()) {
+            return Response.ok(ListComponentPoliciesResponse.builder()
+                    .policies(policies.stream()
+                            .<ComponentPolicy>map(policy -> mapPolicy(qm, policy))
+                            .toList())
+                    .build()).build();
+        }
+    }
+
+    @Override
+    @PermissionRequired(Permissions.Constants.POLICY_MANAGEMENT)
+    public Response createComponentPolicy(final UpsertComponentPolicyRequest request) {
+        validateCondition(request.getCondition());
+        try (final var qm = new QueryManager()) {
+            final Long licenseId = resolveLicenseId(qm, request.getLicense());
+            final long id = inJdbiTransaction(handle -> new ComponentPolicyDao(handle).create(
+                    request.getName(), request.getDescription(), getPrincipal().getName(),
+                    Objects.requireNonNullElse(request.getEnabled(), true),
+                    Objects.requireNonNullElse(request.getPriority(), 0),
+                    request.getCondition(), licenseId, request.getDetails(),
+                    request.getValidFrom() != null ? request.getValidFrom().toInstant() : null,
+                    request.getValidUntil() != null ? request.getValidUntil().toInstant() : null));
+            return Response.created(uriInfo.getBaseUriBuilder()
+                            .path("/component-policies")
+                            .path(String.valueOf(id))
+                            .build())
+                    .build();
+        }
+    }
+
+    @Override
+    @PermissionRequired(Permissions.Constants.POLICY_MANAGEMENT)
+    public Response updateComponentPolicy(final Long id, final UpsertComponentPolicyRequest request) {
+        validateCondition(request.getCondition());
+        try (final var qm = new QueryManager()) {
+            final Long licenseId = resolveLicenseId(qm, request.getLicense());
+            final boolean updated = inJdbiTransaction(handle -> new ComponentPolicyDao(handle).update(
+                    id, request.getName(), request.getDescription(),
+                    Objects.requireNonNullElse(request.getEnabled(), true),
+                    Objects.requireNonNullElse(request.getPriority(), 0),
+                    request.getCondition(), licenseId, request.getDetails(),
+                    request.getValidFrom() != null ? request.getValidFrom().toInstant() : null,
+                    request.getValidUntil() != null ? request.getValidUntil().toInstant() : null));
+            if (!updated) {
+                throw new NotFoundException();
+            }
+            return Response.noContent().build();
+        }
+    }
+
+    @Override
+    @PermissionRequired(Permissions.Constants.POLICY_MANAGEMENT)
+    public Response deleteComponentPolicy(final Long id) {
+        final boolean deleted = inJdbiTransaction(
+                handle -> new ComponentPolicyDao(handle).delete(id));
+        if (!deleted) {
+            throw new NotFoundException();
+        }
+        return Response.noContent().build();
+    }
+
+    private static void validateCondition(final String condition) {
+        try {
+            CelPolicyCompiler.getInstance(CelPolicyType.COMPONENT)
+                    .compile(condition, CelPolicyCompiler.CacheMode.NO_CACHE);
+        } catch (CelValidationException e) {
+            throw new BadRequestException("Invalid CEL condition: " + e.getMessage());
+        }
+    }
+
+    private static Long resolveLicenseId(final QueryManager qm, final String licenseIdOrName) {
+        if (licenseIdOrName == null) {
+            return null;
+        }
+        final License license = qm.getLicenseByIdOrName(licenseIdOrName);
+        if (license != null && license != License.UNRESOLVED) {
+            return license.getId();
+        }
+        final License customLicense = qm.getCustomLicenseByName(licenseIdOrName);
+        if (customLicense != null && customLicense != License.UNRESOLVED) {
+            return customLicense.getId();
+        }
+        throw new BadRequestException("License %s is not known; create it as a custom license first".formatted(licenseIdOrName));
+    }
+
+    private static ComponentPolicy mapPolicy(final QueryManager qm, final ComponentPolicyDao.ComponentPolicy policy) {
+        String license = null;
+        if (policy.licenseId() != null) {
+            final License resolved = qm.getObjectById(License.class, policy.licenseId());
+            if (resolved != null) {
+                license = resolved.getLicenseId() != null ? resolved.getLicenseId() : resolved.getName();
+            }
+        }
+        return ComponentPolicy.builder()
+                .id(policy.id())
+                .name(policy.name())
+                .description(policy.description())
+                .author(policy.author())
+                .enabled(policy.enabled())
+                .priority(policy.priority())
+                .condition(policy.condition())
+                .license(license)
+                .details(policy.details())
+                .validFrom(policy.validFrom() != null
+                        ? policy.validFrom().atOffset(java.time.ZoneOffset.UTC) : null)
+                .validUntil(policy.validUntil() != null
+                        ? policy.validUntil().atOffset(java.time.ZoneOffset.UTC) : null)
+                .build();
+    }
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/ComponentsResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/ComponentsResource.java
@@ -364,6 +364,7 @@ public class ComponentsResource extends AbstractApiResource implements Component
             component.setResolvedLicense(null);
         }
         component.setNotes(StringUtils.trimToNull(request.getNotes()));
+        component.setManuallyCreated(true);
 
         qm.createComponent(component, true);
 

--- a/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
@@ -499,7 +499,10 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
                             return previous;
                         }));
 
+        // Manually created components are not part of any BOM and must
+        // survive synchronization.
         final Set<Long> idsOfComponentsToDelete = persistentComponents.stream()
+                .filter(component -> !component.isManuallyCreated())
                 .map(Component::getId)
                 .collect(Collectors.toSet());
 
@@ -550,6 +553,10 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
                 applyIfChanged(persistentComponent, component, Component::getLicenseUrl, persistentComponent::setLicenseUrl);
                 applyIfChanged(persistentComponent, component, Component::getLicenseExpression, persistentComponent::setLicenseExpression);
                 applyIfChanged(persistentComponent, component, Component::isInternal, persistentComponent::setInternal);
+                // A BOM component matching the identity of a manually created
+                // component takes it over: the flag clears and the component
+                // becomes read-only like any other imported component.
+                applyIfChanged(persistentComponent, component, Component::isManuallyCreated, persistentComponent::setManuallyCreated);
                 applyIfChanged(persistentComponent, component, Component::getExternalReferences, persistentComponent::setExternalReferences);
                 applyIfChanged(persistentComponent, component, Component::getScope, persistentComponent::setScope);
 

--- a/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
@@ -26,6 +26,7 @@ import org.cyclonedx.parsers.Parser;
 import org.datanucleus.flush.FlushMode;
 import org.dependencytrack.analysis.AnalyzeProjectWorkflow;
 import org.dependencytrack.common.Mappers;
+import org.dependencytrack.componentanalysis.ComponentAnalysisApplier;
 import org.dependencytrack.dex.api.Activity;
 import org.dependencytrack.dex.api.ActivityContext;
 import org.dependencytrack.dex.api.ActivitySpec;
@@ -585,6 +586,13 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
         if (componentsDeleted > 0) {
             qm.getPersistenceManager().flush();
         }
+
+        // Durable license curation, applied AFTER BOM field synchronization
+        // (overrides win over BOM-declared licenses) and before policy
+        // evaluation (LICENSE violations see the curated license).
+        final var componentAnalysisApplier = ComponentAnalysisApplier.forProject(qm, project.getId());
+        persistentComponentByIdentity.values().forEach(componentAnalysisApplier::apply);
+        qm.getPersistenceManager().flush();
 
         return persistentComponentByIdentity;
     }

--- a/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
@@ -27,6 +27,7 @@ import org.datanucleus.flush.FlushMode;
 import org.dependencytrack.analysis.AnalyzeProjectWorkflow;
 import org.dependencytrack.common.Mappers;
 import org.dependencytrack.componentanalysis.ComponentAnalysisApplier;
+import org.dependencytrack.policy.cel.CelComponentPolicyApplier;
 import org.dependencytrack.dex.api.Activity;
 import org.dependencytrack.dex.api.ActivityContext;
 import org.dependencytrack.dex.api.ActivitySpec;
@@ -589,7 +590,10 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
 
         // Durable license curation, applied AFTER BOM field synchronization
         // (overrides win over BOM-declared licenses) and before policy
-        // evaluation (LICENSE violations see the curated license).
+        // evaluation (LICENSE violations see the curated license): component
+        // policies maintain their analyses first, then all analyses are
+        // re-applied onto the synchronized components.
+        CelComponentPolicyApplier.applyPolicies(project, persistentComponentByIdentity.values());
         final var componentAnalysisApplier = ComponentAnalysisApplier.forProject(qm, project.getId());
         persistentComponentByIdentity.values().forEach(componentAnalysisApplier::apply);
         qm.getPersistenceManager().flush();

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/VulnerabilityDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/VulnerabilityDaoTest.java
@@ -19,8 +19,10 @@
 package org.dependencytrack.persistence.jdbi;
 
 import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.persistence.command.MakeAnalysisCommand;
 import org.jdbi.v3.core.Handle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,6 +76,44 @@ public class VulnerabilityDaoTest extends PersistenceCapableTest {
         attributions.forEach(fa -> fa.setDeletedAt(new Date()));
 
         assertThat(vulnerabilityDao.getVulnerableComponents(project.getId(), java.util.List.of(vuln.getId()))).isEmpty();
+    }
+
+    @Test
+    public void testGetVulnerabilitiesByComponentWithAnalysesOnSiblingComponents() {
+        final var project = qm.createProject("acme-app", null, "1.0.0", null, null, null, null, false);
+
+        final var componentA = new Component();
+        componentA.setProject(project);
+        componentA.setName("acme-lib-a");
+        componentA.setVersion("1.0.0");
+        qm.persist(componentA);
+
+        final var componentB = new Component();
+        componentB.setProject(project);
+        componentB.setName("acme-lib-b");
+        componentB.setVersion("1.0.0");
+        qm.persist(componentB);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("INT-123");
+        vuln.setSource(NVD);
+        qm.persist(vuln);
+
+        qm.addVulnerability(vuln, componentA, "internal", "Vuln1", "http://vuln.com/vuln1", new Date());
+        qm.addVulnerability(vuln, componentB, "internal", "Vuln1", "http://vuln.com/vuln1", new Date());
+        qm.makeAnalysis(new MakeAnalysisCommand(componentA, vuln)
+                .withState(AnalysisState.IN_TRIAGE));
+        qm.makeAnalysis(new MakeAnalysisCommand(componentB, vuln)
+                .withState(AnalysisState.NOT_AFFECTED)
+                .withSuppress(true));
+
+        // one row per vulnerability, even with analyses of the same
+        // vulnerability on sibling components of the project
+        assertThat(vulnerabilityDao.getVulnerabilitiesByComponent(componentA.getId(), true)).hasSize(1);
+        // the sibling's suppression must not hide component A's finding
+        assertThat(vulnerabilityDao.getVulnerabilitiesByComponent(componentA.getId(), false)).hasSize(1);
+        // component B's own suppression still applies
+        assertThat(vulnerabilityDao.getVulnerabilitiesByComponent(componentB.getId(), false)).isEmpty();
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ComponentPropertyResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ComponentPropertyResourceTest.java
@@ -181,6 +181,7 @@ public class ComponentPropertyResourceTest extends ResourceTest {
         final var component = new Component();
         component.setProject(project);
         component.setName("acme-lib");
+        component.setManuallyCreated(true);
         qm.persist(component);
 
         final Response response = jersey.target("%s/%s/property".formatted(V1_COMPONENT, component.getUuid())).request()
@@ -220,6 +221,7 @@ public class ComponentPropertyResourceTest extends ResourceTest {
         final var component = new Component();
         component.setProject(project);
         component.setName("acme-lib");
+        component.setManuallyCreated(true);
         qm.persist(component);
 
         final Response response = jersey.target("%s/%s/property".formatted(V1_COMPONENT, component.getUuid())).request()
@@ -257,6 +259,7 @@ public class ComponentPropertyResourceTest extends ResourceTest {
         final var component = new Component();
         component.setProject(project);
         component.setName("acme-lib");
+        component.setManuallyCreated(true);
         qm.persist(component);
 
         final var property = new ComponentProperty();
@@ -327,6 +330,7 @@ public class ComponentPropertyResourceTest extends ResourceTest {
         final var component = new Component();
         component.setProject(project);
         component.setName("acme-lib");
+        component.setManuallyCreated(true);
         qm.persist(component);
 
         final Supplier<Response> responseSupplier = () -> jersey
@@ -369,6 +373,7 @@ public class ComponentPropertyResourceTest extends ResourceTest {
         final var component = new Component();
         component.setProject(project);
         component.setName("acme-lib");
+        component.setManuallyCreated(true);
         qm.persist(component);
 
         final var property = new ComponentProperty();
@@ -399,6 +404,7 @@ public class ComponentPropertyResourceTest extends ResourceTest {
         final var component = new Component();
         component.setProject(project);
         component.setName("acme-lib");
+        component.setManuallyCreated(true);
         qm.persist(component);
 
         final var property = new ComponentProperty();
@@ -428,6 +434,66 @@ public class ComponentPropertyResourceTest extends ResourceTest {
 
         response = responseSupplier.get();
         assertThat(response.getStatus()).isEqualTo(204);
+    }
+
+    @Test
+    public void createPropertyOnImportedComponentTest() {
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_CREATE);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        qm.persist(component);
+
+        final Response response = jersey.target("%s/%s/property".formatted(V1_COMPONENT, component.getUuid())).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity("""
+                        {
+                          "groupName": "foo",
+                          "propertyName": "bar",
+                          "propertyValue": "baz",
+                          "propertyType": "STRING",
+                          "description": "qux"
+                        }
+                        """, MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(405);
+        assertThat(response.readEntity(String.class)).isEqualTo(
+                "Imported components are read-only: they are managed by SBOM uploads and curated via component analyses or component policies. Only manually created components can be modified.");
+    }
+
+    @Test
+    public void deletePropertyOnImportedComponentTest() {
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_DELETE);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        qm.persist(component);
+
+        final var property = new ComponentProperty();
+        property.setComponent(component);
+        property.setGroupName("foo");
+        property.setPropertyName("bar");
+        property.setPropertyValue("baz");
+        property.setPropertyType(PropertyType.STRING);
+        qm.persist(property);
+
+        final Response response = jersey.target("%s/%s/property/%s".formatted(V1_COMPONENT, component.getUuid(), property.getUuid())).request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+
+        assertThat(response.getStatus()).isEqualTo(405);
+        assertThat(response.readEntity(String.class)).isEqualTo(
+                "Imported components are read-only: they are managed by SBOM uploads and curated via component analyses or component policies. Only manually created components can be modified.");
     }
 
 }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ComponentResourceTest.java
@@ -637,6 +637,7 @@ public class ComponentResourceTest extends ResourceTest {
         Assertions.assertEquals("APPLICATION", json.getString("classifier"));
         Assertions.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
         assertThat(resolutionStatusForPurl("pkg:maven/org.acme/abc")).isEqualTo("PENDING");
+        Assertions.assertTrue(json.getBoolean("manuallyCreated"));
     }
 
     @Test
@@ -727,6 +728,7 @@ public class ComponentResourceTest extends ResourceTest {
         component.setName("My Component");
         component.setVersion("1.0");
         component.setClassifier(Classifier.APPLICATION);
+        component.setManuallyCreated(true);
         qm.createComponent(component, false);
 
         var jsonComponent = new Component();
@@ -813,6 +815,7 @@ public class ComponentResourceTest extends ResourceTest {
         component.setDescription("some description");
         component.setLicense("Apache-2.0");
         component.setCopyright("Copyright Acme");
+        component.setManuallyCreated(true);
         qm.persist(component);
 
         final Response response = jersey.target(V1_COMPONENT).request()
@@ -873,6 +876,7 @@ public class ComponentResourceTest extends ResourceTest {
         component.setProject(project);
         component.setName("acme-lib");
         component.setVersion("1.0.0");
+        component.setManuallyCreated(true);
         qm.persist(component);
 
         final var jsonComponent = new Component();
@@ -918,6 +922,7 @@ public class ComponentResourceTest extends ResourceTest {
         final var component = new Component();
         component.setProject(project);
         component.setName("acme-lib");
+        component.setManuallyCreated(true);
         qm.persist(component);
 
         final Supplier<Response> responseSupplier = () -> jersey.target(V1_COMPONENT).request()
@@ -955,6 +960,7 @@ public class ComponentResourceTest extends ResourceTest {
         component.setUuid(UUID.randomUUID());
         component.setName("My Component");
         component.setVersion("1.0");
+        component.setManuallyCreated(true);
         component = qm.createComponent(component, false);
         Response response = jersey.target(V1_COMPONENT + "/" + component.getUuid().toString())
                 .request().header(X_API_KEY, apiKey).delete();
@@ -987,6 +993,7 @@ public class ComponentResourceTest extends ResourceTest {
         final var component = new Component();
         component.setProject(project);
         component.setName("acme-lib");
+        component.setManuallyCreated(true);
         qm.persist(component);
 
         final Supplier<Response> responseSupplier = () -> jersey
@@ -1008,6 +1015,56 @@ public class ComponentResourceTest extends ResourceTest {
 
         response = responseSupplier.get();
         assertThat(response.getStatus()).isEqualTo(204);
+    }
+
+    @Test
+    public void updateImportedComponentTest() {
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_UPDATE);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        qm.persist(component);
+
+        final Response response = jersey.target(V1_COMPONENT).request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "uuid": "%s",
+                          "name": "acme-lib-foobar",
+                          "classifier": "LIBRARY"
+                        }
+                        """.formatted(component.getUuid())));
+
+        assertThat(response.getStatus()).isEqualTo(405);
+        assertThat(response.readEntity(String.class)).isEqualTo(
+                "Imported components are read-only: they are managed by SBOM uploads and curated via component analyses or component policies. Only manually created components can be modified.");
+    }
+
+    @Test
+    public void deleteImportedComponentTest() {
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_DELETE);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        qm.persist(component);
+
+        final Response response = jersey.target(V1_COMPONENT + "/" + component.getUuid()).request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+
+        assertThat(response.getStatus()).isEqualTo(405);
+        assertThat(response.readEntity(String.class)).isEqualTo(
+                "Imported components are read-only: they are managed by SBOM uploads and curated via component analyses or component policies. Only manually created components can be modified.");
     }
 
     @Test
@@ -1354,6 +1411,7 @@ public class ComponentResourceTest extends ResourceTest {
                           },
                           "expandDependencyGraph": false,
                           "isInternal": false,
+                          "manuallyCreated": false,
                           "occurrenceCount": 0
                         }
                         """);

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -361,7 +361,8 @@ public class VulnerabilityResourceTest extends ResourceTest {
                                  "sha256": "47602d7dfe910ad941fea52e85e6e3f1c175434b0e6e261c31c766fe4c078a25",
                                  "uuid": "${json-unit.any-string}",
                                  "expandDependencyGraph": false,
-                                 "isInternal": false
+                                 "isInternal": false,
+                                 "manuallyCreated": false
                              }
                          ],
                          "uuid": "${json-unit.any-string}",
@@ -390,7 +391,8 @@ public class VulnerabilityResourceTest extends ResourceTest {
                                  "sha256": "47602d7dfe910ad941fea52e85e6e3f1c175434b0e6e261c31c766fe4c078a25",
                                  "uuid": "${json-unit.any-string}",
                                  "expandDependencyGraph": false,
-                                 "isInternal": false
+                                 "isInternal": false,
+                                 "manuallyCreated": false
                              }
                          ],
                          "uuid": "${json-unit.any-string}",
@@ -423,7 +425,8 @@ public class VulnerabilityResourceTest extends ResourceTest {
                                  "sha256": "418716b003fe0268b6521ef7acbed13f5ba491d593896d5deb2058c42d87002d",
                                  "uuid": "${json-unit.any-string}",
                                  "expandDependencyGraph": false,
-                                 "isInternal": false
+                                 "isInternal": false,
+                                 "manuallyCreated": false
                              }
                          ],
                          "uuid": "${json-unit.any-string}",
@@ -446,7 +449,8 @@ public class VulnerabilityResourceTest extends ResourceTest {
                                  "sha256": "418716b003fe0268b6521ef7acbed13f5ba491d593896d5deb2058c42d87002d",
                                  "uuid": "${json-unit.any-string}",
                                  "expandDependencyGraph": false,
-                                 "isInternal": false
+                                 "isInternal": false,
+                                 "manuallyCreated": false
                              }
                          ],
                          "uuid": "${json-unit.any-string}",
@@ -534,7 +538,8 @@ public class VulnerabilityResourceTest extends ResourceTest {
                                 "sha256": "418716b003fe0268b6521ef7acbed13f5ba491d593896d5deb2058c42d87002d",
                                 "uuid": "${json-unit.any-string}",
                                 "expandDependencyGraph": false,
-                                "isInternal": false
+                                "isInternal": false,
+                                "manuallyCreated": false
                             }
                         ],
                         "uuid": "${json-unit.any-string}",
@@ -557,7 +562,8 @@ public class VulnerabilityResourceTest extends ResourceTest {
                                 "sha256": "418716b003fe0268b6521ef7acbed13f5ba491d593896d5deb2058c42d87002d",
                                 "uuid": "${json-unit.any-string}",
                                 "expandDependencyGraph": false,
-                                "isInternal": false
+                                "isInternal": false,
+                                "manuallyCreated": false
                             }
                         ],
                         "uuid": "${json-unit.any-string}",

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/ComponentAnalysesResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/ComponentAnalysesResourceTest.java
@@ -1,0 +1,440 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v2;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import net.javacrumbs.jsonunit.core.Option;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.License;
+import org.dependencytrack.model.Project;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.UUID;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+class ComponentAnalysesResourceTest extends ResourceTest {
+
+    @RegisterExtension
+    static JerseyTestExtension jersey = new JerseyTestExtension(
+            new ResourceConfig());
+
+    @Test
+    void shouldCreateAnalysisWithAuditTrail() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT, Permissions.VIEW_PORTFOLIO);
+        final Project project = qm.createProject("acme-app", null, null, null, null, null, null, false);
+        createSpdxLicense("Apache-2.0", "Apache License 2.0");
+
+        final Response response = upsertAnalysis(/* language=JSON */ """
+                {
+                  "project_uuid": "%s",
+                  "group": "org.acme",
+                  "name": "acme-lib",
+                  "version": "1.0.0",
+                  "license": "Apache-2.0",
+                  "details": "curated"
+                }
+                """.formatted(project.getUuid()));
+
+        assertThat(response.getStatus()).isEqualTo(204);
+        assertThat(getPlainTextBody(response)).isEmpty();
+
+        final JsonObject analysis = getAnalysisFromList(project.getUuid(), "acme-lib");
+        assertThatJson(analysis.toString()).isEqualTo(/* language=JSON */ """
+                {
+                  "id": "${json-unit.any-number}",
+                  "group": "org.acme",
+                  "name": "acme-lib",
+                  "version": "1.0.0",
+                  "license": "Apache-2.0",
+                  "details": "curated"
+                }
+                """);
+
+        final Response commentsResponse = getComments(analysis.getJsonNumber("id").longValue());
+        assertThat(commentsResponse.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(commentsResponse)).isEqualTo(/* language=JSON */ """
+                {
+                  "comments": [
+                    {
+                      "timestamp": "${json-unit.any-number}",
+                      "commenter": "${json-unit.any-string}",
+                      "comment": "License override: not set → Apache-2.0"
+                    },
+                    {
+                      "timestamp": "${json-unit.any-number}",
+                      "commenter": "${json-unit.any-string}",
+                      "comment": "Details: not set → curated"
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void shouldApplyLicenseToMatchingComponentsImmediately() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT, Permissions.VIEW_PORTFOLIO);
+        final Project project = qm.createProject("acme-app", null, null, null, null, null, null, false);
+        final License apache = createSpdxLicense("Apache-2.0", "Apache License 2.0");
+        final Component component = createComponent(project, "org.acme", "acme-lib", "1.0.0", "Unknown License");
+
+        final Response response = upsertAnalysis(/* language=JSON */ """
+                {
+                  "project_uuid": "%s",
+                  "group": "org.acme",
+                  "name": "acme-lib",
+                  "version": "1.0.0",
+                  "license": "Apache-2.0",
+                  "details": "curated"
+                }
+                """.formatted(project.getUuid()));
+
+        assertThat(response.getStatus()).isEqualTo(204);
+
+        final JsonObject analysis = getAnalysisFromList(project.getUuid(), "acme-lib");
+        assertThat(analysis.getString("declared_license")).isEqualTo("Unknown License");
+
+        qm.getPersistenceManager().evictAll();
+        final Component updatedComponent = qm.getObjectByUuid(Component.class, component.getUuid());
+        assertThat(updatedComponent.getResolvedLicense()).isNotNull();
+        assertThat(updatedComponent.getResolvedLicense().getId()).isEqualTo(apache.getId());
+        assertThat(updatedComponent.getNotes()).isEqualTo("curated");
+    }
+
+    @Test
+    void shouldListAnalysesByProject() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT, Permissions.VIEW_PORTFOLIO);
+        final Project project = qm.createProject("acme-app", null, null, null, null, null, null, false);
+        final Project otherProject = qm.createProject("other-app", null, null, null, null, null, null, false);
+        createSpdxLicense("Apache-2.0", "Apache License 2.0");
+
+        for (final String componentName : new String[]{"acme-lib-a", "acme-lib-b"}) {
+            final Response response = upsertAnalysis(/* language=JSON */ """
+                    {
+                      "project_uuid": "%s",
+                      "name": "%s",
+                      "license": "Apache-2.0"
+                    }
+                    """.formatted(project.getUuid(), componentName));
+            assertThat(response.getStatus()).isEqualTo(204);
+        }
+        final Response otherResponse = upsertAnalysis(/* language=JSON */ """
+                {
+                  "project_uuid": "%s",
+                  "name": "other-lib",
+                  "license": "Apache-2.0"
+                }
+                """.formatted(otherProject.getUuid()));
+        assertThat(otherResponse.getStatus()).isEqualTo(204);
+
+        final Response response = listAnalyses(project.getUuid());
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .withOptions(Option.IGNORING_ARRAY_ORDER)
+                .isEqualTo(/* language=JSON */ """
+                        {
+                          "analyses": [
+                            {
+                              "id": "${json-unit.any-number}",
+                              "name": "acme-lib-a",
+                              "license": "Apache-2.0"
+                            },
+                            {
+                              "id": "${json-unit.any-number}",
+                              "name": "acme-lib-b",
+                              "license": "Apache-2.0"
+                            }
+                          ]
+                        }
+                        """);
+    }
+
+    @Test
+    void shouldReturn404WhenListingUnknownProject() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+
+        final Response response = jersey
+                .target("/component-analyses")
+                .queryParam("project", UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    void shouldRecordLicenseTransitionOnUpdate() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT, Permissions.VIEW_PORTFOLIO);
+        final Project project = qm.createProject("acme-app", null, null, null, null, null, null, false);
+        createSpdxLicense("Apache-2.0", "Apache License 2.0");
+        createSpdxLicense("MIT", "MIT License");
+
+        final Response firstResponse = upsertAnalysis(/* language=JSON */ """
+                {
+                  "project_uuid": "%s",
+                  "name": "acme-lib",
+                  "license": "Apache-2.0"
+                }
+                """.formatted(project.getUuid()));
+        assertThat(firstResponse.getStatus()).isEqualTo(204);
+        final long analysisId = getAnalysisFromList(project.getUuid(), "acme-lib")
+                .getJsonNumber("id").longValue();
+
+        final Response secondResponse = upsertAnalysis(/* language=JSON */ """
+                {
+                  "project_uuid": "%s",
+                  "name": "acme-lib",
+                  "license": "MIT"
+                }
+                """.formatted(project.getUuid()));
+        assertThat(secondResponse.getStatus()).isEqualTo(204);
+
+        final JsonObject updatedAnalysis = getAnalysisFromList(project.getUuid(), "acme-lib");
+        assertThat(updatedAnalysis.getJsonNumber("id").longValue()).isEqualTo(analysisId);
+        assertThat(updatedAnalysis.getString("license")).isEqualTo("MIT");
+
+        final Response commentsResponse = getComments(analysisId);
+        assertThat(commentsResponse.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(commentsResponse))
+                .node("comments").isArray().anySatisfy(comment -> assertThatJson(comment)
+                        .node("comment").isEqualTo("License override: Apache-2.0 → MIT"));
+    }
+
+    @Test
+    void shouldRestoreDeclaredLicenseWhenOverrideCleared() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT, Permissions.VIEW_PORTFOLIO);
+        final Project project = qm.createProject("acme-app", null, null, null, null, null, null, false);
+        createSpdxLicense("Apache-2.0", "Apache License 2.0");
+        final Component component = createComponent(project, "org.acme", "acme-lib", "1.0.0", "Proprietary Foo");
+
+        final Response overrideResponse = upsertAnalysis(/* language=JSON */ """
+                {
+                  "project_uuid": "%s",
+                  "group": "org.acme",
+                  "name": "acme-lib",
+                  "version": "1.0.0",
+                  "license": "Apache-2.0"
+                }
+                """.formatted(project.getUuid()));
+        assertThat(overrideResponse.getStatus()).isEqualTo(204);
+        final long analysisId = getAnalysisFromList(project.getUuid(), "acme-lib")
+                .getJsonNumber("id").longValue();
+
+        final Response clearResponse = upsertAnalysis(/* language=JSON */ """
+                {
+                  "project_uuid": "%s",
+                  "group": "org.acme",
+                  "name": "acme-lib",
+                  "version": "1.0.0"
+                }
+                """.formatted(project.getUuid()));
+        assertThat(clearResponse.getStatus()).isEqualTo(204);
+
+        final JsonObject clearedAnalysis = getAnalysisFromList(project.getUuid(), "acme-lib");
+        assertThat(clearedAnalysis.containsKey("license")).isFalse();
+        assertThat(clearedAnalysis.getString("declared_license")).isEqualTo("Proprietary Foo");
+
+        qm.getPersistenceManager().evictAll();
+        final Component restoredComponent = qm.getObjectByUuid(Component.class, component.getUuid());
+        assertThat(restoredComponent.getResolvedLicense()).isNull();
+        assertThat(restoredComponent.getLicense()).isEqualTo("Proprietary Foo");
+
+        final Response commentsResponse = getComments(analysisId);
+        assertThat(commentsResponse.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(commentsResponse))
+                .node("comments").isArray().anySatisfy(comment -> assertThatJson(comment)
+                        .node("comment").isEqualTo("License override: Apache-2.0 → not set"));
+    }
+
+    @Test
+    void shouldCreateManualComment() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT, Permissions.VIEW_PORTFOLIO);
+        final Project project = qm.createProject("acme-app", null, null, null, null, null, null, false);
+        createSpdxLicense("Apache-2.0", "Apache License 2.0");
+
+        final Response upsertResponse = upsertAnalysis(/* language=JSON */ """
+                {
+                  "project_uuid": "%s",
+                  "name": "acme-lib",
+                  "license": "Apache-2.0"
+                }
+                """.formatted(project.getUuid()));
+        assertThat(upsertResponse.getStatus()).isEqualTo(204);
+        final long analysisId = getAnalysisFromList(project.getUuid(), "acme-lib")
+                .getJsonNumber("id").longValue();
+
+        final Response createCommentResponse = jersey
+                .target("/component-analyses/%d/comments".formatted(analysisId))
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "comment": "manually reviewed"
+                        }
+                        """));
+        assertThat(createCommentResponse.getStatus()).isEqualTo(201);
+        assertThat(createCommentResponse.getLocation()).isNotNull();
+        assertThat(createCommentResponse.getLocation().getPath())
+                .endsWith("/component-analyses/%d/comments".formatted(analysisId));
+
+        final Response commentsResponse = getComments(analysisId);
+        assertThat(commentsResponse.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(commentsResponse))
+                .node("comments").isArray().anySatisfy(comment -> assertThatJson(comment)
+                        .node("comment").isEqualTo("manually reviewed"));
+    }
+
+    @Test
+    void shouldDeleteAnalysis() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT, Permissions.VIEW_PORTFOLIO);
+        final Project project = qm.createProject("acme-app", null, null, null, null, null, null, false);
+        createSpdxLicense("Apache-2.0", "Apache License 2.0");
+
+        final Response upsertResponse = upsertAnalysis(/* language=JSON */ """
+                {
+                  "project_uuid": "%s",
+                  "name": "acme-lib",
+                  "license": "Apache-2.0"
+                }
+                """.formatted(project.getUuid()));
+        assertThat(upsertResponse.getStatus()).isEqualTo(204);
+        final long analysisId = getAnalysisFromList(project.getUuid(), "acme-lib")
+                .getJsonNumber("id").longValue();
+
+        final Response deleteResponse = jersey
+                .target("/component-analyses/" + analysisId)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+        assertThat(deleteResponse.getStatus()).isEqualTo(204);
+
+        final Response listResponse = listAnalyses(project.getUuid());
+        assertThat(listResponse.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(listResponse))
+                .node("analyses").isArray().isEmpty();
+    }
+
+    @Test
+    void shouldReturn404WhenDeletingNonExistentAnalysis() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final Response response = jersey
+                .target("/component-analyses/999999")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+
+        assertThat(response.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    void shouldReturn403WhenUpsertingWithoutPolicyManagementPermission() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+        final Project project = qm.createProject("acme-app", null, null, null, null, null, null, false);
+
+        final Response response = upsertAnalysis(/* language=JSON */ """
+                {
+                  "project_uuid": "%s",
+                  "name": "acme-lib"
+                }
+                """.formatted(project.getUuid()));
+
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void shouldReturn403WhenListingWithoutViewPortfolioPermission() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+        final Project project = qm.createProject("acme-app", null, null, null, null, null, null, false);
+
+        final Response response = listAnalyses(project.getUuid());
+
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    private Response upsertAnalysis(final String requestBody) {
+        return jersey
+                .target("/component-analyses")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(requestBody));
+    }
+
+    private Response listAnalyses(final UUID projectUuid) {
+        return jersey
+                .target("/component-analyses")
+                .queryParam("project", projectUuid)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+    }
+
+    private JsonObject getAnalysisFromList(final UUID projectUuid, final String componentName) {
+        final Response response = listAnalyses(projectUuid);
+        assertThat(response.getStatus()).isEqualTo(200);
+        for (final JsonValue analysis : parseJsonObject(response).getJsonArray("analyses")) {
+            if (componentName.equals(analysis.asJsonObject().getString("name"))) {
+                return analysis.asJsonObject();
+            }
+        }
+        return fail("No analysis found for component %s", componentName);
+    }
+
+    private Response getComments(final long analysisId) {
+        return jersey
+                .target("/component-analyses/%d/comments".formatted(analysisId))
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+    }
+
+    private License createSpdxLicense(final String licenseId, final String name) {
+        final var license = new License();
+        license.setLicenseId(licenseId);
+        license.setName(name);
+        return qm.persist(license);
+    }
+
+    private Component createComponent(
+            final Project project,
+            final String group,
+            final String name,
+            final String version,
+            final String declaredLicenseName) {
+        final var component = new Component();
+        component.setProject(project);
+        component.setGroup(group);
+        component.setName(name);
+        component.setVersion(version);
+        component.setLicense(declaredLicenseName);
+        return qm.createComponent(component, false);
+    }
+
+}

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/ComponentPoliciesResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/ComponentPoliciesResourceTest.java
@@ -1,0 +1,324 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v2;
+
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.License;
+import org.dependencytrack.persistence.jdbi.ComponentPolicyDao;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.inJdbiTransaction;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
+
+class ComponentPoliciesResourceTest extends ResourceTest {
+
+    @RegisterExtension
+    static JerseyTestExtension jersey = new JerseyTestExtension(
+            new ResourceConfig());
+
+    @Test
+    void shouldCreateComponentPolicy() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+        createSpdxLicense("Apache-2.0", "Apache License 2.0");
+
+        final Response response = jersey
+                .target("/component-policies")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "name": "acme-curation",
+                          "description": "Curates the license of acme-lib",
+                          "condition": "component.name == \\"acme-lib\\"",
+                          "license": "Apache-2.0",
+                          "details": "curated by policy",
+                          "enabled": true,
+                          "priority": 5
+                        }
+                        """));
+
+        assertThat(response.getStatus()).isEqualTo(201);
+        assertThat(getPlainTextBody(response)).isEmpty();
+        assertThat(response.getLocation()).isNotNull();
+        assertThat(response.getLocation().getPath()).matches(".*/component-policies/\\d+$");
+
+        final Response listResponse = jersey
+                .target("/component-policies")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(listResponse.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(listResponse)).isEqualTo(/* language=JSON */ """
+                {
+                  "policies": [
+                    {
+                      "id": "${json-unit.any-number}",
+                      "name": "acme-curation",
+                      "description": "Curates the license of acme-lib",
+                      "author": "${json-unit.any-string}",
+                      "enabled": true,
+                      "priority": 5,
+                      "condition": "component.name == \\"acme-lib\\"",
+                      "license": "Apache-2.0",
+                      "details": "curated by policy"
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void shouldRejectCreateWithInvalidCelCondition() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final Response response = jersey
+                .target("/component-policies")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "name": "broken-condition",
+                          "condition": "doesNotExist == true"
+                        }
+                        """));
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThatJson(getPlainTextBody(response))
+                .node("detail").isString().startsWith("Invalid CEL condition");
+        final List<ComponentPolicyDao.ComponentPolicy> policies = withJdbiHandle(
+                handle -> new ComponentPolicyDao(handle).getAll());
+        assertThat(policies).isEmpty();
+    }
+
+    @Test
+    void shouldNotCreatePolicyWithUnknownLicense() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final Response response = jersey
+                .target("/component-policies")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "name": "unknown-license-policy",
+                          "condition": "component.name == \\"acme-lib\\"",
+                          "license": "No-Such-License-1.0"
+                        }
+                        """));
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        final List<ComponentPolicyDao.ComponentPolicy> policies = withJdbiHandle(
+                handle -> new ComponentPolicyDao(handle).getAll());
+        assertThat(policies).isEmpty();
+    }
+
+    @Test
+    void shouldListComponentPoliciesInEvaluationOrder() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        inJdbiTransaction(handle -> {
+            final var dao = new ComponentPolicyDao(handle);
+            dao.create("second-policy", null, "tester", true, 2,
+                    "component.name == \"bar\"", null, null, null, null);
+            return dao.create("first-policy", null, "tester", false, 1,
+                    "component.name == \"foo\"", null, null, null, null);
+        });
+
+        final Response response = jersey
+                .target("/component-policies")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "policies": [
+                    {
+                      "id": "${json-unit.any-number}",
+                      "name": "first-policy",
+                      "author": "tester",
+                      "enabled": false,
+                      "priority": 1,
+                      "condition": "component.name == \\"foo\\""
+                    },
+                    {
+                      "id": "${json-unit.any-number}",
+                      "name": "second-policy",
+                      "author": "tester",
+                      "enabled": true,
+                      "priority": 2,
+                      "condition": "component.name == \\"bar\\""
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void shouldUpdateComponentPolicy() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+        createSpdxLicense("MIT", "MIT License");
+
+        final long policyId = inJdbiTransaction(handle -> new ComponentPolicyDao(handle).create(
+                "acme-curation", null, "tester", true, 0,
+                "component.name == \"acme-lib\"", null, null, null, null));
+
+        final Response response = jersey
+                .target("/component-policies/" + policyId)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "name": "acme-curation-updated",
+                          "description": "now with a license",
+                          "condition": "component.group == \\"org.acme\\"",
+                          "license": "MIT",
+                          "enabled": false,
+                          "priority": 7
+                        }
+                        """));
+
+        assertThat(response.getStatus()).isEqualTo(204);
+        assertThat(getPlainTextBody(response)).isEmpty();
+
+        final Response listResponse = jersey
+                .target("/component-policies")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(listResponse.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(listResponse)).isEqualTo(/* language=JSON */ """
+                {
+                  "policies": [
+                    {
+                      "id": %d,
+                      "name": "acme-curation-updated",
+                      "description": "now with a license",
+                      "author": "tester",
+                      "enabled": false,
+                      "priority": 7,
+                      "condition": "component.group == \\"org.acme\\"",
+                      "license": "MIT"
+                    }
+                  ]
+                }
+                """.formatted(policyId));
+
+        final Optional<ComponentPolicyDao.ComponentPolicy> updated = withJdbiHandle(
+                handle -> new ComponentPolicyDao(handle).getById(policyId));
+        assertThat(updated).isPresent();
+        assertThat(updated.get().name()).isEqualTo("acme-curation-updated");
+        assertThat(updated.get().enabled()).isFalse();
+        assertThat(updated.get().priority()).isEqualTo(7);
+    }
+
+    @Test
+    void shouldReturn404WhenUpdatingNonExistentPolicy() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final Response response = jersey
+                .target("/component-policies/999999")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "name": "does-not-exist",
+                          "condition": "component.name == \\"foo\\""
+                        }
+                        """));
+
+        assertThat(response.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    void shouldDeleteComponentPolicy() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final long policyId = inJdbiTransaction(handle -> new ComponentPolicyDao(handle).create(
+                "to-be-deleted", null, "tester", true, 0,
+                "component.name == \"foo\"", null, null, null, null));
+
+        final Response response = jersey
+                .target("/component-policies/" + policyId)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+
+        assertThat(response.getStatus()).isEqualTo(204);
+        final Optional<ComponentPolicyDao.ComponentPolicy> deleted = withJdbiHandle(
+                handle -> new ComponentPolicyDao(handle).getById(policyId));
+        assertThat(deleted).isEmpty();
+    }
+
+    @Test
+    void shouldReturn404WhenDeletingNonExistentPolicy() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final Response response = jersey
+                .target("/component-policies/999999")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+
+        assertThat(response.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    void shouldReturn403WhenMissingPolicyManagementPermission() {
+        initializeWithPermissions();
+
+        final Response listResponse = jersey
+                .target("/component-policies")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(listResponse.getStatus()).isEqualTo(403);
+
+        final Response createResponse = jersey
+                .target("/component-policies")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "name": "not-allowed",
+                          "condition": "component.name == \\"foo\\""
+                        }
+                        """));
+        assertThat(createResponse.getStatus()).isEqualTo(403);
+    }
+
+    private License createSpdxLicense(final String licenseId, final String name) {
+        final var license = new License();
+        license.setLicenseId(licenseId);
+        license.setName(name);
+        return qm.persist(license);
+    }
+
+}

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/ComponentsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/ComponentsResourceTest.java
@@ -114,7 +114,8 @@ public class ComponentsResourceTest extends ResourceTest {
                     "uuid" : "${json-unit.any-string}",
                     "expandDependencyGraph" : false,
                     "occurrenceCount" : 0,
-                    "isInternal" : false
+                    "isInternal" : false,
+                    "manuallyCreated" : true
                   } ]
                 }
                 """);

--- a/apiserver/src/test/java/org/dependencytrack/tasks/ImportBomActivityTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/ImportBomActivityTest.java
@@ -1769,6 +1769,90 @@ class ImportBomActivityTest extends PersistenceCapableTest {
         }
     }
 
+
+    @Test
+    void informShouldKeepManuallyCreatedComponents() throws Exception {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var manualComponent = new Component();
+        manualComponent.setProject(project);
+        manualComponent.setName("acme-internal-lib");
+        manualComponent.setVersion("2.0.0");
+        manualComponent.setClassifier(Classifier.LIBRARY);
+        manualComponent.setManuallyCreated(true);
+        qm.persist(manualComponent);
+
+        final var bomFileMetadata = storeBomFile("""
+                {
+                  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.4",
+                  "version": 1,
+                  "components": [
+                    {
+                      "type": "library",
+                      "name": "acme-lib",
+                      "version": "1.0.0"
+                    }
+                  ]
+                }
+                """.getBytes());
+        activity.execute(null, buildArg(project, bomFileMetadata, UUID.randomUUID()));
+        assertBomProcessedNotification();
+
+        assertThat(qm.getAllComponents(project)).satisfiesExactlyInAnyOrder(
+                component -> {
+                    assertThat(component.getName()).isEqualTo("acme-internal-lib");
+                    assertThat(component.isManuallyCreated()).isTrue();
+                },
+                component -> {
+                    assertThat(component.getName()).isEqualTo("acme-lib");
+                    assertThat(component.isManuallyCreated()).isFalse();
+                });
+    }
+
+    @Test
+    void informShouldTakeOverManuallyCreatedComponentMatchingBomComponent() throws Exception {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var manualComponent = new Component();
+        manualComponent.setProject(project);
+        manualComponent.setName("acme-lib");
+        manualComponent.setVersion("1.0.0");
+        manualComponent.setClassifier(Classifier.LIBRARY);
+        manualComponent.setManuallyCreated(true);
+        qm.persist(manualComponent);
+        final UUID manualComponentUuid = manualComponent.getUuid();
+
+        final var bomFileMetadata = storeBomFile("""
+                {
+                  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.4",
+                  "version": 1,
+                  "components": [
+                    {
+                      "type": "library",
+                      "name": "acme-lib",
+                      "version": "1.0.0"
+                    }
+                  ]
+                }
+                """.getBytes());
+        activity.execute(null, buildArg(project, bomFileMetadata, UUID.randomUUID()));
+        assertBomProcessedNotification();
+
+        qm.getPersistenceManager().refresh(manualComponent);
+        assertThat(qm.getAllComponents(project)).satisfiesExactly(component -> {
+            assertThat(component.getUuid()).isEqualTo(manualComponentUuid);
+            assertThat(component.isManuallyCreated()).isFalse();
+        });
+    }
+
     private FileMetadata storeBomFile(final String testFileName) throws Exception {
         final Path bomFilePath = Paths.get(resourceToURL("/unit/" + testFileName).toURI());
 

--- a/docs/adr/036-durable-component-license-curation.md
+++ b/docs/adr/036-durable-component-license-curation.md
@@ -1,0 +1,81 @@
+# Durable component license curation
+
+| Status   | Date       | Author(s)                                          |
+|:---------|:-----------|:---------------------------------------------------|
+| Accepted | 2026-07-22 | [@canikrichard](https://github.com/canikrichard)   |
+
+## Context
+
+License policy violations frequently point at a *data* problem rather than a
+*risk* problem: the component's license is known, but the uploaded BOM either
+omits it or declares it incorrectly. The existing remediation options are all
+unsatisfactory:
+
+* Suppressing the violation hides a finding instead of correcting the data,
+  and the suppression does not explain what the license actually is.
+* Editing the component through the REST API does not survive the next BOM
+  upload: `ImportBomActivity` synchronizes all component fields from the BOM
+  on every import (intended behavior), so manual corrections are silently
+  overwritten. Component rows are also deleted and recreated as components
+  enter and leave the BOM, so nothing keyed to the component row survives.
+* Feature request [#251] (open since 2018) confirms there is no upstream
+  mechanism for durable license overrides, and no extension point hooks into
+  BOM ingestion or policy evaluation.
+
+At the same time, allowing arbitrary component edits alongside BOM-managed
+data creates a second, uncontrolled write path: edits bypass any audit trail
+and produce component data whose provenance is unclear.
+
+## Decision
+
+License curation becomes a first-class, durable, audited concept, and ad-hoc
+component mutation is removed:
+
+1. **Component analyses** (`COMPONENT_ANALYSIS`, `COMPONENT_ANALYSIS_COMMENT`)
+   store a per-component license override and free-text details, keyed by the
+   component's *identity* (purl, falling back to group/name/version) within a
+   project. It is never keyed by the component row's primary key, because rows
+   are recreated across uploads. Every field change appends an audit comment
+   recording the old and new value and the author. The declared license is
+   snapshotted on first override so clearing the override restores the
+   BOM-declared value. Overrides are re-applied at the end of every BOM
+   import, after field synchronization and before policy evaluation, so
+   LICENSE violations always evaluate against the curated license.
+
+2. **Component policies** (`COMPONENT_POLICY`) automate the same mechanism: a
+   CEL condition over component and project fields, evaluated at every BOM
+   import with first-match-wins priority ordering, maintains component
+   analyses carrying the policy's license and details. Manual analyses always
+   win over policy-maintained ones. When no policy matches anymore, the
+   policy-maintained analysis is retracted and the imported license applies
+   again. Policy actions write the same audit comments as manual edits, with
+   the policy identified as the author.
+
+3. **Imported components are read-only.** Component update, delete, and
+   property mutations respond `405` for components that originate from BOM
+   uploads; the BOM is their single source of truth and curation happens via
+   analyses and policies. Components created by hand through the REST API
+   carry a `MANUALLY_CREATED` flag: they remain fully editable and are never
+   deleted by BOM synchronization. If a BOM component matches a manual
+   component's identity, the BOM takes ownership: the flag clears and the
+   component becomes read-only.
+
+## Consequences
+
+* License corrections survive BOM re-uploads, carry a complete audit trail,
+  and can be automated fleet-wide with policies, satisfying traceability
+  expectations without blocking uploads.
+* Policy evaluation sees curated licenses, so a corrected license resolves
+  the violation instead of requiring a suppression.
+* The BOM remains the single source of truth for imported component data;
+  the only durable divergence is the explicit, audited license override.
+* Manually created components support inventory that has no SBOM producer,
+  at the cost of a dual regime (editable vs. read-only) that the UI must
+  communicate clearly.
+* `ImportBomActivity` gains one hook at the end of component processing;
+  this is deliberately the only touch point in the ingestion path to keep
+  rebases onto upstream releases cheap.
+* Existing API consumers that relied on mutating imported components will
+  receive `405` and must migrate to component analyses.
+
+[#251]: https://github.com/DependencyTrack/dependency-track/issues/251

--- a/migration/src/main/resources/org/dependencytrack/migration/V202608121000__component_analysis.sql
+++ b/migration/src/main/resources/org/dependencytrack/migration/V202608121000__component_analysis.sql
@@ -1,3 +1,12 @@
+-- Components created by hand through the REST API (as opposed to BOM
+-- imports) stay editable and are never deleted by BOM synchronization.
+-- A BOM component matching a manual component's identity takes it over:
+-- the flag clears and the component becomes read-only.
+-- Nullable like "INTERNAL": the JDO layer writes NULL for components it
+-- creates without the flag, and NULL reads as false.
+ALTER TABLE "COMPONENT"
+  ADD COLUMN IF NOT EXISTS "MANUALLY_CREATED" BOOLEAN;
+
 -- Component policies: automated license curation. A CEL condition matched
 -- against each component at BOM ingest (first match by priority wins)
 -- creates/maintains a component analysis with the patch below. Manual

--- a/migration/src/main/resources/org/dependencytrack/migration/V202608121000__component_analysis.sql
+++ b/migration/src/main/resources/org/dependencytrack/migration/V202608121000__component_analysis.sql
@@ -1,0 +1,69 @@
+-- Component policies: automated license curation. A CEL condition matched
+-- against each component at BOM ingest (first match by priority wins)
+-- creates/maintains a component analysis with the patch below. Manual
+-- analyses always win over policies.
+CREATE TABLE IF NOT EXISTS "COMPONENT_POLICY" (
+  "ID"          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  "NAME"        TEXT NOT NULL CONSTRAINT "COMPONENT_POLICY_NAME_UNIQUE" UNIQUE,
+  "DESCRIPTION" TEXT,
+  "AUTHOR"      TEXT,
+  "ENABLED"     BOOLEAN NOT NULL DEFAULT TRUE,
+  "PRIORITY"    BIGINT NOT NULL DEFAULT 0,
+  "CONDITION"   TEXT NOT NULL,
+  "LICENSE_ID"  BIGINT REFERENCES "LICENSE" ("ID") ON DELETE SET NULL,
+  "DETAILS"     TEXT,
+  -- Optional validity window; the policy only applies while NOW() is inside.
+  "VALID_FROM"  TIMESTAMPTZ,
+  "VALID_UNTIL" TIMESTAMPTZ,
+  "CREATED_AT"  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "UPDATED_AT"  TIMESTAMPTZ
+);
+
+-- Durable, identity-keyed license curation for components. Component rows are
+-- deleted and recreated across BOM uploads, so the analysis is keyed by the
+-- component's identity (purl, or group/name/version) within a project and
+-- re-applied on every ingest.
+CREATE TABLE IF NOT EXISTS "COMPONENT_ANALYSIS" (
+  "ID"                 BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  "PROJECT_ID"         BIGINT NOT NULL REFERENCES "PROJECT" ("ID") ON DELETE CASCADE,
+  "PURL"               TEXT,
+  "GROUP"              TEXT,
+  "NAME"               TEXT NOT NULL,
+  "VERSION"            TEXT,
+  -- License override: a resolved license, incl. custom licenses.
+  "LICENSE_ID"         BIGINT REFERENCES "LICENSE" ("ID") ON DELETE SET NULL,
+  -- Snapshot of the BOM-declared license taken whenever the override is
+  -- applied, refreshed on every ingest: clearing the override restores the
+  -- uploaded value instantly, without waiting for the next upload.
+  "DECLARED_LICENSE_ID"         BIGINT REFERENCES "LICENSE" ("ID") ON DELETE SET NULL,
+  "DECLARED_LICENSE_NAME"       TEXT,
+  "DECLARED_LICENSE_EXPRESSION" TEXT,
+  "DETAILS"            TEXT,
+  -- Set when the analysis is created and maintained by a component policy;
+  -- NULL = manual analysis, which a policy never touches. Deleting a policy
+  -- keeps the analyses and their audit trails, converting them to manual.
+  "POLICY_ID"          BIGINT REFERENCES "COMPONENT_POLICY" ("ID") ON DELETE SET NULL,
+  "CREATED_AT"         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "UPDATED_AT"         TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "COMPONENT_ANALYSIS_IDENTITY_IDX"
+    ON "COMPONENT_ANALYSIS" (
+       "PROJECT_ID",
+       COALESCE("PURL", ''),
+       COALESCE("GROUP", ''),
+       "NAME",
+       COALESCE("VERSION", ''));
+
+-- Append-only audit trail of curation decisions (manual edits and, later,
+-- component-policy applications; distinguished by the COMMENTER identity).
+CREATE TABLE IF NOT EXISTS "COMPONENT_ANALYSIS_COMMENT" (
+  "ID"                    BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  "COMPONENT_ANALYSIS_ID" BIGINT NOT NULL REFERENCES "COMPONENT_ANALYSIS" ("ID") ON DELETE CASCADE,
+  "TIMESTAMP"             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "COMMENTER"             TEXT,
+  "COMMENT"               TEXT NOT NULL
+);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "COMPONENT_ANALYSIS_COMMENT_ANALYSIS_IDX"
+    ON "COMPONENT_ANALYSIS_COMMENT" ("COMPONENT_ANALYSIS_ID");

--- a/migration/src/main/resources/org/dependencytrack/migration/V202608121000__component_analysis.sql.conf
+++ b/migration/src/main/resources/org/dependencytrack/migration/V202608121000__component_analysis.sql.conf
@@ -1,0 +1,1 @@
+executeInTransaction=false


### PR DESCRIPTION
### Description

Adds durable, audited license curation for components. When a BOM declares a component's license incorrectly (or omits it), the only options today are suppressing the resulting policy violation — which hides a finding instead of correcting the data — or editing the component via REST, which the next BOM upload silently reverts. This PR makes the license correction a first-class concept that survives re-uploads:

- **Component analyses**: a per-component license override with free-text details, keyed by the component's *identity* (purl, falling back to group/name/version) within a project, so it survives component rows being recreated on every import. Every field change appends an audit comment (old value, new value, author). The BOM-declared license is snapshotted on first override, so clearing the override restores it. Overrides are re-applied at the end of every BOM import — after field synchronization, before policy evaluation — so LICENSE policy violations always evaluate against the curated license.
- **Component policies**: CEL conditions over component and project fields that maintain the same analyses automatically on every import, first-match-wins by priority. Manual analyses always win over policy-maintained ones; when a policy stops matching, its analysis is retracted and the imported license applies again. Policy actions write the same audit trail, with the policy as author.
- **Spec-first v2 REST API** for both: `/component-analyses` (+ `{id}`, `{id}/comments`) and `/component-policies` (+ `{id}`).
- **Imported components become read-only**: update, delete, and property mutations respond 405 for BOM-originated components — the BOM stays their single source of truth, and curation happens through analyses and policies. Components created manually via REST carry a `MANUALLY_CREATED` flag, remain fully editable, and are never deleted by BOM synchronization; if a BOM component later matches a manual component's identity, the BOM takes ownership (the flag clears and the component becomes read-only).

### Addressed Issue

Closes #251

### Additional Details

- The design and its trade-offs are recorded in [ADR 036](https://github.com/brightpick/dependency-track/blob/component-audit-main/docs/adr/036-durable-component-license-curation.md), included in this PR.
- Keying analyses by component identity instead of the component row was the central decision: rows are deleted and recreated as components enter and leave the BOM, so nothing keyed to the row survives an upload. Identity (purl / group+name+version within the project) is the stable handle.
- `ImportBomActivity` gains a single hook at the end of component processing — deliberately the only touch point in the ingestion path.
- The last commit adds a Dao-level test for the vulnerabilities-by-component duplicate-rows bug fixed in bb9d2c9d7; it additionally pins that a sibling component's suppression neither hides nor leaks into another component's findings.
- Breaking change to be aware of: API consumers that mutate BOM-imported components will now receive 405 and need to migrate to component analyses. Everything else is additive (new tables `COMPONENT_ANALYSIS`, `COMPONENT_ANALYSIS_COMMENT`, `COMPONENT_POLICY` via migration `V202608121000`, plus the `MANUALLY_CREATED` component flag).
- Verified locally: the 9 touched test classes pass (207 tests, 0 failures), including new suites for both v2 resources and the import re-application logic.

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [x] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: https://github.com/DependencyTrack/dependency-track/tree/main/docs/adr
[ADR criteria]: https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: https://github.com/DependencyTrack/dependency-track/blob/main/CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: https://github.com/DependencyTrack/dependency-track/blob/main/DEVELOPING.md#database-migrations
