### PR TITLE
Log child projects deleted with their parent

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
@@ -760,10 +760,10 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
     List<DeletedProjectRow> deleteProjects(@Bind Collection<UUID> projectUuids);
 
     record DeletedProjectRow(
-            @ColumnName("UUID") UUID uuid,
-            @ColumnName("NAME") String name,
-            @ColumnName("VERSION") String version,
-            @ColumnName("ANCESTOR_UUID") @Nullable UUID ancestorUuid) {
+            UUID uuid,
+            String name,
+            @Nullable String version,
+            @Nullable UUID ancestorUuid) {
     }
 
     @SqlQuery("""

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
@@ -737,6 +737,44 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
     @GetGeneratedKeys
     Set<UUID> deleteProjects(@Bind Collection<UUID> projectUuids);
 
+    /**
+     * Projects that will be removed by {@code ON DELETE CASCADE} when the given
+     * ancestors are deleted. When multiple requested ancestors are on the same
+     * path, each descendant is attributed to the closest one ({@code DEPTH} ascending).
+     */
+    @SqlQuery("""
+            SELECT DISTINCT ON (descendant."ID")
+                   descendant."UUID" AS "UUID"
+                 , descendant."NAME" AS "NAME"
+                 , descendant."VERSION" AS "VERSION"
+                 , ph."DEPTH" AS "DEPTH"
+                 , ancestor."UUID" AS "ANCESTOR_UUID"
+                 , ancestor."NAME" AS "ANCESTOR_NAME"
+                 , ancestor."VERSION" AS "ANCESTOR_VERSION"
+              FROM "PROJECT_HIERARCHY" AS ph
+             INNER JOIN "PROJECT" AS ancestor
+                ON ancestor."ID" = ph."PARENT_PROJECT_ID"
+             INNER JOIN "PROJECT" AS descendant
+                ON descendant."ID" = ph."CHILD_PROJECT_ID"
+             WHERE ancestor."UUID" = ANY(:ancestorUuids)
+               AND ph."DEPTH" > 0
+             ORDER BY descendant."ID"
+                    , ph."DEPTH"
+                    , ancestor."ID"
+            """)
+    @RegisterConstructorMapper(ProjectDeletedAsDescendant.class)
+    List<ProjectDeletedAsDescendant> getProjectsDeletedAsDescendants(@Bind Collection<UUID> ancestorUuids);
+
+    record ProjectDeletedAsDescendant(
+            @ColumnName("UUID") UUID uuid,
+            @ColumnName("NAME") String name,
+            @ColumnName("VERSION") String version,
+            @ColumnName("DEPTH") int depth,
+            @ColumnName("ANCESTOR_UUID") UUID ancestorUuid,
+            @ColumnName("ANCESTOR_NAME") String ancestorName,
+            @ColumnName("ANCESTOR_VERSION") String ancestorVersion) {
+    }
+
     @SqlQuery("""
              WITH "CTE" AS (
                SELECT "ID"

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
@@ -43,7 +43,6 @@ import org.jdbi.v3.sqlobject.customizer.AllowUnusedBindings;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindMap;
 import org.jdbi.v3.sqlobject.customizer.Define;
-import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jspecify.annotations.Nullable;
@@ -720,59 +719,51 @@ public interface ProjectDao extends SqlObject, PaginationSupport {
             """)
     int deleteProject(@Bind final UUID projectUuid);
 
-    @SqlUpdate("""
-            WITH cte_locked AS (
+    /**
+     * Deletes accessible projects and returns a row for each removed project,
+     * including descendants removed by {@code ON DELETE CASCADE}.
+     * {@code ancestorUuid} is {@code null} for explicitly requested projects;
+     * otherwise it is the closest requested ancestor.
+     */
+    @SqlQuery(/* language=InjectedFreeMarker */ """
+            <#-- @ftlvariable name="apiProjectAclCondition" type="String" -->
+            WITH
+            cte_locked AS (
               SELECT "ID"
                 FROM "PROJECT"
                WHERE ${apiProjectAclCondition}
                  AND "UUID" = ANY(:projectUuids)
                ORDER BY "ID"
                  FOR UPDATE
+            ),
+            cte_deleted AS (
+              DELETE
+                FROM "PROJECT"
+               WHERE "ID" IN (SELECT "ID" FROM cte_locked)
+              RETURNING "ID"
             )
-            DELETE
-              FROM "PROJECT"
-             WHERE "ID" IN (SELECT "ID" FROM cte_locked)
-            RETURNING "UUID"
-            """)
-    @GetGeneratedKeys
-    Set<UUID> deleteProjects(@Bind Collection<UUID> projectUuids);
-
-    /**
-     * Projects that will be removed by {@code ON DELETE CASCADE} when the given
-     * ancestors are deleted. When multiple requested ancestors are on the same
-     * path, each descendant is attributed to the closest one ({@code DEPTH} ascending).
-     */
-    @SqlQuery("""
-            SELECT DISTINCT ON (descendant."ID")
-                   descendant."UUID" AS "UUID"
-                 , descendant."NAME" AS "NAME"
-                 , descendant."VERSION" AS "VERSION"
-                 , ph."DEPTH" AS "DEPTH"
-                 , ancestor."UUID" AS "ANCESTOR_UUID"
-                 , ancestor."NAME" AS "ANCESTOR_NAME"
-                 , ancestor."VERSION" AS "ANCESTOR_VERSION"
+            SELECT DISTINCT ON (project."ID")
+                   project."UUID" AS "UUID"
+                 , project."NAME" AS "NAME"
+                 , project."VERSION" AS "VERSION"
+                 , CASE WHEN ph."DEPTH" = 0 THEN NULL ELSE ancestor."UUID" END AS "ANCESTOR_UUID"
               FROM "PROJECT_HIERARCHY" AS ph
              INNER JOIN "PROJECT" AS ancestor
                 ON ancestor."ID" = ph."PARENT_PROJECT_ID"
-             INNER JOIN "PROJECT" AS descendant
-                ON descendant."ID" = ph."CHILD_PROJECT_ID"
-             WHERE ancestor."UUID" = ANY(:ancestorUuids)
-               AND ph."DEPTH" > 0
-             ORDER BY descendant."ID"
+             INNER JOIN "PROJECT" AS project
+                ON project."ID" = ph."CHILD_PROJECT_ID"
+             WHERE ph."PARENT_PROJECT_ID" IN (SELECT "ID" FROM cte_deleted)
+             ORDER BY project."ID"
                     , ph."DEPTH"
-                    , ancestor."ID"
             """)
-    @RegisterConstructorMapper(ProjectDeletedAsDescendant.class)
-    List<ProjectDeletedAsDescendant> getProjectsDeletedAsDescendants(@Bind Collection<UUID> ancestorUuids);
+    @RegisterConstructorMapper(DeletedProjectRow.class)
+    List<DeletedProjectRow> deleteProjects(@Bind Collection<UUID> projectUuids);
 
-    record ProjectDeletedAsDescendant(
+    record DeletedProjectRow(
             @ColumnName("UUID") UUID uuid,
             @ColumnName("NAME") String name,
             @ColumnName("VERSION") String version,
-            @ColumnName("DEPTH") int depth,
-            @ColumnName("ANCESTOR_UUID") UUID ancestorUuid,
-            @ColumnName("ANCESTOR_NAME") String ancestorName,
-            @ColumnName("ANCESTOR_VERSION") String ancestorVersion) {
+            @ColumnName("ANCESTOR_UUID") @Nullable UUID ancestorUuid) {
     }
 
     @SqlQuery("""

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -1022,41 +1022,35 @@ public class ProjectResource extends AbstractApiResource {
                     responseCode = "403",
                     description = "Access to the requested project is forbidden",
                     content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
-            @ApiResponse(responseCode = "404", description = "The UUID of the project could not be found"),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "The UUID of the project could not be found",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "500", description = "Unable to delete components of the project")
     })
     @PermissionRequired({Permissions.Constants.PORTFOLIO_MANAGEMENT, Permissions.Constants.PORTFOLIO_MANAGEMENT_DELETE})
     public Response deleteProject(
             @Parameter(description = "The UUID of the project to delete", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid) {
-        try (final var qm = new QueryManager(getAlpineRequest())) {
-            qm.runInTransaction(() -> {
-                final Project project = qm.getObjectByUuid(Project.class, uuid, Project.FetchGroup.ALL.name());
-                if (project == null) {
-                    throw new ClientErrorException(Response
-                            .status(Response.Status.NOT_FOUND)
-                            .entity("The UUID of the project could not be found.")
-                            .build());
-                }
-                requireAccess(qm, project);
-
-                final List<ProjectDao.ProjectDeletedAsDescendant> deletedAsDescendants = withJdbiHandle(
-                        getAlpineRequest(),
-                        handle -> handle.attach(ProjectDao.class)
-                                .getProjectsDeletedAsDescendants(Set.of(project.getUuid())));
-
-                try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, project.getUuid().toString());
-                     var _ = MDC.putCloseable(MDC_PROJECT_NAME, project.getName());
-                     var _ = MDC.putCloseable(MDC_PROJECT_VERSION, project.getVersion())) {
-                    LOGGER.info(SecurityMarkers.SECURITY_AUDIT,
-                            "Project {} deletion request by {}", project, super.getPrincipal().getName());
-                }
-                logProjectsDeletedAsDescendants(deletedAsDescendants);
-
-                qm.delete(project);
-            });
+        final UUID projectUuid = UUID.fromString(uuid);
+        final List<ProjectDao.DeletedProjectRow> deletedProjects = inJdbiTransaction(getAlpineRequest(), handle -> {
+            requireProjectAccess(handle, projectUuid);
+            return handle.attach(ProjectDao.class).deleteProjects(Set.of(projectUuid));
+        });
+        for (final ProjectDao.DeletedProjectRow deletedProject : deletedProjects) {
+            if (deletedProject.ancestorUuid() != null) {
+                continue;
+            }
+            try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, deletedProject.uuid().toString());
+                 var _ = MDC.putCloseable(MDC_PROJECT_NAME, deletedProject.name());
+                 var _ = MDC.putCloseable(MDC_PROJECT_VERSION, String.valueOf(deletedProject.version()))) {
+                LOGGER.info(SecurityMarkers.SECURITY_AUDIT,
+                        "Project {} deletion request by {}",
+                        formatDeletedProject(deletedProject),
+                        super.getPrincipal().getName());
+            }
         }
-
+        logProjectsDeletedAsDescendants(deletedProjects);
         return Response.status(Response.Status.NO_CONTENT).build();
     }
 
@@ -1077,44 +1071,39 @@ public class ProjectResource extends AbstractApiResource {
             Permissions.Constants.PORTFOLIO_MANAGEMENT_DELETE
     })
     public Response deleteProjects(@Size(min = 1, max = 1000) final Set<UUID> uuids) {
-        record BatchDeleteResult(
-                Set<UUID> deletedProjectUuids,
-                List<ProjectDao.ProjectDeletedAsDescendant> deletedAsDescendants) {
+        final List<ProjectDao.DeletedProjectRow> deletedProjects = inJdbiTransaction(getAlpineRequest(), handle ->
+                handle.attach(ProjectDao.class).deleteProjects(uuids));
+        for (final ProjectDao.DeletedProjectRow deletedProject : deletedProjects) {
+            if (deletedProject.ancestorUuid() != null) {
+                continue;
+            }
+            LOGGER.info(SecurityMarkers.SECURITY_AUDIT, "Deleted project {}", deletedProject.uuid());
         }
-
-        final BatchDeleteResult result = inJdbiTransaction(getAlpineRequest(), handle -> {
-            final ProjectDao projectDao = handle.attach(ProjectDao.class);
-            final Set<UUID> accessibleProjectUuids = projectDao.getAccessibleProjectUuids(uuids);
-            final List<ProjectDao.ProjectDeletedAsDescendant> deletedAsDescendants = accessibleProjectUuids.isEmpty()
-                    ? List.of()
-                    : projectDao.getProjectsDeletedAsDescendants(accessibleProjectUuids).stream()
-                    // Skip projects that were explicitly requested for deletion;
-                    // those are covered by the direct "Deleted project" log below.
-                    .filter(descendant -> !accessibleProjectUuids.contains(descendant.uuid()))
-                    .toList();
-            return new BatchDeleteResult(projectDao.deleteProjects(uuids), deletedAsDescendants);
-        });
-        for (final UUID deletedUuid : result.deletedProjectUuids()) {
-            LOGGER.info(SecurityMarkers.SECURITY_AUDIT, "Deleted project {}", deletedUuid);
-        }
-        logProjectsDeletedAsDescendants(result.deletedAsDescendants());
+        logProjectsDeletedAsDescendants(deletedProjects);
         return Response.status(Response.Status.NO_CONTENT).build();
     }
 
     private static void logProjectsDeletedAsDescendants(
-            final List<ProjectDao.ProjectDeletedAsDescendant> deletedAsDescendants) {
-        for (final ProjectDao.ProjectDeletedAsDescendant deletedAsDescendant : deletedAsDescendants) {
-            try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, deletedAsDescendant.uuid().toString());
-                 var _ = MDC.putCloseable(MDC_PROJECT_NAME, deletedAsDescendant.name());
-                 var _ = MDC.putCloseable(MDC_PROJECT_VERSION, deletedAsDescendant.version())) {
+            final List<ProjectDao.DeletedProjectRow> deletedProjects) {
+        for (final ProjectDao.DeletedProjectRow deletedProject : deletedProjects) {
+            if (deletedProject.ancestorUuid() == null) {
+                continue;
+            }
+            try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, deletedProject.uuid().toString());
+                 var _ = MDC.putCloseable(MDC_PROJECT_NAME, deletedProject.name());
+                 var _ = MDC.putCloseable(MDC_PROJECT_VERSION, String.valueOf(deletedProject.version()))) {
                 LOGGER.info(SecurityMarkers.SECURITY_AUDIT,
                         "Project {} deleted as child of {}",
-                        deletedAsDescendant.version() == null
-                                ? deletedAsDescendant.name()
-                                : deletedAsDescendant.name() + " : " + deletedAsDescendant.version(),
-                        deletedAsDescendant.ancestorUuid());
+                        formatDeletedProject(deletedProject),
+                        deletedProject.ancestorUuid());
             }
         }
+    }
+
+    private static String formatDeletedProject(final ProjectDao.DeletedProjectRow deletedProject) {
+        return deletedProject.version() == null
+                ? deletedProject.name()
+                : deletedProject.name() + " : " + deletedProject.version();
     }
 
     @PUT

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -1040,11 +1040,18 @@ public class ProjectResource extends AbstractApiResource {
                 }
                 requireAccess(qm, project);
 
+                final List<ProjectDao.ProjectDeletedAsDescendant> deletedAsDescendants = withJdbiHandle(
+                        getAlpineRequest(),
+                        handle -> handle.attach(ProjectDao.class)
+                                .getProjectsDeletedAsDescendants(Set.of(project.getUuid())));
+
                 try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, project.getUuid().toString());
                      var _ = MDC.putCloseable(MDC_PROJECT_NAME, project.getName());
                      var _ = MDC.putCloseable(MDC_PROJECT_VERSION, project.getVersion())) {
-                    LOGGER.info("Project {} deletion request by {}", project, super.getPrincipal().getName());
+                    LOGGER.info(SecurityMarkers.SECURITY_AUDIT,
+                            "Project {} deletion request by {}", project, super.getPrincipal().getName());
                 }
+                logProjectsDeletedAsDescendants(deletedAsDescendants);
 
                 qm.delete(project);
             });
@@ -1070,13 +1077,44 @@ public class ProjectResource extends AbstractApiResource {
             Permissions.Constants.PORTFOLIO_MANAGEMENT_DELETE
     })
     public Response deleteProjects(@Size(min = 1, max = 1000) final Set<UUID> uuids) {
-        final Set<UUID> deletedProjectUuids = inJdbiTransaction(
-                getAlpineRequest(),
-                handle -> handle.attach(ProjectDao.class).deleteProjects(uuids));
-        for (final UUID uuid : deletedProjectUuids) {
-            LOGGER.info(SecurityMarkers.SECURITY_AUDIT, "Deleted project {}", uuid);
+        record BatchDeleteResult(
+                Set<UUID> deletedProjectUuids,
+                List<ProjectDao.ProjectDeletedAsDescendant> deletedAsDescendants) {
         }
+
+        final BatchDeleteResult result = inJdbiTransaction(getAlpineRequest(), handle -> {
+            final ProjectDao projectDao = handle.attach(ProjectDao.class);
+            final Set<UUID> accessibleProjectUuids = projectDao.getAccessibleProjectUuids(uuids);
+            final List<ProjectDao.ProjectDeletedAsDescendant> deletedAsDescendants = accessibleProjectUuids.isEmpty()
+                    ? List.of()
+                    : projectDao.getProjectsDeletedAsDescendants(accessibleProjectUuids).stream()
+                    // Skip projects that were explicitly requested for deletion;
+                    // those are covered by the direct "Deleted project" log below.
+                    .filter(descendant -> !accessibleProjectUuids.contains(descendant.uuid()))
+                    .toList();
+            return new BatchDeleteResult(projectDao.deleteProjects(uuids), deletedAsDescendants);
+        });
+        for (final UUID deletedUuid : result.deletedProjectUuids()) {
+            LOGGER.info(SecurityMarkers.SECURITY_AUDIT, "Deleted project {}", deletedUuid);
+        }
+        logProjectsDeletedAsDescendants(result.deletedAsDescendants());
         return Response.status(Response.Status.NO_CONTENT).build();
+    }
+
+    private static void logProjectsDeletedAsDescendants(
+            final List<ProjectDao.ProjectDeletedAsDescendant> deletedAsDescendants) {
+        for (final ProjectDao.ProjectDeletedAsDescendant deletedAsDescendant : deletedAsDescendants) {
+            try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, deletedAsDescendant.uuid().toString());
+                 var _ = MDC.putCloseable(MDC_PROJECT_NAME, deletedAsDescendant.name());
+                 var _ = MDC.putCloseable(MDC_PROJECT_VERSION, deletedAsDescendant.version())) {
+                LOGGER.info(SecurityMarkers.SECURITY_AUDIT,
+                        "Project {} deleted as child of {}",
+                        deletedAsDescendant.version() == null
+                                ? deletedAsDescendant.name()
+                                : deletedAsDescendant.name() + " : " + deletedAsDescendant.version(),
+                        deletedAsDescendant.ancestorUuid());
+            }
+        }
     }
 
     @PUT

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -1033,24 +1033,10 @@ public class ProjectResource extends AbstractApiResource {
             @Parameter(description = "The UUID of the project to delete", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid) {
         final UUID projectUuid = UUID.fromString(uuid);
-        final List<ProjectDao.DeletedProjectRow> deletedProjects = inJdbiTransaction(getAlpineRequest(), handle -> {
+        logDeletedProjects(inJdbiTransaction(getAlpineRequest(), handle -> {
             requireProjectAccess(handle, projectUuid);
             return handle.attach(ProjectDao.class).deleteProjects(Set.of(projectUuid));
-        });
-        for (final ProjectDao.DeletedProjectRow deletedProject : deletedProjects) {
-            if (deletedProject.ancestorUuid() != null) {
-                continue;
-            }
-            try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, deletedProject.uuid().toString());
-                 var _ = MDC.putCloseable(MDC_PROJECT_NAME, deletedProject.name());
-                 var _ = MDC.putCloseable(MDC_PROJECT_VERSION, String.valueOf(deletedProject.version()))) {
-                LOGGER.info(SecurityMarkers.SECURITY_AUDIT,
-                        "Project {} deletion request by {}",
-                        formatDeletedProject(deletedProject),
-                        super.getPrincipal().getName());
-            }
-        }
-        logProjectsDeletedAsDescendants(deletedProjects);
+        }));
         return Response.status(Response.Status.NO_CONTENT).build();
     }
 
@@ -1071,31 +1057,24 @@ public class ProjectResource extends AbstractApiResource {
             Permissions.Constants.PORTFOLIO_MANAGEMENT_DELETE
     })
     public Response deleteProjects(@Size(min = 1, max = 1000) final Set<UUID> uuids) {
-        final List<ProjectDao.DeletedProjectRow> deletedProjects = inJdbiTransaction(getAlpineRequest(), handle ->
-                handle.attach(ProjectDao.class).deleteProjects(uuids));
-        for (final ProjectDao.DeletedProjectRow deletedProject : deletedProjects) {
-            if (deletedProject.ancestorUuid() != null) {
-                continue;
-            }
-            LOGGER.info(SecurityMarkers.SECURITY_AUDIT, "Deleted project {}", deletedProject.uuid());
-        }
-        logProjectsDeletedAsDescendants(deletedProjects);
+        logDeletedProjects(inJdbiTransaction(getAlpineRequest(), handle ->
+                handle.attach(ProjectDao.class).deleteProjects(uuids)));
         return Response.status(Response.Status.NO_CONTENT).build();
     }
 
-    private static void logProjectsDeletedAsDescendants(
-            final List<ProjectDao.DeletedProjectRow> deletedProjects) {
+    private static void logDeletedProjects(final List<ProjectDao.DeletedProjectRow> deletedProjects) {
         for (final ProjectDao.DeletedProjectRow deletedProject : deletedProjects) {
-            if (deletedProject.ancestorUuid() == null) {
-                continue;
-            }
             try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, deletedProject.uuid().toString());
                  var _ = MDC.putCloseable(MDC_PROJECT_NAME, deletedProject.name());
                  var _ = MDC.putCloseable(MDC_PROJECT_VERSION, String.valueOf(deletedProject.version()))) {
-                LOGGER.info(SecurityMarkers.SECURITY_AUDIT,
-                        "Project {} deleted as child of {}",
-                        formatDeletedProject(deletedProject),
-                        deletedProject.ancestorUuid());
+                if (deletedProject.ancestorUuid() == null) {
+                    LOGGER.info(SecurityMarkers.SECURITY_AUDIT, "Deleted project {}",
+                            formatDeletedProject(deletedProject));
+                } else {
+                    LOGGER.info(SecurityMarkers.SECURITY_AUDIT, "Deleted project {} as descendant of {}",
+                            formatDeletedProject(deletedProject),
+                            deletedProject.ancestorUuid());
+                }
             }
         }
     }

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/ProjectDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/ProjectDaoTest.java
@@ -402,4 +402,67 @@ public class ProjectDaoTest extends PersistenceCapableTest {
         qm.persist(project);
         assertThat(projectDao.getProjectId(project.getUuid())).isEqualTo(project.getId());
     }
+
+    @Test
+    public void testGetProjectsDeletedAsDescendants() {
+        final var parent = new Project();
+        parent.setName("acme-app-parent");
+        parent.setVersion("1.0.0");
+        qm.persist(parent);
+
+        final var child = new Project();
+        child.setParent(parent);
+        child.setName("acme-app-child");
+        child.setVersion("1.0.0");
+        qm.persist(child);
+
+        final var grandChild = new Project();
+        grandChild.setParent(child);
+        grandChild.setName("acme-app-grandchild");
+        grandChild.setVersion("1.0.0");
+        qm.persist(grandChild);
+
+        final var unrelated = new Project();
+        unrelated.setName("other-app");
+        unrelated.setVersion("1.0.0");
+        qm.persist(unrelated);
+
+        assertThat(projectDao.getProjectsDeletedAsDescendants(List.of(parent.getUuid())))
+                .satisfiesExactlyInAnyOrder(
+                        descendant -> {
+                            assertThat(descendant.uuid()).isEqualTo(child.getUuid());
+                            assertThat(descendant.name()).isEqualTo("acme-app-child");
+                            assertThat(descendant.version()).isEqualTo("1.0.0");
+                            assertThat(descendant.depth()).isEqualTo(1);
+                            assertThat(descendant.ancestorUuid()).isEqualTo(parent.getUuid());
+                            assertThat(descendant.ancestorName()).isEqualTo("acme-app-parent");
+                            assertThat(descendant.ancestorVersion()).isEqualTo("1.0.0");
+                        },
+                        descendant -> {
+                            assertThat(descendant.uuid()).isEqualTo(grandChild.getUuid());
+                            assertThat(descendant.name()).isEqualTo("acme-app-grandchild");
+                            assertThat(descendant.version()).isEqualTo("1.0.0");
+                            assertThat(descendant.depth()).isEqualTo(2);
+                            assertThat(descendant.ancestorUuid()).isEqualTo(parent.getUuid());
+                            assertThat(descendant.ancestorName()).isEqualTo("acme-app-parent");
+                            assertThat(descendant.ancestorVersion()).isEqualTo("1.0.0");
+                        });
+
+        // When both parent and child are deleted, attribute grandchild to the closest ancestor.
+        assertThat(projectDao.getProjectsDeletedAsDescendants(List.of(parent.getUuid(), child.getUuid())))
+                .satisfiesExactlyInAnyOrder(
+                        descendant -> {
+                            assertThat(descendant.uuid()).isEqualTo(child.getUuid());
+                            assertThat(descendant.depth()).isEqualTo(1);
+                            assertThat(descendant.ancestorUuid()).isEqualTo(parent.getUuid());
+                        },
+                        descendant -> {
+                            assertThat(descendant.uuid()).isEqualTo(grandChild.getUuid());
+                            assertThat(descendant.depth()).isEqualTo(1);
+                            assertThat(descendant.ancestorUuid()).isEqualTo(child.getUuid());
+                        });
+
+        assertThat(projectDao.getProjectsDeletedAsDescendants(List.of(unrelated.getUuid()))).isEmpty();
+        assertThat(projectDao.getProjectsDeletedAsDescendants(List.of(grandChild.getUuid()))).isEmpty();
+    }
 }

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/ProjectDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/ProjectDaoTest.java
@@ -61,6 +61,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.openJdbiHandle;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiHandle;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 
 public class ProjectDaoTest extends PersistenceCapableTest {
 
@@ -404,7 +405,7 @@ public class ProjectDaoTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testGetProjectsDeletedAsDescendants() {
+    public void testDeleteProjectsReturnsRequestedProjectsAndCascadeDeletedDescendants() {
         final var parent = new Project();
         parent.setName("acme-app-parent");
         parent.setVersion("1.0.0");
@@ -427,42 +428,70 @@ public class ProjectDaoTest extends PersistenceCapableTest {
         unrelated.setVersion("1.0.0");
         qm.persist(unrelated);
 
-        assertThat(projectDao.getProjectsDeletedAsDescendants(List.of(parent.getUuid())))
-                .satisfiesExactlyInAnyOrder(
-                        descendant -> {
-                            assertThat(descendant.uuid()).isEqualTo(child.getUuid());
-                            assertThat(descendant.name()).isEqualTo("acme-app-child");
-                            assertThat(descendant.version()).isEqualTo("1.0.0");
-                            assertThat(descendant.depth()).isEqualTo(1);
-                            assertThat(descendant.ancestorUuid()).isEqualTo(parent.getUuid());
-                            assertThat(descendant.ancestorName()).isEqualTo("acme-app-parent");
-                            assertThat(descendant.ancestorVersion()).isEqualTo("1.0.0");
-                        },
-                        descendant -> {
-                            assertThat(descendant.uuid()).isEqualTo(grandChild.getUuid());
-                            assertThat(descendant.name()).isEqualTo("acme-app-grandchild");
-                            assertThat(descendant.version()).isEqualTo("1.0.0");
-                            assertThat(descendant.depth()).isEqualTo(2);
-                            assertThat(descendant.ancestorUuid()).isEqualTo(parent.getUuid());
-                            assertThat(descendant.ancestorName()).isEqualTo("acme-app-parent");
-                            assertThat(descendant.ancestorVersion()).isEqualTo("1.0.0");
-                        });
+        final List<ProjectDao.DeletedProjectRow> deleted = withJdbiHandle(handle ->
+                handle.attach(ProjectDao.class).deleteProjects(List.of(parent.getUuid())));
 
-        // When both parent and child are deleted, attribute grandchild to the closest ancestor.
-        assertThat(projectDao.getProjectsDeletedAsDescendants(List.of(parent.getUuid(), child.getUuid())))
-                .satisfiesExactlyInAnyOrder(
-                        descendant -> {
-                            assertThat(descendant.uuid()).isEqualTo(child.getUuid());
-                            assertThat(descendant.depth()).isEqualTo(1);
-                            assertThat(descendant.ancestorUuid()).isEqualTo(parent.getUuid());
-                        },
-                        descendant -> {
-                            assertThat(descendant.uuid()).isEqualTo(grandChild.getUuid());
-                            assertThat(descendant.depth()).isEqualTo(1);
-                            assertThat(descendant.ancestorUuid()).isEqualTo(child.getUuid());
-                        });
+        assertThat(deleted).satisfiesExactlyInAnyOrder(
+                row -> {
+                    assertThat(row.uuid()).isEqualTo(parent.getUuid());
+                    assertThat(row.name()).isEqualTo("acme-app-parent");
+                    assertThat(row.version()).isEqualTo("1.0.0");
+                    assertThat(row.ancestorUuid()).isNull();
+                },
+                row -> {
+                    assertThat(row.uuid()).isEqualTo(child.getUuid());
+                    assertThat(row.name()).isEqualTo("acme-app-child");
+                    assertThat(row.version()).isEqualTo("1.0.0");
+                    assertThat(row.ancestorUuid()).isEqualTo(parent.getUuid());
+                },
+                row -> {
+                    assertThat(row.uuid()).isEqualTo(grandChild.getUuid());
+                    assertThat(row.name()).isEqualTo("acme-app-grandchild");
+                    assertThat(row.version()).isEqualTo("1.0.0");
+                    assertThat(row.ancestorUuid()).isEqualTo(parent.getUuid());
+                });
 
-        assertThat(projectDao.getProjectsDeletedAsDescendants(List.of(unrelated.getUuid()))).isEmpty();
-        assertThat(projectDao.getProjectsDeletedAsDescendants(List.of(grandChild.getUuid()))).isEmpty();
+        assertThat(projectDao.getProjectId(parent.getUuid())).isNull();
+        assertThat(projectDao.getProjectId(child.getUuid())).isNull();
+        assertThat(projectDao.getProjectId(grandChild.getUuid())).isNull();
+        assertThat(projectDao.getProjectId(unrelated.getUuid())).isEqualTo(unrelated.getId());
+    }
+
+    @Test
+    public void testDeleteProjectsAttributesDescendantsToClosestRequestedAncestor() {
+        final var parent = new Project();
+        parent.setName("acme-app-parent");
+        parent.setVersion("1.0.0");
+        qm.persist(parent);
+
+        final var child = new Project();
+        child.setParent(parent);
+        child.setName("acme-app-child");
+        child.setVersion("1.0.0");
+        qm.persist(child);
+
+        final var grandChild = new Project();
+        grandChild.setParent(child);
+        grandChild.setName("acme-app-grandchild");
+        grandChild.setVersion("1.0.0");
+        qm.persist(grandChild);
+
+        // Child is explicitly requested, so it is a deletion root rather than a descendant of parent.
+        final List<ProjectDao.DeletedProjectRow> deleted = withJdbiHandle(handle ->
+                handle.attach(ProjectDao.class).deleteProjects(List.of(parent.getUuid(), child.getUuid())));
+
+        assertThat(deleted).satisfiesExactlyInAnyOrder(
+                row -> {
+                    assertThat(row.uuid()).isEqualTo(parent.getUuid());
+                    assertThat(row.ancestorUuid()).isNull();
+                },
+                row -> {
+                    assertThat(row.uuid()).isEqualTo(child.getUuid());
+                    assertThat(row.ancestorUuid()).isNull();
+                },
+                row -> {
+                    assertThat(row.uuid()).isEqualTo(grandChild.getUuid());
+                    assertThat(row.ancestorUuid()).isEqualTo(child.getUuid());
+                });
     }
 }


### PR DESCRIPTION
### Description

When a project is deleted, its children are now recorded in the security audit log as well, not only the project that was explicitly requested.

### Addressed Issue

Closes #6975

### Additional Details
For batch delete, projects that were explicitly requested keep the existing “Deleted project” log and are not also logged as cascade children. When several requested projects sit on the same path, each descendant is attributed to the closest requested ancestor.

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- [ ] ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations