### PR TITLE
Backport: Fix conversion of OSV version ranges

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/parser/dependencytrack/BovModelConverter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/dependencytrack/BovModelConverter.java
@@ -477,7 +477,8 @@ public final class BovModelConverter {
             return Vers.parseLenient(range).validate().split();
         } catch (InvalidVersionException e) {
             String[] rangeParts = range.split(":", 2);
-            if (SCHEME_GENERIC.equals(rangeParts[0])) {
+            String[] versions = rangeParts[1].split("/", 2);
+            if (SCHEME_GENERIC.equals(versions[0])) {
                 LOGGER.warn("""
                         Range '{}' could not be parsed because one or more versions \
                         do not comply with the versioning scheme's rules; Skipping""", range, e);
@@ -488,7 +489,6 @@ public final class BovModelConverter {
                     Range '{}' could not be parsed because one or more versions \
                     do not comply with the versioning scheme's rules; \
                     Falling back to versioning scheme 'generic' instead""", range, e);
-            String[] versions = rangeParts[1].split("/", 2);
             var genericRange = rangeParts[0] + ":" + SCHEME_GENERIC + "/" + versions[1];
             return convertRangeToVersList(genericRange);
         }

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/compat/CoordinatesCelPolicyScriptSourceBuilder.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/compat/CoordinatesCelPolicyScriptSourceBuilder.java
@@ -75,12 +75,16 @@ public class CoordinatesCelPolicyScriptSourceBuilder implements CelPolicyScriptS
         //Do an exact match if no operator found
         if (!versionOperatorMatcher.find()) {
 
-            Vers conditionVers = Vers.builder(SCHEME_GENERIC)
+            Vers conditionVers = "*".equals(conditionVersionPart)
+                    ? Vers.builder(SCHEME_GENERIC)
+                    .withConstraint(Comparator.WILDCARD, null)
+                    .build()
+                    : Vers.builder(SCHEME_GENERIC)
                     .withConstraint(Comparator.EQUAL, conditionVersionPart)
                     .build();
             return """
-                component.group.matches("%s") && component.name.matches("%s") && component.matches_range("%s")
-                """.formatted(escapeQuotes(group), escapeQuotes(name), conditionVers.toString());
+                    component.group.matches("%s") && component.name.matches("%s") && component.matches_range("%s")
+                    """.formatted(escapeQuotes(group), escapeQuotes(name), conditionVers.toString());
         }
 
         io.github.nscuro.versatile.Comparator versionComparator = switch (versionOperatorMatcher.group(1)) {

--- a/apiserver/src/test/java/org/dependencytrack/parser/dependencytrack/BovModelConverterTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/parser/dependencytrack/BovModelConverterTest.java
@@ -263,6 +263,17 @@ class BovModelConverterTest {
     }
 
     @Test
+    void shouldSplitDisjointIntervalsByBoundDirection() {
+        // Pairing constraints positionally yields "<1.11.27|>=2.2", which matches every version above 2.2.
+        // See https://github.com/DependencyTrack/dependency-track/issues/6989.
+        final List<Vers> versList = BovModelConverter.convertRangeToVersList("vers:pypi/<1.11.27|>=2.2|<2.2.9");
+
+        assertThat(versList).extracting(Vers::toString).containsExactly(
+                "vers:pypi/<1.11.27",
+                "vers:pypi/>=2.2|<2.2.9");
+    }
+
+    @Test
     public void testConvertWithRatingsWithCvssV4() {
         final Bom bovInput = Bom.newBuilder().addVulnerabilities(
                 org.cyclonedx.proto.v1_7.Vulnerability.newBuilder()
@@ -460,6 +471,28 @@ class BovModelConverterTest {
                         assertThat(vs.getVersionStartExcluding()).isNull();
                         assertThat(vs.getVersionEndIncluding()).isNull();
                         assertThat(vs.getVersionEndExcluding()).isNull();
+                    });
+        }
+
+        @Test
+        void shouldNotWidenRangeWithDisjointIntervals() {
+            final Bom bov = createBovWithVersionRange("vers:pypi/<1.11.27|>=2.2|<2.2.9");
+            final List<VulnerableSoftware> vsList = BovModelConverter.extractVulnerableSoftware(bov);
+
+            assertThat(vsList).satisfiesExactlyInAnyOrder(
+                    vs -> {
+                        assertThat(vs.getVersion()).isNull();
+                        assertThat(vs.getVersionStartIncluding()).isNull();
+                        assertThat(vs.getVersionStartExcluding()).isNull();
+                        assertThat(vs.getVersionEndIncluding()).isNull();
+                        assertThat(vs.getVersionEndExcluding()).isEqualTo("1.11.27");
+                    },
+                    vs -> {
+                        assertThat(vs.getVersion()).isNull();
+                        assertThat(vs.getVersionStartIncluding()).isEqualTo("2.2");
+                        assertThat(vs.getVersionStartExcluding()).isNull();
+                        assertThat(vs.getVersionEndIncluding()).isNull();
+                        assertThat(vs.getVersionEndExcluding()).isEqualTo("2.2.9");
                     });
         }
 

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/CoordinatesConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/CoordinatesConditionTest.java
@@ -58,6 +58,8 @@ public class CoordinatesConditionTest extends PersistenceCapableTest {
                 new Object[]{PolicyCondition.Operator.MATCHES, "{\"group\": \"acme-app\", \"name\": \"*\", \"version\": \"1.0.0\"}", "{\"group\": \"acme-app\", \"name\": \"Anything\", \"version\": \"1.0.0\"}", true},
                 //Matches on wild card version
                 new Object[]{PolicyCondition.Operator.MATCHES, "{\"group\": \"acme-app\", \"name\": \"Test Component\", \"version\": \">=*\"}", "{\"group\": \"acme-app\", \"name\": \"Test Component\", \"version\": \"4.4.4\"}", true},
+                //Matches on bare wild card version
+                new Object[]{PolicyCondition.Operator.MATCHES, "{\"group\": \"acme-app\", \"name\": \"Test Component\", \"version\": \"*\"}", "{\"group\": \"acme-app\", \"name\": \"Test Component\", \"version\": \"4.4.4\"}", true},
                 //Matches on empty policy - uncomment after fixing script builder
                 //new Object[]{PolicyCondition.Operator.MATCHES, "{}", "{}", true},
                 //Does not match on lower version

--- a/migration/src/main/resources/org/dependencytrack/migration/V202608231543__reset_osv_watermarks.sql
+++ b/migration/src/main/resources/org/dependencytrack/migration/V202608231543__reset_osv_watermarks.sql
@@ -1,0 +1,5 @@
+DELETE
+  FROM "EXTENSION_KV_STORE"
+ WHERE "EXTENSION_POINT" = 'vuln-data-source'
+   AND "EXTENSION" = 'osv'
+   AND "KEY" LIKE 'watermark/%';

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <lib.system-stubs.version>2.1.8</lib.system-stubs.version>
         <lib.testcontainers.version>2.0.5</lib.testcontainers.version>
         <lib.tink.version>1.23.0</lib.tink.version>
-        <lib.versatile.version>0.22.0</lib.versatile.version>
+        <lib.versatile.version>0.24.0</lib.versatile.version>
         <lib.wiremock.version>3.13.2</lib.wiremock.version>
         <lib.zstd-jni.version>1.5.7-13</lib.zstd-jni.version>
         <!-- Number of JVM processes to use for unit test parallelization -->

--- a/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/ModelConverter.java
+++ b/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/ModelConverter.java
@@ -579,25 +579,25 @@ final class ModelConverter {
             rangeEvents.add(objectMapper.convertValue(event, RANGE_EVENT_TYPE_REF));
         }
 
-        final boolean lastIsUpperBound = isUpperBound(rangeEvents.getLast().getKey());
-        final Map<String, Object> dbProps = !lastIsUpperBound && databaseSpecific != null
-                ? databaseSpecific.getAdditionalProperties()
-                : null;
+        final Map<String, Object> dbProps =
+                databaseSpecific != null ? databaseSpecific.getAdditionalProperties() : null;
 
+        final List<Vers> verses;
         try {
-            final Vers vers = versFromOsvRange(rangeType.value(), ecosystem, rangeEvents, dbProps);
-            return List.of(
-                    VulnerabilityAffectedVersions.newBuilder()
-                            .setRange(vers.toString())
-                            .build());
+            verses = versFromOsvRange(rangeType.value(), ecosystem, rangeEvents, dbProps);
         } catch (Exception e) {
-            LOGGER.debug("Exception while parsing OSV version range.", e);
+            LOGGER.debug("Failed to convert OSV version range to vers intervals", e);
             return List.of();
         }
-    }
 
-    private static boolean isUpperBound(String eventKey) {
-        return "fixed".equals(eventKey) || "limit".equals(eventKey) || "last_affected".equals(eventKey);
+        final var affectedVersions = new ArrayList<VulnerabilityAffectedVersions>(verses.size());
+        for (final Vers vers : verses) {
+            affectedVersions.add(VulnerabilityAffectedVersions.newBuilder()
+                    .setRange(vers.toString())
+                    .build());
+        }
+
+        return affectedVersions;
     }
 
     private static @Nullable VulnerabilityCredits convertCredits(@Nullable List<Credit> credits) {

--- a/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/ModelConverterTest.java
+++ b/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/ModelConverterTest.java
@@ -201,7 +201,10 @@ class ModelConverterTest {
                                       "ref": "${json-unit.any-string}",
                                       "versions": [
                                         {
-                                          "range": "vers:maven/>=1|<2|>=3|<4"
+                                          "range": "vers:maven/>=1|<2"
+                                        },
+                                        {
+                                          "range": "vers:maven/>=3|<4"
                                         },
                                         {
                                           "range": "vers:maven/<1"
@@ -212,10 +215,7 @@ class ModelConverterTest {
                                       "ref": "${json-unit.any-string}",
                                       "versions": [
                                         {
-                                          "version": "1.0.0.RELEASE"
-                                        },
-                                        {
-                                          "version": "2.0.9.RELEASE"
+                                          "range": "vers:maven/>=3|<5"
                                         }
                                       ]
                                     },
@@ -680,6 +680,422 @@ class ModelConverterTest {
                     .isEqualTo("\"vers:golang/>=1.0.0\"");
         }
 
+        @Test
+        void shouldEmitSeparateRangesForDisjointIntervals() throws IOException {
+            // Modelled after PYSEC-2019-16, which encodes two disjoint intervals in a single range.
+            // See https://github.com/DependencyTrack/dependency-track/issues/6989.
+            final Bom bov = convertRangeEvents(/* language=JSON */ """
+                    [
+                      { "introduced": "0" },
+                      { "fixed": "1.11.27" },
+                      { "introduced": "2.2" },
+                      { "fixed": "2.2.9" }
+                    ]
+                    """);
+
+            assertThatBov(bov)
+                    .inPath("$.vulnerabilities[0].affects[0].versions")
+                    .isEqualTo(/* language=JSON */ """
+                            [
+                              { "range": "vers:pypi/<1.11.27" },
+                              { "range": "vers:pypi/>=2.2|<2.2.9" }
+                            ]
+                            """);
+        }
+
+        @Test
+        void shouldSortEventsBeforeGrouping() throws IOException {
+            // OSV evaluates `sorted(range.events)`. The array order is only a recommendation.
+            final Bom bov = convertRangeEvents(/* language=JSON */ """
+                    [
+                      { "fixed": "1.2.0" },
+                      { "introduced": "0" }
+                    ]
+                    """);
+
+            assertThatBov(bov)
+                    .inPath("$.vulnerabilities[0].affects[0].versions")
+                    .isEqualTo(/* language=JSON */ """
+                            [
+                              { "range": "vers:pypi/<1.2.0" }
+                            ]
+                            """);
+        }
+
+        @Test
+        void shouldUseLowestIntroducedWhenEventsAreOutOfOrder() throws IOException {
+            final Bom bov = convertRangeEvents(/* language=JSON */ """
+                    [
+                      { "introduced": "2.0.0" },
+                      { "introduced": "1.0.0" },
+                      { "fixed": "2.5.0" }
+                    ]
+                    """);
+
+            assertThatBov(bov)
+                    .inPath("$.vulnerabilities[0].affects[0].versions")
+                    .isEqualTo(/* language=JSON */ """
+                            [
+                              { "range": "vers:pypi/>=1.0.0|<2.5.0" }
+                            ]
+                            """);
+        }
+
+        @Test
+        void shouldIgnoreUpperBoundsBeforeFirstIntroduced() throws IOException {
+            // Nothing is affected below the first `introduced`, so the leading `fixed` is a no-op.
+            final Bom bov = convertRangeEvents(/* language=JSON */ """
+                    [
+                      { "fixed": "1.2.0" },
+                      { "introduced": "3.0.0" }
+                    ]
+                    """);
+
+            assertThatBov(bov)
+                    .inPath("$.vulnerabilities[0].affects[0].versions")
+                    .isEqualTo(/* language=JSON */ """
+                            [
+                              { "range": "vers:pypi/>=3.0.0" }
+                            ]
+                            """);
+        }
+
+        @Test
+        void shouldUseLowestUpperBoundWhenIntervalHasMultiple() throws IOException {
+            // Modelled after PYSEC-2024-265, whose last_affected events are not in ascending order.
+            //
+            // Note that computing <=1.2.0 here is aligned with the OSV evaluation algorithm,
+            // although the advisory author likely meant <=1.2.1. As a result, we may be under-reporting.
+            // However, the range as presented doesn't make sense, and it's arguably a data quality issue.
+            final Bom bov = convertRangeEvents(/* language=JSON */ """
+                    [
+                      { "introduced": "0" },
+                      { "last_affected": "1.2.1" },
+                      { "last_affected": "1.2.0" }
+                    ]
+                    """);
+
+            assertThatBov(bov)
+                    .inPath("$.vulnerabilities[0].affects[0].versions")
+                    .isEqualTo(/* language=JSON */ """
+                            [
+                              { "range": "vers:pypi/<=1.2.0" }
+                            ]
+                            """);
+        }
+
+        @Test
+        void shouldUseLowestUpperBoundPerIntervalWhenMultipleIntervals() throws IOException {
+            // Modelled after PYSEC-2022-43170, which trails a multi-interval range with an
+            // additional fixed event.
+            //
+            // Note that computing >=6.2.0|<6.2.2 here is aligned with the OSV evaluation algorithm,
+            // although the advisory author likely meant >=6.2.0|<6.2.6. As a result, we may be under-reporting.
+            // However, the range as presented doesn't make sense, and it's arguably a data quality issue.
+            final Bom bov = convertRangeEvents(/* language=JSON */ """
+                    [
+                      { "introduced": "5.0.0" },
+                      { "fixed": "5.0.12" },
+                      { "introduced": "6.2.0" },
+                      { "fixed": "6.2.2" },
+                      { "fixed": "6.2.6" }
+                    ]
+                    """);
+
+            assertThatBov(bov)
+                    .inPath("$.vulnerabilities[0].affects[0].versions")
+                    .isEqualTo(/* language=JSON */ """
+                            [
+                              { "range": "vers:pypi/>=5.0.0|<5.0.12" },
+                              { "range": "vers:pypi/>=6.2.0|<6.2.2" }
+                            ]
+                            """);
+        }
+
+        @Test
+        void shouldNotOpenNewIntervalForConsecutiveIntroduced() throws IOException {
+            // The lowest `introduced` wins, so `introduced=0` must not be narrowed to >=1.0.0.
+            final Bom bov = convertRangeEvents(/* language=JSON */ """
+                    [
+                      { "introduced": "0" },
+                      { "introduced": "1.0.0" },
+                      { "fixed": "1.1.0" }
+                    ]
+                    """);
+
+            assertThatBov(bov)
+                    .inPath("$.vulnerabilities[0].affects[0].versions")
+                    .isEqualTo(/* language=JSON */ """
+                            [
+                              { "range": "vers:pypi/<1.1.0" }
+                            ]
+                            """);
+        }
+
+        @Test
+        void shouldKeepTrailingIntervalOpenWhenNotFixed() throws IOException {
+            final Bom bov = convertRangeEvents(/* language=JSON */ """
+                    [
+                      { "introduced": "1.0.0" },
+                      { "fixed": "1.2.0" },
+                      { "introduced": "2.0.0" }
+                    ]
+                    """);
+
+            assertThatBov(bov)
+                    .inPath("$.vulnerabilities[0].affects[0].versions")
+                    .isEqualTo(/* language=JSON */ """
+                            [
+                              { "range": "vers:pypi/>=1.0.0|<1.2.0" },
+                              { "range": "vers:pypi/>=2.0.0" }
+                            ]
+                            """);
+        }
+
+        @Test
+        void shouldCapRangeAtHighestLimit() throws IOException {
+            // Per OSV's `BeforeLimits`, nothing at or above the highest limit is affected,
+            // no matter which interval it falls into.
+            final Bom bov = convertRangeEvents(/* language=JSON */ """
+                    [
+                      { "introduced": "0" },
+                      { "fixed": "1.0.0" },
+                      { "introduced": "2.0.0" },
+                      { "limit": "3.0.0" }
+                    ]
+                    """);
+
+            assertThatBov(bov)
+                    .inPath("$.vulnerabilities[0].affects[0].versions")
+                    .isEqualTo(/* language=JSON */ """
+                            [
+                              { "range": "vers:pypi/<1.0.0" },
+                              { "range": "vers:pypi/>=2.0.0|<3.0.0" }
+                            ]
+                            """);
+        }
+
+        @Test
+        void shouldIgnoreWildcardLimit() throws IOException {
+            // `limit` allows "*" to represent infinity.
+            final Bom bov = convertRangeEvents(/* language=JSON */ """
+                    [
+                      { "introduced": "1.0.0" },
+                      { "limit": "*" }
+                    ]
+                    """);
+
+            assertThatBov(bov)
+                    .inPath("$.vulnerabilities[0].affects[0].versions")
+                    .isEqualTo(/* language=JSON */ """
+                            [
+                              { "range": "vers:pypi/>=1.0.0" }
+                            ]
+                            """);
+        }
+
+        @Test
+        void shouldKeepRangeWithSchemeViolatingVersionInsteadOfFallingBackToVersions() throws IOException {
+            // "2.0.x" is not a valid PEP 440 version. Dropping the range would fall back to the
+            // enumerated `versions`, which only covers the releases known at publication time.
+            final var advisory = MAPPER.readValue(/* language=JSON */ """
+                    {
+                      "id": "OSV-2026-0010",
+                      "affected": [
+                        {
+                          "package": {
+                            "name": "foo",
+                            "ecosystem": "PyPI",
+                            "purl": "pkg:pypi/foo"
+                          },
+                          "versions": [
+                            "1.0"
+                          ],
+                          "ranges": [
+                            {
+                              "type": "ECOSYSTEM",
+                              "events": [
+                                { "introduced": "1.0" },
+                                { "fixed": "2.0.x" }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                    """, Osv.class);
+
+            final Bom bov = new ModelConverter(MAPPER).convert(advisory, false, "PyPI");
+
+            assertThatBov(bov)
+                    .inPath("$.vulnerabilities[0].affects[0].versions")
+                    .isEqualTo(/* language=JSON */ """
+                            [
+                              { "range": "vers:generic/>=1.0|<2.0.x" }
+                            ]
+                            """);
+        }
+
+        @Test
+        void shouldTreatDebianUnfixedAsOpenInterval() throws IOException {
+            final var advisory = MAPPER.readValue(/* language=JSON */ """
+                    {
+                      "id": "OSV-2026-0009",
+                      "affected": [
+                        {
+                          "package": {
+                            "name": "foo",
+                            "ecosystem": "Debian:12",
+                            "purl": "pkg:deb/debian/foo"
+                          },
+                          "ranges": [
+                            {
+                              "type": "ECOSYSTEM",
+                              "events": [
+                                { "introduced": "0" },
+                                { "fixed": "<unfixed>" }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                    """, Osv.class);
+
+            final Bom bov = new ModelConverter(MAPPER).convert(advisory, false, "Debian:12");
+
+            assertThatBov(bov)
+                    .inPath("$.vulnerabilities[0].affects[0].versions")
+                    .isEqualTo(/* language=JSON */ """
+                            [
+                              { "range": "vers:deb/*" }
+                            ]
+                            """);
+        }
+
+        @Test
+        void shouldEmitSeparateRangesForEachIntervalOfSemverRange() throws IOException {
+            // GO-2022-0344, whose three intervals were previously paired across interval boundaries,
+            // yielding inverted ranges such as `>=1.5.0|<1.4.13`.
+            // See https://github.com/DependencyTrack/dependency-track/issues/7054.
+            final var advisory = MAPPER.readValue(/* language=JSON */ """
+                    {
+                      "id": "GO-2022-0344",
+                      "affected": [
+                        {
+                          "package": {
+                            "name": "github.com/containerd/containerd",
+                            "ecosystem": "Go",
+                            "purl": "pkg:golang/github.com/containerd/containerd"
+                          },
+                          "ranges": [
+                            {
+                              "type": "SEMVER",
+                              "events": [
+                                { "introduced": "0" },
+                                { "fixed": "1.4.13" },
+                                { "introduced": "1.5.0" },
+                                { "fixed": "1.5.10" },
+                                { "introduced": "1.6.0" },
+                                { "fixed": "1.6.1" }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                    """, Osv.class);
+
+            final Bom bov = new ModelConverter(MAPPER).convert(advisory, false, "Go");
+
+            assertThatBov(bov)
+                    .inPath("$.vulnerabilities[0].affects[0].versions")
+                    .isEqualTo(/* language=JSON */ """
+                            [
+                              { "range": "vers:golang/<1.4.13" },
+                              { "range": "vers:golang/>=1.5.0|<1.5.10" },
+                              { "range": "vers:golang/>=1.6.0|<1.6.1" }
+                            ]
+                            """);
+        }
+
+        @Test
+        void shouldSortIntervalsThatAppearOutOfOrder() throws IOException {
+            // PYSEC-2023-192 lists the 2.x interval before the 1.x one,
+            // so pairing events in document order produces the inverted range `>=2.0.0|<1.26.17`.
+            // See https://github.com/DependencyTrack/dependency-track/issues/7054.
+            final Bom bov = convertRangeEvents(/* language=JSON */ """
+                    [
+                      { "introduced": "2.0.0" },
+                      { "fixed": "2.0.6" },
+                      { "introduced": "0" },
+                      { "fixed": "1.26.17" }
+                    ]
+                    """);
+
+            assertThatBov(bov)
+                    .inPath("$.vulnerabilities[0].affects[0].versions")
+                    .isEqualTo(/* language=JSON */ """
+                            [
+                              { "range": "vers:pypi/<1.26.17" },
+                              { "range": "vers:pypi/>=2.0.0|<2.0.6" }
+                            ]
+                            """);
+        }
+
+        @Test
+        void shouldIgnoreGitRangeAccompanyingEcosystemRange() throws IOException {
+            // PYSEC-2023-192 pairs a GIT range with an ECOSYSTEM range and an enumerated
+            // `versions` array. Dropping the GIT range must not make the advisory look
+            // range-less, which would fall back to the enumerated versions.
+            final var advisory = MAPPER.readValue(/* language=JSON */ """
+                    {
+                      "id": "PYSEC-2023-192",
+                      "affected": [
+                        {
+                          "package": {
+                            "name": "urllib3",
+                            "ecosystem": "PyPI",
+                            "purl": "pkg:pypi/urllib3"
+                          },
+                          "ranges": [
+                            {
+                              "type": "GIT",
+                              "repo": "https://github.com/urllib3/urllib3",
+                              "events": [
+                                { "introduced": "0" },
+                                { "fixed": "644124ecd0b6e417c527191f866daa05a5a2056d" },
+                                { "fixed": "01220354d389cd05474713f8c982d05c9b17aafb" }
+                              ]
+                            },
+                            {
+                              "type": "ECOSYSTEM",
+                              "events": [
+                                { "introduced": "2.0.0" },
+                                { "fixed": "2.0.6" },
+                                { "introduced": "0" },
+                                { "fixed": "1.26.17" }
+                              ]
+                            }
+                          ],
+                          "versions": [ "1.26.16", "2.0.0", "2.0.5" ]
+                        }
+                      ]
+                    }
+                    """, Osv.class);
+
+            final Bom bov = new ModelConverter(MAPPER).convert(advisory, false, "PyPI");
+
+            assertThatBov(bov)
+                    .inPath("$.vulnerabilities[0].affects[0].versions")
+                    .isEqualTo(/* language=JSON */ """
+                            [
+                              { "range": "vers:pypi/<1.26.17" },
+                              { "range": "vers:pypi/>=2.0.0|<2.0.6" }
+                            ]
+                            """);
+        }
+
     }
 
     @Nested
@@ -926,6 +1342,31 @@ class ModelConverterTest {
 
     private static ConfigurableJsonAssert assertThatBov(Bom bov) throws InvalidProtocolBufferException {
         return assertThatJson(JsonFormat.printer().print(bov));
+    }
+
+    private static Bom convertRangeEvents(String eventsJson) throws IOException {
+        final var advisory = MAPPER.readValue(/* language=JSON */ """
+                    {
+                      "id": "OSV-TEST",
+                      "affected": [
+                        {
+                          "package": {
+                            "name": "foo",
+                            "ecosystem": "PyPI",
+                            "purl": "pkg:pypi/foo"
+                          },
+                          "ranges": [
+                            {
+                              "type": "ECOSYSTEM",
+                              "events": %s
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                    """.formatted(eventsJson), Osv.class);
+
+        return new ModelConverter(MAPPER).convert(advisory, false, "PyPI");
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes conversion of OSV version ranges.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #7054
Backports #7058

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
