### PR TITLE
Bypass JDO for bulk deletions

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/ComponentProperty.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/ComponentProperty.java
@@ -31,6 +31,8 @@ import jakarta.validation.constraints.Size;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.jdo.annotations.Column;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
@@ -62,6 +64,11 @@ public class ComponentProperty implements IConfigProperty, Serializable {
     private long id;
 
     @Persistent
+    @ForeignKey(
+            name = "COMPONENT_PROPERTY_COMPONENT_ID_FK",
+            deferred = "true",
+            deleteAction = ForeignKeyAction.CASCADE,
+            updateAction = ForeignKeyAction.NONE)
     @Column(name = "COMPONENT_ID", allowsNull = "false")
     @JsonIgnore
     private Component component;

--- a/apiserver/src/main/java/org/dependencytrack/persistence/TagQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/TagQueryManager.java
@@ -20,6 +20,7 @@ package org.dependencytrack.persistence;
 
 import alpine.persistence.OrderDirection;
 import alpine.persistence.PaginatedResult;
+import alpine.persistence.ScopedCustomization;
 import alpine.resources.AlpineRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.auth.Permissions;
@@ -48,6 +49,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import static org.datanucleus.PropertyNames.PROPERTY_QUERY_SQL_ALLOWALL;
 
 public class TagQueryManager extends QueryManager {
 
@@ -320,16 +323,18 @@ public class TagQueryManager extends QueryManager {
             if (!errorByTagName.isEmpty()) {
                 throw TagOperationFailedException.forDeletion(errorByTagName);
             }
+            
+            final Long[] tagIds = candidateRows.stream()
+                    .map(TagDeletionCandidateRow::id)
+                    .toArray(Long[]::new);
 
-            final Query<Tag> deletionQuery = pm.newQuery(Tag.class);
-            deletionQuery.setFilter(":ids.contains(id)");
-            try {
-                deletionQuery.deletePersistentAll(
-                        candidateRows.stream()
-                                .map(TagDeletionCandidateRow::id)
-                                .toList());
-            } finally {
-                deletionQuery.closeAll();
+            try (var _ = new ScopedCustomization(pm).withProperty(PROPERTY_QUERY_SQL_ALLOWALL, "true")) {
+                final Query<?> deletionQuery = pm.newQuery(Query.SQL, /* language=SQL */ """
+                        DELETE
+                          FROM "TAG"
+                         WHERE "ID" = ANY(:ids)
+                        """);
+                executeAndCloseWithMap(deletionQuery, Map.of("ids", tagIds));
             }
         });
     }

--- a/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.tasks;
 
+import alpine.persistence.ScopedCustomization;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.cyclonedx.exception.ParseException;
@@ -85,6 +86,7 @@ import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.apache.commons.lang3.time.DurationFormatUtils.formatDurationHMS;
 import static org.datanucleus.PropertyNames.PROPERTY_FLUSH_MODE;
 import static org.datanucleus.PropertyNames.PROPERTY_PERSISTENCE_BY_REACHABILITY_AT_COMMIT;
+import static org.datanucleus.PropertyNames.PROPERTY_QUERY_SQL_ALLOWALL;
 import static org.datanucleus.PropertyNames.PROPERTY_RETAIN_VALUES;
 import static org.dependencytrack.common.MdcKeys.MDC_BOM_FORMAT;
 import static org.dependencytrack.common.MdcKeys.MDC_BOM_SERIAL_NUMBER;
@@ -822,9 +824,21 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
             return 0;
         }
 
-        final PersistenceManager pm = qm.getPersistenceManager();
         LOGGER.info("Deleting %d component(s) that are no longer part of the project".formatted(componentIds.size()));
-        return pm.newQuery(Component.class, ":ids.contains(id)").deletePersistentAll(componentIds);
+
+        final PersistenceManager pm = qm.getPersistenceManager();
+        try (var _ = new ScopedCustomization(pm).withProperty(PROPERTY_QUERY_SQL_ALLOWALL, "true")) {
+            final Query<?> query = pm.newQuery(Query.SQL, /* language=SQL */ """
+                    DELETE
+                      FROM "COMPONENT"
+                     WHERE "ID" = ANY(:ids)
+                    """);
+            try {
+                return (Long) query.executeWithMap(Map.of("ids", componentIds.toArray(new Long[0])));
+            } finally {
+                query.closeAll();
+            }
+        }
     }
 
     private static long deleteServicesById(final QueryManager qm, final Collection<Long> serviceIds) {

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
@@ -406,6 +406,8 @@ class TagResourceTest extends ResourceTest {
 
         qm.getPersistenceManager().evictAll();
         assertThat(qm.getTagByName("foo")).isNull();
+        assertThat(qm.getTagByName("bar")).isNull();
+        assertThat(qm.getObjectById(Project.class, project.getId()).getTags()).isEmpty();
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/tasks/ImportBomActivityTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/ImportBomActivityTest.java
@@ -1224,6 +1224,61 @@ class ImportBomActivityTest extends PersistenceCapableTest {
         });
     }
 
+    @Test
+    void informWithExistingComponentNoLongerPartOfBomTest() throws Exception {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var removedComponent = new Component();
+        removedComponent.setProject(project);
+        removedComponent.setName("acme-lib-removed");
+        removedComponent.setClassifier(Classifier.LIBRARY);
+        qm.persist(removedComponent);
+
+        final var removedComponentProperty = new ComponentProperty();
+        removedComponentProperty.setComponent(removedComponent);
+        removedComponentProperty.setPropertyName("foo");
+        removedComponentProperty.setPropertyValue("bar");
+        removedComponentProperty.setPropertyType(PropertyType.STRING);
+        qm.persist(removedComponentProperty);
+
+        final var removedComponentOccurrence = new ComponentOccurrence();
+        removedComponentOccurrence.setComponent(removedComponent);
+        removedComponentOccurrence.setLocation("/foo/bar/baz");
+        qm.persist(removedComponentOccurrence);
+
+        final var retainedComponent = new Component();
+        retainedComponent.setProject(project);
+        retainedComponent.setName("acme-lib-retained");
+        retainedComponent.setClassifier(Classifier.LIBRARY);
+        qm.persist(retainedComponent);
+
+        final var bomFileMetadata = storeBomFile(/* language=JSON */ """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.6",
+                  "version": 1,
+                  "components": [
+                    {
+                      "type": "library",
+                      "name": "acme-lib-retained"
+                    }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8));
+        final var bomUploadToken = UUID.randomUUID();
+        activity.execute(null, buildArg(project, bomFileMetadata, bomUploadToken));
+        assertBomProcessedNotification();
+
+        qm.getPersistenceManager().evictAll();
+        assertThat(qm.getAllComponents(project)).satisfiesExactly(
+                component -> assertThat(component.getName()).isEqualTo("acme-lib-retained"));
+        
+        assertThat(qm.getPersistenceManager().newQuery(ComponentProperty.class).executeList()).isEmpty();
+        assertThat(qm.getPersistenceManager().newQuery(ComponentOccurrence.class).executeList()).isEmpty();
+    }
+
     @Test // https://github.com/DependencyTrack/dependency-track/issues/3957
     void informIssue3957Test() throws Exception {
         final var licenseA = new License();


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Bypasses JDO for bulk deletions.

Bulk-deletes tags and components through raw SQL instead of going through JDO's `deletePersistentAll`. The latter always loads the to-be-deleted records into memory first, and then deletes them one-by-one, which defeats the batching property we're after.

Also adds a missing JDO `@ForeignKey` annotation on `ComponentProperty`, which lead DataNucleus to not bulk-cascade deletions of `Component` when deleting via the JDO API.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
