### PR TITLE
Enforce global database query timeout

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/Application.java
+++ b/apiserver/src/main/java/org/dependencytrack/Application.java
@@ -45,6 +45,7 @@ import org.dependencytrack.cache.CacheManagerInitializer;
 import org.dependencytrack.common.ConfigKeys;
 import org.dependencytrack.common.LegacyConfigPropertyValidator;
 import org.dependencytrack.common.datasource.DataSourceRegistry;
+import org.dependencytrack.common.datasource.QueryTimeout;
 import org.dependencytrack.common.health.HealthCheckRegistry;
 import org.dependencytrack.dev.DevServices;
 import org.dependencytrack.dex.DexEngineBinder;
@@ -169,7 +170,13 @@ public final class Application {
                 final var initTaskExecutor = new InitTaskExecutor(
                         config, dataSourceRegistry.get(dataSourceName),
                         initTasksHealthCheck);
-                initTaskExecutor.execute();
+
+                // NB: Init tasks include schema migrations, whose statements legitimately
+                // run longer than the default query timeout allows. Bypass the timeout for them.
+                QueryTimeout.bypassing(() -> {
+                    initTaskExecutor.execute();
+                    return null;
+                });
 
                 if (config.getValue(ConfigKeys.INIT_TASKS_DATASOURCE_CLOSE_AFTER_COMPLETION, boolean.class)) {
                     dataSourceRegistry.close(dataSourceName);

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/MetricsDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/MetricsDao.java
@@ -22,9 +22,11 @@ import org.dependencytrack.model.DependencyMetrics;
 import org.dependencytrack.model.PortfolioMetrics;
 import org.dependencytrack.model.ProjectMetrics;
 import org.dependencytrack.model.VulnerabilityMetrics;
+import org.jdbi.v3.core.statement.SqlStatements;
 import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.QueryTimeOut;
 import org.jdbi.v3.sqlobject.statement.SqlCall;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -188,6 +190,7 @@ public interface MetricsDao extends SqlObject {
     @SqlUpdate("""
             REFRESH MATERIALIZED VIEW CONCURRENTLY "PORTFOLIOMETRICS_GLOBAL"
             """)
+    @QueryTimeOut(0) // Exempt from global query timeout b/c refreshes may legitimately run longer.
     void refreshGlobalPortfolioMetrics();
 
     default void refreshVulnerabilityMetrics() {
@@ -203,8 +206,14 @@ public interface MetricsDao extends SqlObject {
         // via schema migration. If the view ever needs updating for unrelated
         // reasons, this workaround could be removed.
         getHandle().execute("SET LOCAL TIME ZONE 'UTC'");
-        getHandle().execute("REFRESH MATERIALIZED VIEW CONCURRENTLY \"VULNERABILITYMETRICS\"");
+        refreshVulnerabilityMetricsView();
     }
+
+    @SqlUpdate("""
+            REFRESH MATERIALIZED VIEW CONCURRENTLY "VULNERABILITYMETRICS"
+            """)
+    @QueryTimeOut(0) // Exempt from global query timeout b/c refreshes may legitimately run longer.
+    void refreshVulnerabilityMetricsView();
 
     @SqlQuery("""
             SELECT "YEAR" AS "year"
@@ -665,7 +674,12 @@ public interface MetricsDao extends SqlObject {
                     trx.execute("ALTER TABLE %s DETACH PARTITION %s FINALIZE".formatted(parentTable, partition));
                 });
             } else {
-                getHandle().execute("ALTER TABLE %s DETACH PARTITION %s CONCURRENTLY".formatted(parentTable, partition));
+                getHandle()
+                        .createUpdate("ALTER TABLE %s DETACH PARTITION %s CONCURRENTLY".formatted(parentTable, partition))
+                        // Exempt from global query timeout b/c detachment has to wait for all
+                        // transactions accessing the partition to complete.
+                        .configure(SqlStatements.class, cfg -> cfg.setQueryTimeout(0))
+                        .execute();
             }
             getHandle().execute("DROP TABLE IF EXISTS %s".formatted(partition));
             deletedCount++;

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/exception/QueryTimeoutExceptionMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/exception/QueryTimeoutExceptionMapper.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.exception;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import org.dependencytrack.resources.v1.problems.ProblemDetails;
+import org.dependencytrack.resources.v2.exception.ProblemType;
+import org.dependencytrack.support.jdbi.exception.QueryTimeoutException;
+
+import java.net.URI;
+
+/// @since 5.1.0
+@Provider
+public final class QueryTimeoutExceptionMapper implements ExceptionMapper<QueryTimeoutException> {
+
+    @Override
+    public Response toResponse(QueryTimeoutException exception) {
+        final var problemDetails = new ProblemDetails(
+                ProblemType.TIMEOUT.status(),
+                ProblemType.TIMEOUT.title(),
+                "The request was aborted because it took too long to complete.");
+        problemDetails.setType(URI.create(ProblemType.TIMEOUT.type()));
+        return problemDetails.toResponse();
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/exception/ProblemType.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/exception/ProblemType.java
@@ -31,6 +31,7 @@ public enum ProblemType {
     INVALID_SORT_FIELD("invalid-sort-field", 400, "Invalid sort field"),
     KEV_DATA_SOURCE_MIRROR_ALREADY_RUNNING("kev-data-source-mirror-already-running", 409),
     KEV_DATA_SOURCE_NOT_ENABLED("kev-data-source-not-enabled", 400),
+    TIMEOUT("timeout", 504, "Request timed out"),
     VULN_DATA_SOURCE_MIRROR_ALREADY_RUNNING("vuln-data-source-mirror-already-running", 409),
     VULN_DATA_SOURCE_NOT_ENABLED("vuln-data-source-not-enabled", 400),
     VULN_POLICY_BUNDLE_SYNC_ALREADY_RUNNING("vuln-policy-bundle-sync-already-running", 409);

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/exception/QueryTimeoutExceptionMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/exception/QueryTimeoutExceptionMapper.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v2.exception;
+
+import jakarta.ws.rs.ext.Provider;
+import org.dependencytrack.api.v2.model.ProblemDetails;
+import org.dependencytrack.support.jdbi.exception.QueryTimeoutException;
+
+/// @since 5.1.0
+@Provider
+public final class QueryTimeoutExceptionMapper extends ProblemDetailsExceptionMapper<QueryTimeoutException, ProblemDetails> {
+
+    @Override
+    ProblemDetails map(QueryTimeoutException exception) {
+        return ProblemDetails.builder()
+                .type(ProblemType.TIMEOUT.type())
+                .status(ProblemType.TIMEOUT.status())
+                .title(ProblemType.TIMEOUT.title())
+                .detail("The request was aborted because it took too long to complete.")
+                .build();
+    }
+
+}

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -114,6 +114,20 @@ dt.datasource.pool.keepalive-interval-ms=60000
 # @type:     integer
 # dt.datasource.pool.leak-detection-threshold-ms=
 
+# Defines the maximum time in milliseconds any single database query may run before it is aborted.
+# <br/><br/>
+# Acts as a guardrail against runaway queries occupying a connection indefinitely,
+# which can otherwise exhaust the connection pool.
+# <br/><br/>
+# Note that the timeout is not enforced for work that may legitimately exceed query timeouts,
+# such as database migrations and portfolio-wide metrics refreshes.
+# <br/><br/>
+# Set to `0` to disable query timeouts entirely.
+#
+# @category: Database
+# @type:     integer
+# dt.datasource.query-timeout-ms=60000
+
 # Defines the cache provider to use.
 #
 # @category:     Cache

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/JdbiFactoryTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/JdbiFactoryTest.java
@@ -23,6 +23,8 @@ import org.dependencytrack.model.Project;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.Test;
 
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,6 +61,17 @@ public class JdbiFactoryTest extends PersistenceCapableTest {
                     handle.createQuery("SELECT \"NAME\" FROM \"PROJECT\"").mapTo(String.class).findFirst());
             assertThat(projectName).isNotPresent();
         });
+    }
+
+    @Test
+    public void testStatementsCarryQueryTimeoutDefault() throws SQLException {
+        final int queryTimeout = JdbiFactory.<Integer, SQLException>withJdbiHandle(handle -> {
+            try (Statement statement = handle.getConnection().createStatement()) {
+                return statement.getQueryTimeout();
+            }
+        });
+
+        assertThat(queryTimeout).isEqualTo(60);
     }
 
 }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/exception/QueryTimeoutExceptionMapperTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/exception/QueryTimeoutExceptionMapperTest.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.exception;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.resources.v1.problems.ProblemDetails;
+import org.dependencytrack.support.jdbi.exception.QueryTimeoutException;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import static java.util.Objects.requireNonNull;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QueryTimeoutExceptionMapperTest extends ResourceTest {
+
+    @RegisterExtension
+    static JerseyTestExtension jersey = new JerseyTestExtension(
+            new ResourceConfig(TestResource.class)
+                    .register(QueryTimeoutExceptionMapper.class));
+
+    @Test
+    void shouldMapToGatewayTimeoutProblem() {
+        final Response response = jersey.target("/test").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(504);
+        assertThat(response.getHeaderString("Content-Type")).isEqualTo(ProblemDetails.MEDIA_TYPE_JSON);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "type": "/problems/timeout",
+                  "status": 504,
+                  "title": "Request timed out",
+                  "detail": "The request was aborted because it took too long to complete."
+                }
+                """);
+    }
+
+    @Path("/test")
+    public static class TestResource {
+
+        @GET
+        public Response get() {
+            throw requireNonNull(QueryTimeoutException.of(new PSQLException(
+                    "canceling statement due to statement timeout", PSQLState.QUERY_CANCELED)));
+        }
+
+    }
+
+}

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/exception/QueryTimeoutExceptionMapperTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/exception/QueryTimeoutExceptionMapperTest.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v2.exception;
+
+import alpine.server.auth.AuthenticationNotRequired;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.resources.v2.ResourceConfig;
+import org.dependencytrack.support.jdbi.exception.QueryTimeoutException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import static java.util.Objects.requireNonNull;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.resources.v2.OpenApiValidationClientResponseFilter.DISABLE_OPENAPI_VALIDATION;
+
+public class QueryTimeoutExceptionMapperTest {
+
+    @RegisterExtension
+    static JerseyTestExtension jersey = new JerseyTestExtension(
+            new ResourceConfig().register(TestResource.class));
+
+    @Test
+    public void shouldMapToTimeoutProblem() {
+        final Response response = jersey.target("/test/query-timeout")
+                .request()
+                .property(DISABLE_OPENAPI_VALIDATION, "true")
+                .get();
+        assertThat(response.getStatus()).isEqualTo(504);
+        assertThat(response.getHeaderString("Content-Type")).isEqualTo("application/problem+json");
+        assertThatJson(response.readEntity(String.class)).isEqualTo(/* language=JSON */ """
+                {
+                  "type": "/problems/timeout",
+                  "status": 504,
+                  "title": "Request timed out",
+                  "detail": "The request was aborted because it took too long to complete."
+                }
+                """);
+    }
+
+    @Path("/test")
+    public static class TestResource {
+
+        @GET
+        @Path("/query-timeout")
+        @AuthenticationNotRequired
+        public Response get() {
+            throw requireNonNull(QueryTimeoutException.of(
+                    new PSQLException(
+                            "canceling statement due to statement timeout",
+                            PSQLState.QUERY_CANCELED)));
+        }
+
+    }
+
+}

--- a/common/datasource/src/main/java/org/dependencytrack/common/datasource/DataSourceConfig.java
+++ b/common/datasource/src/main/java/org/dependencytrack/common/datasource/DataSourceConfig.java
@@ -64,6 +64,12 @@ final class DataSourceConfig {
         return config.getOptionalValue(PREFIX + "%s.connection-timeout-ms".formatted(name), long.class);
     }
 
+    long getQueryTimeoutMillis() {
+        return config
+                .getOptionalValue(PREFIX + "%s.query-timeout-ms".formatted(name), long.class)
+                .orElse(60_000L);
+    }
+
     boolean isPoolEnabled() {
         return config.getOptionalValue(PREFIX + "%s.pool.enabled".formatted(name), boolean.class).orElse(false);
     }

--- a/common/datasource/src/main/java/org/dependencytrack/common/datasource/DataSourceFactory.java
+++ b/common/datasource/src/main/java/org/dependencytrack/common/datasource/DataSourceFactory.java
@@ -40,6 +40,19 @@ final class DataSourceFactory {
     }
 
     static DataSource createDataSource(DataSourceConfig config) {
+        final DataSource dataSource = createDataSourceInternal(config);
+
+        final long queryTimeoutMillis = config.getQueryTimeoutMillis();
+        if (queryTimeoutMillis <= 0) {
+            return dataSource;
+        }
+        
+        return new QueryTimeoutDataSource(
+                dataSource,
+                Math.toIntExact(Math.max(1, TimeUnit.MILLISECONDS.toSeconds(queryTimeoutMillis))));
+    }
+
+    private static DataSource createDataSourceInternal(DataSourceConfig config) {
         final String appName = "dependency-track[%s]".formatted(config.getName());
 
         if (config.isPoolEnabled()) {

--- a/common/datasource/src/main/java/org/dependencytrack/common/datasource/QueryTimeout.java
+++ b/common/datasource/src/main/java/org/dependencytrack/common/datasource/QueryTimeout.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.common.datasource;
+
+import org.jspecify.annotations.Nullable;
+
+/// @since 5.1.0
+public final class QueryTimeout {
+
+    private static final ScopedValue<Boolean> BYPASSED = ScopedValue.newInstance();
+
+    private QueryTimeout() {
+    }
+
+    /// Runs {@code op} with the data source's global query timeout bypassed.
+    ///
+    /// To be used for operations that may legitimately exceed query timeouts,
+    /// e.g. calls of stored procedures operating on large volumes of data.
+    ///
+    /// @param op  the operation to run without query timeout.
+    /// @param <T> type of the return value.
+    /// @param <X> type of the exception.
+    /// @return the result of the operation.
+    public static <T, X extends Throwable> @Nullable T bypassing(ScopedValue.CallableOp<@Nullable T, X> op) throws X {
+        if (isBypassed()) {
+            return op.call();
+        }
+
+        return ScopedValue.where(BYPASSED, true).call(op);
+    }
+
+    static boolean isBypassed() {
+        return BYPASSED.isBound() && BYPASSED.get();
+    }
+
+}

--- a/common/datasource/src/main/java/org/dependencytrack/common/datasource/QueryTimeoutDataSource.java
+++ b/common/datasource/src/main/java/org/dependencytrack/common/datasource/QueryTimeoutDataSource.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.common.datasource;
+
+import org.postgresql.PGConnection;
+
+import javax.sql.DataSource;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+
+import static java.util.Objects.requireNonNull;
+
+/// A [DataSource] enforcing global query timeouts transparently.
+///
+/// @since 5.1.0
+final class QueryTimeoutDataSource implements DataSource, Closeable {
+
+    private final DataSource delegate;
+    private final int timeoutSeconds;
+
+    QueryTimeoutDataSource(DataSource delegate, int timeoutSeconds) {
+        this.delegate = requireNonNull(delegate, "delegate must not be null");
+        if (timeoutSeconds < 1) {
+            throw new IllegalArgumentException("timeoutSeconds must not be less than 1");
+        }
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return withQueryTimeout(delegate.getConnection());
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return withQueryTimeout(delegate.getConnection(username, password));
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (delegate instanceof Closeable closeable) {
+            closeable.close();
+        }
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        if (iface.isInstance(this)) {
+            return iface.cast(this);
+        }
+        
+        return delegate.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return iface.isInstance(this) || delegate.isWrapperFor(iface);
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return delegate.getLogWriter();
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        delegate.setLogWriter(out);
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+        delegate.setLoginTimeout(seconds);
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return delegate.getLoginTimeout();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return delegate.getParentLogger();
+    }
+
+    private Connection withQueryTimeout(Connection connection) throws SQLException {
+        connection
+                .unwrap(PGConnection.class)
+                .setQueryTimeout(
+                        !QueryTimeout.isBypassed()
+                                ? timeoutSeconds
+                                : 0);
+        return connection;
+    }
+
+}

--- a/common/datasource/src/test/java/org/dependencytrack/common/datasource/DataSourceRegistryTest.java
+++ b/common/datasource/src/test/java/org/dependencytrack/common/datasource/DataSourceRegistryTest.java
@@ -33,6 +33,10 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -69,7 +73,7 @@ class DataSourceRegistryTest {
     }
 
     @Test
-    void shouldCreateSimpleDataSourceWhenPoolIsDisabled() {
+    void shouldCreateSimpleDataSourceWhenPoolIsDisabled() throws SQLException {
         MemoryConfigSource.setProperties(Map.ofEntries(
                 Map.entry("dt.datasource.url", postgresContainer.getJdbcUrl()),
                 Map.entry("dt.datasource.username", postgresContainer.getUsername()),
@@ -77,11 +81,11 @@ class DataSourceRegistryTest {
                 Map.entry("dt.datasource.pool.enabled", "false")));
 
         final DataSource dataSource = registry.getDefault();
-        assertThat(dataSource).isInstanceOf(PGSimpleDataSource.class);
+        assertThat(dataSource.isWrapperFor(PGSimpleDataSource.class)).isTrue();
     }
 
     @Test
-    void shouldCreatePooledDataSourceWhenPoolIsEnabled() {
+    void shouldCreatePooledDataSourceWhenPoolIsEnabled() throws SQLException {
         MemoryConfigSource.setProperties(Map.ofEntries(
                 Map.entry("dt.datasource.url", postgresContainer.getJdbcUrl()),
                 Map.entry("dt.datasource.username", postgresContainer.getUsername()),
@@ -91,12 +95,13 @@ class DataSourceRegistryTest {
                 Map.entry("dt.datasource.pool.min-idle", "1")));
 
         final DataSource dataSource = registry.getDefault();
-        assertThat(dataSource).isInstanceOf(HikariDataSource.class);
-
-        final var hikariDataSource = (HikariDataSource) dataSource;
+        final HikariDataSource hikariDataSource = dataSource.unwrap(HikariDataSource.class);
         assertThat(hikariDataSource.getPoolName()).isEqualTo("default");
         assertThat(hikariDataSource.getMaximumPoolSize()).isEqualTo(2);
         assertThat(hikariDataSource.getMinimumIdle()).isEqualTo(1);
+
+        registry.closeAll();
+        assertThat(hikariDataSource.isClosed()).isTrue();
     }
 
     @Test
@@ -122,6 +127,119 @@ class DataSourceRegistryTest {
 
         final DataSource dataSource = registry.get("foo");
         assertThat(dataSource).isNotNull();
+    }
+
+    @Test
+    void shouldApplyDefaultQueryTimeoutToStatements() throws SQLException {
+        MemoryConfigSource.setProperties(Map.ofEntries(
+                Map.entry("dt.datasource.url", postgresContainer.getJdbcUrl()),
+                Map.entry("dt.datasource.username", postgresContainer.getUsername()),
+                Map.entry("dt.datasource.password", postgresContainer.getPassword()),
+                Map.entry("dt.datasource.pool.enabled", "false")));
+
+        final DataSource dataSource = registry.getDefault();
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement();
+             PreparedStatement preparedStatement = connection.prepareStatement("SELECT 1")) {
+            assertThat(statement.getQueryTimeout()).isEqualTo(60);
+            assertThat(preparedStatement.getQueryTimeout()).isEqualTo(60);
+        }
+    }
+
+    @Test
+    void shouldNotApplyQueryTimeoutWhenDisabled() throws SQLException {
+        MemoryConfigSource.setProperties(Map.ofEntries(
+                Map.entry("dt.datasource.url", postgresContainer.getJdbcUrl()),
+                Map.entry("dt.datasource.username", postgresContainer.getUsername()),
+                Map.entry("dt.datasource.password", postgresContainer.getPassword()),
+                Map.entry("dt.datasource.pool.enabled", "false"),
+                Map.entry("dt.datasource.query-timeout-ms", "0")));
+
+        final DataSource dataSource = registry.getDefault();
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            assertThat(statement.getQueryTimeout()).isZero();
+        }
+    }
+
+    @Test
+    void shouldCancelStatementExceedingQueryTimeout() throws SQLException {
+        MemoryConfigSource.setProperties(Map.ofEntries(
+                Map.entry("dt.datasource.url", postgresContainer.getJdbcUrl()),
+                Map.entry("dt.datasource.username", postgresContainer.getUsername()),
+                Map.entry("dt.datasource.password", postgresContainer.getPassword()),
+                Map.entry("dt.datasource.pool.enabled", "false"),
+                Map.entry("dt.datasource.query-timeout-ms", "1000")));
+
+        final DataSource dataSource = registry.getDefault();
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            assertThatExceptionOfType(SQLException.class)
+                    .isThrownBy(() -> statement.execute("SELECT PG_SLEEP(2)"))
+                    .satisfies(e -> assertThat(e.getSQLState()).isEqualTo("57014"));
+        }
+    }
+
+    @Test
+    void shouldAllowStatementsToOverrideQueryTimeout() throws SQLException {
+        MemoryConfigSource.setProperties(Map.ofEntries(
+                Map.entry("dt.datasource.url", postgresContainer.getJdbcUrl()),
+                Map.entry("dt.datasource.username", postgresContainer.getUsername()),
+                Map.entry("dt.datasource.password", postgresContainer.getPassword()),
+                Map.entry("dt.datasource.pool.enabled", "false"),
+                Map.entry("dt.datasource.query-timeout-ms", "1000")));
+
+        final DataSource dataSource = registry.getDefault();
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.setQueryTimeout(0);
+            assertThat(statement.execute("SELECT PG_SLEEP(1.1)")).isTrue();
+        }
+    }
+
+    @Test
+    void shouldBypassQueryTimeoutForCallersThatMustRunUnbounded() throws SQLException {
+        MemoryConfigSource.setProperties(Map.ofEntries(
+                Map.entry("dt.datasource.url", postgresContainer.getJdbcUrl()),
+                Map.entry("dt.datasource.username", postgresContainer.getUsername()),
+                Map.entry("dt.datasource.password", postgresContainer.getPassword()),
+                Map.entry("dt.datasource.pool.enabled", "false")));
+
+        final DataSource dataSource = registry.getDefault();
+        final Integer queryTimeout = QueryTimeout.bypassing(() -> {
+            try (Connection connection = dataSource.getConnection();
+                 Statement statement = connection.createStatement()) {
+                return statement.getQueryTimeout();
+            }
+        });
+
+        assertThat(queryTimeout).isZero();
+    }
+
+    @Test
+    void shouldRearmQueryTimeoutOnEveryAcquisition() throws SQLException {
+        MemoryConfigSource.setProperties(Map.ofEntries(
+                Map.entry("dt.datasource.url", postgresContainer.getJdbcUrl()),
+                Map.entry("dt.datasource.username", postgresContainer.getUsername()),
+                Map.entry("dt.datasource.password", postgresContainer.getPassword()),
+                Map.entry("dt.datasource.pool.enabled", "true"),
+                Map.entry("dt.datasource.pool.max-size", "1"),
+                Map.entry("dt.datasource.pool.min-idle", "1")));
+
+        final DataSource dataSource = registry.getDefault();
+
+        final Integer bypassedTimeout = QueryTimeout.bypassing(() -> {
+            try (Connection connection = dataSource.getConnection();
+                 Statement statement = connection.createStatement()) {
+                return statement.getQueryTimeout();
+            }
+        });
+        assertThat(bypassedTimeout).isZero();
+
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            assertThat(statement.getQueryTimeout()).isEqualTo(60);
+        }
     }
 
     @ParameterizedTest

--- a/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/ConstraintViolationException.java
+++ b/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/ConstraintViolationException.java
@@ -50,7 +50,7 @@ public sealed class ConstraintViolationException extends RuntimeException
     }
 
     public static @Nullable ConstraintViolationException of(Throwable throwable) {
-        final PSQLException psqlException = findPSQLException(throwable);
+        final PSQLException psqlException = PSQLExceptions.find(throwable);
         if (psqlException == null) {
             return null;
         }
@@ -97,17 +97,6 @@ public sealed class ConstraintViolationException extends RuntimeException
 
     public String getSqlState() {
         return sqlState;
-    }
-
-    private static @Nullable PSQLException findPSQLException(Throwable throwable) {
-        Throwable current = throwable;
-        while (current != null) {
-            if (current instanceof PSQLException psql) {
-                return psql;
-            }
-            current = current.getCause();
-        }
-        return null;
     }
 
 }

--- a/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/ExceptionTranslationCallbackDecorator.java
+++ b/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/ExceptionTranslationCallbackDecorator.java
@@ -36,10 +36,16 @@ final class ExceptionTranslationCallbackDecorator implements HandleCallbackDecor
             try {
                 return delegated.withHandle(handle);
             } catch (RuntimeException e) {
-                final ConstraintViolationException translated = ConstraintViolationException.of(e);
-                if (translated != null) {
-                    throw translated;
+                final var cve = ConstraintViolationException.of(e);
+                if (cve != null) {
+                    throw cve;
                 }
+
+                final var qte = QueryTimeoutException.of(e);
+                if (qte != null) {
+                    throw qte;
+                }
+
                 throw e;
             }
         };

--- a/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/PSQLExceptions.java
+++ b/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/PSQLExceptions.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.jdbi.exception;
+
+import org.jspecify.annotations.Nullable;
+import org.postgresql.util.PSQLException;
+
+final class PSQLExceptions {
+
+    private PSQLExceptions() {
+    }
+
+    static @Nullable PSQLException find(Throwable throwable) {
+        Throwable current = throwable;
+
+        while (current != null) {
+            if (current instanceof final PSQLException pe) {
+                return pe;
+            }
+
+            current = current.getCause();
+        }
+
+        return null;
+    }
+
+}

--- a/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/QueryTimeoutException.java
+++ b/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/QueryTimeoutException.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.jdbi.exception;
+
+import org.jspecify.annotations.Nullable;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+/// @since 5.1.0
+public final class QueryTimeoutException extends RuntimeException {
+
+    private final String sqlState;
+
+    private QueryTimeoutException(@Nullable String message, Throwable cause, String sqlState) {
+        super(message, cause);
+        this.sqlState = sqlState;
+    }
+
+    public static @Nullable QueryTimeoutException of(Throwable throwable) {
+        final PSQLException psqlException = PSQLExceptions.find(throwable);
+        if (psqlException == null
+                || !PSQLState.QUERY_CANCELED.getState().equals(psqlException.getSQLState())) {
+            return null;
+        }
+        
+        return new QueryTimeoutException(
+                psqlException.getMessage(),
+                throwable,
+                psqlException.getSQLState());
+    }
+
+    public String getSqlState() {
+        return sqlState;
+    }
+
+}

--- a/support/jdbi/src/test/java/org/dependencytrack/support/jdbi/exception/ExceptionTranslationPluginTest.java
+++ b/support/jdbi/src/test/java/org/dependencytrack/support/jdbi/exception/ExceptionTranslationPluginTest.java
@@ -91,4 +91,14 @@ class ExceptionTranslationPluginTest {
                 });
     }
 
+    @Test
+    void shouldTranslateQueryTimeout() {
+        assertThatExceptionOfType(QueryTimeoutException.class)
+                .isThrownBy(() -> jdbi.useHandle(handle -> {
+                    handle.execute("SET statement_timeout TO 100");
+                    handle.createQuery("SELECT pg_sleep(1)").mapTo(String.class).one();
+                }))
+                .satisfies(e -> assertThat(e.getSqlState()).isEqualTo("57014"));
+    }
+
 }


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Enforces a global database query timeout.

Previously, all queries ran unbounded, so a stuck or rogue query could block a connection for prolonged periods of time. This change introduces a query timeout, configurable at the datasource-level, defaulting to 60s.

In most setups, a reverse proxy / ingress controller / etc. will terminate requests after ~30s, which is already excessive for user-facing actions. 60s is thus on the conservative side still.

The global timeout is overridable per query, and a `QueryTimeout#bypassing(() -> ...)` mechanism can be used to bypass it entirely for a scoped operation. The latter is used for init tasks, to ensure that database migrations can complete without premature interruption.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
