### PR TITLE
Stop bumping AffectedVersionAttribution.lastSeen

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/AffectedVersionAttribution.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/AffectedVersionAttribution.java
@@ -71,7 +71,10 @@ public class AffectedVersionAttribution implements Serializable {
 
     @Persistent
     @Column(name = "LAST_SEEN", allowsNull = "false")
-    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            deprecated = true,
+            description = "Deprecated; always equal to firstSeen")
     private Date lastSeen;
 
     @Persistent
@@ -115,12 +118,15 @@ public class AffectedVersionAttribution implements Serializable {
 
     public void setFirstSeen(final Date firstSeen) {
         this.firstSeen = firstSeen;
+        this.lastSeen = firstSeen;
     }
 
+    @Deprecated(forRemoval = true, since = "5.1.0")
     public Date getLastSeen() {
         return lastSeen;
     }
 
+    @Deprecated(forRemoval = true, since = "5.1.0")
     public void setLastSeen(final Date lastSeen) {
         this.lastSeen = lastSeen;
     }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -692,13 +692,6 @@ public class QueryManager extends AlpineQueryManager {
         getVulnerabilityQueryManager().deleteAffectedVersionAttributions(vulnerability, vulnerableSoftwares, source);
     }
 
-    public boolean hasAffectedVersionAttribution(
-            final Vulnerability vulnerability,
-            final VulnerableSoftware vulnerableSoftware,
-            final Vulnerability.Source source) {
-        return getVulnerabilityQueryManager().hasAffectedVersionAttribution(vulnerability, vulnerableSoftware, source);
-    }
-
     public boolean hasVulnerabilities(final Project project) {
         return getVulnerabilityQueryManager().hasVulnerabilities(project);
     }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -563,31 +563,6 @@ final class VulnerabilityQueryManager extends QueryManager {
     }
 
     /**
-     * Check if any {@link AffectedVersionAttribution} exists for a given {@link Vulnerability}-{@link VulnerableSoftware} relationship.
-     *
-     * @param vulnerability      The {@link Vulnerability} to check for
-     * @param vulnerableSoftware The {@link VulnerableSoftware} to check for
-     * @param source             The {@link Vulnerability.Source} to check for
-     * @return {@code true} when an attribution exists, otherwise {@code false}
-     * @since 4.10.0
-     */
-    @Override
-    public boolean hasAffectedVersionAttribution(
-            final Vulnerability vulnerability,
-            final VulnerableSoftware vulnerableSoftware,
-            final Vulnerability.Source source) {
-        final Query<AffectedVersionAttribution> query = pm.newQuery(AffectedVersionAttribution.class);
-        query.setFilter("source == :source && vulnerability == :vuln && vulnerableSoftware == :vs");
-        query.setNamedParameters(Map.of(
-                "source", source,
-                "vuln", vulnerability,
-                "vs", vulnerableSoftware));
-        query.setRange(0, 1);
-        query.setResult("id");
-        return !executeAndCloseResultList(query, Long.class).isEmpty();
-    }
-
-    /**
      * @since 5.0.0
      */
     @Override

--- a/apiserver/src/main/java/org/dependencytrack/persistence/VulnerableSoftwareQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/VulnerableSoftwareQueryManager.java
@@ -29,11 +29,14 @@ import org.slf4j.LoggerFactory;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static java.util.stream.Collectors.groupingBy;
 import static org.dependencytrack.util.PersistenceUtil.assertNonPersistentAll;
@@ -245,7 +248,7 @@ final class VulnerableSoftwareQueryManager extends QueryManager {
             // Note: For SOME ODD REASON, duplicate (as in, same database ID and all) VulnerableSoftware
             // records are returned. We thus have to deduplicate here.
             final List<VulnerableSoftware> vsOldList = persistentVuln.getVulnerableSoftware().stream().distinct().toList();
-            LOGGER.trace("%s: Existing VS: %d".formatted(persistentVuln.getVulnId(), vsOldList.size()));
+            LOGGER.trace("{}: Existing VS: {}", persistentVuln.getVulnId(), vsOldList.size());
 
             // Get attributions for all existing VulnerableSoftware records.
             final Map<Long, List<AffectedVersionAttribution>> attributionsByVsId =
@@ -262,14 +265,18 @@ final class VulnerableSoftwareQueryManager extends QueryManager {
             final var vsListToKeep = new ArrayList<VulnerableSoftware>();
 
             // Separately track existing VulnerableSoftware records that are reported by the source.
-            // Records in this list must be attributed to the source.
-            // Records in vsListToKeep that are NOT in this list could have been reported by other sources.
-            final var matchedOldVsList = new ArrayList<VulnerableSoftware>();
+            // Records in this set must be attributed to the source.
+            // Records in vsListToKeep that are NOT in this set could have been reported by other sources.
+            //
+            // NB: Identity-based because the entries are instances taken from vsOldList,
+            // so reference equality is sufficient.
+            final Set<VulnerableSoftware> matchedOldVsSet =
+                    Collections.newSetFromMap(new IdentityHashMap<>());
 
             for (final VulnerableSoftware vsOld : vsOldList) {
                 if (mutableVsList.removeIf(vsOld::equalsIgnoringDatastoreIdentity)) {
                     vsListToKeep.add(vsOld);
-                    matchedOldVsList.add(vsOld);
+                    matchedOldVsSet.add(vsOld);
                 } else {
                     final List<AffectedVersionAttribution> attributions = vsOld.getAffectedVersionAttributions();
                     if (attributions == null || attributions.isEmpty()) {
@@ -292,8 +299,8 @@ final class VulnerableSoftwareQueryManager extends QueryManager {
                     }
                 }
             }
-            LOGGER.trace("%s: vsListToKeep: %d".formatted(persistentVuln.getVulnId(), vsListToKeep.size()));
-            LOGGER.trace("%s: vsListToRemove: %d".formatted(persistentVuln.getVulnId(), vsListToRemove.size()));
+            LOGGER.trace("{}: vsListToKeep: {}", persistentVuln.getVulnId(), vsListToKeep.size());
+            LOGGER.trace("{}: vsListToRemove: {}", persistentVuln.getVulnId(), vsListToRemove.size());
 
             // Remove attributions for VulnerableSoftware records that are no longer reported.
             if (!vsListToRemove.isEmpty()) {
@@ -302,24 +309,20 @@ final class VulnerableSoftwareQueryManager extends QueryManager {
 
             final var attributionDate = new Date();
 
-            // For VulnerableSoftware records that existed before, update the lastSeen timestamp,
-            // or create an attribution if it doesn't exist already.
+            // For VulnerableSoftware records that existed before,
+            // create an attribution if it doesn't exist already.
+            //
+            // NB: Attributions that already exist remain untouched.
+            // Refreshing their lastSeen timestamp causes unnecessary write amplification.
             for (final VulnerableSoftware oldVs : vsListToKeep) {
-                boolean hasAttribution = false;
-                if (oldVs.getAffectedVersionAttributions() != null) {
-                    for (final AffectedVersionAttribution attribution : oldVs.getAffectedVersionAttributions()) {
-                        if (attribution.getSource() == source) {
-                            attribution.setLastSeen(attributionDate);
-                            hasAttribution = true;
-                            break;
-                        }
-                    }
-                }
+                final List<AffectedVersionAttribution> attributions = oldVs.getAffectedVersionAttributions();
+                final boolean hasAttribution = attributions != null
+                        && attributions.stream().anyMatch(attribution -> attribution.getSource() == source);
 
                 // The record was previously reported by others, but now the source reports it, too.
                 // Ensure that an attribution is added accordingly.
-                if (matchedOldVsList.contains(oldVs) && !hasAttribution) {
-                    LOGGER.trace("%s: Adding attribution".formatted(persistentVuln.getVulnId()));
+                if (matchedOldVsSet.contains(oldVs) && !hasAttribution) {
+                    LOGGER.trace("{}: Adding attribution", persistentVuln.getVulnId());
                     final AffectedVersionAttribution attribution = createAttribution(
                             persistentVuln, oldVs, attributionDate, source);
                     persist(attribution);
@@ -353,20 +356,19 @@ final class VulnerableSoftwareQueryManager extends QueryManager {
                     throw new IllegalStateException("VulnerableSoftware must define a CPE or PURL, but %s has neither".formatted(vs));
                 }
                 if (existingVs != null) {
-                    final boolean hasAttribution = hasAffectedVersionAttribution(persistentVuln, existingVs, source);
-                    if (!hasAttribution) {
-                        LOGGER.trace("%s: Adding attribution".formatted(persistentVuln.getVulnId()));
+                    final AffectedVersionAttribution existingAttribution =
+                            getAffectedVersionAttribution(persistentVuln, existingVs, source);
+                    if (existingAttribution == null) {
+                        LOGGER.trace("{}: Adding attribution", persistentVuln.getVulnId());
                         final AffectedVersionAttribution attribution = createAttribution(persistentVuln, existingVs, attributionDate, source);
                         persist(attribution);
                     } else {
-                        LOGGER.debug("%s: Encountered dangling attribution; Re-using by updating firstSeen and lastSeen timestamps".formatted(persistentVuln.getVulnId()));
-                        final AffectedVersionAttribution existingAttribution = getAffectedVersionAttribution(persistentVuln, existingVs, source);
+                        LOGGER.debug("{}: Encountered dangling attribution; Re-using by updating firstSeen timestamp", persistentVuln.getVulnId());
                         existingAttribution.setFirstSeen(attributionDate);
-                        existingAttribution.setLastSeen(attributionDate);
                     }
                     vsListToKeep.add(existingVs);
                 } else {
-                    LOGGER.trace("%s: Creating new VS".formatted(persistentVuln.getVulnId()));
+                    LOGGER.trace("{}: Creating new VS", persistentVuln.getVulnId());
                     final VulnerableSoftware persistentVs = persist(vs);
                     final AffectedVersionAttribution attribution = createAttribution(persistentVuln, persistentVs, attributionDate, source);
                     persist(attribution);
@@ -374,9 +376,9 @@ final class VulnerableSoftwareQueryManager extends QueryManager {
                 }
             }
 
-            LOGGER.trace("%s: Final vsList: %d".formatted(persistentVuln.getVulnId(), vsListToKeep.size()));
+            LOGGER.trace("{}: Final vsList: {}", persistentVuln.getVulnId(), vsListToKeep.size());
             if (!Objects.equals(persistentVuln.getVulnerableSoftware(), vsListToKeep)) {
-                LOGGER.trace("%s: vsList has changed: %s".formatted(persistentVuln.getVulnId(), new PersistenceUtil.Diff(persistentVuln.getVulnerableSoftware(), vsListToKeep)));
+                LOGGER.trace("{}: vsList has changed: {}", persistentVuln.getVulnId(), new PersistenceUtil.Diff(persistentVuln.getVulnerableSoftware(), vsListToKeep));
                 persistentVuln.setVulnerableSoftware(vsListToKeep);
             }
         });
@@ -392,7 +394,6 @@ final class VulnerableSoftwareQueryManager extends QueryManager {
         attribution.setVulnerability(vuln);
         attribution.setVulnerableSoftware(vs);
         attribution.setFirstSeen(attributionDate);
-        attribution.setLastSeen(attributionDate);
         return attribution;
     }
 

--- a/apiserver/src/test/java/org/dependencytrack/persistence/VulnerableSoftwareQueryManagerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/VulnerableSoftwareQueryManagerTest.java
@@ -105,7 +105,8 @@ public class VulnerableSoftwareQueryManagerTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testSynchronizeVulnerableSoftwareUpdatesLastSeen() {
+    @SuppressWarnings("removal")
+    public void shouldNotUpdateAttributionTimestampsWhenSynchronizeVulnerableSoftwareReportsUnchangedVersions() {
         final VulnerableSoftware vs = new VulnerableSoftware();
         vs.setCpe23("cpe:2.3:a:acme:product:1.0.0:*:*:*:*:*:*:*");
 
@@ -139,10 +140,26 @@ public class VulnerableSoftwareQueryManagerTest extends PersistenceCapableTest {
                 Vulnerability.Source.NVD
         );
 
-        // Verify lastSeen was updated
-        assertThat(attribution2.getLastSeen()).isAfter(firstLastSeen);
-        // Verify firstSeen was not changed
+        // Re-reporting the same affected version must not write to the attribution at all.
+        assertThat(attribution2.getLastSeen()).isEqualTo(firstLastSeen);
         assertThat(attribution2.getFirstSeen()).isEqualTo(attribution1.getFirstSeen());
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    public void shouldRecordLastSeenEqualToFirstSeenWhenSynchronizeVulnerableSoftwareCreatesAttribution() {
+        final VulnerableSoftware vs = new VulnerableSoftware();
+        vs.setCpe23("cpe:2.3:a:acme:product:1.0.0:*:*:*:*:*:*:*");
+        qm.persist(vs);
+
+        final VulnerableSoftware vsTransient = new VulnerableSoftware();
+        vsTransient.setCpe23("cpe:2.3:a:acme:product:1.0.0:*:*:*:*:*:*:*");
+        qm.synchronizeVulnerableSoftware(vulnerability, List.of(vsTransient), Vulnerability.Source.NVD);
+
+        final AffectedVersionAttribution attribution =
+                qm.getAffectedVersionAttribution(vulnerability, vs, Vulnerability.Source.NVD);
+
+        assertThat(attribution.getLastSeen()).isEqualTo(attribution.getFirstSeen());
     }
 
     @Test
@@ -568,25 +585,7 @@ public class VulnerableSoftwareQueryManagerTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testHasAffectedVersionAttribution() {
-        final VulnerableSoftware vs = new VulnerableSoftware();
-        vs.setCpe23("cpe:2.3:a:acme:product:1.0.0:*:*:*:*:*:*:*");
-        qm.persist(vs);
-
-        // Initially, no attribution exists
-        assertThat(qm.hasAffectedVersionAttribution(vulnerability, vs, Vulnerability.Source.NVD)).isFalse();
-
-        // Create attribution using a new transient object
-        final VulnerableSoftware vsTransient = new VulnerableSoftware();
-        vsTransient.setCpe23("cpe:2.3:a:acme:product:1.0.0:*:*:*:*:*:*:*");
-        qm.synchronizeVulnerableSoftware(vulnerability, List.of(vsTransient), Vulnerability.Source.NVD);
-
-        // Now attribution should exist
-        assertThat(qm.hasAffectedVersionAttribution(vulnerability, vs, Vulnerability.Source.NVD)).isTrue();
-    }
-
-    @Test
-    public void testHasAffectedVersionAttributionWithDifferentSource() {
+    public void shouldReturnNullWhenGetAffectedVersionAttributionQueriesAnotherSource() {
         final VulnerableSoftware vs = new VulnerableSoftware();
         vs.setCpe23("cpe:2.3:a:acme:product:1.0.0:*:*:*:*:*:*:*");
         qm.persist(vs);
@@ -596,11 +595,8 @@ public class VulnerableSoftwareQueryManagerTest extends PersistenceCapableTest {
         vsTransient.setCpe23("cpe:2.3:a:acme:product:1.0.0:*:*:*:*:*:*:*");
         qm.synchronizeVulnerableSoftware(vulnerability, List.of(vsTransient), Vulnerability.Source.NVD);
 
-        // Check for NVD - should exist
-        assertThat(qm.hasAffectedVersionAttribution(vulnerability, vs, Vulnerability.Source.NVD)).isTrue();
-
-        // Check for OSV - should not exist
-        assertThat(qm.hasAffectedVersionAttribution(vulnerability, vs, Vulnerability.Source.OSV)).isFalse();
+        assertThat(qm.getAffectedVersionAttribution(vulnerability, vs, Vulnerability.Source.NVD)).isNotNull();
+        assertThat(qm.getAffectedVersionAttribution(vulnerability, vs, Vulnerability.Source.OSV)).isNull();
     }
 
     @Test


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Stops bumping `AffectedVersionAttribution.lastSeen`.

The field / column was introduced at a time where vuln data source mirroring was NOT incremental. It doesn't provide any value outside of manual inspection, but leads to large amounts of `UPDATE` queries, which can slow down mirroring runs by means of network latency alone.

This change merely deprecates the field and stops bumping it. `lastSeen` will always be equal to `firstSeen` until its removal. The corresponding DB column stays around to enable smooth rolling upgrades for users coming from 5.0.x. We'll drop the column in 5.2.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #5934 
Relates to #6971 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
