### PR TITLE
Fix KEV filter performance regression in findings endpoints

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -204,7 +204,7 @@ public interface FindingDao extends PaginationSupport {
                  , JSONB_VULN_ALIASES(v."SOURCE", v."VULNID") AS "vulnAliasesJson"
                  , e."SCORE" AS "epssScore"
                  , e."PERCENTILE" AS "epssPercentile"
-                 , <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "kev"
+                 , <@sql.isKevColumn vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "kev"
                  , fa."ANALYZERIDENTITY"
                  , fa."ATTRIBUTED_ON"
                  , fa."ALT_ID"
@@ -254,7 +254,7 @@ public interface FindingDao extends PaginationSupport {
                AND e."SCORE" <= :epssTo
             </#if>
             <#if isKev>
-               AND <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> = :isKev
+               AND <@sql.isKevFilter vulnIdColumn='cv."VULNERABILITY_ID"'/> = :isKev
             </#if>
             <#if searchText>
                AND (
@@ -366,7 +366,7 @@ public interface FindingDao extends PaginationSupport {
                    AND e."SCORE" <= :epssTo
             </#if>
             <#if isKev>
-                   AND <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> = :isKev
+                   AND <@sql.isKevFilter vulnIdColumn='cv."VULNERABILITY_ID"'/> = :isKev
             </#if>
             <#if searchText>
                    AND (
@@ -600,7 +600,7 @@ public interface FindingDao extends PaginationSupport {
                  ${queryFilter}
             </#if>
             <#if isKev>
-                 AND <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> = :isKev
+                 AND <@sql.isKevFilter vulnIdColumn='cv."VULNERABILITY_ID"'/> = :isKev
             </#if>
             <#if apiOrderByClause??>
                ${apiOrderByClause}
@@ -691,7 +691,7 @@ public interface FindingDao extends PaginationSupport {
                  , ep."SCORE" AS "epssScore"
                  , ep."PERCENTILE" AS "epssPercentile"
             </#if>
-                 , <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "kev"
+                 , <@sql.isKevColumn vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "kev"
                  , fa."ANALYZERIDENTITY"
                  , fa."ATTRIBUTED_ON"
                  , fa."ALT_ID"
@@ -853,7 +853,7 @@ public interface FindingDao extends PaginationSupport {
                    ${queryFilter}
             </#if>
             <#if isKev>
-                   AND <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> = :isKev
+                   AND <@sql.isKevFilter vulnIdColumn='cv."VULNERABILITY_ID"'/> = :isKev
             </#if>
             <#if threshold>
                  LIMIT (:threshold + 1)
@@ -979,7 +979,7 @@ public interface FindingDao extends PaginationSupport {
                    END AS "cvssV4Score"
                  , ed."SCORE" AS "epssScore"
                  , ed."PERCENTILE" AS "epssPercentile"
-                 , <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "kev"
+                 , <@sql.isKevColumn vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "kev"
                  , v."PUBLISHED" AS "vulnPublished"
                  , CAST(STRING_TO_ARRAY(v."CWES", ',') AS INT[]) AS "CWES"
                  , fa."ANALYZERIDENTITY"
@@ -1018,7 +1018,7 @@ public interface FindingDao extends PaginationSupport {
                 ${queryFilter}
             </#if>
             <#if isKev>
-                AND <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> = :isKev
+                AND <@sql.isKevFilter vulnIdColumn='cv."VULNERABILITY_ID"'/> = :isKev
             </#if>
             GROUP BY v."ID"
                   , v."SOURCE"
@@ -1161,7 +1161,7 @@ public interface FindingDao extends PaginationSupport {
                 case "epssPercentileTo" ->
                         processRangeFilter(queryFilter, params, filter, filters.get(filter), "ed.\"PERCENTILE\"", false, false, false);
                 // NB: isKev is applied directly in the query templates via the shared
-                // <@sql.isKev/> macro, not as a queryFilter fragment.
+                // <@sql.isKevFilter/> macro, not as a queryFilter fragment.
             }
         }
     }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -154,7 +154,7 @@ public interface NotificationSubjectDao extends SqlObject {
                  , COALESCE(a."SEVERITY", v."SEVERITY") AS "vulnSeverity"
                  , STRING_TO_ARRAY(v."CWES", ',') AS "vulnCwes"
                  , JSONB_VULN_ALIASES(v."SOURCE", v."VULNID") AS "vulnAliasesJson"
-                 , <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "vulnIsKev"
+                 , <@sql.isKevColumn vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "vulnIsKev"
               FROM UNNEST(:componentIds, :vulnerabilityIds)
                 AS req(component_id, vulnerability_id)
              INNER JOIN "COMPONENTS_VULNERABILITIES" AS cv
@@ -269,7 +269,7 @@ public interface NotificationSubjectDao extends SqlObject {
                              , COALESCE(a."SEVERITY", v."SEVERITY") AS "vulnSeverity"
                              , STRING_TO_ARRAY(v."CWES", ',') AS "vulnCwes"
                              , JSONB_VULN_ALIASES(v."SOURCE", v."VULNID") AS "vulnAliasesJson"
-                             , <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "vulnIsKev"
+                             , <@sql.isKevColumn vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "vulnIsKev"
                           FROM "COMPONENT" AS c
                          INNER JOIN "PROJECT" AS p
                             ON p."ID" = c."PROJECT_ID"
@@ -416,7 +416,7 @@ public interface NotificationSubjectDao extends SqlObject {
                              , COALESCE(a."SEVERITY", v."SEVERITY") AS "vulnSeverity"
                              , STRING_TO_ARRAY(v."CWES", ',') AS "vulnCwes"
                              , JSONB_VULN_ALIASES(v."SOURCE", v."VULNID") AS "vulnAliasesJson"
-                             , <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "vulnIsKev"
+                             , <@sql.isKevColumn vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "vulnIsKev"
                              , req.analysis_state AS "vulnAnalysisState"
                              , req.suppressed AS "isVulnAnalysisSuppressed"
                              , format('/api/v1/vulnerability/source/%s/vuln/%s/projects', v."SOURCE", v."VULNID") AS "affectedProjectsApiUrl"
@@ -607,7 +607,7 @@ public interface NotificationSubjectDao extends SqlObject {
                              , COALESCE(a."SEVERITY", v."SEVERITY") AS "vulnSeverity"
                              , STRING_TO_ARRAY(v."CWES", ',') AS "vulnCwes"
                              , JSONB_VULN_ALIASES(v."SOURCE", v."VULNID") AS "vulnAliasesJson"
-                             , <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "vulnIsKev"
+                             , <@sql.isKevColumn vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "vulnIsKev"
                           FROM UNNEST(:componentIds, :vulnDbIds)
                             AS t(component_id, vuln_db_id)
                          INNER JOIN "VULNERABILITY" AS v

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
@@ -81,7 +81,7 @@ public interface VulnerabilityDao {
                  , JSONB_VULN_ALIASES("V"."SOURCE", "V"."VULNID") AS "vulnAliasesJson"
                  , "EPSS"."SCORE"
                  , "EPSS"."PERCENTILE"
-                 , <@sql.isKev vulnSource='"V"."SOURCE"' vulnId='"V"."VULNID"'/> AS "kev"
+                 , <@sql.isKevColumn vulnSource='"V"."SOURCE"' vulnId='"V"."VULNID"'/> AS "kev"
                  ,  (SELECT JSONB_AGG(JSONB_BUILD_OBJECT('id', "ID", 'name', "NAME"))
                         FROM "TAG"
                         INNER JOIN "VULNERABILITIES_TAGS"
@@ -318,7 +318,7 @@ public interface VulnerabilityDao {
                  , JSONB_VULN_ALIASES("V"."SOURCE", "V"."VULNID") AS "vulnAliasesJson"
                  , "EPSS"."SCORE"
                  , "EPSS"."PERCENTILE"
-                 , <@sql.isKev vulnSource='"V"."SOURCE"' vulnId='"V"."VULNID"'/> AS "kev"
+                 , <@sql.isKevColumn vulnSource='"V"."SOURCE"' vulnId='"V"."VULNID"'/> AS "kev"
                  ,  (SELECT JSONB_AGG(JSONB_BUILD_OBJECT('id', "ID", 'name', "NAME"))
                         FROM "TAG"
                         INNER JOIN "VULNERABILITIES_TAGS"
@@ -471,7 +471,7 @@ public interface VulnerabilityDao {
                  , ARRAY_AGG(DISTINCT("COMPONENT"."ID")) as "componentIdsArray"
                  , "EPSS"."SCORE"
                  , "EPSS"."PERCENTILE"
-                 , <@sql.isKev vulnSource='"V"."SOURCE"' vulnId='"V"."VULNID"'/> AS "kev"
+                 , <@sql.isKevColumn vulnSource='"V"."SOURCE"' vulnId='"V"."VULNID"'/> AS "kev"
                  ,  (SELECT JSONB_AGG(JSONB_BUILD_OBJECT('id', "ID", 'name', "NAME"))
                         FROM "TAG"
                         INNER JOIN "VULNERABILITIES_TAGS"

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
@@ -319,7 +319,7 @@ public final class CelPolicyDao {
                         <#-- @ftlvariable name="shouldFetchIsKev" type="boolean" -->
                         SELECT ${fetchColumns?join(", ")}
                         <#if shouldFetchIsKev>
-                             , <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS is_kev
+                             , <@sql.isKevColumn vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS is_kev
                         </#if>
                           FROM "VULNERABILITY" AS v
                         <#if shouldFetchEpss!false>
@@ -748,7 +748,7 @@ public final class CelPolicyDao {
                              , ${fetchColumns?join(", ")}
                         </#if>
                         <#if shouldFetchIsKev>
-                             , <@sql.isKev vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS is_kev
+                             , <@sql.isKevColumn vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS is_kev
                         </#if>
                           FROM "VULNERABILITY" AS v
                         <#if needsEpss!false>

--- a/apiserver/src/main/resources/ftl/sql-macros.ftl
+++ b/apiserver/src/main/resources/ftl/sql-macros.ftl
@@ -16,11 +16,42 @@
      AND alias_self."VULN_ID" = ${vulnId}
 </#macro>
 
-<#macro isKev vulnSource vulnId>
+<#--
+  Whether one vulnerability is known exploited.
+  Use for point-lookups or enrichment in a SELECT, NOT for filtering large result sets.
+-->
+<#macro isKevColumn vulnSource vulnId>
   EXISTS (
     SELECT 1
       FROM "KEV_ASSERTION" AS ka
      WHERE (ka."VULN_SOURCE", ka."VULN_ID") IN (<@vulnAliasGroup vulnSource=vulnSource vulnId=vulnId/>)
+  )
+</#macro>
+
+<#--
+  Whether a vulnerability is known exploited.
+  Use for filtering large result sets, use `isKevColumn` otherwise.
+
+  This variant computes the full set of KEV vulns upfront,
+  which pays off for filtering but degrades badly for point-lookups and SELECT enrichment.
+
+  NB: Keep the ARRAY(...) notation! Postgres then builds the set once and counts it,
+  so it knows the filter keeps very few rows. IN or a join leaves it guessing,
+  and for a sorted page it scans the whole VULNERABILITY table instead of the
+  few rows that match.
+-->
+<#macro isKevFilter vulnIdColumn>
+  (
+    ${vulnIdColumn} = ANY(ARRAY(
+      SELECT DISTINCT kev_v."ID"
+        FROM "KEV_ASSERTION" AS kev_ka
+       INNER JOIN LATERAL (
+         <@vulnAliasGroup vulnSource='kev_ka."VULN_SOURCE"' vulnId='kev_ka."VULN_ID"'/>
+       ) AS kev_group("SOURCE", "VULN_ID") ON TRUE
+       INNER JOIN "VULNERABILITY" AS kev_v
+          ON kev_v."VULNID" = kev_group."VULN_ID"
+         AND kev_v."SOURCE" = kev_group."SOURCE"
+    ))
   )
 </#macro>
 

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -50,10 +50,12 @@ import org.dependencytrack.model.PackageMetadata;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.VulnerabilityKey;
 import org.dependencytrack.persistence.command.MakeAnalysisCommand;
 import org.dependencytrack.persistence.jdbi.EpssDao;
 import org.dependencytrack.persistence.jdbi.KevDao;
 import org.dependencytrack.persistence.jdbi.PackageMetadataDao;
+import org.dependencytrack.persistence.jdbi.VulnerabilityAliasDao;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -78,6 +80,7 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -1174,6 +1177,80 @@ public class FindingResourceTest extends ResourceTest {
         final String nonKevBody = getPlainTextBody(response);
         assertThatJson(nonKevBody).isArray().hasSize(1);
         assertThatJson(nonKevBody).node("[0].vulnerability.vulnId").isEqualTo("Vuln-NON-KEV");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"portfolio", "grouped", "project"})
+    void shouldFilterByKevAssertedOnAnAlias(String endpoint) {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
+        final Component component = createComponent(project, "Component A", "1.0");
+        qm.addVulnerability(createVulnerability("INT-ALIASED", Severity.CRITICAL), component, "none");
+        qm.addVulnerability(createVulnerability("INT-UNRELATED", Severity.HIGH), component, "none");
+
+        useJdbiTransaction(handle -> {
+            new VulnerabilityAliasDao(handle).syncAssertions(
+                    "NVD",
+                    new VulnerabilityKey("CVE-2021-9999", Vulnerability.Source.NVD),
+                    Set.of(new VulnerabilityKey("INT-ALIASED", Vulnerability.Source.INTERNAL)));
+            handle.attach(KevDao.class).upsertBatch("cisa", List.of(
+                    new KevAssertion(
+                            "NVD",
+                            "CVE-2021-9999",
+                            null,
+                            null,
+                            null,
+                            null,
+                            JsonNodeFactory.instance.objectNode())));
+        });
+
+        final String target = switch (endpoint) {
+            case "grouped" -> V1_FINDING + "/grouped";
+            case "project" -> V1_FINDING + "/project/" + project.getUuid();
+            default -> V1_FINDING;
+        };
+
+        final Response response = jersey
+                .target(target)
+                .queryParam("isKev", "true")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        final String body = getPlainTextBody(response);
+        assertThatJson(body).isArray().hasSize(1);
+        assertThatJson(body).node("[0].vulnerability.vulnId").isEqualTo("INT-ALIASED");
+    }
+
+    @Test
+    void shouldFilterByEpssScoreResolvedThroughAlias() {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
+        final Component component = createComponent(project, "Component A", "1.0");
+        qm.addVulnerability(createVulnerability("INT-ALIASED", Severity.CRITICAL), component, "none");
+        qm.addVulnerability(createVulnerability("INT-UNRELATED", Severity.HIGH), component, "none");
+
+        useJdbiTransaction(handle -> {
+            new VulnerabilityAliasDao(handle).syncAssertions(
+                    "NVD",
+                    new VulnerabilityKey("CVE-2021-9998", Vulnerability.Source.NVD),
+                    Set.of(new VulnerabilityKey("INT-ALIASED", Vulnerability.Source.INTERNAL)));
+            handle.attach(EpssDao.class).createOrUpdateAll(
+                    List.of(new Epss("CVE-2021-9998", new BigDecimal("0.95"), null)));
+        });
+
+        final Response response = jersey
+                .target(V1_FINDING)
+                .queryParam("epssFrom", "0.9")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        final String body = getPlainTextBody(response);
+        assertThatJson(body).isArray().hasSize(1);
+        assertThatJson(body).node("[0].vulnerability.vulnId").isEqualTo("INT-ALIASED");
     }
 
     @Test

--- a/docs/adr/037-portfolio-finding-lists-live-not-materialized.md
+++ b/docs/adr/037-portfolio-finding-lists-live-not-materialized.md
@@ -30,7 +30,7 @@ as does access control that grants a user only a few projects.
 In their current shape, with arbitrary sorts, filters, and aggregations over the entire portfolio,
 these endpoints are an analytical workload. Our schema is built for transactional processing,
 which is a poor fit for this kind of workload once the data gets large.
-None of the solutions below removes this mismatch.
+None of the proposed solutions removes this mismatch.
 
 ### Constraints
 
@@ -130,6 +130,7 @@ and pay for that with staleness, write amplification, or new infrastructure.
 We keep the cost on the read path instead, where only the queries that need it pay for it.
 
 * The default view stays live and fast at any size: default order, combined with the bounded count from [ADR 036].
+  A filter that matches few or no rows is the exception, see [Consequences > Filters](#filters).
 * Expensive operations are bounded by the platform's global query timeout
   (`dt.datasource.query-timeout-ms`, 60 seconds per default).
   Requests that exceed it fail with `504` instead of hanging.
@@ -162,7 +163,9 @@ without changing what the result means.
 * Small and medium portfolios are unaffected. The page, every sort, and the exact count keep working,
   with no added infrastructure, storage, or staleness.
 * Very large portfolios keep the same page and a fast default view. Expensive sorts hit the timeout,
-  whether filtered or not. No feature is removed, and there is no separate product for large tenants.
+  whether filtered or not. We ship the same features to every deployment, and there is no separate
+  product for large tenants. For the user this is worse than removing the sort would be, because they
+  wait a minute for a `504` instead of seeing that the sort is unavailable.
 * The boundary is a timeout, so it is not a sharp line. The same query can pass with a warm cache and fail under load,
   and portfolios near the limit will see intermittent `504` responses.
   A deterministic guard, e.g. rejecting a sort when the estimated result is too large, would draw a sharper line.
@@ -170,6 +173,26 @@ without changing what the result means.
   it can predict. We accept the fuzziness, in exchange for a bound that catches every expensive request.
 * The frontend must opt into the bounded count, as otherwise the default view still requests an exact count,
   which times out on the portfolios this ADR is about. The frontend change is part of this work.
+
+### Filters
+
+For some filters the exact count is the faster option, which inverts the premise of [ADR 036].
+The exact count runs inside the page query and forces the database to build the whole result set.
+The bounded count runs separately, so the page query can walk an index and stop at the requested page.
+That walk makes the default view fast. For a filter the database cannot estimate,
+it reads far more rows than the page returns. This affects only correlated subquery filters.
+
+The fix is to resolve the filter's set once, which works only where a small table supplies that set.
+The KEV filter now does this, because the catalog of known exploited vulnerabilities stays
+small at any portfolio size. The EPSS score filter cannot, because one EPSS record per
+vulnerability means building the set reads the whole portfolio. On the 100 million finding
+dataset that costs more than the filter saves, so it keeps the timeout as its boundary.
+
+A filter that matches few or no rows breaks the default view for a different reason.
+The page walks an index until it has enough rows to return, so such a filter makes it walk the whole table.
+On the 100 million finding dataset, an EPSS score filter matching nothing reads every finding and times out,
+even in the default order with the bounded count. We have no fix, because the database cannot know how many
+rows a filter matches without looking.
 
 ### Hardware Considerations
 


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes KEV filter performance regression in findings endpoints.

Turns out the exact count via window function could force a more optimal query plan. The KEV filter now drives from a materialized array so the query planner cannot degrade it to point-lookups for every single finding.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #7035  

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
