### PR TITLE
Support display names for extensions and KEV asserters

### DIFF
--- a/api/src/main/openapi/resources/extensions/schemas/list-extensions-response-item.yaml
+++ b/api/src/main/openapi/resources/extensions/schemas/list-extensions-response-item.yaml
@@ -18,6 +18,9 @@ type: object
 properties:
   name:
     type: string
+  display_name:
+    type: string
+    description: Human-readable name of the extension.
   configurable:
     type: boolean
     description: Whether the extension supports runtime configuration.
@@ -26,5 +29,6 @@ properties:
     description: Whether the extension can be tested.
 required:
 - name
+- display_name
 - configurable
 - testable

--- a/api/src/main/openapi/resources/vulns/schemas/kev-assertion.yaml
+++ b/api/src/main/openapi/resources/vulns/schemas/kev-assertion.yaml
@@ -19,7 +19,10 @@ description: A single assertion that a vulnerability is known to be exploited.
 properties:
   asserter:
     type: string
-    description: The entity that asserted the vulnerability is known to be exploited (e.g. `CISA`, `ENISA`).
+    description: The entity that asserted the vulnerability is known to be exploited (e.g. `cisa`, `enisa`).
+  asserter_display_name:
+    type: string
+    description: Human-readable name of the asserting entity (e.g. `CISA KEV`).
   vuln_source:
     type: string
     description: Source of the asserted vulnerability identifier (e.g. `NVD`).
@@ -46,6 +49,7 @@ properties:
     $ref: "../../../shared/schemas/timestamp.yaml"
 required:
 - asserter
+- asserter_display_name
 - vuln_source
 - vuln_id
 - created_at

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/ExtensionsResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/ExtensionsResource.java
@@ -137,6 +137,7 @@ public class ExtensionsResource extends AbstractApiResource implements Extension
                                 .<ListExtensionsResponseItem>map(
                                         extensionFactory -> ListExtensionsResponseItem.builder()
                                                 .name(extensionFactory.extensionName())
+                                                .displayName(extensionFactory.displayName())
                                                 .configurable(extensionFactory instanceof RuntimeConfigurable)
                                                 .testable(extensionFactory instanceof Testable)
                                                 .build())

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/VulnsResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/VulnsResource.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.resources.v2;
 
 import alpine.server.auth.PermissionRequired;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
@@ -28,19 +29,31 @@ import org.dependencytrack.api.v2.model.ListVulnKevAssertionsResponse;
 import org.dependencytrack.api.v2.model.TotalCount;
 import org.dependencytrack.api.v2.model.TotalCountType;
 import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.kevdatasource.api.KevDataSource;
 import org.dependencytrack.persistence.jdbi.KevDao;
 import org.dependencytrack.persistence.jdbi.KevDao.KevAssertionRow;
 import org.dependencytrack.persistence.jdbi.VulnerabilityDao;
+import org.dependencytrack.plugin.api.ExtensionFactory;
+import org.dependencytrack.plugin.runtime.PluginManager;
 import org.dependencytrack.resources.AbstractApiResource;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 
 /// @since 5.1.0
 @Provider
 public final class VulnsResource extends AbstractApiResource implements VulnsApi {
+
+    private final PluginManager pluginManager;
+
+    @Inject
+    VulnsResource(PluginManager pluginManager) {
+        this.pluginManager = pluginManager;
+    }
 
     @Override
     @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
@@ -53,11 +66,21 @@ public final class VulnsResource extends AbstractApiResource implements VulnsApi
             return handle.attach(KevDao.class).getAssertions(source, vulnId);
         });
 
