### PR TITLE
Backport: Fix unassigned severity missing from component metrics

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/MetricsDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/MetricsDao.java
@@ -217,7 +217,9 @@ public interface MetricsDao extends SqlObject {
     List<VulnerabilityMetrics> getVulnerabilityMetrics();
 
     @SqlQuery("""
-            SELECT *, "RISKSCORE" AS inherited_risk_score FROM "PROJECTMETRICS"
+            SELECT *, "RISKSCORE" AS inherited_risk_score
+                 , "UNASSIGNED_SEVERITY" AS unassigned
+              FROM "PROJECTMETRICS"
             WHERE "PROJECT_ID" = :projectId
             AND "LAST_OCCURRENCE" >= :since
             ORDER BY "LAST_OCCURRENCE" ASC
@@ -226,7 +228,9 @@ public interface MetricsDao extends SqlObject {
     List<ProjectMetrics> getProjectMetricsSince(@Bind long projectId, @Bind Instant since);
 
     @SqlQuery("""
-            SELECT *, "RISKSCORE" AS inherited_risk_score FROM "DEPENDENCYMETRICS"
+            SELECT *, "RISKSCORE" AS inherited_risk_score
+                 , "UNASSIGNED_SEVERITY" AS unassigned
+              FROM "DEPENDENCYMETRICS"
             WHERE "COMPONENT_ID" = :componentId
             AND "LAST_OCCURRENCE" >= :since
             ORDER BY "LAST_OCCURRENCE" ASC
@@ -242,6 +246,7 @@ public interface MetricsDao extends SqlObject {
 
     @SqlQuery("""
             SELECT *, "RISKSCORE" AS inherited_risk_score
+                 , "UNASSIGNED_SEVERITY" AS unassigned
             FROM "PROJECTMETRICS"
             WHERE "PROJECT_ID" = :projectId
             ORDER BY "LAST_OCCURRENCE" DESC
@@ -252,6 +257,7 @@ public interface MetricsDao extends SqlObject {
 
     @SqlQuery("""
             SELECT metrics.*, metrics."RISKSCORE" AS inherited_risk_score
+                 , metrics."UNASSIGNED_SEVERITY" AS unassigned
               FROM UNNEST(:projectIds) AS project(id)
              INNER JOIN LATERAL (
                SELECT *
@@ -535,6 +541,7 @@ public interface MetricsDao extends SqlObject {
 
     @SqlQuery("""
             SELECT *, "RISKSCORE" AS inherited_risk_score
+                 , "UNASSIGNED_SEVERITY" AS unassigned
             FROM "DEPENDENCYMETRICS"
             WHERE "COMPONENT_ID" = :componentId
             ORDER BY "LAST_OCCURRENCE" DESC
@@ -545,6 +552,7 @@ public interface MetricsDao extends SqlObject {
 
     @SqlQuery("""
             SELECT metrics.*, metrics."RISKSCORE" AS inherited_risk_score
+                 , metrics."UNASSIGNED_SEVERITY" AS unassigned
               FROM UNNEST(:componentIds) AS component(id)
              INNER JOIN LATERAL (
                SELECT *

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/MetricsTestDao.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/MetricsTestDao.java
@@ -105,9 +105,9 @@ public interface MetricsTestDao extends SqlObject {
     @SqlQuery("""
             INSERT INTO "DEPENDENCYMETRICS"(
                 "COMPONENT_ID", "PROJECT_ID", "FIRST_OCCURRENCE", "LAST_OCCURRENCE", "CRITICAL", "HIGH", "MEDIUM", "LOW", "RISKSCORE",
-                "SUPPRESSED", "VULNERABILITIES")
+                "SUPPRESSED", "UNASSIGNED_SEVERITY", "VULNERABILITIES")
             VALUES (:componentId, :projectId, :firstOccurrence, :lastOccurrence, :critical, :high, :medium, :low, :inheritedRiskScore,
-                 :suppressed, :vulnerabilities)
+                 :suppressed, :unassigned, :vulnerabilities)
             RETURNING *
             """)
     @RegisterBeanMapper(DependencyMetrics.class)

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/ComponentsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/ComponentsResourceTest.java
@@ -28,16 +28,21 @@ import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentIdentity;
+import org.dependencytrack.model.DependencyMetrics;
 import org.dependencytrack.model.PackageArtifactMetadata;
 import org.dependencytrack.model.PackageMetadata;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Scope;
 import org.dependencytrack.persistence.jdbi.PackageArtifactMetadataDao;
+import org.dependencytrack.persistence.jdbi.MetricsTestDao;
 import org.dependencytrack.persistence.jdbi.PackageMetadataDao;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Date;
 import java.util.List;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
@@ -824,6 +829,77 @@ public class ComponentsResourceTest extends ResourceTest {
                 .inPath("$.items[*].name")
                 .isArray()
                 .containsExactly("c1");
+    }
+
+    @Test
+    public void listComponentsWithMetricsTest() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+
+        final Project project = qm.createProject("test", null, "1.0", null, null, null, null, false);
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("comp");
+        qm.createComponent(component, false);
+
+        useJdbiHandle(handle -> {
+            final var dao = handle.attach(MetricsTestDao.class);
+            dao.createMetricsPartitionsForDate("DEPENDENCYMETRICS", LocalDate.now(ZoneOffset.UTC));
+
+            final var metrics = new DependencyMetrics();
+            metrics.setProjectId(project.getId());
+            metrics.setComponentId(component.getId());
+            metrics.setFirstOccurrence(Date.from(Instant.now()));
+            metrics.setLastOccurrence(Date.from(Instant.now()));
+            metrics.setCritical(1);
+            metrics.setHigh(2);
+            metrics.setMedium(3);
+            metrics.setLow(4);
+            metrics.setUnassigned(5);
+            metrics.setVulnerabilities(10);
+            metrics.setInheritedRiskScore(5.0);
+            dao.createDependencyMetrics(metrics);
+        });
+
+        final Response response = jersey
+                .target("/components")
+                .queryParam("expand", "metrics")
+                .queryParam("limit", 10)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.items[0].metrics")
+                .isEqualTo(/* language=JSON */ """
+                        {
+                          "critical": 1,
+                          "high": 2,
+                          "medium": 3,
+                          "low": 4,
+                          "unassigned": 5,
+                          "vulnerabilities": 10,
+                          "suppressed": 0,
+                          "inherited_risk_score": 5.0,
+                          "findings_total": 0,
+                          "findings_audited": 0,
+                          "findings_unaudited": 0,
+                          "policy_violations_fail": 0,
+                          "policy_violations_warn": 0,
+                          "policy_violations_info": 0,
+                          "policy_violations_total": 0,
+                          "policy_violations_audited": 0,
+                          "policy_violations_unaudited": 0,
+                          "policy_violations_security_total": 0,
+                          "policy_violations_security_audited": 0,
+                          "policy_violations_security_unaudited": 0,
+                          "policy_violations_license_total": 0,
+                          "policy_violations_license_audited": 0,
+                          "policy_violations_license_unaudited": 0,
+                          "policy_violations_operational_total": 0,
+                          "policy_violations_operational_audited": 0,
+                          "policy_violations_operational_unaudited": 0
+                        }
+                        """);
     }
 
     private Component createComponentWithPublishedAt(final Project project, final String name, final Instant publishedAt) throws Exception {


### PR DESCRIPTION

### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes unassigned severity missing from component metrics.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6960
Backports #6962

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
