### PR TITLE
Backport: Fix component license name not being returned by v2 component APIs

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ComponentDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ComponentDao.java
@@ -236,7 +236,7 @@ public interface ComponentDao extends SqlObject, PaginationSupport {
                  , "C"."GROUP"
                  , "C"."INTERNAL"
                  , "C"."LAST_RISKSCORE"
-                 , "C"."LICENSE" AS "componentLicenseName"
+                 , "C"."LICENSE" AS "license"
                  , "C"."LICENSE_EXPRESSION" AS "licenseExpression"
                  , "C"."LICENSE_URL" AS "licenseUrl"
                  , "C"."TEXT"
@@ -513,7 +513,7 @@ public interface ComponentDao extends SqlObject, PaginationSupport {
                         "C"."GROUP",
                         "C"."INTERNAL",
                         "C"."LAST_RISKSCORE",
-                        "C"."LICENSE" AS "componentLicenseName",
+                        "C"."LICENSE" AS "license",
                         "C"."LICENSE_EXPRESSION" AS "licenseExpression",
                         "C"."LICENSE_URL" AS "licenseUrl",
                         "C"."TEXT",

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/ComponentsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/ComponentsResourceTest.java
@@ -222,6 +222,7 @@ public class ComponentsResourceTest extends ResourceTest {
                         },
                         "internal": false,
                         "last_inherited_risk_score": 2.3,
+                        "license": "Public Domain",
                         "uuid": "${json-unit.any-string}",
                         "project": {
                             "name": "projectB",
@@ -263,6 +264,7 @@ public class ComponentsResourceTest extends ResourceTest {
                         },
                         "internal": false,
                         "last_inherited_risk_score": 2.3,
+                        "license": "Public Domain",
                         "uuid": "${json-unit.any-string}",
                         "project": {
                             "name": "projectB",
@@ -499,6 +501,7 @@ public class ComponentsResourceTest extends ResourceTest {
                         },
                         "internal": false,
                         "last_inherited_risk_score": 2.3,
+                        "license": "Public Domain",
                         "uuid": "${json-unit.any-string}",
                         "project": {
                             "name": "projectB",
@@ -887,6 +890,7 @@ public class ComponentsResourceTest extends ResourceTest {
         componentC.setPurl("pkg:maven/groupC/nameC@versionC?baz=qux");
         componentC.setSha1("da39a3ee5e6b4b0d3255bfef95601890afd80709");
         componentC.setLastInheritedRiskScore(2.3);
+        componentC.setLicense("Public Domain");
         qm.createComponent(componentC, false);
     }
 }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/ProjectsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/ProjectsResourceTest.java
@@ -124,6 +124,7 @@ public class ProjectsResourceTest extends ResourceTest {
                        "group" : "component-group",
                        "purl" : "pkg:maven/foo/bar@3.0",
                        "internal" : false,
+                       "license" : "Public Domain",
                        "uuid" : "${json-unit.any-string}"
                       }
                   ],
@@ -745,6 +746,7 @@ public class ProjectsResourceTest extends ResourceTest {
         component.setName("component-name");
         component.setVersion("3.0");
         component.setPurl("pkg:maven/foo/bar@3.0");
+        component.setLicense("Public Domain");
         qm.createComponent(component, false);
 
         return project;


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes component license name not being returned by v2 component APIs.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #7014
Backports #7023

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
