### PR TITLE
Remove stale internal-analyzer findings when affected components are cleared

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -843,6 +843,10 @@ public class QueryManager extends AlpineQueryManager {
         getVulnerabilityQueryManager().removeVulnerability(vulnerability, component);
     }
 
+    public void removeStaleInternalFindings(Vulnerability vulnerability) {
+        getVulnerabilityQueryManager().removeStaleInternalFindings(vulnerability);
+    }
+
     public FindingAttribution getFindingAttribution(Vulnerability vulnerability, Component component) {
         return getVulnerabilityQueryManager().getFindingAttribution(vulnerability, component);
     }

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -24,6 +24,7 @@ import alpine.persistence.PaginatedResult;
 import alpine.resources.AlpineRequest;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.dependencytrack.event.ComponentMetricsUpdateEvent;
 import org.dependencytrack.event.IndexEvent;
 import org.dependencytrack.model.AffectedVersionAttribution;
 import org.dependencytrack.model.Analysis;
@@ -1080,6 +1081,30 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
         query.setRange(0, 1);
         query.setResult("id");
         return !executeAndCloseResultList(query, Long.class).isEmpty();
+    }
+
+    /**
+     * Removes findings attributed to the internal analyzer for the given vulnerability.
+     * Used when all affected components are removed from an INTERNAL vulnerability:
+     * the internal analyzer only ever adds findings, so previously matched components
+     * would otherwise retain their findings indefinitely.
+     * @param vulnerability the vulnerability whose internal-analyzer findings should be removed
+     */
+    public void removeStaleInternalFindings(final Vulnerability vulnerability) {
+        if (vulnerability == null) {
+            return;
+        }
+        final Query<FindingAttribution> query = pm.newQuery(FindingAttribution.class,
+                "vulnerability == :vulnerability && analyzerIdentity == :identity");
+        @SuppressWarnings("unchecked")
+        final List<FindingAttribution> stale = (List<FindingAttribution>) query.execute(
+                vulnerability, AnalyzerIdentity.INTERNAL_ANALYZER);
+        for (final FindingAttribution fa : stale) {
+            final Component component = fa.getComponent();
+            component.removeVulnerability(vulnerability);
+            delete(fa);
+            Event.dispatch(new ComponentMetricsUpdateEvent(component.getUuid()));
+        }
     }
 
 }

--- a/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
@@ -466,6 +466,12 @@ public class VulnerabilityResource extends AlpineResource {
                 return qm.callInTransaction(() -> {
                     final Vulnerability persistentVuln = qm.updateVulnerability(jsonVuln, true);
                     qm.synchronizeVulnerableSoftware(persistentVuln, vsList, Vulnerability.Source.INTERNAL);
+                    if (vsList.isEmpty()) {
+                        // The internal analyzer only ever adds findings. When the last affected
+                        // component definition is removed, previously matched findings must be
+                        // removed as well, or they linger indefinitely.
+                        qm.removeStaleInternalFindings(persistentVuln);
+                    }
                     if (persistentVuln.getVulnerableSoftware() != null && !persistentVuln.getVulnerableSoftware().isEmpty()) {
                         persistentVuln.setAffectedComponents(persistentVuln.getVulnerableSoftware().stream()
                                 .peek(vs -> vs.setAffectedVersionAttributions(qm.getAffectedVersionAttributions(persistentVuln, vs)))

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -675,6 +675,44 @@ class VulnerabilityResourceTest extends ResourceTest {
     }
 
     @Test
+    void updateVulnerabilityRemovesStaleInternalFindingsWhenAffectedComponentsClearedTest() {
+        Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+        Component component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("1.0.0");
+        component = qm.createComponent(component, false);
+
+        Vulnerability vuln = new Vulnerability();
+        vuln.setVulnId("INT-123");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln = qm.createVulnerability(vuln, false);
+
+        // Simulate a finding previously created by the internal analyzer.
+        qm.addVulnerability(vuln, component, AnalyzerIdentity.INTERNAL_ANALYZER);
+        Assertions.assertNotNull(qm.getFindingAttribution(vuln, component));
+        Assertions.assertEquals(1, qm.getAllVulnerabilities(component).size());
+
+        // Update the vulnerability with all affected components removed.
+        JsonObject payload = Json.createObjectBuilder()
+                .add("vulnId", "INT-123")
+                .add("source", "INTERNAL")
+                .add("description", "Something is vulnerable")
+                .add("affectedComponents", Json.createArrayBuilder())
+                .add("uuid", vuln.getUuid().toString())
+                .build();
+        Response response = jersey.target(V1_VULNERABILITY).request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(payload.toString()));
+        Assertions.assertEquals(200, response.getStatus(), 0);
+
+        // The previously matched finding must be gone.
+        qm.getPersistenceManager().evictAll();
+        Assertions.assertNull(qm.getFindingAttribution(vuln, component));
+        Assertions.assertEquals(0, qm.getAllVulnerabilities(component).size());
+    }
+
+    @Test
     void testReconcileVulnerableSoftwareWithInternalSource() {
         Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)


### PR DESCRIPTION
### Description
Fixes stale findings left behind by the internal analyzer. Updating an INTERNAL
vulnerability synchronizes its VulnerableSoftware records, but findings previously
created by the internal analyzer were never removed. Since the internal analyzer only
ever adds findings, clearing all affected components from a vulnerability left the
matched components carrying the finding indefinitely.

The update endpoint now removes INTERNAL_ANALYZER finding attributions and component
links when the affected-components list is emptied, and dispatches metrics updates
for the affected components.

### Addressed Issue
fixes #7029

### Additional Details
- New `removeStaleInternalFindings` in `VulnerabilityQueryManager`, invoked from the
  update path inside the existing transaction when the synchronized VulnerableSoftware
  list is empty.
- Regression test included; it fails without the fix (the finding attribution survives
  the update) and passes with it.
- Note: touches the same method as open PR #6639 (adjacent, non-overlapping lines) —
  whichever merges second needs a trivial rebase.

### Checklist
- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations