### PR TITLE
Add missing @Consumes annotations

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/AccessControlResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/AccessControlResource.java
@@ -33,6 +33,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Validator;
 import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.PUT;
@@ -123,6 +124,7 @@ public class AccessControlResource extends AbstractApiResource {
     @PUT
     @Path("/mapping")
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Adds an ACL mapping",
             description = "<p>Requires permission <strong>ACCESS_MANAGEMENT</strong></p>"

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/LdapResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/LdapResource.java
@@ -34,6 +34,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Validator;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.PUT;
@@ -155,6 +156,7 @@ public class LdapResource extends AbstractApiResource {
     @PUT
     @Path("/mapping")
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Adds a mapping",
             description = "<p>Requires permission <strong>ACCESS_MANAGEMENT</strong> or <strong>ACCESS_MANAGEMENT_CREATE</strong></p>"

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/LicenseResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/LicenseResource.java
@@ -32,6 +32,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Validator;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.PUT;
@@ -159,6 +160,7 @@ public class LicenseResource extends AbstractApiResource {
 
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Creates a new custom license",
             description = "<p>Requires permission <strong>SYSTEM_CONFIGURATION</strong> or <strong>SYSTEM_CONFIGURATION_CREATE</strong></p>"

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/OidcResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/OidcResource.java
@@ -247,6 +247,7 @@ public class OidcResource extends AbstractApiResource {
     @PUT
     @Path("/mapping")
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Adds a mapping",
             description = "<p>Requires permission <strong>ACCESS_MANAGEMENT</strong> or <strong>ACCESS_MANAGEMENT_CREATE</strong></p>"

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/UserResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/UserResource.java
@@ -356,6 +356,7 @@ public class UserResource extends AbstractApiResource {
     @POST
     @Path("self")
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Updates information about the current logged in user."
     )


### PR DESCRIPTION
### Description

Some `@Consumes` annotations were missing, resulting in `*/*` as accepted content type in the generated OpenAPI.

After this change, the following returns no results anymore:

```
grep -F '*/*' apiserver/target/classes/org/dependencytrack/api/v1/openapi.yaml
```

### Addressed Issue

Fixes #6977.

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
