### PR TITLE
v4-migrator: Skip repeatable Flyway migrations

### DIFF
--- a/dex/engine-migration/src/main/java/org/dependencytrack/dex/engine/migration/MigrationExecutor.java
+++ b/dex/engine-migration/src/main/java/org/dependencytrack/dex/engine/migration/MigrationExecutor.java
@@ -23,7 +23,7 @@ import javax.sql.DataSource;
 public final class MigrationExecutor extends org.dependencytrack.support.flyway.MigrationExecutor {
 
     public MigrationExecutor(DataSource dataSource) {
-        super(dataSource, "0.0.0", "classpath:org/dependencytrack/dex/engine/migration", "dex_schema_history", null, false);
+        super(dataSource, "0.0.0", "classpath:org/dependencytrack/dex/engine/migration", "dex_schema_history", /* targetVersion */ null, /* outOfOrder */ false, /* skipRepeatable */ false);
     }
 
 }

--- a/migration/src/main/java/org/dependencytrack/migration/MigrationExecutor.java
+++ b/migration/src/main/java/org/dependencytrack/migration/MigrationExecutor.java
@@ -25,11 +25,18 @@ import javax.sql.DataSource;
 public final class MigrationExecutor extends org.dependencytrack.support.flyway.MigrationExecutor {
 
     public MigrationExecutor(DataSource dataSource) {
-        this(dataSource, null);
+        this(dataSource, /* targetVersion */ null, /* skipRepeatable */ false);
     }
 
-    public MigrationExecutor(DataSource dataSource, @Nullable String targetVersion) {
-        super(dataSource, "202605022031", "classpath:org/dependencytrack/migration", null, targetVersion, true);
+    public MigrationExecutor(DataSource dataSource, @Nullable String targetVersion, boolean skipRepeatable) {
+        super(
+                dataSource,
+                "202605022031",
+                "classpath:org/dependencytrack/migration",
+                /* schemaHistoryTable */ null,
+                targetVersion,
+                /* outOfOrder */ true,
+                skipRepeatable);
     }
 
 }

--- a/migration/src/test/java/org/dependencytrack/migration/AddPackageMetadataResolutionMigrationTest.java
+++ b/migration/src/test/java/org/dependencytrack/migration/AddPackageMetadataResolutionMigrationTest.java
@@ -53,7 +53,7 @@ class AddPackageMetadataResolutionMigrationTest {
         dataSource.setPassword(postgresContainer.getPassword());
 
         // Migrate up to the previous schema version.
-        new MigrationExecutor(dataSource, "202606292105").execute();
+        new MigrationExecutor(dataSource, "202606292105", /* skipRepeatable */ false).execute();
 
         // Seed component and package (artifact) metadata to migrate.
         try (final Connection connection = dataSource.getConnection();
@@ -97,7 +97,7 @@ class AddPackageMetadataResolutionMigrationTest {
         }
 
         // Execute migration and backfill.
-        new MigrationExecutor(dataSource, "202608041242").execute();
+        new MigrationExecutor(dataSource, "202608041242", /* skipRepeatable */ false).execute();
 
         final Map<String, ResolutionRow> rowByPurl = fetchResolutionRows(dataSource);
         assertThat(rowByPurl).containsOnlyKeys(

--- a/support/flyway/src/main/java/org/dependencytrack/support/flyway/MigrationExecutor.java
+++ b/support/flyway/src/main/java/org/dependencytrack/support/flyway/MigrationExecutor.java
@@ -42,6 +42,10 @@ public class MigrationExecutor {
     /// from the mainline without blocking the subsequent minor upgrade on validation.
     /// Enable only where backports are anticipated. When disabled, Flyway aborts if it discovers an
     /// unapplied migration with a version lower than the latest in history.
+    /// @param skipRepeatable     Whether to skip repeatable migrations entirely.
+    /// Repeatable migrations always run last, irrespective of `targetVersion`, and thus assume that
+    /// all versioned migrations were applied. Enable this when migrating to a `targetVersion` older
+    /// than the latest, where repeatable migrations may depend on DDL that does not exist yet.
     /// @see [How to fix or avoid ignored migrations in Flyway](https://www.red-gate.com/hub/product-learning/flyway/how-to-fix-or-avoid-ignored-migrations-in-flyway/).
     public MigrationExecutor(
             DataSource dataSource,
@@ -49,7 +53,8 @@ public class MigrationExecutor {
             String location,
             @Nullable String schemaHistoryTable,
             @Nullable String targetVersion,
-            boolean outOfOrder) {
+            boolean outOfOrder,
+            boolean skipRepeatable) {
         final FluentConfiguration config = Flyway.configure()
                 .dataSource(requireNonNull(dataSource, "dataSource must not be null"))
                 .baselineVersion(requireNonNull(baselineVersion, "baselineVersion must not be null"))
@@ -72,6 +77,9 @@ public class MigrationExecutor {
         }
         if (targetVersion != null) {
             config.target(targetVersion);
+        }
+        if (skipRepeatable) {
+            config.repeatableSqlMigrationPrefix("DISABLED_REPEATABLE_");
         }
         this.flyway = config.load();
     }

--- a/support/flyway/src/test/java/org/dependencytrack/support/flyway/MigrationExecutorTest.java
+++ b/support/flyway/src/test/java/org/dependencytrack/support/flyway/MigrationExecutorTest.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.support.flyway;
 
+import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.exception.FlywayValidateException;
 import org.junit.jupiter.api.Test;
 import org.postgresql.ds.PGSimpleDataSource;
@@ -42,6 +43,7 @@ class MigrationExecutorTest {
 
     private static final String STAGE1_MIGRATIONS_LOCATION = "classpath:org/dependencytrack/support/flyway/outoforder/stage1";
     private static final String STAGE2_MIGRATIONS_LOCATION = "classpath:org/dependencytrack/support/flyway/outoforder/stage2";
+    private static final String REPEATABLE_MIGRATIONS_LOCATION = "classpath:org/dependencytrack/support/flyway/repeatable";
     private static final String BASELINE_SCHEMA_VERSION = "0";
 
     @Container
@@ -54,9 +56,23 @@ class MigrationExecutorTest {
     void shouldApplyMigrationsOutOfOrder() throws Exception {
         final DataSource dataSource = createDataSource();
 
-        new MigrationExecutor(dataSource, BASELINE_SCHEMA_VERSION, STAGE1_MIGRATIONS_LOCATION, null, null, true).execute();
+        new MigrationExecutor(
+                dataSource,
+                BASELINE_SCHEMA_VERSION,
+                STAGE1_MIGRATIONS_LOCATION,
+                /* schemaHistoryTable */ null,
+                /* targetVersion */ null,
+                /* outOfOrder */ true,
+                /* skipRepeatable */ false).execute();
 
-        new MigrationExecutor(dataSource, BASELINE_SCHEMA_VERSION, STAGE2_MIGRATIONS_LOCATION, null, null, true).execute();
+        new MigrationExecutor(
+                dataSource,
+                BASELINE_SCHEMA_VERSION,
+                STAGE2_MIGRATIONS_LOCATION,
+                /* schemaHistoryTable */ null,
+                /* targetVersion */ null,
+                /* outOfOrder */ true,
+                /* skipRepeatable */ false).execute();
 
         final Map<String, Integer> ranksByVersion = readSchemaHistoryRanks();
         assertThat(ranksByVersion).containsKeys("001", "002", "003");
@@ -67,19 +83,73 @@ class MigrationExecutorTest {
     void shouldRejectOutOfOrderMigrationWhenOutOfOrderIsDisabled() {
         final DataSource dataSource = createDataSource();
 
-        new MigrationExecutor(dataSource, BASELINE_SCHEMA_VERSION, STAGE1_MIGRATIONS_LOCATION, null, null, false).execute();
+        new MigrationExecutor(
+                dataSource,
+                BASELINE_SCHEMA_VERSION,
+                STAGE1_MIGRATIONS_LOCATION,
+                /* schemaHistoryTable */ null,
+                /* targetVersion */ null,
+                /* outOfOrder */ false,
+                /* skipRepeatable */ false).execute();
 
         assertThatThrownBy(() ->
-                new MigrationExecutor(dataSource, BASELINE_SCHEMA_VERSION, STAGE2_MIGRATIONS_LOCATION, null, null, false).execute())
+                new MigrationExecutor(
+                        dataSource,
+                        BASELINE_SCHEMA_VERSION,
+                        STAGE2_MIGRATIONS_LOCATION,
+                        /* schemaHistoryTable */ null,
+                        /* targetVersion */ null,
+                        /* outOfOrder */ false,
+                        /* skipRepeatable */ false).execute())
                 .isInstanceOf(FlywayValidateException.class)
                 .hasMessageContaining("Detected resolved migration not applied to database: 002");
     }
 
     @Test
+    void shouldSkipRepeatableMigrations() {
+        final DataSource dataSource = createDataSource();
+
+        new MigrationExecutor(
+                dataSource,
+                BASELINE_SCHEMA_VERSION,
+                REPEATABLE_MIGRATIONS_LOCATION,
+                /* schemaHistoryTable */ null,
+                /* targetVersion */ null,
+                /* outOfOrder */ true,
+                /* skipRepeatable */ true).execute();
+
+        assertThatThrownBy(() ->
+                new MigrationExecutor(
+                        dataSource,
+                        BASELINE_SCHEMA_VERSION,
+                        REPEATABLE_MIGRATIONS_LOCATION,
+                        /* schemaHistoryTable */ null,
+                        /* targetVersion */ null,
+                        /* outOfOrder */ true,
+                        /* skipRepeatable */ false).execute())
+                .isInstanceOf(FlywayException.class)
+                .hasMessageContaining("table_that_does_not_exist");
+    }
+
+    @Test
     void shouldExecuteMigrationIdempotently() {
         final DataSource dataSource = createDataSource();
-        new MigrationExecutor(dataSource, BASELINE_SCHEMA_VERSION, STAGE1_MIGRATIONS_LOCATION, null, null, true).execute();
-        new MigrationExecutor(dataSource, BASELINE_SCHEMA_VERSION, STAGE1_MIGRATIONS_LOCATION, null, null, true).execute();
+        new MigrationExecutor(
+                dataSource,
+                BASELINE_SCHEMA_VERSION,
+                STAGE1_MIGRATIONS_LOCATION,
+                /* schemaHistoryTable */ null,
+                /* targetVersion */ null,
+                /* outOfOrder */ true,
+                /* skipRepeatable */ false).execute();
+        new MigrationExecutor(
+                dataSource,
+                BASELINE_SCHEMA_VERSION,
+                STAGE1_MIGRATIONS_LOCATION,
+                /* schemaHistoryTable */ null,
+                /* targetVersion */ null,
+                /* outOfOrder */ true,
+                /* skipRepeatable */ false).execute();
     }
 
     private DataSource createDataSource() {

--- a/support/flyway/src/test/resources/org/dependencytrack/support/flyway/repeatable/R__fail_when_executed.sql
+++ b/support/flyway/src/test/resources/org/dependencytrack/support/flyway/repeatable/R__fail_when_executed.sql
@@ -1,0 +1,1 @@
+INSERT INTO table_that_does_not_exist (id) VALUES (1);

--- a/support/flyway/src/test/resources/org/dependencytrack/support/flyway/repeatable/V001__create_a.sql
+++ b/support/flyway/src/test/resources/org/dependencytrack/support/flyway/repeatable/V001__create_a.sql
@@ -1,0 +1,1 @@
+CREATE TABLE a (id INT);

--- a/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/cli/BootstrapCommand.java
+++ b/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/cli/BootstrapCommand.java
@@ -44,7 +44,10 @@ public final class BootstrapCommand extends AbstractMigratorCommand {
     @Override
     protected int execute(final Jdbi target) {
         LOGGER.info("Applying v5 Flyway schema up to {}", Preflight.EXPECTED_FLYWAY_HEAD);
-        new MigrationExecutor(Connections.targetDataSource(global), Preflight.EXPECTED_FLYWAY_HEAD).execute();
+        new MigrationExecutor(
+                Connections.targetDataSource(global),
+                Preflight.EXPECTED_FLYWAY_HEAD,
+                /* skipRepeatable */ true).execute();
 
         final String head = target.withHandle(h ->
             h.createQuery("""

--- a/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/MetricsDedupIT.java
+++ b/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/MetricsDedupIT.java
@@ -80,8 +80,8 @@ class MetricsDedupIT {
                     "FIRST_OCCURRENCE", "LAST_OCCURRENCE",
                     "RISKSCORE", "SUPPRESSED", "VULNERABILITIES"
                 ) VALUES
-                  (1, 10, 1, 1, 0, 0, 0, '2026-05-12T10:00:00Z', '2026-05-12T10:00:00Z', 1.5, 0, 1),
-                  (2, 10, 1, 7, 0, 0, 0, '2026-05-12T10:00:00Z', '2026-05-12T10:00:00Z', 9.9, 0, 7)
+                  (1, 10, 1, 1, 0, 0, 0, NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 day', 1.5, 0, 1),
+                  (2, 10, 1, 7, 0, 0, 0, NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 day', 9.9, 0, 7)
                 """);
         });
 

--- a/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/testsupport/V5TargetContainer.java
+++ b/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/testsupport/V5TargetContainer.java
@@ -45,7 +45,7 @@ public final class V5TargetContainer implements AutoCloseable {
 
     public V5TargetContainer start() {
         container.start();
-        new MigrationExecutor(dataSource(), Preflight.EXPECTED_FLYWAY_HEAD).execute();
+        new MigrationExecutor(dataSource(), Preflight.EXPECTED_FLYWAY_HEAD, /* skipRepeatable */ true).execute();
         // Mimic the bootstrap step. PermissionCatalog.seed is what the BootstrapCommand
         // invokes immediately after applying Flyway, so downstream phases see the full
         // v5 PERMISSION catalog.


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

v4-migrator: Skip repeatable Flyway migrations.

Repeatable migrations (e.g. component metrics computation) always targets the latest schema version, whereas v4-migrator targets a specific (older) schema version.

Currently, repeatable migrations targeting the latest schema are attempted to be executed against an older schema as part of v4-migrator's `bootstrap` command. They are however not required for the v4 migration, so this failure mode is entirely avoidable by simply not executing them here.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
