### PR TITLE
Backport: Fix 500 in /v1/vulnerability/component/{uuid} when a project has >1 analysis for the same vuln

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
@@ -321,6 +321,7 @@ public interface VulnerabilityDao {
                 ON "COMPONENTS_VULNERABILITIES"."COMPONENT_ID" = "COMPONENT"."ID"
               LEFT JOIN "ANALYSIS"
             	ON "V"."ID" = "ANALYSIS"."VULNERABILITY_ID"
+               AND "COMPONENT"."ID" = "ANALYSIS"."COMPONENT_ID"
                AND "COMPONENT"."PROJECT_ID" = "ANALYSIS"."PROJECT_ID"
               LEFT JOIN LATERAL (
                 SELECT "CVE"
@@ -375,8 +376,8 @@ public interface VulnerabilityDao {
             <#-- @ftlvariable name="includeSuppressed" type="boolean" -->
             <#-- @ftlvariable name="apiProjectAclCondition" type="String" -->
             SELECT "VULNERABILITY"."ID" AS "id"
-                 , COUNT("PROJECT"."ID") AS "totalProjectCount"
-                 , COUNT(*) FILTER (WHERE "PROJECT"."INACTIVE_SINCE" IS NULL) AS "activeProjectCount"
+                 , COUNT(DISTINCT "PROJECT"."ID") AS "totalProjectCount"
+                 , COUNT(DISTINCT "PROJECT"."ID") FILTER (WHERE "PROJECT"."INACTIVE_SINCE" IS NULL) AS "activeProjectCount"
               FROM "VULNERABILITY"
              INNER JOIN "COMPONENTS_VULNERABILITIES"
              	ON "VULNERABILITY"."ID" = "COMPONENTS_VULNERABILITIES"."VULNERABILITY_ID"
@@ -388,6 +389,7 @@ public interface VulnerabilityDao {
               LEFT JOIN "ANALYSIS"
                 ON "ANALYSIS"."VULNERABILITY_ID" = "VULNERABILITY"."ID"
                AND "ANALYSIS"."COMPONENT_ID" = "COMPONENT"."ID"
+               AND "ANALYSIS"."PROJECT_ID" = "COMPONENT"."PROJECT_ID"
             </#if>
              WHERE "VULNERABILITY"."ID" = ANY(:vulnerabilityIds)
             <#if !includeSuppressed>

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -156,6 +156,83 @@ public class VulnerabilityResourceTest extends ResourceTest {
     }
 
     @Test
+    public void getVulnerabilitiesByComponentShouldReturnVulnerabilityOnceWhenAnalyzedOnMultipleComponentsOfSameProject() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+
+        final Project project = qm.createProject("Project 1", null, null, null, null, null, null, false);
+
+        final var componentA = new Component();
+        componentA.setProject(project);
+        componentA.setName("Component A");
+        qm.createComponent(componentA, false);
+
+        final var componentB = new Component();
+        componentB.setProject(project);
+        componentB.setName("Component B");
+        qm.createComponent(componentB, false);
+
+        var vuln = new Vulnerability();
+        vuln.setVulnId("INT-1");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        vuln.setDescription("Description 1");
+        vuln = qm.createVulnerability(vuln);
+        qm.addVulnerability(vuln, componentA, "none");
+        qm.addVulnerability(vuln, componentB, "none");
+
+        qm.makeAnalysis(
+                new MakeAnalysisCommand(componentA, vuln)
+                        .withState(AnalysisState.NOT_AFFECTED)
+                        .withSuppress(false));
+        qm.makeAnalysis(
+                new MakeAnalysisCommand(componentB, vuln)
+                        .withState(AnalysisState.FALSE_POSITIVE)
+                        .withSuppress(true));
+
+        final String expectedJson = /* language=JSON */ """
+                [
+                  {
+                    "vulnId": "INT-1",
+                    "source": "INTERNAL",
+                    "description": "Description 1",
+                    "severity": "HIGH",
+                    "uuid": "${json-unit.any-string}",
+                    "affectedProjectCount": 1,
+                    "affectedActiveProjectCount": 1,
+                    "affectedInactiveProjectCount": 0
+                  }
+                ]
+                """;
+
+        Response response = jersey
+                .target(V1_VULNERABILITY + "/component/" + componentA.getUuid())
+                .queryParam("suppressed", "true")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+        assertThatJson(getPlainTextBody(response)).isEqualTo(expectedJson);
+
+        response = jersey
+                .target(V1_VULNERABILITY + "/component/" + componentA.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+        assertThatJson(getPlainTextBody(response)).isEqualTo(expectedJson);
+
+        response = jersey
+                .target(V1_VULNERABILITY + "/component/" + componentB.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("0");
+    }
+
+    @Test
     public void getVulnerabilitiesByComponentInvalidTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes 500 in /v1/vulnerability/component/{uuid} when a project has >1 analysis for the same vuln.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6907
Backports #6930

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
