### PR TITLE
Declaratively define capabilities of CycloneDX export variants

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXExporter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXExporter.java
@@ -33,6 +33,7 @@ import org.dependencytrack.persistence.jdbi.FindingDao;
 
 import javax.jdo.FetchGroup;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -47,17 +48,52 @@ public class CycloneDXExporter {
         XML
     }
 
+    public enum Capability {
+        EMITS_COMPONENTS,
+        EMITS_DEPENDENCY_GRAPH,
+        EMITS_FINDINGS,
+        EMITS_SERVICES,
+        FILTERS_TO_VULNERABLE_COMPONENTS
+    }
+
     public enum Variant {
-        INVENTORY,
-        INVENTORY_WITH_VULNERABILITIES,
-        VDR,
-        VEX
+
+        INVENTORY(
+                Capability.EMITS_COMPONENTS,
+                Capability.EMITS_SERVICES,
+                Capability.EMITS_DEPENDENCY_GRAPH),
+        INVENTORY_WITH_VULNERABILITIES(
+                Capability.EMITS_FINDINGS,
+                Capability.EMITS_COMPONENTS,
+                Capability.EMITS_SERVICES,
+                Capability.EMITS_DEPENDENCY_GRAPH),
+        VDR(
+                Capability.FILTERS_TO_VULNERABLE_COMPONENTS,
+                Capability.EMITS_FINDINGS,
+                Capability.EMITS_COMPONENTS,
+                Capability.EMITS_SERVICES,
+                Capability.EMITS_DEPENDENCY_GRAPH),
+        VEX(
+                Capability.EMITS_FINDINGS);
+
+        private final Set<Capability> capabilities;
+
+        Variant(Capability... capabilities) {
+            final Set<Capability> set = EnumSet.noneOf(Capability.class);
+            set.addAll(List.of(capabilities));
+            this.capabilities = set;
+        }
+
+        public boolean hasCapability(Capability capability) {
+            return capabilities.contains(capability);
+        }
+
     }
 
     private final QueryManager qm;
-    private final CycloneDXExporter.Variant variant;
+    private final Variant variant;
 
-    public CycloneDXExporter(final CycloneDXExporter.Variant variant, final QueryManager qm) {
+    public CycloneDXExporter(final Variant variant, final QueryManager qm) {
         this.variant = variant;
         this.qm = qm;
     }
@@ -70,11 +106,9 @@ public class CycloneDXExporter {
             components = qm.getAllComponents(project);
             services = qm.getAllServiceComponents(project);
         }
-        final List<Finding> findings = switch (variant) {
-            case INVENTORY_WITH_VULNERABILITIES, VDR, VEX -> withJdbiHandle(handle ->
-                    handle.attach(FindingDao.class).getFindings(project.getId(), true));
-            default -> null;
-        };
+        final List<Finding> findings = variant.hasCapability(Capability.EMITS_FINDINGS)
+                ? withJdbiHandle(handle -> handle.attach(FindingDao.class).getFindings(project.getId(), true))
+                : null;
         return create(components, services, findings, project, version);
     }
 
@@ -90,7 +124,7 @@ public class CycloneDXExporter {
             final List<Finding> findings,
             final Project project,
             final Version version) {
-        if (Variant.VDR == variant) {
+        if (variant.hasCapability(Capability.FILTERS_TO_VULNERABLE_COMPONENTS)) {
             final Set<UUID> vulnerableComponentUuids = findings.stream()
                     .map(finding -> (UUID) finding.getComponent().get("uuid"))
                     .collect(Collectors.toSet());
@@ -98,8 +132,14 @@ public class CycloneDXExporter {
                     .filter(component -> vulnerableComponentUuids.contains(component.getUuid()))
                     .toList();
         }
-        final List<org.cyclonedx.model.Component> cycloneComponents = (Variant.VEX != variant && components != null) ? components.stream().map(component -> ModelConverter.convert(component)).collect(Collectors.toList()) : null;
-        final List<org.cyclonedx.model.Service> cycloneServices = (Variant.VEX != variant && services != null) ? services.stream().map(service -> ModelConverter.convert(qm, service)).collect(Collectors.toList()) : null;
+        final List<org.cyclonedx.model.Component> cycloneComponents =
+                (variant.hasCapability(Capability.EMITS_COMPONENTS) && components != null)
+                        ? components.stream().map(ModelConverter::convert).collect(Collectors.toList())
+                        : null;
+        final List<org.cyclonedx.model.Service> cycloneServices =
+                (variant.hasCapability(Capability.EMITS_SERVICES) && services != null)
+                        ? services.stream().map(service -> ModelConverter.convert(qm, service)).collect(Collectors.toList())
+                        : null;
         final Bom bom = new Bom();
         bom.setSerialNumber("urn:uuid:" + UUID.randomUUID());
         bom.setVersion(1);
@@ -107,7 +147,7 @@ public class CycloneDXExporter {
         bom.setComponents(cycloneComponents);
         bom.setServices(cycloneServices);
         bom.setVulnerabilities(ModelConverter.generateVulnerabilities(qm, variant, findings));
-        if (cycloneComponents != null) {
+        if (variant.hasCapability(Capability.EMITS_DEPENDENCY_GRAPH) && cycloneComponents != null) {
             bom.setDependencies(ModelConverter.generateDependencies(project, components));
         }
         return bom;


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Cleans up the export code by replacing format checks with capability lookups. Also makes it easier to see at once glance what a given variant includes.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Extracted from https://github.com/DependencyTrack/dependency-track/pull/6555, which did the same but using boolean flags instead of a `Capability` enum.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
