### PR TITLE
Add REST API endpoints to view and trigger KEV mirroring runs

### DIFF
--- a/api/src/main/openapi/openapi.yaml
+++ b/api/src/main/openapi/openapi.yaml
@@ -187,6 +187,8 @@ tags:
   description: Endpoints related to components
 - name: Extensions
   description: Endpoints related to extensions
+- name: Kev Data Sources
+  description: Endpoints related to KEV data sources
 - name: Projects
   description: Endpoints related to projects
 - name: Secrets
@@ -217,6 +219,10 @@ paths:
     $ref: "./resources/extensions/extension-config-schema.yaml"
   /extension-points/{extension_point_name}/extensions/{extension_name}/test:
     $ref: "./resources/extensions/extension-test.yaml"
+  /kev-data-sources/{name}/mirror-runs:
+    $ref: "./resources/kev-data-sources/kev-data-source-mirror-runs.yaml"
+  /kev-data-sources/{name}/mirror-runs/latest:
+    $ref: "./resources/kev-data-sources/kev-data-source-mirror-run-latest.yaml"
   /projects/{uuid}/clone:
     $ref: "./resources/projects/project-clone.yaml"
   /projects/{uuid}/components:

--- a/api/src/main/openapi/resources/kev-data-sources/kev-data-source-mirror-run-latest.yaml
+++ b/api/src/main/openapi/resources/kev-data-sources/kev-data-source-mirror-run-latest.yaml
@@ -1,0 +1,52 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+get:
+  operationId: getLatestKevDataSourceMirrorRun
+  summary: Get the latest KEV data source mirror run
+  description: |-
+    Returns the status of the most recent mirror run for a given
+    KEV data source.
+
+    Returns 404 if no mirror run is available
+    (e.g. none has been triggered yet, or the most recent run
+    is no longer retained), or if the data source is unknown.
+
+    Requires permission `SYSTEM_CONFIGURATION` or `SYSTEM_CONFIGURATION_READ`.
+  tags:
+    - Kev Data Sources
+  parameters:
+    - name: name
+      in: path
+      description: Name of the KEV data source (e.g. `cisa`, `enisa`).
+      required: true
+      schema:
+        type: string
+  responses:
+    "200":
+      description: Mirror run status
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/kev-data-source-mirror-status.yaml"
+    "401":
+      $ref: "../../shared/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../../shared/responses/generic-forbidden-error.yaml"
+    "404":
+      $ref: "../../shared/responses/generic-not-found-error.yaml"
+    default:
+      $ref: "../../shared/responses/generic-error.yaml"

--- a/api/src/main/openapi/resources/kev-data-sources/kev-data-source-mirror-runs.yaml
+++ b/api/src/main/openapi/resources/kev-data-sources/kev-data-source-mirror-runs.yaml
@@ -1,0 +1,61 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+post:
+  operationId: triggerKevDataSourceMirrorRun
+  summary: Trigger a KEV data source mirror run
+  description: |-
+    Triggers a mirror run for the given KEV data source.
+
+    Requires permission `SYSTEM_CONFIGURATION` or `SYSTEM_CONFIGURATION_UPDATE`.
+  tags:
+    - Kev Data Sources
+  parameters:
+    - name: name
+      in: path
+      description: Name of the KEV data source (e.g. `cisa`, `enisa`).
+      required: true
+      schema:
+        type: string
+  responses:
+    "202":
+      description: Mirror run triggered
+      headers:
+        Location:
+          description: URL of the latest mirror run resource.
+          schema:
+            type: string
+            format: uri
+    "400":
+      description: Mirror run cannot be started
+      content:
+        application/problem+json:
+          schema:
+            $ref: "../../shared/schemas/problem-details.yaml"
+    "401":
+      $ref: "../../shared/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../../shared/responses/generic-forbidden-error.yaml"
+    "404":
+      $ref: "../../shared/responses/generic-not-found-error.yaml"
+    "409":
+      description: A mirror run is already in progress
+      content:
+        application/problem+json:
+          schema:
+            $ref: "../../shared/schemas/problem-details.yaml"
+    default:
+      $ref: "../../shared/responses/generic-error.yaml"

