### PR TITLE
Fix S3 credential provider properties docs

### DIFF
--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -1134,35 +1134,44 @@ dt.file-storage.local.directory=${dt.data-directory}/storage
 
 # Defines the source of the credentials used to authenticate against the S3 endpoint.
 # <br/><br/>
-# When set to `static`, the statically configured `dt.file-storage.s3.access-key` and
-# `dt.file-storage.s3.secret-key` are used. When both are missing, requests are performed
+# When set to `static`, the statically configured dt.file-storage.s3.access-key and
+# dt.file-storage.s3.secret-key are used. When both are missing, requests are performed
 # anonymously. When only one of the two is set, startup fails.
 # <br/><br/>
-# When set to `aws`, credentials are resolved from the environment, mirroring the credential
-# provider chain of the AWS SDK: `AWS_*` environment variables, the shared AWS config file
-# (~/.aws/credentials), ECS task roles, EKS IRSA / web identity tokens, and the EC2 instance
-# metadata service, in that order. Static keys are not required and are ignored in this mode.
-# Startup fails if no credentials can be resolved.
+# When set to `aws`, credentials are resolved from the environment, in this order:
+# <br/>
+# 1. `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment variables
+# <br/>
+# 2. The shared AWS credentials file (`AWS_SHARED_CREDENTIALS_FILE`, or `~/.aws/credentials`)
+# <br/>
+# 3. EKS IRSA / web identity tokens (`AWS_WEB_IDENTITY_TOKEN_FILE`)
+# <br/>
+# 4. ECS task roles (`AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` or `AWS_CONTAINER_CREDENTIALS_FULL_URI`)
+# <br/>
+# 5. The EC2 instance metadata service
 # <br/><br/>
+# Startup fails if no credentials can be resolved. dt.file-storage.s3.access-key and
+# dt.file-storage.s3.secret-key must not be set in this mode.
+# <br/>
 # EKS Pod Identity is not supported: the S3 client does not read
-# AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE and rejects the non-loopback Pod Identity Agent
+# `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` and rejects the non-loopback Pod Identity Agent
 # endpoint. Use IRSA instead.
 #
 # @category:     Storage
 # @default:      static
 # @type:         enum
 # @valid-values: [static, aws]
-# dt.file-storage.s3.credentials-source=static
+# dt.file-storage.s3.credentials-source=
 
 # Defines the S3 access key / username.
-# Has no effect when dt.file-storage.s3.credentials-source is `aws`.
+# Must not be set when dt.file-storage.s3.credentials-source is `aws`.
 #
 # @category: Storage
 # @type:     string
 # dt.file-storage.s3.access-key=
 
 # Defines the S3 secret key / password.
-# Has no effect when dt.file-storage.s3.credentials-source is `aws`.
+# Must not be set when dt.file-storage.s3.credentials-source is `aws`.
 #
 # @category: Storage
 # @type:     string

--- a/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorageProvider.java
+++ b/file-storage/provider-s3/src/main/java/org/dependencytrack/filestorage/s3/S3FileStorageProvider.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.ProxySelector;
 import java.time.Duration;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -104,27 +103,24 @@ public final class S3FileStorageProvider implements FileStorageProvider {
                 .getOptionalValue("dt.file-storage.s3.credentials-source", CredentialsSource.class)
                 .orElse(CredentialsSource.STATIC);
 
+        final var accessKey = config
+                .getOptionalValue("dt.file-storage.s3.access-key", String.class).orElse(null);
+        final var secretKey = config
+                .getOptionalValue("dt.file-storage.s3.secret-key", String.class).orElse(null);
+
         return switch (credentialsSource) {
             case STATIC -> {
-                final var accessKey = config
-                        .getOptionalValue("dt.file-storage.s3.access-key", String.class).orElse(null);
-                final var secretKey = config
-                        .getOptionalValue("dt.file-storage.s3.secret-key", String.class).orElse(null);
-                if (Objects.nonNull(accessKey) && Objects.nonNull(secretKey)) {
+                if (accessKey != null && secretKey != null) {
                     yield Optional.of(new StaticProvider(accessKey, secretKey, null));
                 }
-                if (Objects.nonNull(accessKey) || Objects.nonNull(secretKey)) {
+                if (accessKey != null || secretKey != null) {
                     throw new IllegalStateException(
                             "Both dt.file-storage.s3.access-key and dt.file-storage.s3.secret-key must be set when using static credentials");
                 }
                 yield Optional.empty();
             }
             case AWS -> {
-                final var accessKey = config
-                        .getOptionalValue("dt.file-storage.s3.access-key", String.class).orElse(null);
-                final var secretKey = config
-                        .getOptionalValue("dt.file-storage.s3.secret-key", String.class).orElse(null);
-                if (Objects.nonNull(accessKey) || Objects.nonNull(secretKey)) {
+                if (accessKey != null || secretKey != null) {
                     throw new IllegalStateException(
                             "Conflicting credentials configuration: dt.file-storage.s3.credentials-source is aws, "
                                     + "but dt.file-storage.s3.access-key or dt.file-storage.s3.secret-key is also configured");

--- a/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
+++ b/file-storage/provider-s3/src/test/java/org/dependencytrack/filestorage/s3/S3FileStorageTest.java
@@ -53,7 +53,7 @@ class S3FileStorageTest {
     void shouldThrowWhenBucketDoesNotExist() {
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> {
-                    try (final FileStorage ignored = createStorage(Map.ofEntries(
+                    try (final FileStorage _ = createStorage(Map.ofEntries(
                             Map.entry("dt.file-storage.s3.endpoint", s3MockContainer.getHttpEndpoint()),
                             Map.entry("dt.file-storage.s3.access-key", "foo"),
                             Map.entry("dt.file-storage.s3.secret-key", "bar"),
@@ -66,7 +66,7 @@ class S3FileStorageTest {
     void shouldThrowWhenBucketExistenceCheckFailed() {
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> {
-                    try (final FileStorage ignored = createStorage(Map.ofEntries(
+                    try (final FileStorage _ = createStorage(Map.ofEntries(
                             Map.entry("dt.file-storage.s3.endpoint", "http://localhost:1"),
                             Map.entry("dt.file-storage.s3.access-key", "foo"),
                             Map.entry("dt.file-storage.s3.secret-key", "bar"),


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes S3 credential provider properties docs:

* Fixes resolution order to reflect what minio-java actually does.
* Fixes static credential properties stating "has no effect" when them being set for credential source `aws` actually causes startup failure.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #6851

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
