### PR TITLE
Make version parameter on project/lookup optional

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -386,7 +386,7 @@ public class ProjectResource extends AbstractApiResource {
     public Response getProject(
             @Parameter(description = "The name of the project to query on", required = true)
             @QueryParam("name") String name,
-            @Parameter(description = "The version of the project to query on", required = true)
+            @Parameter(description = "The version of the project to query on", required = false)
             @QueryParam("version") String version) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final Project project = ProjectAccess.unrestricted(() -> qm.getProject(name, version));


### PR DESCRIPTION
### Description

Accept a missing `version` parameter to look for projects without a version.

This is in line with the actual behavior of the API (see addressed issue).

### Addressed Issue

Fixes #6972

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have ~~provided tests to verify that the fix is effective~~ tested manually, see below
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

### Manual testing

- `make build`
- Inspect `apiserver/target/classes/org/dependencytrack/api/v1/openapi.yaml` to check that `version` is no longer required.

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
