### PR TITLE
Expose assigned project access teams.

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/Project.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/Project.java
@@ -305,6 +305,8 @@ public class Project implements Serializable {
     @Persistent(table = "PROJECT_ACCESS_TEAMS")
     @Join(column = "PROJECT_ID", primaryKey = "PROJECT_ACCESS_TEAMS_PK")
     @Element(column = "TEAM_ID")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonIncludeProperties({"uuid", "name"})
     private Set<Team> accessTeams;
 
     @Persistent(defaultFetchGroup = "true")
@@ -592,7 +594,6 @@ public class Project implements Serializable {
         this.versions = versions;
     }
 
-    @JsonIgnore
     public Set<Team> getAccessTeams() {
         return accessTeams;
     }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -313,6 +313,9 @@ public class ProjectResource extends AbstractApiResource {
                             && qm.hasAccess(getPrincipal(), project.getParent());
 
             qm.makeTransient(project);
+            if (project.getAccessTeams() != null) {
+                qm.makeTransientAll(project.getAccessTeams());
+            }
             if (!isParentAccessible) {
                 project.setParent(null);
             }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -2093,6 +2093,51 @@ class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
+    void getProjectByUuidWithAccessTeamsTest() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        project.addAccessTeam(team);
+        qm.persist(project);
+
+        final Response response = jersey.target(V1_PROJECT + "/" + project.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
+                .withMatcher("teamUuid", equalTo(team.getUuid().toString()))
+                .isEqualTo(/* language=JSON */ """
+                        {
+                          "name": "acme-app",
+                          "version": "1.0.0",
+                          "uuid": "${json-unit.matches:projectUuid}",
+                          "children": [],
+                          "tags": [],
+                          "accessTeams": [
+                            {
+                              "uuid": "${json-unit.matches:teamUuid}",
+                              "name": "Test Users"
+                            }
+                          ],
+                          "isLatest": false,
+                          "active":true,
+                          "versions": [
+                            {
+                              "uuid": "${json-unit.matches:projectUuid}",
+                              "version": "1.0.0",
+                              "isLatest": false,
+                              "active": true
+                            }
+                          ]
+                        }
+                        """);
+    }
+
+    @Test
     void getProjectByUuidNotPermittedTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
         enablePortfolioAccessControl();
@@ -4488,6 +4533,7 @@ class ProjectResourceTest extends ResourceTest {
                         """.formatted(team.getUuid())));
         assertThat(response.getStatus()).isEqualTo(201);
         assertThatJson(getPlainTextBody(response))
+                .withMatcher("teamUuid", equalTo(team.getUuid().toString()))
                 .isEqualTo(/* language=JSON */ """
                         {
                           "uuid": "${json-unit.any-string}",
@@ -4495,6 +4541,12 @@ class ProjectResourceTest extends ResourceTest {
                           "classifier": "APPLICATION",
                           "children": [],
                           "tags": [],
+                          "accessTeams": [
+                            {
+                              "uuid": "${json-unit.matches:teamUuid}",
+                              "name": "Test Users"
+                            }
+                          ],
                           "active": true,
                           "isLatest": false
                         }
@@ -4529,6 +4581,7 @@ class ProjectResourceTest extends ResourceTest {
                         """.formatted(team.getName())));
         assertThat(response.getStatus()).isEqualTo(201);
         assertThatJson(getPlainTextBody(response))
+                .withMatcher("teamUuid", equalTo(team.getUuid().toString()))
                 .isEqualTo(/* language=JSON */ """
                         {
                           "uuid": "${json-unit.any-string}",
@@ -4536,6 +4589,12 @@ class ProjectResourceTest extends ResourceTest {
                           "classifier": "APPLICATION",
                           "children": [],
                           "tags": [],
+                          "accessTeams": [
+                            {
+                              "uuid": "${json-unit.matches:teamUuid}",
+                              "name": "Test Users"
+                            }
+                          ],
                           "isLatest":false,
                           "active": true
                         }
@@ -4677,6 +4736,7 @@ class ProjectResourceTest extends ResourceTest {
                         """.formatted(otherTeam.getUuid())));
         assertThat(response.getStatus()).isEqualTo(201);
         assertThatJson(getPlainTextBody(response))
+                .withMatcher("teamUuid", equalTo(otherTeam.getUuid().toString()))
                 .isEqualTo(/* language=JSON */ """
                         {
                           "uuid": "${json-unit.any-string}",
@@ -4684,6 +4744,12 @@ class ProjectResourceTest extends ResourceTest {
                           "classifier": "APPLICATION",
                           "children": [],
                           "tags": [],
+                          "accessTeams": [
+                            {
+                              "uuid": "${json-unit.matches:teamUuid}",
+                              "name": "otherTeam"
+                            }
+                          ],
                           "isLatest":false,
                           "active":true
                         }
@@ -4772,6 +4838,7 @@ class ProjectResourceTest extends ResourceTest {
                         """.formatted(team.getUuid())));
         assertThat(response.getStatus()).isEqualTo(201);
         assertThatJson(getPlainTextBody(response))
+                .withMatcher("teamUuid", equalTo(team.getUuid().toString()))
                 .isEqualTo(/* language=JSON */ """
                         {
                           "uuid": "${json-unit.any-string}",
@@ -4779,6 +4846,12 @@ class ProjectResourceTest extends ResourceTest {
                           "classifier": "APPLICATION",
                           "children": [],
                           "tags": [],
+                          "accessTeams": [
+                            {
+                              "uuid": "${json-unit.matches:teamUuid}",
+                              "name": "Test Users"
+                            }
+                          ],
                           "isLatest":false,
                           "active":true
                         }


### PR DESCRIPTION
### Description
Expose assigned project access teams in project API responses.

accessTeams was previously ignored during JSON serialization, so clients could not see which teams are assigned to a project. Project responses now include accessTeams with only uuid and name. Empty assignments are omitted.

### Addressed Issue
[https://github.com/DependencyTrack/frontend/issues/1752](https://github.com/DependencyTrack/frontend/issues/1752)

### Additional Details
Frontend PR: [https://github.com/DependencyTrack/frontend/pull/1753](https://github.com/DependencyTrack/frontend/pull/1753)

### Checklist
- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