+        final Map<String, String> displayNameByExtensionName =
+                pluginManager.getFactories(KevDataSource.class).stream()
+                        .collect(Collectors.toMap(
+                                ExtensionFactory::extensionName,
+                                ExtensionFactory::displayName));
+
         final var items = new ArrayList<KevAssertion>(rows.size());
         for (final KevAssertionRow row : rows) {
             items.add(
                     KevAssertion.builder()
                             .asserter(row.asserter())
+                            .asserterDisplayName(
+                                    displayNameByExtensionName.getOrDefault(
+                                            row.asserter(),
+                                            row.asserter()))
                             .vulnSource(row.vulnSource())
                             .vulnId(row.vulnId())
                             .publishedAt(row.publishedAt() != null

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/ExtensionsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/ExtensionsResourceTest.java
@@ -127,7 +127,7 @@ class ExtensionsResourceTest extends ResourceTest {
     @Test
     void listExtensionsShouldListAllExtensions() {
         pluginManager.loadPlugins(List.of(
-                () -> List.of(new DummyExtensionFactory())));
+                () -> List.of(new DummyExtensionFactory(), new NonConfigurableExtensionFactory())));
 
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
 
@@ -139,15 +139,22 @@ class ExtensionsResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(200);
         assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
                 {
-                  "items":[
+                  "items": [
                     {
                       "name": "dummy-extension",
+                      "display_name": "Dummy Extension",
                       "configurable": true,
+                      "testable": false
+                    },
+                    {
+                      "name": "non-configurable-extension",
+                      "display_name": "non-configurable-extension",
+                      "configurable": false,
                       "testable": false
                     }
                   ],
                   "total": {
-                    "count": 1,
+                    "count": 2,
                     "type": "EXACT"
                   }
                 }
@@ -598,6 +605,11 @@ class ExtensionsResourceTest extends ResourceTest {
         @Override
         public @NonNull String extensionName() {
             return "dummy-extension";
+        }
+
+        @Override
+        public @NonNull String displayName() {
+            return "Dummy Extension";
         }
 
         @Override

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/VulnsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/VulnsResourceTest.java
@@ -19,21 +19,37 @@
 package org.dependencytrack.resources.v2;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.smallrye.config.SmallRyeConfigBuilder;
 import jakarta.ws.rs.core.Response;
 import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.cache.api.NoopCacheManager;
 import org.dependencytrack.kevdatasource.api.KevAssertion;
+import org.dependencytrack.kevdatasource.api.KevDataSource;
+import org.dependencytrack.kevdatasource.api.KevDataSourceFactory;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityKey;
+import org.dependencytrack.persistence.jdbi.JdbiFactory;
 import org.dependencytrack.persistence.jdbi.KevDao;
 import org.dependencytrack.persistence.jdbi.VulnerabilityAliasDao;
+import org.dependencytrack.plugin.api.ServiceRegistry;
+import org.dependencytrack.plugin.runtime.PluginManager;
+import org.dependencytrack.secret.TestSecretManager;
+import org.dependencytrack.secret.management.SecretManager;
+import org.glassfish.jersey.inject.hk2.AbstractBinder;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.net.http.HttpClient;
 import java.time.Instant;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Set;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
@@ -42,11 +58,47 @@ import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiTransactio
 
 class VulnsResourceTest extends ResourceTest {
 
+    private static SecretManager secretManager;
+    private static PluginManager pluginManager;
+
     @RegisterExtension
-    static JerseyTestExtension jersey = new JerseyTestExtension(new ResourceConfig());
+    static JerseyTestExtension jersey = new JerseyTestExtension(
+            new ResourceConfig()
+                    .register(new AbstractBinder() {
+                        @Override
+                        protected void configure() {
+                            bindFactory(() -> pluginManager).to(PluginManager.class);
+                        }
+                    }));
+
+    @BeforeAll
+    static void beforeAll() {
+        secretManager = new TestSecretManager();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        pluginManager = new PluginManager(
+                new SmallRyeConfigBuilder().build(),
+                new NoopCacheManager(),
+                secretManager::getSecretValue,
+                JdbiFactory.createJdbi(),
+                HttpClient.newHttpClient(),
+                List.of(KevDataSource.class));
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (pluginManager != null) {
+            pluginManager.close();
+        }
+    }
 
     @Test
     void listVulnerabilityKevAssertionsShouldListKevAssertionsIncludingThoseOfAliases() {
+        pluginManager.loadPlugins(List.of(
+                () -> List.of(new DummyKevDataSourceFactory())));
+
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 
         var cve = new Vulnerability();
@@ -68,7 +120,7 @@ class VulnsResourceTest extends ResourceTest {
                     Set.of(new VulnerabilityKey("GHSA-jfh8-c2jp-5v3q", Vulnerability.Source.GITHUB)));
 
             final var kevDao = handle.attach(KevDao.class);
-            kevDao.upsertBatch("cisa", List.of(
+            kevDao.upsertBatch("dummy-kev-data-source", List.of(
                     new KevAssertion(
                             "NVD",
                             "CVE-2021-44228",
@@ -77,7 +129,7 @@ class VulnsResourceTest extends ResourceTest {
                             true,
                             "Log4Shell",
                             JsonNodeFactory.instance.objectNode().put("cveID", "CVE-2021-44228"))));
-            kevDao.upsertBatch("enisa", List.of(
+            kevDao.upsertBatch("unregistered-kev-data-source", List.of(
                     new KevAssertion(
                             "GITHUB",
                             "GHSA-jfh8-c2jp-5v3q",
@@ -99,14 +151,16 @@ class VulnsResourceTest extends ResourceTest {
                 {
                   "items": [
                     {
-                      "asserter": "enisa",
+                      "asserter": "unregistered-kev-data-source",
+                      "asserter_display_name": "unregistered-kev-data-source",
                       "vuln_source": "GITHUB",
                       "vuln_id": "GHSA-jfh8-c2jp-5v3q",
                       "created_at": "${json-unit.any-number}",
                       "updated_at": "${json-unit.any-number}"
                     },
                     {
-                      "asserter": "cisa",
+                      "asserter": "dummy-kev-data-source",
+                      "asserter_display_name": "Dummy KEV",
                       "vuln_source": "NVD",
                       "vuln_id": "CVE-2021-44228",
                       "published_at": 1639094400000,
@@ -176,4 +230,57 @@ class VulnsResourceTest extends ResourceTest {
 
         assertThat(response.getStatus()).isEqualTo(403);
     }
+
+    private static final class DummyKevDataSource implements KevDataSource {
+
+        @Override
+        public boolean hasNext() {
+            return false;
+        }
+
+        @Override
+        public KevAssertion next() {
+            throw new NoSuchElementException();
+        }
+
+    }
+
+    private static final class DummyKevDataSourceFactory implements KevDataSourceFactory {
+
+        @Override
+        public @NonNull String extensionName() {
+            return "dummy-kev-data-source";
+        }
+
+        @Override
+        public @NonNull String displayName() {
+            return "Dummy KEV";
+        }
+
+        @Override
+        public @NonNull Class<? extends KevDataSource> extensionClass() {
+            return DummyKevDataSource.class;
+        }
+
+        @Override
+        public int priority() {
+            return PRIORITY_HIGHEST;
+        }
+
+        @Override
+        public void init(@NonNull ServiceRegistry serviceRegistry) {
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return true;
+        }
+
+        @Override
+        public @NonNull KevDataSource create() {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
 }

--- a/kev-data-source/builtin/src/main/java/org/dependencytrack/kevdatasource/cisa/CisaKevDataSourceFactory.java
+++ b/kev-data-source/builtin/src/main/java/org/dependencytrack/kevdatasource/cisa/CisaKevDataSourceFactory.java
@@ -47,6 +47,11 @@ public final class CisaKevDataSourceFactory implements KevDataSourceFactory, Run
     }
 
     @Override
+    public String displayName() {
+        return "CISA KEV";
+    }
+
+    @Override
     public Class<? extends KevDataSource> extensionClass() {
         return CisaKevDataSource.class;
     }

--- a/kev-data-source/builtin/src/main/java/org/dependencytrack/kevdatasource/enisa/EnisaKevDataSourceFactory.java
+++ b/kev-data-source/builtin/src/main/java/org/dependencytrack/kevdatasource/enisa/EnisaKevDataSourceFactory.java
@@ -47,6 +47,11 @@ public final class EnisaKevDataSourceFactory implements KevDataSourceFactory, Ru
     }
 
     @Override
+    public String displayName() {
+        return "ENISA EU KEV";
+    }
+
+    @Override
     public Class<? extends KevDataSource> extensionClass() {
         return EnisaKevDataSource.class;
     }

--- a/plugin/api/src/main/java/org/dependencytrack/plugin/api/ExtensionFactory.java
+++ b/plugin/api/src/main/java/org/dependencytrack/plugin/api/ExtensionFactory.java
@@ -34,6 +34,14 @@ public interface ExtensionFactory<T extends ExtensionPoint> extends Closeable {
     String extensionName();
 
     /**
+     * @return Human-readable name of the extension, for display purposes. Defaults to {@link #extensionName()}.
+     * @since 5.1.0
+     */
+    default String displayName() {
+        return extensionName();
+    }
+
+    /**
      * @return {@link Class} of the extension.
      */
     Class<? extends T> extensionClass();


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Supports display names for extensions and KEV asserters.

Some proprietary data sources like VulnCheck require attribution with a specific string (in their case `VulnCheck KEV`), which the slug-style extension name we used so far does not satisfy.

This adds a new (optional) display name option to extensions, which is then used for asserters in KEV assertion responses as well.

Only adds display names for KEV data sources for now. We should extend this to vuln data sources, vuln analyzers etc. later.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #2267 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
