### PR TITLE
Backport: v4-migrator: Fix unique constraint violation on duplicate OIDC group mappings

### DIFF
--- a/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/TableRegistry.java
+++ b/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/TableRegistry.java
@@ -3036,6 +3036,11 @@ public final class TableRegistry {
      * 1:1 migration of {@code MAPPEDLDAPGROUP}. {@code TEAM_ID} is rewritten through
      * {@code team_canonical_id_map}. UUID stays {@code varchar(36)} in v5 (a straggler that
      * did not convert to native uuid). v5 IDs are preserved.
+     *
+     * <p>v4 and v5 both enforce {@code UNIQUE (TEAM_ID, DN)}, but the team collapse can turn
+     * two rows that were distinct in v4 into the same pair (same DN, two same-named teams).
+     * The staging tgt enforces the composite key and {@code DISTINCT ON} keeps {@code MIN(ID)},
+     * matching the canonical-ID convention and keeping reruns deterministic.
      */
     private static final TableMigration MAPPEDLDAPGROUP = new TableMigration(
         "MAPPEDLDAPGROUP",
@@ -3063,6 +3068,7 @@ public final class TableRegistry {
           , "DN"      varchar(1024) NOT NULL
           , "TEAM_ID" bigint NOT NULL
           , "UUID"    varchar(36) NOT NULL
+          , UNIQUE ("TEAM_ID", "DN")
         );
         INSERT INTO "%1$s".tgt_mappedldapgroup (
             "ID"
@@ -3070,12 +3076,14 @@ public final class TableRegistry {
           , "TEAM_ID"
           , "UUID"
         )
-        SELECT s."ID"
+        SELECT DISTINCT ON (tm.canonical_id, s."DN")
+               s."ID"
              , s."DN"
              , tm.canonical_id
              , s."UUID"
           FROM "%1$s".src_mappedldapgroup s
           JOIN "%1$s".team_canonical_id_map tm ON tm.orig_id = s."TEAM_ID"
+         ORDER BY tm.canonical_id, s."DN", s."ID"
         """,
         """
         INSERT INTO "MAPPEDLDAPGROUP" (
@@ -3096,6 +3104,12 @@ public final class TableRegistry {
      * {@code team_canonical_id_map} and {@code GROUP_ID} through
      * {@code oidcgroup_canonical_id_map}. UUID stays {@code varchar(36)} in v5 (straggler).
      * v5 IDs are preserved.
+     *
+     * <p>v4 and v5 both enforce {@code UNIQUE (TEAM_ID, GROUP_ID)}, but the team and OIDC group
+     * collapses can turn two rows that were distinct in v4 into the same pair (two same-named
+     * teams mapped to one group, or one team mapped to two same-named groups). The staging tgt
+     * enforces the composite key and {@code DISTINCT ON} keeps {@code MIN(ID)}, matching the
+     * canonical-ID convention and keeping reruns deterministic.
      */
     private static final TableMigration MAPPEDOIDCGROUP = new TableMigration(
         "MAPPEDOIDCGROUP",
@@ -3123,6 +3137,7 @@ public final class TableRegistry {
           , "GROUP_ID" bigint NOT NULL
           , "TEAM_ID"  bigint NOT NULL
           , "UUID"     varchar(36) NOT NULL
+          , UNIQUE ("TEAM_ID", "GROUP_ID")
         );
         INSERT INTO "%1$s".tgt_mappedoidcgroup (
             "ID"
@@ -3130,13 +3145,15 @@ public final class TableRegistry {
           , "TEAM_ID"
           , "UUID"
         )
-        SELECT s."ID"
+        SELECT DISTINCT ON (tm.canonical_id, gm.canonical_id)
+               s."ID"
              , gm.canonical_id
              , tm.canonical_id
              , s."UUID"
           FROM "%1$s".src_mappedoidcgroup s
           JOIN "%1$s".team_canonical_id_map     tm ON tm.orig_id = s."TEAM_ID"
           JOIN "%1$s".oidcgroup_canonical_id_map gm ON gm.orig_id = s."GROUP_ID"
+         ORDER BY tm.canonical_id, gm.canonical_id, s."ID"
         """,
         """
         INSERT INTO "MAPPEDOIDCGROUP" (

--- a/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/verify/RowCountNotes.java
+++ b/support/v4-migrator/src/main/java/org/dependencytrack/v4migrator/verify/RowCountNotes.java
@@ -45,6 +45,8 @@ final class RowCountNotes {
         Map.entry("FINDINGATTRIBUTION", "one attribution per (component, vulnerability, analyzer)"),
         Map.entry("VULNERABLESOFTWARE", "dropped rows without vulnerability refs or with invalid UUID"),
         Map.entry("USER", "consolidated from MANAGED/LDAP/OIDC users; invalid rows skipped"),
+        Map.entry("MAPPEDLDAPGROUP", "dedup on (TEAM_ID, DN) after team collapse"),
+        Map.entry("MAPPEDOIDCGROUP", "dedup on (TEAM_ID, GROUP_ID) after team and group collapse"),
         // Permission join tables: v4-only permissions are dropped during the rename remap, while
         // v5-only permissions (PORTFOLIO_ACCESS_CONTROL_BYPASS, SECRET_MANAGEMENT) are fanned out
         // for the v4 holders of their v4-era equivalents. The net delta is a deterministic

--- a/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/MappedGroupDedupIT.java
+++ b/support/v4-migrator/src/test/java/org/dependencytrack/v4migrator/MappedGroupDedupIT.java
@@ -1,0 +1,132 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.v4migrator;
+
+import org.dependencytrack.v4migrator.config.GlobalOptions;
+import org.dependencytrack.v4migrator.config.SourceOptions;
+import org.dependencytrack.v4migrator.extract.ExtractPhase;
+import org.dependencytrack.v4migrator.load.LoadPhase;
+import org.dependencytrack.v4migrator.testsupport.V4PostgresSource;
+import org.dependencytrack.v4migrator.testsupport.V5TargetContainer;
+import org.dependencytrack.v4migrator.transform.TransformPhase;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+/**
+ * Mappings that are distinct under v4's UNIQUE (TEAM_ID, GROUP_ID) / (TEAM_ID, DN) can collapse
+ * onto the same pair once same-named TEAMs and OIDCGROUPs are canonicalized. The migrator must
+ * merge them instead of failing the load on MAPPEDOIDCGROUP_U1 / MAPPEDLDAPGROUP_U1.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MappedGroupDedupIT {
+
+    private V4PostgresSource source;
+    private V5TargetContainer target;
+
+    @BeforeAll
+    void start() {
+        source = new V4PostgresSource().start();
+        target = new V5TargetContainer().start();
+    }
+
+    @AfterAll
+    void stop() {
+        if (source != null) {
+            source.close();
+        }
+        if (target != null) {
+            target.close();
+        }
+    }
+
+    @Test
+    void shouldMergeMappingsThatCollideAfterTeamAndGroupCollapse() throws Exception {
+        source.jdbi().useHandle(h -> {
+            // Two TEAMs share NAME 'Engineering'; canonical = ID 1 (MIN(ID)).
+            h.execute("INSERT INTO \"TEAM\" (\"ID\", \"NAME\", \"UUID\") VALUES (1, 'Engineering', '11111111-1111-1111-1111-111111111111')");
+            h.execute("INSERT INTO \"TEAM\" (\"ID\", \"NAME\", \"UUID\") VALUES (5, 'Engineering', '55555555-5555-5555-5555-555555555555')");
+
+            // Two OIDCGROUPs share NAME 'admins'; canonical = ID 8 (MIN(ID)).
+            h.execute("INSERT INTO \"OIDCGROUP\" (\"ID\", \"NAME\", \"UUID\") VALUES (8, 'admins', '88888888-8888-8888-8888-888888888888')");
+            h.execute("INSERT INTO \"OIDCGROUP\" (\"ID\", \"NAME\", \"UUID\") VALUES (9, 'admins', '99999999-9999-9999-9999-999999999999')");
+
+            // Distinct in v4: (1, 8), (5, 8), (1, 9). All three collapse onto (1, 8).
+            h.execute("INSERT INTO \"MAPPEDOIDCGROUP\" (\"ID\", \"GROUP_ID\", \"TEAM_ID\", \"UUID\") VALUES (200, 8, 1, 'aaaaaaaa-0000-0000-0000-000000000200')");
+            h.execute("INSERT INTO \"MAPPEDOIDCGROUP\" (\"ID\", \"GROUP_ID\", \"TEAM_ID\", \"UUID\") VALUES (201, 8, 5, 'aaaaaaaa-0000-0000-0000-000000000201')");
+            h.execute("INSERT INTO \"MAPPEDOIDCGROUP\" (\"ID\", \"GROUP_ID\", \"TEAM_ID\", \"UUID\") VALUES (202, 9, 1, 'aaaaaaaa-0000-0000-0000-000000000202')");
+
+            // Distinct in v4: (1, cn=eng), (5, cn=eng). Both collapse onto (1, cn=eng).
+            // (7, cn=sec) is unaffected and must survive.
+            h.execute("INSERT INTO \"TEAM\" (\"ID\", \"NAME\", \"UUID\") VALUES (7, 'Security', '77777777-7777-7777-7777-777777777777')");
+            h.execute("INSERT INTO \"MAPPEDLDAPGROUP\" (\"ID\", \"DN\", \"TEAM_ID\", \"UUID\") VALUES (100, 'cn=eng,dc=example,dc=com', 1, 'bbbbbbbb-0000-0000-0000-000000000100')");
+            h.execute("INSERT INTO \"MAPPEDLDAPGROUP\" (\"ID\", \"DN\", \"TEAM_ID\", \"UUID\") VALUES (101, 'cn=eng,dc=example,dc=com', 5, 'bbbbbbbb-0000-0000-0000-000000000101')");
+            h.execute("INSERT INTO \"MAPPEDLDAPGROUP\" (\"ID\", \"DN\", \"TEAM_ID\", \"UUID\") VALUES (102, 'cn=sec,dc=example,dc=com', 7, 'bbbbbbbb-0000-0000-0000-000000000102')");
+        });
+
+        runPipeline();
+
+        // One surviving OIDC mapping, keeping MIN(ID) and its UUID.
+        final List<Map<String, Object>> oidc = target.jdbi().withHandle(h ->
+            h.createQuery("""
+                    SELECT "ID", "GROUP_ID", "TEAM_ID", "UUID"
+                      FROM "MAPPEDOIDCGROUP"
+                     ORDER BY "ID"
+                    """).mapToMap().list());
+        assertThat(oidc).extracting("id", "group_id", "team_id", "uuid")
+            .containsExactly(tuple(200L, 8L, 1L, "aaaaaaaa-0000-0000-0000-000000000200"));
+
+        final List<Map<String, Object>> ldap = target.jdbi().withHandle(h ->
+            h.createQuery("""
+                    SELECT "ID", "DN", "TEAM_ID", "UUID"
+                      FROM "MAPPEDLDAPGROUP"
+                     ORDER BY "ID"
+                    """).mapToMap().list());
+        assertThat(ldap).extracting("id", "dn", "team_id", "uuid")
+            .containsExactly(
+                tuple(100L, "cn=eng,dc=example,dc=com", 1L, "bbbbbbbb-0000-0000-0000-000000000100"),
+                tuple(102L, "cn=sec,dc=example,dc=com", 7L, "bbbbbbbb-0000-0000-0000-000000000102")
+            );
+    }
+
+    private void runPipeline() throws Exception {
+        final GlobalOptions global = new GlobalOptions();
+        global.targetUrl = target.jdbcUrl();
+        global.targetUser = target.username();
+        global.targetPass = target.password();
+        global.stagingSchema = "dt_v4_migration";
+        global.logLevel = "INFO";
+
+        final SourceOptions src = new SourceOptions();
+        src.sourceUrl = source.jdbcUrl();
+        src.sourceUser = source.username();
+        src.sourcePass = source.password();
+
+        new ExtractPhase(global, src, target.jdbi(), 90).run();
+        new TransformPhase(global, target.jdbi()).run();
+        new LoadPhase(global, target.jdbi(), false).run();
+    }
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

v4-migrator: Fix unique constraint violation on duplicate OIDC group mappings.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6903
Backports #6952

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
