### PR TITLE
Fix project-create team picker stopping at 100 teams.

### DIFF
--- a/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
+++ b/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
@@ -566,6 +566,7 @@ public class AlpineQueryManager extends AbstractAlpineQueryManager {
         if (filter != null) {
             query.setFilter("name.toLowerCase().matches(:filter)");
             final String filterString = ".*" + filter.toLowerCase() + ".*";
+            query.setOrdering("name asc");
             return execute(query, filterString);
         }
         query.setOrdering("name asc");

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -81,7 +81,7 @@ import javax.jdo.FetchGroup;
 import java.security.Principal;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -98,7 +98,6 @@ import static org.dependencytrack.common.MdcKeys.MDC_PROJECT_VERSION;
 import static org.dependencytrack.notification.api.NotificationFactory.createProjectCreatedNotification;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.inJdbiTransaction;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
-import static org.dependencytrack.util.PersistenceUtil.isPersistent;
 import static org.dependencytrack.util.PersistenceUtil.isUniqueConstraintViolation;
 
 /**
@@ -596,23 +595,30 @@ public class ProjectResource extends AbstractApiResource {
                     } else {
                         userTeams = List.of();
                     }
+                    if (userTeams == null) {
+                        userTeams = List.of();
+                    }
 
                     boolean canSeeAllTeams =
                             super.hasPermission(Permissions.Constants.ACCESS_MANAGEMENT)
                                     || super.hasPermission(Permissions.Constants.ACCESS_MANAGEMENT_READ);
-                    List<Team> visibleTeams = canSeeAllTeams ? qm.getTeams().getList(Team.class) : userTeams;
-                    final var visibleTeamByUuid = new HashMap<UUID, Team>(visibleTeams.size());
-                    final var visibleTeamByName = new HashMap<String, Team>(visibleTeams.size());
-                    for (final Team visibleTeam : visibleTeams) {
-                        visibleTeamByUuid.put(visibleTeam.getUuid(), visibleTeam);
-                        visibleTeamByName.put(visibleTeam.getName(), visibleTeam);
+                    final Set<UUID> memberTeamUuids = new HashSet<>();
+                    if (!canSeeAllTeams) {
+                        for (final Team userTeam : userTeams) {
+                            memberTeamUuids.add(userTeam.getUuid());
+                        }
                     }
 
                     for (Team chosenTeam : chosenTeams) {
-                        Team visibleTeam = visibleTeamByUuid.getOrDefault(
-                                chosenTeam.getUuid(),
-                                visibleTeamByName.get(chosenTeam.getName()));
-                        if (visibleTeam == null) {
+                        Team visibleTeam = null;
+                        if (chosenTeam.getUuid() != null) {
+                            visibleTeam = qm.getObjectByUuid(Team.class, chosenTeam.getUuid());
+                        }
+                        if (visibleTeam == null && chosenTeam.getName() != null) {
+                            visibleTeam = qm.getTeam(chosenTeam.getName());
+                        }
+                        if (visibleTeam == null
+                                || (!canSeeAllTeams && !memberTeamUuids.contains(visibleTeam.getUuid()))) {
                             throw new ClientErrorException(Response
                                     .status(Response.Status.BAD_REQUEST)
                                     .entity("""
@@ -622,11 +628,6 @@ public class ProjectResource extends AbstractApiResource {
                                             ? "UUID " + chosenTeam.getUuid()
                                             : "name " + chosenTeam.getName()))
                                     .build());
-                        }
-                        if (!isPersistent(visibleTeam)) {
-                            // Teams sourced from the principal will not be in persistent state
-                            // and need to be attached to the persistence context.
-                            visibleTeam = qm.getObjectById(Team.class, visibleTeam.getId());
                         }
                         jsonProject.addAccessTeam(visibleTeam);
                     }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
@@ -27,6 +27,7 @@ import alpine.security.InvalidApiKeyFormatException;
 import alpine.server.auth.PermissionRequired;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -61,6 +62,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.datanucleus.PropertyNames.PROPERTY_RETAIN_VALUES;
@@ -248,9 +250,25 @@ public class TeamResource extends AbstractApiResource {
     @GET
     @Path("/visible")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Returns a list of Teams that are visible", description = "<p></p>")
+    @Operation(
+            summary = "Returns a list of Teams that are visible",
+            description = """
+                    <p>Optional query parameter <code>searchText</code>. The search is case insensitive \
+                    and matches team names.</p>"""
+    )
+    @PaginatedApi
+    @Parameter(
+            name = "searchText",
+            in = ParameterIn.QUERY,
+            description = "Optional case-insensitive substring match on team name."
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "The Visible Teams", content = @Content(array = @ArraySchema(schema = @Schema(implementation = VisibleTeams.class)))),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "The Visible Teams",
+                    headers = @Header(name = TOTAL_COUNT_HEADER, description = "The total number of visible teams", schema = @Schema(format = "integer")),
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = VisibleTeams.class)))
+            ),
             @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
     public Response availableTeams() {
@@ -258,23 +276,39 @@ public class TeamResource extends AbstractApiResource {
             boolean isAllTeams =
                     super.hasPermission(Permissions.Constants.ACCESS_MANAGEMENT)
                             || super.hasPermission(Permissions.Constants.ACCESS_MANAGEMENT_READ);
-            List<Team> teams = new ArrayList<>();
+            final List<Team> teams;
+            final long total;
             if (isAllTeams) {
-                var paginatedResult = qm.getTeams();
+                final PaginatedResult paginatedResult = qm.getTeams();
                 teams = paginatedResult.getList(Team.class);
+                total = paginatedResult.getTotal();
             } else {
-                if (getPrincipal() instanceof final User user) {
-                    teams = user.getTeams();
-                } else if (getPrincipal() instanceof final ApiKey apiKey) {
-                    teams = apiKey.getTeams();
+                List<Team> visibleTeams = List.of();
+                if (getPrincipal() instanceof final User user && user.getTeams() != null) {
+                    visibleTeams = user.getTeams();
+                } else if (getPrincipal() instanceof final ApiKey apiKey && apiKey.getTeams() != null) {
+                    visibleTeams = apiKey.getTeams();
                 }
+                final String filter = getAlpineRequest().getFilter();
+                if (filter != null && !filter.isBlank()) {
+                    final String needle = filter.toLowerCase();
+                    visibleTeams = visibleTeams.stream()
+                            .filter(team -> team.getName() != null && team.getName().toLowerCase().contains(needle))
+                            .toList();
+                }
+                total = visibleTeams.size();
+                teams = visibleTeams.stream()
+                        .sorted(Comparator.comparing(Team::getName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
+                        .skip(getAlpineRequest().getPagination().getOffset())
+                        .limit(getAlpineRequest().getPagination().getLimit())
+                        .toList();
             }
 
-            List<VisibleTeams> response = new ArrayList<>();
+            final List<VisibleTeams> response = new ArrayList<>(teams.size());
             for (Team team : teams) {
                 response.add(new VisibleTeams(team.getName(), team.getUuid()));
             }
-            return Response.ok(response).build();
+            return Response.ok(response).header(TOTAL_COUNT_HEADER, total).build();
         }
     }
 

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -4694,6 +4694,43 @@ class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
+    void createProjectAsUserWithAclEnabledAndTeamBeyondDefaultPageSizeAdminTest() {
+        initializeWithPermissions(Permissions.ACCESS_MANAGEMENT, Permissions.PORTFOLIO_MANAGEMENT_CREATE);
+        enablePortfolioAccessControl();
+
+        final ManagedUser testUser = qm.createManagedUser("testuser", TEST_USER_PASSWORD_HASH);
+        qm.addUserToTeam(testUser, team);
+
+        final String userSessionToken = new SessionTokenService().createSession(testUser.getId());
+
+        // getTeams() is ordered by name and defaults to page size 100.
+        // Names starting with "Z" sort after the built-in "Test Users" team.
+        Team lastTeam = null;
+        for (int i = 0; i < 100; i++) {
+            lastTeam = qm.createTeam("ZTeam " + String.format("%03d", i));
+        }
+        final Team assignedTeam = lastTeam;
+
+        final Response response = jersey.target(V1_PROJECT)
+                .request()
+                .header("Authorization", "Bearer " + userSessionToken)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "name": "acme-app",
+                          "accessTeams": [
+                            {
+                              "uuid": "%s"
+                            }
+                          ]
+                        }
+                        """.formatted(assignedTeam.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(201);
+
+        assertThat(qm.getProject("acme-app", null)).satisfies(project ->
+                assertThat(project.getAccessTeams()).extracting(Team::getName).containsOnly(assignedTeam.getName()));
+    }
+
+    @Test
     void createProjectAsUserWithAclEnabledAndTeamNotExistingNoAdminTest() {
         enablePortfolioAccessControl();
 

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
@@ -594,6 +594,86 @@ public class TeamResourceTest extends ResourceTest {
     }
 
     @Test
+    public void getVisibleAdminTeamsPaginationTest() {
+        initializeWithPermissions(Permissions.ACCESS_MANAGEMENT_READ);
+
+        for (int i = 0; i < 100; i++) {
+            qm.createTeam("Extra Team " + i);
+        }
+
+        Response response = jersey.target(V1_TEAM + "/visible")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        org.junit.jupiter.api.Assertions.assertEquals(200, response.getStatus(), 0);
+        JsonArray teams = parseJsonArray(response);
+        // ResourceTest creates one built-in team, plus 100 extras. Default page size is 100.
+        org.junit.jupiter.api.Assertions.assertEquals(100, teams.size());
+        org.junit.jupiter.api.Assertions.assertEquals("101", response.getHeaderString(TOTAL_COUNT_HEADER));
+
+        response = jersey.target(V1_TEAM + "/visible")
+                .queryParam("pageNumber", "2")
+                .queryParam("pageSize", "10")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        org.junit.jupiter.api.Assertions.assertEquals(200, response.getStatus(), 0);
+        teams = parseJsonArray(response);
+        org.junit.jupiter.api.Assertions.assertEquals(10, teams.size());
+        org.junit.jupiter.api.Assertions.assertEquals("101", response.getHeaderString(TOTAL_COUNT_HEADER));
+    }
+
+    @Test
+    public void getVisibleAdminTeamsFilterByNameTest() {
+        initializeWithPermissions(Permissions.ACCESS_MANAGEMENT_READ);
+
+        qm.createTeam("Alpha Team");
+        qm.createTeam("Beta Team");
+        qm.createTeam("Alphabet Soup");
+
+        Response response = jersey.target(V1_TEAM + "/visible")
+                .queryParam("searchText", "alpha")
+                .queryParam("pageSize", "10")
+                .queryParam("pageNumber", "1")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        org.junit.jupiter.api.Assertions.assertEquals(200, response.getStatus(), 0);
+        JsonArray teams = parseJsonArray(response);
+        org.junit.jupiter.api.Assertions.assertEquals(2, teams.size());
+        org.junit.jupiter.api.Assertions.assertEquals("2", response.getHeaderString(TOTAL_COUNT_HEADER));
+        org.junit.jupiter.api.Assertions.assertEquals("Alpha Team", teams.getJsonObject(0).getString("name"));
+        org.junit.jupiter.api.Assertions.assertEquals("Alphabet Soup", teams.getJsonObject(1).getString("name"));
+    }
+
+    @Test
+    public void getVisibleNotAdminTeamsFilterByNameTest() {
+        setUpUser(false);
+        qm.createTeam("Unrelated Team");
+
+        Response response = jersey.target(V1_TEAM + "/visible")
+                .queryParam("searchText", "test")
+                .request()
+                .header("Authorization", "Bearer " + sessionToken)
+                .get();
+        org.junit.jupiter.api.Assertions.assertEquals(200, response.getStatus(), 0);
+        JsonArray teams = parseJsonArray(response);
+        org.junit.jupiter.api.Assertions.assertEquals(1, teams.size());
+        org.junit.jupiter.api.Assertions.assertEquals("1", response.getHeaderString(TOTAL_COUNT_HEADER));
+        org.junit.jupiter.api.Assertions.assertEquals(this.team.getUuid().toString(), teams.getFirst().asJsonObject().getString("uuid"));
+
+        response = jersey.target(V1_TEAM + "/visible")
+                .queryParam("searchText", "unrelated")
+                .request()
+                .header("Authorization", "Bearer " + sessionToken)
+                .get();
+        org.junit.jupiter.api.Assertions.assertEquals(200, response.getStatus(), 0);
+        teams = parseJsonArray(response);
+        org.junit.jupiter.api.Assertions.assertEquals(0, teams.size());
+        org.junit.jupiter.api.Assertions.assertEquals("0", response.getHeaderString(TOTAL_COUNT_HEADER));
+    }
+
+    @Test
     public void getVisibleNotAdminTeams() {
         setUpUser(false);
         Response response = jersey.target(V1_TEAM + "/visible")


### PR DESCRIPTION
### Description
The API that lists teams for project creation now supports search and paging, so the new team picker can find teams without loading the full list.

### Addressed Issue
#6991 

### Additional Details
Frontend PR: [https://github.com/DependencyTrack/frontend/pull/1755](https://github.com/DependencyTrack/frontend/pull/1755)

### Checklist
- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`
