### PR TITLE
Improve BOV model conversion for vulns with many affected components

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/parser/dependencytrack/BovModelConverter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/dependencytrack/BovModelConverter.java
@@ -59,13 +59,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static io.github.nscuro.versatile.version.KnownVersioningSchemes.SCHEME_GENERIC;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
@@ -272,16 +274,17 @@ public final class BovModelConverter {
             return Collections.emptyList();
         }
 
-        final var componentByBomRef = new HashMap<String, Component>();
+        final Map<String, Component> componentByBomRef =
+                bov.getComponentsList().stream().collect(
+                        Collectors.toMap(
+                                Component::getBomRef,
+                                Function.identity(),
+                                (first, _) -> first));
+
         final var vsList = new ArrayList<VulnerableSoftware>();
 
         for (final VulnerabilityAffects bovVulnAffects : vuln.getAffectsList()) {
-            final Component component = componentByBomRef.computeIfAbsent(
-                    bovVulnAffects.getRef(),
-                    bomRef -> bov.getComponentsList().stream()
-                            .filter(c -> bomRef.equals(c.getBomRef()))
-                            .findAny()
-                            .orElse(null));
+            final Component component = componentByBomRef.get(bovVulnAffects.getRef());
             if (component == null) {
                 LOGGER.warn(
                         "No component in the BOV for {} is matching the BOM ref '{}' of the affects node; Skipping",


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Improves BOV model conversion for vulns with many affected components.

Avoids repetitive `O(n)` list iteration to identify component records by their BOM ref by simply indexing them upfront in a map.

Really just a very minor optimization that will only have noticeable impact for vulns with A LOT of affected components, which is more likely with BOVs emitted by the OSV data source for Linux distro ecosystems.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #5934 
Relates to #6971 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
