### PR TITLE
Backport: Fix teams being logged as object references instead of names

### DIFF
--- a/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
+++ b/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
@@ -421,7 +421,7 @@ public class AlpineQueryManager extends AbstractAlpineQueryManager {
             }
             for (final String groupDN: groupDNs) {
                 for (final MappedLdapGroup mappedLdapGroup: getMappedLdapGroups(groupDN)) {
-                    LOGGER.debug("Adding user: {} to team: {}", user.getUsername(), mappedLdapGroup.getTeam());
+                    LOGGER.debug("Adding user: {} to team: {}", user.getUsername(), mappedLdapGroup.getTeam().getName());
                     addUserToTeam(user, mappedLdapGroup.getTeam());
                 }
             }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -572,7 +572,7 @@ public class ProjectResource extends AbstractApiResource {
                                 .entity("""
                                         accessTeams must either specify a UUID or a name,\
                                         but the team %s has neither.\
-                                        """.formatted(chosenTeam))
+                                        """.formatted(chosenTeam.getName()))
                                 .build());
                     }
                 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/UserResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/UserResource.java
@@ -852,7 +852,7 @@ public class UserResource extends AbstractApiResource {
                 principal.setTeams(requestedTeams);
                 qm.persist(principal);
                 super.logSecurityEvent(LOGGER, SecurityMarkers.SECURITY_AUDIT,
-                        "Added team membership for: " + principal.getUsername() + " / team: " + requestedTeams.toString());
+                        "Added team membership for: " + principal.getUsername() + " / team: " + requestedTeams.stream().map(Team::getName).toList());
                 return Response.ok(principal).build();
             });
         }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes teams being logged as object references instead of names.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6915
Backports #6919

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