--- a/api/src/main/openapi/resources/kev-data-sources/schemas/kev-data-source-mirror-status.yaml
+++ b/api/src/main/openapi/resources/kev-data-sources/schemas/kev-data-source-mirror-status.yaml
@@ -1,0 +1,35 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  status:
+    type: string
+    description: Status of the mirror run.
+    enum:
+    - PENDING
+    - RUNNING
+    - COMPLETED
+    - FAILED
+  started_at:
+    $ref: "../../../shared/schemas/timestamp.yaml"
+  completed_at:
+    $ref: "../../../shared/schemas/timestamp.yaml"
+  failure_reason:
+    type: string
+    description: Reason for why the mirror run failed.
+required:
+- status

--- a/apiserver/src/main/java/org/dependencytrack/kevdatasource/KevDataSourceMirrorService.java
+++ b/apiserver/src/main/java/org/dependencytrack/kevdatasource/KevDataSourceMirrorService.java
@@ -1,0 +1,183 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.kevdatasource;
+
+import org.dependencytrack.common.pagination.Page;
+import org.dependencytrack.common.pagination.SortDirection;
+import org.dependencytrack.dex.engine.api.DexEngine;
+import org.dependencytrack.dex.engine.api.WorkflowRun;
+import org.dependencytrack.dex.engine.api.WorkflowRunMetadata;
+import org.dependencytrack.dex.engine.api.WorkflowRunStatus;
+import org.dependencytrack.dex.engine.api.request.CreateWorkflowRunRequest;
+import org.dependencytrack.dex.engine.api.request.ListWorkflowRunsRequest;
+import org.dependencytrack.kevdatasource.api.KevDataSource;
+import org.dependencytrack.kevdatasource.api.KevDataSourceFactory;
+import org.dependencytrack.plugin.runtime.NoSuchExtensionException;
+import org.dependencytrack.plugin.runtime.PluginManager;
+import org.dependencytrack.proto.internal.workflow.v1.MirrorKevDataSourceArg;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import static java.util.Objects.requireNonNull;
+import static org.dependencytrack.dex.DexWorkflowLabels.WF_LABEL_TRIGGERED_BY;
+
+/// @since 5.1.0
+public final class KevDataSourceMirrorService {
+
+    private static final String WORKFLOW_INSTANCE_ID_PREFIX = "mirror-kev-data-source:";
+
+    private final PluginManager pluginManager;
+    private final DexEngine dexEngine;
+
+    public KevDataSourceMirrorService(PluginManager pluginManager, DexEngine dexEngine) {
+        this.pluginManager = requireNonNull(pluginManager, "pluginManager must not be null");
+        this.dexEngine = requireNonNull(dexEngine, "dexEngine must not be null");
+    }
+
+    public sealed interface TriggerResult {
+
+        record Triggered(UUID runId) implements TriggerResult {
+        }
+
+        record AlreadyRunning() implements TriggerResult {
+        }
+
+        record NotEnabled() implements TriggerResult {
+        }
+
+        record NotFound() implements TriggerResult {
+        }
+
+    }
+
+    public TriggerResult trigger(String dataSourceName, @Nullable String triggeredBy) {
+        final KevDataSourceFactory factory;
+        try {
+            factory = pluginManager.getFactory(KevDataSource.class, dataSourceName);
+        } catch (NoSuchExtensionException e) {
+            return new TriggerResult.NotFound();
+        }
+
+        if (!factory.isEnabled()) {
+            return new TriggerResult.NotEnabled();
+        }
+
+        CreateWorkflowRunRequest<MirrorKevDataSourceArg> request =
+                new CreateWorkflowRunRequest<>(MirrorKevDataSourceWorkflow.class)
+                        .withWorkflowInstanceId(workflowInstanceId(dataSourceName))
+                        .withArgument(MirrorKevDataSourceArg.newBuilder()
+                                .setDataSourceName(dataSourceName)
+                                .build());
+        if (triggeredBy != null) {
+            request = request.withLabels(Map.of(WF_LABEL_TRIGGERED_BY, triggeredBy));
+        }
+
+        final UUID runId = dexEngine.createRun(request);
+        if (runId == null) {
+            return new TriggerResult.AlreadyRunning();
+        }
+
+        return new TriggerResult.Triggered(runId);
+    }
+
+    public record MirrorStatus(
+            Status status,
+            @Nullable Instant startedAt,
+            @Nullable Instant completedAt,
+            @Nullable String failureReason) {
+
+        public enum Status {
+
+            PENDING,
+            RUNNING,
+            COMPLETED,
+            FAILED;
+
+            private static Status of(WorkflowRunStatus runStatus) {
+                return switch (runStatus) {
+                    case CREATED, SUSPENDED -> MirrorStatus.Status.PENDING;
+                    case RUNNING -> MirrorStatus.Status.RUNNING;
+                    case COMPLETED -> MirrorStatus.Status.COMPLETED;
+                    case CANCELLED, FAILED -> MirrorStatus.Status.FAILED;
+                };
+            }
+
+        }
+
+    }
+
+    public @Nullable MirrorStatus getLatestStatus(String dataSourceName) {
+        try {
+            pluginManager.getFactory(KevDataSource.class, dataSourceName);
+        } catch (NoSuchExtensionException e) {
+            return null;
+        }
+
+        final Page<WorkflowRunMetadata> runsPage = dexEngine.listRuns(
+                new ListWorkflowRunsRequest()
+                        .withWorkflowInstanceId(workflowInstanceId(dataSourceName))
+                        .withSortBy(ListWorkflowRunsRequest.SortBy.CREATED_AT)
+                        .withSortDirection(SortDirection.DESC)
+                        .withLimit(1));
+        if (runsPage.items().isEmpty()) {
+            return null;
+        }
+
+        final WorkflowRunMetadata runMetadata = runsPage.items().getFirst();
+        final String failureReason = switch (runMetadata.status()) {
+            case FAILED -> extractFailureReason(runMetadata.id());
+            case CANCELLED -> "Cancelled";
+            default -> null;
+        };
+
+        return new MirrorStatus(
+                MirrorStatus.Status.of(runMetadata.status()),
+                runMetadata.startedAt(),
+                runMetadata.completedAt(),
+                failureReason);
+    }
+
+    private @Nullable String extractFailureReason(UUID runId) {
+        final WorkflowRun run = dexEngine.getRunById(runId);
+        if (run == null || run.failure() == null) {
+            return null;
+        }
+
+        return switch (run.failure().getFailureDetailsCase()) {
+            case ACTIVITY_FAILURE_DETAILS,
+                 CHILD_WORKFLOW_FAILURE_DETAILS -> {
+                if (!run.failure().hasCause()) {
+                    yield "Unknown failure";
+                }
+
+                final String causeMessage = run.failure().getCause().getMessage();
+                yield causeMessage.isEmpty() ? "Unknown failure" : causeMessage;
+            }
+            default -> run.failure().getMessage();
+        };
+    }
+
+    private static String workflowInstanceId(String dataSourceName) {
+        return WORKFLOW_INSTANCE_ID_PREFIX + dataSourceName;
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/kevdatasource/KevDataSourceMirrorServiceBinder.java
+++ b/apiserver/src/main/java/org/dependencytrack/kevdatasource/KevDataSourceMirrorServiceBinder.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.kevdatasource;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.servlet.ServletContext;
+import org.dependencytrack.dex.engine.api.DexEngine;
+import org.dependencytrack.plugin.runtime.PluginManager;
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+import static java.util.Objects.requireNonNull;
+
+/// @since 5.1.0
+public final class KevDataSourceMirrorServiceBinder extends AbstractBinder {
+
+    @Override
+    protected void configure() {
+        bindFactory(KevDataSourceMirrorServiceFactory.class)
+                .to(KevDataSourceMirrorService.class)
+                .in(Singleton.class);
+    }
+
+    private static final class KevDataSourceMirrorServiceFactory implements Factory<KevDataSourceMirrorService> {
+
+        private final ServletContext servletContext;
+
+        @Inject
+        private KevDataSourceMirrorServiceFactory(ServletContext servletContext) {
+            this.servletContext = servletContext;
+        }
+
+        @Override
+        public KevDataSourceMirrorService provide() {
+            final var pluginManager = (PluginManager) servletContext.getAttribute(PluginManager.class.getName());
+            final var dexEngine = (DexEngine) servletContext.getAttribute(DexEngine.class.getName());
+            return new KevDataSourceMirrorService(
+                    requireNonNull(pluginManager, "pluginManager is not initialized"),
+                    requireNonNull(dexEngine, "dexEngine is not initialized"));
+        }
+
+        @Override
+        public void dispose(KevDataSourceMirrorService instance) {
+        }
+
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/KevDataSourcesResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/KevDataSourcesResource.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v2;
+
+import alpine.server.auth.PermissionRequired;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+import org.dependencytrack.api.v2.KevDataSourcesApi;
+import org.dependencytrack.api.v2.model.KevDataSourceMirrorStatus;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.kevdatasource.KevDataSourceMirrorService;
+import org.dependencytrack.kevdatasource.KevDataSourceMirrorService.MirrorStatus;
+import org.dependencytrack.kevdatasource.KevDataSourceMirrorService.TriggerResult;
+import org.dependencytrack.resources.AbstractApiResource;
+import org.dependencytrack.resources.v2.exception.ProblemDetailsException;
+import org.dependencytrack.resources.v2.exception.ProblemType;
+import org.owasp.security.logging.SecurityMarkers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/// @since 5.1.0
+@Provider
+public final class KevDataSourcesResource extends AbstractApiResource implements KevDataSourcesApi {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KevDataSourcesResource.class);
+
+    private final KevDataSourceMirrorService mirrorService;
+
+    @Inject
+    KevDataSourcesResource(KevDataSourceMirrorService mirrorService) {
+        this.mirrorService = mirrorService;
+    }
+
+    @Override
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_READ
+    })
+    public Response getLatestKevDataSourceMirrorRun(String name) {
+        final MirrorStatus status = mirrorService.getLatestStatus(name);
+        if (status == null) {
+            throw new NotFoundException();
+        }
+
+        return Response
+                .ok(KevDataSourceMirrorStatus.builder()
+                        .status(convert(status.status()))
+                        .startedAt(status.startedAt() != null
+                                ? status.startedAt().toEpochMilli()
+                                : null)
+                        .completedAt(status.completedAt() != null
+                                ? status.completedAt().toEpochMilli()
+                                : null)
+                        .failureReason(status.failureReason())
+                        .build())
+                .build();
+    }
+
+    @Override
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_UPDATE
+    })
+    public Response triggerKevDataSourceMirrorRun(String name) {
+        final TriggerResult result = mirrorService.trigger(name, getPrincipal().getName());
+
+        return switch (result) {
+            case TriggerResult.Triggered _ -> {
+                LOGGER.info(
+                        SecurityMarkers.SECURITY_AUDIT,
+                        "Triggered KEV data source mirror for {}",
+                        name);
+                yield Response
+                        .accepted()
+                        .header("Location", getUriInfo()
+                                .getBaseUriBuilder()
+                                .path("/kev-data-sources/{name}/mirror-runs/latest")
+                                .resolveTemplate("name", name)
+                                .build())
+                        .build();
+            }
+            case TriggerResult.AlreadyRunning _ -> throw ProblemDetailsException.of(
+                    ProblemType.KEV_DATA_SOURCE_MIRROR_ALREADY_RUNNING,
+                    "A mirror run for this data source is already in progress");
+            case TriggerResult.NotEnabled _ -> throw ProblemDetailsException.of(
+                    ProblemType.KEV_DATA_SOURCE_NOT_ENABLED,
+                    "The KEV data source is not enabled");
+            case TriggerResult.NotFound _ -> throw new NotFoundException();
+        };
+    }
+
+    private static KevDataSourceMirrorStatus.StatusEnum convert(MirrorStatus.Status status) {
+        return switch (status) {
+            case PENDING -> KevDataSourceMirrorStatus.StatusEnum.PENDING;
+            case RUNNING -> KevDataSourceMirrorStatus.StatusEnum.RUNNING;
+            case COMPLETED -> KevDataSourceMirrorStatus.StatusEnum.COMPLETED;
+            case FAILED -> KevDataSourceMirrorStatus.StatusEnum.FAILED;
+        };
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/ResourceConfig.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/ResourceConfig.java
@@ -32,6 +32,7 @@ import org.dependencytrack.dex.DexEngineBinder;
 import org.dependencytrack.filestorage.FileStorageBinder;
 import org.dependencytrack.filters.DeprecationResponseFilter;
 import org.dependencytrack.filters.JerseyMetricsApplicationEventListener;
+import org.dependencytrack.kevdatasource.KevDataSourceMirrorServiceBinder;
 import org.dependencytrack.plugin.PluginManagerBinder;
 import org.dependencytrack.secret.SecretManagerBinder;
 import org.dependencytrack.vulndatasource.VulnDataSourceMirrorServiceBinder;
@@ -77,6 +78,7 @@ public final class ResourceConfig extends org.glassfish.jersey.server.ResourceCo
         register(CacheManagerBinder.class);
         register(DexEngineBinder.class);
         register(FileStorageBinder.class);
+        register(KevDataSourceMirrorServiceBinder.class);
         register(PluginManagerBinder.class);
         register(SecretManagerBinder.class);
         register(SystemCapabilitiesBinder.class);

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/exception/ProblemType.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/exception/ProblemType.java
@@ -29,6 +29,8 @@ import org.jspecify.annotations.Nullable;
 public enum ProblemType {
 
     INVALID_SORT_FIELD("invalid-sort-field", 400, "Invalid sort field"),
+    KEV_DATA_SOURCE_MIRROR_ALREADY_RUNNING("kev-data-source-mirror-already-running", 409),
+    KEV_DATA_SOURCE_NOT_ENABLED("kev-data-source-not-enabled", 400),
     VULN_DATA_SOURCE_MIRROR_ALREADY_RUNNING("vuln-data-source-mirror-already-running", 409),
     VULN_DATA_SOURCE_NOT_ENABLED("vuln-data-source-not-enabled", 400),
     VULN_POLICY_BUNDLE_SYNC_ALREADY_RUNNING("vuln-policy-bundle-sync-already-running", 409);

--- a/apiserver/src/main/java/org/dependencytrack/tasks/TaskSchedulerInitializer.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/TaskSchedulerInitializer.java
@@ -38,7 +38,7 @@ import org.dependencytrack.common.datasource.DataSourceRegistry;
 import org.dependencytrack.common.health.HealthCheckRegistry;
 import org.dependencytrack.dex.engine.api.DexEngine;
 import org.dependencytrack.dex.engine.api.request.CreateWorkflowRunRequest;
-import org.dependencytrack.kevdatasource.MirrorKevDataSourceWorkflow;
+import org.dependencytrack.kevdatasource.KevDataSourceMirrorService;
 import org.dependencytrack.kevdatasource.api.KevDataSource;
 import org.dependencytrack.kevdatasource.api.KevDataSourceFactory;
 import org.dependencytrack.metrics.UpdatePortfolioMetricsWorkflow;
@@ -49,7 +49,6 @@ import org.dependencytrack.persistence.jdbi.VulnerabilityPolicyDao;
 import org.dependencytrack.pkgmetadata.ResolvePackageMetadataWorkflow;
 import org.dependencytrack.plugin.runtime.PluginManager;
 import org.dependencytrack.policy.vulnerability.SyncVulnPolicyBundleWorkflow;
-import org.dependencytrack.proto.internal.workflow.v1.MirrorKevDataSourceArg;
 import org.dependencytrack.proto.internal.workflow.v1.ProcessScheduledNotificationsWorkflowArg;
 import org.dependencytrack.proto.internal.workflow.v1.SyncVulnPolicyBundleArg;
 import org.dependencytrack.secret.management.SecretManager;
@@ -180,6 +179,7 @@ public final class TaskSchedulerInitializer implements ServletContextListener {
             DexEngine dexEngine,
             PluginManager pluginManager,
             SecretManager secretManager) {
+        final var kevDataSourceMirrorService = new KevDataSourceMirrorService(pluginManager, dexEngine);
         final var vulnDataSourceMirrorService = new VulnDataSourceMirrorService(pluginManager, dexEngine);
 
         return List.of(
@@ -202,17 +202,7 @@ public final class TaskSchedulerInitializer implements ServletContextListener {
                             final Collection<KevDataSourceFactory> factories =
                                     pluginManager.getFactories(KevDataSource.class);
                             for (final KevDataSourceFactory factory : factories) {
-                                final String name = factory.extensionName();
-                                if (!factory.isEnabled()) {
-                                    continue;
-                                }
-
-                                dexEngine.createRun(
-                                        new CreateWorkflowRunRequest<>(MirrorKevDataSourceWorkflow.class)
-                                                .withWorkflowInstanceId("mirror-kev-data-source:" + name)
-                                                .withArgument(MirrorKevDataSourceArg.newBuilder()
-                                                        .setDataSourceName(name)
-                                                        .build()));
+                                kevDataSourceMirrorService.trigger(factory.extensionName(), null);
                             }
                         }),
                 recurringTask(

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/KevDataSourcesResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/KevDataSourcesResourceTest.java
@@ -1,0 +1,484 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v2;
+
+import io.smallrye.config.SmallRyeConfigBuilder;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.cache.api.NoopCacheManager;
+import org.dependencytrack.common.pagination.Page;
+import org.dependencytrack.dex.engine.api.DexEngine;
+import org.dependencytrack.dex.engine.api.WorkflowRun;
+import org.dependencytrack.dex.engine.api.WorkflowRunMetadata;
+import org.dependencytrack.dex.engine.api.WorkflowRunStatus;
+import org.dependencytrack.dex.engine.api.request.CreateWorkflowRunRequest;
+import org.dependencytrack.dex.engine.api.request.ListWorkflowRunsRequest;
+import org.dependencytrack.dex.proto.failure.v1.ActivityFailureDetails;
+import org.dependencytrack.dex.proto.failure.v1.Failure;
+import org.dependencytrack.kevdatasource.KevDataSourceMirrorService;
+import org.dependencytrack.kevdatasource.api.KevAssertion;
+import org.dependencytrack.kevdatasource.api.KevDataSource;
+import org.dependencytrack.kevdatasource.api.KevDataSourceFactory;
+import org.dependencytrack.persistence.jdbi.JdbiFactory;
+import org.dependencytrack.plugin.api.ServiceRegistry;
+import org.dependencytrack.plugin.runtime.PluginManager;
+import org.dependencytrack.secret.TestSecretManager;
+import org.dependencytrack.secret.management.SecretManager;
+import org.glassfish.jersey.inject.hk2.AbstractBinder;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentMatchers;
+
+import java.net.http.HttpClient;
+import java.time.Instant;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+class KevDataSourcesResourceTest extends ResourceTest {
+
+    private static final DexEngine DEX_ENGINE_MOCK = mock(DexEngine.class);
+    private static SecretManager secretManager;
+    private static PluginManager pluginManager;
+    private static KevDataSourceMirrorService mirrorService;
+
+    @RegisterExtension
+    static JerseyTestExtension jersey = new JerseyTestExtension(
+            new ResourceConfig()
+                    .register(new AbstractBinder() {
+                        @Override
+                        protected void configure() {
+                            bindFactory(() -> mirrorService).to(KevDataSourceMirrorService.class);
+                        }
+                    }));
+
+    @BeforeAll
+    static void beforeAll() {
+        secretManager = new TestSecretManager();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        reset(DEX_ENGINE_MOCK);
+        pluginManager = new PluginManager(
+                new SmallRyeConfigBuilder().build(),
+                new NoopCacheManager(),
+                secretManager::getSecretValue,
+                JdbiFactory.createJdbi(),
+                HttpClient.newHttpClient(),
+                List.of(KevDataSource.class));
+        mirrorService = new KevDataSourceMirrorService(pluginManager, DEX_ENGINE_MOCK);
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (pluginManager != null) {
+            pluginManager.close();
+        }
+    }
+
+    @Test
+    void shouldTriggerMirror() {
+        loadFactory(new DummyKevDataSourceFactory("cisa", true));
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        when(DEX_ENGINE_MOCK.createRun(ArgumentMatchers.<CreateWorkflowRunRequest<?>>any()))
+                .thenReturn(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+
+        final Response response = jersey
+                .target("/kev-data-sources/cisa/mirror-runs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(null);
+
+        assertThat(response.getStatus()).isEqualTo(202);
+        assertThat(response.getHeaderString("Location")).endsWith("/kev-data-sources/cisa/mirror-runs/latest");
+        assertThat(getPlainTextBody(response)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnConflictWhenMirrorAlreadyInProgress() {
+        loadFactory(new DummyKevDataSourceFactory("cisa", true));
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        when(DEX_ENGINE_MOCK.createRun(ArgumentMatchers.<CreateWorkflowRunRequest<?>>any()))
+                .thenReturn(null);
+
+        final Response response = jersey
+                .target("/kev-data-sources/cisa/mirror-runs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(null);
+
+        assertThat(response.getStatus()).isEqualTo(409);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "type": "/problems/kev-data-source-mirror-already-running",
+                  "status": 409,
+                  "title": "Conflict",
+                  "detail": "A mirror run for this data source is already in progress"
+                }
+                """);
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenDataSourceNotEnabled() {
+        loadFactory(new DummyKevDataSourceFactory("cisa", false));
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        final Response response = jersey
+                .target("/kev-data-sources/cisa/mirror-runs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(null);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "type": "/problems/kev-data-source-not-enabled",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "detail": "The KEV data source is not enabled"
+                }
+                """);
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenTriggeringUnknownDataSource() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        final Response response = jersey
+                .target("/kev-data-sources/does-not-exist/mirror-runs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(null);
+
+        assertThat(response.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    void shouldReturnForbiddenWhenTriggeringWithoutPermission() {
+        loadFactory(new DummyKevDataSourceFactory("cisa", true));
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final Response response = jersey
+                .target("/kev-data-sources/cisa/mirror-runs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(null);
+
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenNoRunExists() {
+        loadFactory(new DummyKevDataSourceFactory("cisa", true));
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        when(DEX_ENGINE_MOCK.listRuns(any(ListWorkflowRunsRequest.class)))
+                .thenReturn(new Page<>(List.of(), null, null));
+
+        final Response response = jersey
+                .target("/kev-data-sources/cisa/mirror-runs/latest")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenGettingStatusOfUnknownDataSource() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final Response response = jersey
+                .target("/kev-data-sources/does-not-exist/mirror-runs/latest")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    void shouldReturnRunningStatus() {
+        loadFactory(new DummyKevDataSourceFactory("cisa", true));
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final var runId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+        final var startedAt = Instant.parse("2026-04-15T10:00:00Z");
+
+        when(DEX_ENGINE_MOCK.listRuns(any(ListWorkflowRunsRequest.class)))
+                .thenReturn(new Page<>(List.of(
+                        new WorkflowRunMetadata(
+                                runId,
+                                null,
+                                "MirrorKevDataSourceWorkflow",
+                                1,
+                                "mirror-kev-data-source:cisa",
+                                "default",
+                                WorkflowRunStatus.RUNNING,
+                                null,
+                                0,
+                                null,
+                                null,
+                                startedAt,
+                                startedAt,
+                                startedAt,
+                                null)),
+                        null,
+                        null));
+
+        final Response response = jersey
+                .target("/kev-data-sources/cisa/mirror-runs/latest")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": "RUNNING",
+                  "started_at": %d
+                }
+                """.formatted(startedAt.toEpochMilli()));
+    }
+
+    @Test
+    void shouldReturnStatusWithFailureReasonWhenRunFailed() {
+        loadFactory(new DummyKevDataSourceFactory("cisa", true));
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final var runId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        final var startedAt = Instant.parse("2026-04-15T10:00:00Z");
+        final var completedAt = Instant.parse("2026-04-15T10:01:00Z");
+
+        final var runMetadata = new WorkflowRunMetadata(
+                runId,
+                null,
+                "MirrorKevDataSourceWorkflow",
+                1,
+                "mirror-kev-data-source:cisa",
+                "default",
+                WorkflowRunStatus.FAILED,
+                null,
+                0,
+                null,
+                null,
+                startedAt,
+                completedAt,
+                startedAt,
+                completedAt);
+
+        final var failure = Failure.newBuilder()
+                .setMessage("activity failed")
+                .setActivityFailureDetails(ActivityFailureDetails.newBuilder()
+                        .setActivityName("MirrorKevDataSourceActivity")
+                        .build())
+                .setCause(Failure.newBuilder()
+                        .setMessage("connection refused")
+                        .build())
+                .build();
+
+        final var run = new WorkflowRun(
+                runId,
+                null,
+                "MirrorKevDataSourceWorkflow",
+                1,
+                "mirror-kev-data-source:cisa",
+                WorkflowRunStatus.FAILED,
+                null,
+                0,
+                null,
+                null,
+                startedAt,
+                completedAt,
+                startedAt,
+                completedAt,
+                null,
+                null,
+                failure,
+                List.of());
+
+        when(DEX_ENGINE_MOCK.listRuns(any(ListWorkflowRunsRequest.class)))
+                .thenReturn(new Page<>(List.of(runMetadata), null, null));
+        when(DEX_ENGINE_MOCK.getRunById(runId)).thenReturn(run);
+
+        final Response response = jersey
+                .target("/kev-data-sources/cisa/mirror-runs/latest")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": "FAILED",
+                  "started_at": %d,
+                  "completed_at": %d,
+                  "failure_reason": "connection refused"
+                }
+                """.formatted(startedAt.toEpochMilli(), completedAt.toEpochMilli()));
+    }
+
+    @Test
+    void shouldReturnGenericFailureReasonWhenCauseAbsent() {
+        loadFactory(new DummyKevDataSourceFactory("cisa", true));
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final var runId = UUID.fromString("00000000-0000-0000-0000-000000000004");
+        final var startedAt = Instant.parse("2026-04-15T10:00:00Z");
+        final var completedAt = Instant.parse("2026-04-15T10:01:00Z");
+
+        final var runMetadata = new WorkflowRunMetadata(
+                runId,
+                null,
+                "MirrorKevDataSourceWorkflow",
+                1,
+                "mirror-kev-data-source:cisa",
+                "default",
+                WorkflowRunStatus.FAILED,
+                null,
+                0,
+                null,
+                null,
+                startedAt,
+                completedAt,
+                startedAt,
+                completedAt);
+
+        final var failure = Failure.newBuilder()
+                .setMessage("activity failed")
+                .setActivityFailureDetails(ActivityFailureDetails.newBuilder()
+                        .setActivityName("MirrorKevDataSourceActivity")
+                        .build())
+                .build();
+
+        final var run = new WorkflowRun(
+                runId,
+                null,
+                "MirrorKevDataSourceWorkflow",
+                1,
+                "mirror-kev-data-source:cisa",
+                WorkflowRunStatus.FAILED,
+                null,
+                0,
+                null,
+                null,
+                startedAt,
+                completedAt,
+                startedAt,
+                completedAt,
+                null,
+                null,
+                failure,
+                List.of());
+
+        when(DEX_ENGINE_MOCK.listRuns(any(ListWorkflowRunsRequest.class)))
+                .thenReturn(new Page<>(List.of(runMetadata), null, null));
+        when(DEX_ENGINE_MOCK.getRunById(runId)).thenReturn(run);
+
+        final Response response = jersey
+                .target("/kev-data-sources/cisa/mirror-runs/latest")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": "FAILED",
+                  "started_at": %d,
+                  "completed_at": %d,
+                  "failure_reason": "Unknown failure"
+                }
+                """.formatted(startedAt.toEpochMilli(), completedAt.toEpochMilli()));
+    }
+
+    private static void loadFactory(KevDataSourceFactory factory) {
+        pluginManager.loadPlugins(List.of(() -> List.of(factory)));
+    }
+
+    private static final class DummyKevDataSource implements KevDataSource {
+        @Override
+        public boolean hasNext() {
+            return false;
+        }
+
+        @Override
+        public KevAssertion next() {
+            throw new NoSuchElementException();
+        }
+    }
+
+    private static final class DummyKevDataSourceFactory implements KevDataSourceFactory {
+
+        private final String name;
+        private final boolean enabled;
+
+        DummyKevDataSourceFactory(String name, boolean enabled) {
+            this.name = name;
+            this.enabled = enabled;
+        }
+
+        @Override
+        public @NonNull String extensionName() {
+            return name;
+        }
+
+        @Override
+        public @NonNull Class<? extends KevDataSource> extensionClass() {
+            return DummyKevDataSource.class;
+        }
+
+        @Override
+        public int priority() {
+            return PRIORITY_HIGHEST;
+        }
+
+        @Override
+        public void init(@NonNull ServiceRegistry serviceRegistry) {
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        @Override
+        public @NonNull KevDataSource create() {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds REST API endpoints to view and trigger KEV mirroring runs.

Enables clients like the frontend to surface the status of recent runs of KEV mirroring, and to allow users to trigger a run ad-hoc.

The code largely duplicates what we have for vuln data source mirroring. I opted to not introduce an abstraction covering both cases yet, as the duplicated code is still simple and small in size. Should revisit once we add another data source mechanism though.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #2267 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
