### PR TITLE
Fix unassigned severity missing from component metrics

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/MetricsDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/MetricsDao.java
@@ -219,7 +219,9 @@ public interface MetricsDao extends SqlObject {
     List<VulnerabilityMetrics> getVulnerabilityMetrics();
 
     @SqlQuery("""
-            SELECT *, "RISKSCORE" AS inherited_risk_score FROM "PROJECTMETRICS"
+            SELECT *, "RISKSCORE" AS inherited_risk_score
+                 , "UNASSIGNED_SEVERITY" AS unassigned
+              FROM "PROJECTMETRICS"
             WHERE "PROJECT_ID" = :projectId
             AND "LAST_OCCURRENCE" >= :since
             ORDER BY "LAST_OCCURRENCE" ASC
@@ -228,7 +230,9 @@ public interface MetricsDao extends SqlObject {
     List<ProjectMetrics> getProjectMetricsSince(@Bind long projectId, @Bind Instant since);
 
     @SqlQuery("""
-            SELECT *, "RISKSCORE" AS inherited_risk_score FROM "DEPENDENCYMETRICS"
+            SELECT *, "RISKSCORE" AS inherited_risk_score
+                 , "UNASSIGNED_SEVERITY" AS unassigned
+              FROM "DEPENDENCYMETRICS"
             WHERE "COMPONENT_ID" = :componentId
             AND "LAST_OCCURRENCE" >= :since
             ORDER BY "LAST_OCCURRENCE" ASC
@@ -244,6 +248,7 @@ public interface MetricsDao extends SqlObject {
 
     @SqlQuery("""
             SELECT *, "RISKSCORE" AS inherited_risk_score
+                 , "UNASSIGNED_SEVERITY" AS unassigned
             FROM "PROJECTMETRICS"
             WHERE "PROJECT_ID" = :projectId
             ORDER BY "LAST_OCCURRENCE" DESC
@@ -254,6 +259,7 @@ public interface MetricsDao extends SqlObject {
 
     @SqlQuery("""
             SELECT metrics.*, metrics."RISKSCORE" AS inherited_risk_score
+                 , metrics."UNASSIGNED_SEVERITY" AS unassigned
               FROM UNNEST(:projectIds) AS project(id)
              INNER JOIN LATERAL (
                SELECT *
@@ -540,6 +546,7 @@ public interface MetricsDao extends SqlObject {
 
     @SqlQuery("""
             SELECT *, "RISKSCORE" AS inherited_risk_score
+                 , "UNASSIGNED_SEVERITY" AS unassigned
             FROM "DEPENDENCYMETRICS"
             WHERE "COMPONENT_ID" = :componentId
             ORDER BY "LAST_OCCURRENCE" DESC
@@ -550,6 +557,7 @@ public interface MetricsDao extends SqlObject {
 
     @SqlQuery("""
             SELECT metrics.*, metrics."RISKSCORE" AS inherited_risk_score
+                 , metrics."UNASSIGNED_SEVERITY" AS unassigned
               FROM UNNEST(:componentIds) AS component(id)
              INNER JOIN LATERAL (
                SELECT *

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/ComponentsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/ComponentsResourceTest.java
@@ -902,6 +902,7 @@ public class ComponentsResourceTest extends ResourceTest {
             metrics.setHigh(2);
             metrics.setMedium(3);
             metrics.setLow(4);
+            metrics.setUnassigned(5);
             metrics.setKev(6);
             metrics.setVulnerabilities(10);
             metrics.setInheritedRiskScore(5.0);
@@ -924,7 +925,7 @@ public class ComponentsResourceTest extends ResourceTest {
                           "high": 2,
                           "medium": 3,
                           "low": 4,
-                          "unassigned": 0,
+                          "unassigned": 5,
                           "kev": 6,
                           "vulnerabilities": 10,
                           "suppressed": 0,


### PR DESCRIPTION
### Description
MetricsDao loaded metrics with SELECT *, so UNASSIGNED_SEVERITY was never mapped to unassigned. Component metrics always returned 0. 

### Addressed Issue
Fixes #6960 

### Additional Details

### Checklist
- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

