### PR TITLE
Align VEX semantics with CISA guidance and tooling ecosystem

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXExporter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXExporter.java
@@ -49,7 +49,8 @@ public class CycloneDXExporter {
     }
 
     public enum Capability {
-        EMITS_COMPONENTS,
+        EMITS_ANALYSIS,
+        EMITS_COMPONENT_DETAILS,
         EMITS_DEPENDENCY_GRAPH,
         EMITS_FINDINGS,
         EMITS_SERVICES,
@@ -59,22 +60,25 @@ public class CycloneDXExporter {
     public enum Variant {
 
         INVENTORY(
-                Capability.EMITS_COMPONENTS,
+                Capability.EMITS_COMPONENT_DETAILS,
                 Capability.EMITS_SERVICES,
                 Capability.EMITS_DEPENDENCY_GRAPH),
         INVENTORY_WITH_VULNERABILITIES(
                 Capability.EMITS_FINDINGS,
-                Capability.EMITS_COMPONENTS,
+                Capability.EMITS_COMPONENT_DETAILS,
                 Capability.EMITS_SERVICES,
                 Capability.EMITS_DEPENDENCY_GRAPH),
         VDR(
                 Capability.FILTERS_TO_VULNERABLE_COMPONENTS,
                 Capability.EMITS_FINDINGS,
-                Capability.EMITS_COMPONENTS,
+                Capability.EMITS_ANALYSIS,
+                Capability.EMITS_COMPONENT_DETAILS,
                 Capability.EMITS_SERVICES,
                 Capability.EMITS_DEPENDENCY_GRAPH),
         VEX(
-                Capability.EMITS_FINDINGS);
+                Capability.FILTERS_TO_VULNERABLE_COMPONENTS,
+                Capability.EMITS_FINDINGS,
+                Capability.EMITS_ANALYSIS);
 
         private final Set<Capability> capabilities;
 
@@ -132,10 +136,13 @@ public class CycloneDXExporter {
                     .filter(component -> vulnerableComponentUuids.contains(component.getUuid()))
                     .toList();
         }
-        final List<org.cyclonedx.model.Component> cycloneComponents =
-                (variant.hasCapability(Capability.EMITS_COMPONENTS) && components != null)
-                        ? components.stream().map(ModelConverter::convert).collect(Collectors.toList())
-                        : null;
+        final List<org.cyclonedx.model.Component> cycloneComponents = components != null
+                ? components.stream()
+                        .map(variant.hasCapability(Capability.EMITS_COMPONENT_DETAILS)
+                                ? ModelConverter::convert
+                                : ModelConverter::convertIdentity)
+                        .collect(Collectors.toList())
+                : null;
         final List<org.cyclonedx.model.Service> cycloneServices =
                 (variant.hasCapability(Capability.EMITS_SERVICES) && services != null)
                         ? services.stream().map(service -> ModelConverter.convert(qm, service)).collect(Collectors.toList())

--- a/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporter.java
@@ -31,6 +31,7 @@ import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.parser.cyclonedx.util.ModelConverter;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.persistence.command.MakeAnalysisCommand;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.dependencytrack.parser.cyclonedx.util.ModelConverter.convertCdxVulnAnalysisJustificationToDtAnalysisJustification;
 import static org.dependencytrack.parser.cyclonedx.util.ModelConverter.convertCdxVulnAnalysisStateToDtAnalysisState;
 
@@ -70,12 +72,8 @@ public class CycloneDXVexImporter {
         final Map<String, List<Component>> componentsByBomRef = new HashMap<>();
 
         for (final org.cyclonedx.model.vulnerability.Vulnerability vexVuln : vexVulns) {
-            final Vulnerability dtVuln = qm.getVulnerabilityByVulnId(vexVuln.getSource().getName(), vexVuln.getId());
+            final Vulnerability dtVuln = resolveVulnerability(qm, vexVuln);
             if (dtVuln == null) {
-                LOGGER.warn("""
-                        VEX contains analysis for vulnerability {}/{}, but the project is not affected by it. \
-                        Analyses can currently only be applied to existing findings.\
-                        """, vexVuln.getSource().getName(), vexVuln.getId());
                 continue;
             }
 
@@ -111,10 +109,51 @@ public class CycloneDXVexImporter {
                             Unable to locate affected element (metadata.component or components[].component) \
                             based on the BOM reference {}. The vulnerability.affects[].ref \
                             node of {}/{} is not resolvable; Skipping it\
-                            """, affectedBomRef, vexVuln.getSource().getName(), vexVuln.getId());
+                            """, affectedBomRef, sourceNameOf(vexVuln), vexVuln.getId());
                 }
             }
         }
+    }
+
+    private static @Nullable String sourceNameOf(final org.cyclonedx.model.vulnerability.Vulnerability vexVuln) {
+        if (vexVuln.getSource() == null) {
+            return null;
+        }
+
+        return trimToNull(vexVuln.getSource().getName());
+    }
+
+    private static @Nullable Vulnerability resolveVulnerability(
+            final QueryManager qm,
+            final org.cyclonedx.model.vulnerability.Vulnerability vexVuln) {
+        final String vexVulnId = vexVuln.getId();
+        final String vexVulnSource = sourceNameOf(vexVuln);
+
+        if (vexVulnSource != null && Vulnerability.Source.isKnownSource(vexVulnSource)) {
+            final Vulnerability dtVuln = qm.getVulnerabilityByVulnId(vexVulnSource, vexVulnId);
+            if (dtVuln != null) {
+                return dtVuln;
+            }
+        }
+
+        final List<Vulnerability> candidates = qm.getVulnerabilitiesByVulnId(vexVulnId);
+        if (candidates.isEmpty()) {
+            LOGGER.warn("""
+                    VEX contains analysis for vulnerability {}, but the project is not affected by it. \
+                    Analyses can currently only be applied to existing findings.\
+                    """, vexVulnId);
+            return null;
+        }
+        if (candidates.size() > 1) {
+            LOGGER.warn("""
+                    VEX contains analysis for vulnerability {} from source {}, which does not identify \
+                    a vulnerability in Dependency-Track. The ID alone matches vulnerabilities from \
+                    multiple sources ({}); Skipping it\
+                    """, vexVulnId, vexVulnSource, candidates.stream().map(Vulnerability::getSource).toList());
+            return null;
+        }
+
+        return candidates.getFirst();
     }
 
     private static List<org.cyclonedx.model.vulnerability.Vulnerability> getApplicableVexVulnerabilities(
@@ -122,21 +161,15 @@ public class CycloneDXVexImporter {
         final var applicableVulns = new ArrayList<org.cyclonedx.model.vulnerability.Vulnerability>();
         for (int vexVulnPos = 0; vexVulnPos < vexVulns.size(); vexVulnPos++) {
             final var vexVuln = vexVulns.get(vexVulnPos);
-            if (isBlank(vexVuln.getId()) || vexVuln.getSource() == null || isBlank(vexVuln.getSource().getName())) {
+            if (isBlank(vexVuln.getId())) {
                 LOGGER.warn(
-                        "VEX vulnerability at position #{} does not have an ID and / or source; Skipping it",
+                        "VEX vulnerability at position #{} does not have an ID; Skipping it",
                         vexVulnPos);
                 continue;
             }
 
             final String vexVulnId = vexVuln.getId();
-            final String vexVulnSource = vexVuln.getSource().getName();
-            if (!Vulnerability.Source.isKnownSource(vexVulnSource)) {
-                LOGGER.warn(
-                        "VEX vulnerability {}/{} at position #{} is from an unsupported source; Skipping it",
-                        vexVulnSource, vexVulnId, vexVulnPos);
-                continue;
-            }
+            final String vexVulnSource = sourceNameOf(vexVuln);
             if (CollectionUtils.isEmpty(vexVuln.getAffects())) {
                 LOGGER.debug(
                         "VEX vulnerability {}/{} at position #{} does not have an affects node; Skipping it",

--- a/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
@@ -80,11 +80,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -185,12 +188,12 @@ public class ModelConverter {
         project.setExternalReferences(convertExternalReferences(cdxComponent.getExternalReferences()));
 
         List<OrganizationalContact> contacts = new ArrayList<>();
-        if(cdxComponent.getAuthor()!=null){
+        if (cdxComponent.getAuthor() != null) {
             contacts.add(new OrganizationalContact() {{
                 setName(cdxComponent.getAuthor());
             }});
         }
-        if(cdxComponent.getAuthors()!=null){
+        if (cdxComponent.getAuthors() != null) {
             contacts.addAll(convertCdxContacts(cdxComponent.getAuthors()));
         }
         project.setAuthors(contacts);
@@ -236,12 +239,12 @@ public class ModelConverter {
         component.setProperties(convertToComponentProperties(cdxComponent.getProperties()));
 
         List<OrganizationalContact> contacts = new ArrayList<>();
-        if(cdxComponent.getAuthor()!=null){
+        if (cdxComponent.getAuthor() != null) {
             contacts.add(new OrganizationalContact() {{
                 setName(cdxComponent.getAuthor());
             }});
         }
-        if(cdxComponent.getAuthors()!=null){
+        if (cdxComponent.getAuthors() != null) {
             contacts.addAll(convertCdxContacts(cdxComponent.getAuthors()));
         }
         component.setAuthors(contacts);
@@ -652,23 +655,19 @@ public class ModelConverter {
         return result;
     }
 
-    public static org.cyclonedx.model.Component convert(final Component component) {
-        final org.cyclonedx.model.Component cycloneComponent = new org.cyclonedx.model.Component();
+    public static org.cyclonedx.model.Component convertIdentity(Component component) {
+        final var cycloneComponent = new org.cyclonedx.model.Component();
         cycloneComponent.setBomRef(component.getUuid().toString());
         cycloneComponent.setGroup(StringUtils.trimToNull(component.getGroup()));
         cycloneComponent.setName(StringUtils.trimToNull(component.getName()));
         cycloneComponent.setVersion(StringUtils.trimToNull(component.getVersion()));
-        cycloneComponent.setDescription(StringUtils.trimToNull(component.getDescription()));
-        cycloneComponent.setCopyright(StringUtils.trimToNull(component.getCopyright()));
         cycloneComponent.setCpe(StringUtils.trimToNull(component.getCpe()));
-        cycloneComponent.setScope(mapCdxScope(component.getScope()));
-        cycloneComponent.setAuthor(StringUtils.trimToNull(convertContactsToString(component.getAuthors())));
-        cycloneComponent.setSupplier(convert(component.getSupplier()));
-        cycloneComponent.setProperties(convert(component.getProperties()));
 
         if (component.getSwidTagId() != null) {
             final Swid swid = new Swid();
             swid.setTagId(component.getSwidTagId());
+            swid.setName(StringUtils.trimToNull(component.getName()));
+            swid.setVersion(StringUtils.trimToNull(component.getVersion()));
             cycloneComponent.setSwid(swid);
         }
 
@@ -688,6 +687,18 @@ public class ModelConverter {
                 cycloneComponent.addHash(new Hash(algorithm, hashValue));
             }
         });
+
+        return cycloneComponent;
+    }
+
+    public static org.cyclonedx.model.Component convert(Component component) {
+        final org.cyclonedx.model.Component cycloneComponent = convertIdentity(component);
+        cycloneComponent.setDescription(StringUtils.trimToNull(component.getDescription()));
+        cycloneComponent.setCopyright(StringUtils.trimToNull(component.getCopyright()));
+        cycloneComponent.setScope(mapCdxScope(component.getScope()));
+        cycloneComponent.setAuthor(StringUtils.trimToNull(convertContactsToString(component.getAuthors())));
+        cycloneComponent.setSupplier(convert(component.getSupplier()));
+        cycloneComponent.setProperties(convert(component.getProperties()));
 
         final LicenseChoice licenses = new LicenseChoice();
         if (component.getResolvedLicense() != null) {
@@ -964,28 +975,19 @@ public class ModelConverter {
         return cycloneService;
     }
 
-    public static org.cyclonedx.model.vulnerability.Vulnerability convert(final QueryManager qm, final CycloneDXExporter.Variant variant,
-                                                                          final Finding finding) {
-        final Component component = qm.getObjectByUuid(Component.class, finding.getComponent().get("uuid").toString());
-        if (component == null) {
-            return null;
-        }
-        final Project project = component.getProject();
-        final Vulnerability vulnerability = qm.getObjectByUuid(Vulnerability.class, finding.getVulnerability().get("uuid").toString());
-        if (vulnerability == null) {
-            return null;
-        }
-
-        final org.cyclonedx.model.vulnerability.Vulnerability cdxVulnerability = new org.cyclonedx.model.vulnerability.Vulnerability();
-        cdxVulnerability.setBomRef(vulnerability.getUuid().toString());
+    private static org.cyclonedx.model.vulnerability.Vulnerability convert(
+            Vulnerability vulnerability,
+            Analysis analysis,
+            SortedSet<String> affectedComponentUuids) {
+        // NB: No bom-ref. It is optional, nothing references a vulnerability entry,
+        // and one vulnerability may yield several entries, which historically made the vulnerability
+        // UUID a source of duplicate bom-refs. CycloneDX requires every bom-ref to be unique within the BOM.
+        final var cdxVulnerability = new org.cyclonedx.model.vulnerability.Vulnerability();
         cdxVulnerability.setId(vulnerability.getVulnId());
-        // Add the vulnerability source
-        org.cyclonedx.model.vulnerability.Vulnerability.Source cdxSource = new org.cyclonedx.model.vulnerability.Vulnerability.Source();
-        cdxSource.setName(vulnerability.getSource());
         cdxVulnerability.setSource(convertDtVulnSourceToCdxVulnSource(Vulnerability.Source.valueOf(vulnerability.getSource())));
 
         if (vulnerability.getCvssV2BaseScore() != null) {
-            org.cyclonedx.model.vulnerability.Vulnerability.Rating rating = new org.cyclonedx.model.vulnerability.Vulnerability.Rating();
+            final var rating = new org.cyclonedx.model.vulnerability.Vulnerability.Rating();
             rating.setSource(convertDtVulnSourceToCdxVulnSource(Vulnerability.Source.valueOf(vulnerability.getSource())));
             rating.setMethod(org.cyclonedx.model.vulnerability.Vulnerability.Rating.Method.CVSSV2);
             rating.setScore(vulnerability.getCvssV2BaseScore().doubleValue());
@@ -1000,7 +1002,7 @@ public class ModelConverter {
             cdxVulnerability.addRating(rating);
         }
         if (vulnerability.getCvssV3BaseScore() != null) {
-            org.cyclonedx.model.vulnerability.Vulnerability.Rating rating = new org.cyclonedx.model.vulnerability.Vulnerability.Rating();
+            final var rating = new org.cyclonedx.model.vulnerability.Vulnerability.Rating();
             rating.setSource(convertDtVulnSourceToCdxVulnSource(Vulnerability.Source.valueOf(vulnerability.getSource())));
             if (vulnerability.getCvssV3Vector() != null && vulnerability.getCvssV3Vector().contains("CVSS:3.0")) {
                 rating.setMethod(org.cyclonedx.model.vulnerability.Vulnerability.Rating.Method.CVSSV3);
@@ -1021,7 +1023,7 @@ public class ModelConverter {
             cdxVulnerability.addRating(rating);
         }
         if (vulnerability.getCvssV4Score() != null) {
-            org.cyclonedx.model.vulnerability.Vulnerability.Rating rating = new org.cyclonedx.model.vulnerability.Vulnerability.Rating();
+            final var rating = new org.cyclonedx.model.vulnerability.Vulnerability.Rating();
             rating.setSource(convertDtVulnSourceToCdxVulnSource(Vulnerability.Source.valueOf(vulnerability.getSource())));
             rating.setScore(vulnerability.getCvssV4Score().doubleValue());
             rating.setVector(vulnerability.getCvssV4Vector());
@@ -1037,7 +1039,7 @@ public class ModelConverter {
             cdxVulnerability.addRating(rating);
         }
         if (vulnerability.getOwaspRRLikelihoodScore() != null && vulnerability.getOwaspRRTechnicalImpactScore() != null && vulnerability.getOwaspRRBusinessImpactScore() != null) {
-            org.cyclonedx.model.vulnerability.Vulnerability.Rating rating = new org.cyclonedx.model.vulnerability.Vulnerability.Rating();
+            final var rating = new org.cyclonedx.model.vulnerability.Vulnerability.Rating();
             rating.setSeverity(convertDtSeverityToCdxSeverity(VulnerabilityUtil.normalizedOwaspRRScore(vulnerability.getOwaspRRLikelihoodScore().doubleValue(), vulnerability.getOwaspRRTechnicalImpactScore().doubleValue(), vulnerability.getOwaspRRBusinessImpactScore().doubleValue())));
             rating.setSource(convertDtVulnSourceToCdxVulnSource(Vulnerability.Source.valueOf(vulnerability.getSource())));
             rating.setMethod(org.cyclonedx.model.vulnerability.Vulnerability.Rating.Method.OWASP);
@@ -1045,7 +1047,7 @@ public class ModelConverter {
             cdxVulnerability.addRating(rating);
         }
         if (vulnerability.getCvssV2BaseScore() == null && vulnerability.getCvssV3BaseScore() == null && vulnerability.getCvssV4Score() == null && vulnerability.getOwaspRRLikelihoodScore() == null) {
-            org.cyclonedx.model.vulnerability.Vulnerability.Rating rating = new org.cyclonedx.model.vulnerability.Vulnerability.Rating();
+            final var rating = new org.cyclonedx.model.vulnerability.Vulnerability.Rating();
             rating.setSeverity(convertDtSeverityToCdxSeverity(vulnerability.getSeverity()));
             rating.setSource(convertDtVulnSourceToCdxVulnSource(Vulnerability.Source.valueOf(vulnerability.getSource())));
             rating.setMethod(org.cyclonedx.model.vulnerability.Vulnerability.Rating.Method.OTHER);
@@ -1065,41 +1067,34 @@ public class ModelConverter {
         cdxVulnerability.setPublished(vulnerability.getPublished());
         cdxVulnerability.setUpdated(vulnerability.getUpdated());
 
-        if (CycloneDXExporter.Variant.INVENTORY_WITH_VULNERABILITIES == variant || CycloneDXExporter.Variant.VDR == variant) {
-            final List<org.cyclonedx.model.vulnerability.Vulnerability.Affect> affects = new ArrayList<>();
-            final org.cyclonedx.model.vulnerability.Vulnerability.Affect affect = new org.cyclonedx.model.vulnerability.Vulnerability.Affect();
-            affect.setRef(component.getUuid().toString());
+        // The affected components are VEX "subcomponents", i.e. the elements of the product
+        // in which the vulnerability originates. The product itself is identified by metadata.component.
+        final var affects = new ArrayList<org.cyclonedx.model.vulnerability.Vulnerability.Affect>(
+                affectedComponentUuids.size());
+        for (final String componentUuid : affectedComponentUuids) {
+            final var affect = new org.cyclonedx.model.vulnerability.Vulnerability.Affect();
+            affect.setRef(componentUuid);
             affects.add(affect);
-            cdxVulnerability.setAffects(affects);
-        } else if (CycloneDXExporter.Variant.VEX == variant && project != null) {
-            final List<org.cyclonedx.model.vulnerability.Vulnerability.Affect> affects = new ArrayList<>();
-            final org.cyclonedx.model.vulnerability.Vulnerability.Affect affect = new org.cyclonedx.model.vulnerability.Vulnerability.Affect();
-            affect.setRef(project.getUuid().toString());
-            affects.add(affect);
-            cdxVulnerability.setAffects(affects);
         }
+        cdxVulnerability.setAffects(affects);
 
-        if (CycloneDXExporter.Variant.VEX == variant || CycloneDXExporter.Variant.VDR == variant) {
-            final Analysis analysis = qm.getAnalysis(component, vulnerability);
-            if (analysis != null) {
-                final org.cyclonedx.model.vulnerability.Vulnerability.Analysis cdxAnalysis = new org.cyclonedx.model.vulnerability.Vulnerability.Analysis();
-                if (analysis.getAnalysisResponse() != null) {
-                    final org.cyclonedx.model.vulnerability.Vulnerability.Analysis.Response response = convertDtVulnAnalysisResponseToCdxAnalysisResponse(analysis.getAnalysisResponse());
-                    if (response != null) {
-                        List<org.cyclonedx.model.vulnerability.Vulnerability.Analysis.Response> responses = new ArrayList<>();
-                        responses.add(response);
-                        cdxAnalysis.setResponses(responses);
-                    }
+        if (analysis != null) {
+            final var cdxAnalysis = new org.cyclonedx.model.vulnerability.Vulnerability.Analysis();
+            if (analysis.getAnalysisResponse() != null) {
+                final org.cyclonedx.model.vulnerability.Vulnerability.Analysis.Response response =
+                        convertDtVulnAnalysisResponseToCdxAnalysisResponse(analysis.getAnalysisResponse());
+                if (response != null) {
+                    cdxAnalysis.setResponses(new ArrayList<>(List.of(response)));
                 }
-                if (analysis.getAnalysisState() != null) {
-                    cdxAnalysis.setState(convertDtVulnAnalysisStateToCdxAnalysisState(analysis.getAnalysisState()));
-                }
-                if (analysis.getAnalysisJustification() != null) {
-                    cdxAnalysis.setJustification(convertDtVulnAnalysisJustificationToCdxAnalysisJustification(analysis.getAnalysisJustification()));
-                }
-                cdxAnalysis.setDetail(StringUtils.trimToNull(analysis.getAnalysisDetails()));
-                cdxVulnerability.setAnalysis(cdxAnalysis);
             }
+            if (analysis.getAnalysisState() != null) {
+                cdxAnalysis.setState(convertDtVulnAnalysisStateToCdxAnalysisState(analysis.getAnalysisState()));
+            }
+            if (analysis.getAnalysisJustification() != null) {
+                cdxAnalysis.setJustification(convertDtVulnAnalysisJustificationToCdxAnalysisJustification(analysis.getAnalysisJustification()));
+            }
+            cdxAnalysis.setDetail(StringUtils.trimToNull(analysis.getAnalysisDetails()));
+            cdxVulnerability.setAnalysis(cdxAnalysis);
         }
 
         return cdxVulnerability;
@@ -1321,19 +1316,80 @@ public class ModelConverter {
     }
 
     public static List<org.cyclonedx.model.vulnerability.Vulnerability> generateVulnerabilities(
-            final QueryManager qm,
-            final CycloneDXExporter.Variant variant,
-            final List<Finding> findings
-    ) {
+            QueryManager qm,
+            CycloneDXExporter.Variant variant,
+            List<Finding> findings) {
         if (findings == null) {
-            return Collections.emptyList();
+            return List.of();
         }
-        final var vulnerabilitiesSeen = new HashSet<org.cyclonedx.model.vulnerability.Vulnerability>();
-        return findings.stream()
-                .map(finding -> convert(qm, variant, finding))
-                .filter(Objects::nonNull)
-                .filter(vulnerabilitiesSeen::add)
+
+        // CISA's VEX minimum requirements allow one statement to cover multiple affected elements,
+        // but only while the status holds for all of them:
+        //
+        //   "If status or other VEX information changes for a subset of products,
+        //   additional VEX statements MUST be created for the respective subset."
+        //
+        // Hence, we group by vulnerability and analysis.
+        final var groups = new LinkedHashMap<VulnerabilityGroupKey, VulnerabilityGroup>();
+        for (final Finding finding : findings) {
+            final Component component = qm.getObjectByUuid(
+                    Component.class,
+                    finding.getComponent().get("uuid").toString());
+            if (component == null) {
+                continue;
+            }
+
+            final Vulnerability vulnerability = qm.getObjectByUuid(
+                    Vulnerability.class,
+                    finding.getVulnerability().get("uuid").toString());
+            if (vulnerability == null) {
+                continue;
+            }
+
+            final Analysis analysis = variant.hasCapability(CycloneDXExporter.Capability.EMITS_ANALYSIS)
+                    ? qm.getAnalysis(component, vulnerability)
+                    : null;
+
+            groups.computeIfAbsent(
+                            VulnerabilityGroupKey.of(vulnerability, analysis),
+                            ignored -> new VulnerabilityGroup(vulnerability, analysis, new TreeSet<>()))
+                    .affectedComponentUuids()
+                    .add(component.getUuid().toString());
+        }
+
+        return groups.values().stream()
+                .map(group -> convert(group.vulnerability(), group.analysis(), group.affectedComponentUuids()))
                 .toList();
+    }
+
+    private record VulnerabilityGroup(
+            Vulnerability vulnerability,
+            Analysis analysis,
+            SortedSet<String> affectedComponentUuids) {
+    }
+
+    private record VulnerabilityGroupKey(
+            UUID vulnerabilityUuid,
+            boolean analyzed,
+            AnalysisState analysisState,
+            AnalysisJustification analysisJustification,
+            AnalysisResponse analysisResponse,
+            String analysisDetails) {
+
+        private static VulnerabilityGroupKey of(Vulnerability vulnerability, Analysis analysis) {
+            if (analysis == null) {
+                return new VulnerabilityGroupKey(vulnerability.getUuid(), false, null, null, null, null);
+            }
+
+            return new VulnerabilityGroupKey(
+                    vulnerability.getUuid(),
+                    true,
+                    analysis.getAnalysisState(),
+                    analysis.getAnalysisJustification(),
+                    analysis.getAnalysisResponse(),
+                    StringUtils.trimToNull(analysis.getAnalysisDetails()));
+        }
+
     }
 
     public static org.cyclonedx.model.Component.Scope mapCdxScope(Scope scope) {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -646,6 +646,10 @@ public class QueryManager extends AlpineQueryManager {
         return getVulnerabilityQueryManager().getVulnerabilityByVulnId(source, vulnId, includeVulnerableSoftware);
     }
 
+    public List<Vulnerability> getVulnerabilitiesByVulnId(String vulnId) {
+        return getVulnerabilityQueryManager().getVulnerabilitiesByVulnId(vulnId);
+    }
+
     public void addVulnerability(
             Vulnerability vulnerability,
             Component component,

--- a/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -172,6 +172,23 @@ final class VulnerabilityQueryManager extends QueryManager {
         return getVulnerabilityByVulnId(source.name(), vulnId, includeVulnerableSoftware);
     }
 
+    /**
+     * Returns all vulnerabilities with the given name (i.e. CVE-2017-0001), across all sources.
+     * <p>
+     * Intended for cases where the source is not known, such as documents from other tools that
+     * name sources differently. More than one match means the name alone does not identify a
+     * vulnerability, and callers are expected to handle that rather than pick one.
+     *
+     * @param vulnId the name of the vulnerability
+     * @return the matching {@link Vulnerability}s, possibly empty
+     * @since 5.1.0
+     */
+    public List<Vulnerability> getVulnerabilitiesByVulnId(String vulnId) {
+        final Query<Vulnerability> query = pm.newQuery(Vulnerability.class, "vulnId == :vulnId");
+        query.setParameters(vulnId);
+        return executeAndCloseList(query);
+    }
+
     public boolean hasVulnerabilities(final Project project) {
         final Query<FindingAttribution> query = pm.newQuery(
                 FindingAttribution.class,

--- a/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporterTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporterTest.java
@@ -19,7 +19,7 @@
 package org.dependencytrack.parser.cyclonedx;
 
 import org.apache.commons.io.IOUtils;
-import org.assertj.core.api.Assertions;
+import org.cyclonedx.Version;
 import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.parsers.BomParserFactory;
 import org.dependencytrack.PersistenceCapableTest;
@@ -32,6 +32,7 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.persistence.command.MakeAnalysisCommand;
 import org.junit.jupiter.api.Test;
 
 import javax.jdo.Query;
@@ -41,6 +42,8 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CycloneDXVexImporterTest extends PersistenceCapableTest {
 
@@ -123,27 +126,46 @@ public class CycloneDXVexImporterTest extends PersistenceCapableTest {
 
         // Assert
         final Query<Analysis> query = qm.getPersistenceManager().newQuery(Analysis.class, "project == :project");
-        var analyses = (List<Analysis>) query.execute(project);
-        // CVE-2020-256[49|50|51] are not audited otherwise analyses.size would have been equal to sources.size()+3
-        org.junit.jupiter.api.Assertions.assertEquals(sources.size(), analyses.size());
-        Assertions.assertThat(analyses).allSatisfy(analysis -> {
-            Assertions.assertThat(analysis.getVulnerability().getVulnId()).isNotEqualTo("CVE-2020-25649");
-            Assertions.assertThat(analysis.getVulnerability().getVulnId()).isNotEqualTo("CVE-2020-25650");
-            Assertions.assertThat(analysis.isSuppressed()).isTrue();
-            Assertions.assertThat(analysis.getAnalysisComments()).satisfiesExactlyInAnyOrder(comment -> {
-                Assertions.assertThat(comment.getCommenter()).isEqualTo("CycloneDX VEX");
-                Assertions.assertThat(comment.getComment()).isEqualTo(String.format("Analysis: %s → %s", AnalysisState.NOT_SET, AnalysisState.FALSE_POSITIVE));
-            }, comment -> {
-                Assertions.assertThat(comment.getCommenter()).isEqualTo("CycloneDX VEX");
-                Assertions.assertThat(comment.getComment()).isEqualTo("Details: Unit test");
-            }, comment -> {
-                Assertions.assertThat(comment.getCommenter()).isEqualTo("CycloneDX VEX");
-                Assertions.assertThat(comment.getComment()).isEqualTo(String.format("Justification: %s → %s", AnalysisJustification.NOT_SET, AnalysisJustification.PROTECTED_BY_MITIGATING_CONTROL));
-            }, comment -> {
-                Assertions.assertThat(comment.getCommenter()).isEqualTo("CycloneDX VEX");
-                Assertions.assertThat(comment.getComment()).isEqualTo("Suppressed");
-            });
-            Assertions.assertThat(analysis.getAnalysisDetails()).isEqualTo("Unit test");
+        query.setParameters(project);
+        final List<Analysis> analyses = query.executeList();
+
+        // The VEX names sources three ways, and none of them matches how
+        // Dependency-Track recorded the vulnerability:
+        //
+        // * "National Vulnerability Database" is not a name it uses.
+        // * "OSSINDEX" is a name it uses but not for these vulnerabilities.
+        // * The third entry has no source at all.
+        //
+        // All three resolve, because the vulnerability ID identifies them on its own.
+        assertThat(analyses)
+                .filteredOn(analysis -> analysis.getVulnerability().getVulnId().startsWith("CVE-"))
+                .extracting(analysis -> analysis.getVulnerability().getVulnId())
+                .containsExactlyInAnyOrder("CVE-2020-25649", "CVE-2020-25650", "CVE-2020-25651");
+
+        final List<Analysis> sourceAudits = analyses.stream()
+                .filter(analysis -> !analysis.getVulnerability().getVulnId().startsWith("CVE-"))
+                .toList();
+        assertThat(sources.size()).isEqualTo(sourceAudits.size());
+        assertThat(sourceAudits).allSatisfy(analysis -> {
+            assertThat(analysis.isSuppressed()).isTrue();
+            assertThat(analysis.getAnalysisComments()).satisfiesExactlyInAnyOrder(
+                    comment -> {
+                        assertThat(comment.getCommenter()).isEqualTo("CycloneDX VEX");
+                        assertThat(comment.getComment()).isEqualTo(String.format("Analysis: %s → %s", AnalysisState.NOT_SET, AnalysisState.FALSE_POSITIVE));
+                    },
+                    comment -> {
+                        assertThat(comment.getCommenter()).isEqualTo("CycloneDX VEX");
+                        assertThat(comment.getComment()).isEqualTo("Details: Unit test");
+                    },
+                    comment -> {
+                        assertThat(comment.getCommenter()).isEqualTo("CycloneDX VEX");
+                        assertThat(comment.getComment()).isEqualTo(String.format("Justification: %s → %s", AnalysisJustification.NOT_SET, AnalysisJustification.PROTECTED_BY_MITIGATING_CONTROL));
+                    },
+                    comment -> {
+                        assertThat(comment.getCommenter()).isEqualTo("CycloneDX VEX");
+                        assertThat(comment.getComment()).isEqualTo("Suppressed");
+                    });
+            assertThat(analysis.getAnalysisDetails()).isEqualTo("Unit test");
         });
     }
 
@@ -198,10 +220,391 @@ public class CycloneDXVexImporterTest extends PersistenceCapableTest {
         vexImporter.applyVex(qm, vex, project);
 
         final Analysis analysis = qm.getAnalysis(component, vuln);
-        Assertions.assertThat(analysis.getAnalysisResponse()).isEqualTo(AnalysisResponse.UPDATE);
-        Assertions.assertThat(analysis.getAnalysisComments())
+        assertThat(analysis.getAnalysisResponse()).isEqualTo(AnalysisResponse.UPDATE);
+        assertThat(analysis.getAnalysisComments())
                 .extracting(AnalysisComment::getComment)
                 .containsExactly("Vendor Response: NOT_SET → UPDATE");
+    }
+
+    @Test
+    public void shouldApplyExportedVexAnalysisOnlyToAnalyzedComponent() throws Exception {
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final var componentA = new Component();
+        componentA.setProject(project);
+        componentA.setName("acme-lib-a");
+        componentA.setVersion("1.0.0");
+        qm.persist(componentA);
+
+        final var componentB = new Component();
+        componentB.setProject(project);
+        componentB.setName("acme-lib-b");
+        componentB.setVersion("1.0.0");
+        qm.persist(componentB);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("INT-001");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        vuln.setComponents(List.of(componentA, componentB));
+        qm.persist(vuln);
+        qm.addVulnerability(vuln, componentA, "none");
+        qm.addVulnerability(vuln, componentB, "none");
+
+        qm.makeAnalysis(
+                new MakeAnalysisCommand(componentA, vuln)
+                        .withState(AnalysisState.NOT_AFFECTED)
+                        .withJustification(AnalysisJustification.CODE_NOT_REACHABLE));
+
+        final var exporter = new CycloneDXExporter(CycloneDXExporter.Variant.VEX, qm);
+        final byte[] vexBytes = exporter
+                .export(
+                        exporter.create(project, Version.VERSION_16),
+                        CycloneDXExporter.Format.JSON,
+                        Version.VERSION_16)
+                .getBytes(StandardCharsets.UTF_8);
+
+        vexImporter.applyVex(qm, BomParserFactory.createParser(vexBytes).parse(vexBytes), project);
+
+        assertThat(qm.getAnalysis(componentA, vuln))
+                .extracting(Analysis::getAnalysisState, Analysis::getAnalysisJustification)
+                .containsExactly(AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE);
+        assertThat(qm.getAnalysis(componentB, vuln)).isNull();
+    }
+
+    @Test
+    public void shouldApplyAnalysisWhenSourceNameIsNotADependencyTrackSourceName() throws ParseException {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("1.0.0");
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-2099-0001");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setSeverity(Severity.HIGH);
+        qm.persist(vuln);
+        qm.addVulnerability(vuln, component, "none");
+
+        final byte[] vexBytes = /* language=JSON */ """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.6",
+                  "version": 1,
+                  "metadata": {
+                    "component": {
+                      "type": "application",
+                      "bom-ref": "project",
+                      "name": "acme-app",
+                      "version": "1.0.0"
+                    }
+                  },
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2099-0001",
+                      "source": {
+                        "name": "National Vulnerability Database"
+                      },
+                      "analysis": {
+                        "state": "not_affected",
+                        "justification": "code_not_reachable"
+                      },
+                      "affects": [
+                        { "ref": "project" }
+                      ]
+                    }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+        vexImporter.applyVex(qm, BomParserFactory.createParser(vexBytes).parse(vexBytes), project);
+
+        assertThat(qm.getAnalysis(component, vuln))
+                .extracting(Analysis::getAnalysisState)
+                .isEqualTo(AnalysisState.NOT_AFFECTED);
+    }
+
+    @Test
+    public void shouldApplyAnalysisWhenSourceIsAbsent() throws ParseException {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("1.0.0");
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-2099-0001");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setSeverity(Severity.HIGH);
+        qm.persist(vuln);
+        qm.addVulnerability(vuln, component, "none");
+
+        final byte[] vexBytes = /* language=JSON */ """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.6",
+                  "version": 1,
+                  "metadata": {
+                    "component": {
+                      "type": "application",
+                      "bom-ref": "project",
+                      "name": "acme-app",
+                      "version": "1.0.0"
+                    }
+                  },
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2099-0001",
+                      "analysis": {
+                        "state": "not_affected",
+                        "justification": "code_not_reachable"
+                      },
+                      "affects": [
+                        { "ref": "project" }
+                      ]
+                    }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+        vexImporter.applyVex(qm, BomParserFactory.createParser(vexBytes).parse(vexBytes), project);
+
+        assertThat(qm.getAnalysis(component, vuln))
+                .extracting(Analysis::getAnalysisState)
+                .isEqualTo(AnalysisState.NOT_AFFECTED);
+    }
+
+    @Test
+    public void shouldApplyAnalysisWhenSourceIsKnownButNotTheOneHoldingTheVulnerability() throws ParseException {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("1.0.0");
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-2099-0001");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setSeverity(Severity.HIGH);
+        qm.persist(vuln);
+        qm.addVulnerability(vuln, component, "none");
+
+        final byte[] vexBytes = /* language=JSON */ """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.6",
+                  "version": 1,
+                  "metadata": {
+                    "component": {
+                      "type": "application",
+                      "bom-ref": "project",
+                      "name": "acme-app",
+                      "version": "1.0.0"
+                    }
+                  },
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2099-0001",
+                      "source": { "name": "OSSINDEX" },
+                      "analysis": {
+                        "state": "not_affected",
+                        "justification": "code_not_reachable"
+                      },
+                      "affects": [
+                        { "ref": "project" }
+                      ]
+                    }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+        vexImporter.applyVex(qm, BomParserFactory.createParser(vexBytes).parse(vexBytes), project);
+
+        assertThat(qm.getAnalysis(component, vuln))
+                .extracting(Analysis::getAnalysisState)
+                .isEqualTo(AnalysisState.NOT_AFFECTED);
+    }
+
+    @Test
+    public void shouldUseSourceToDisambiguateVulnerabilityIdSharedByMultipleSources() throws ParseException {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("1.0.0");
+        qm.persist(component);
+
+        final var nvdVuln = new Vulnerability();
+        nvdVuln.setVulnId("CVE-2099-0001");
+        nvdVuln.setSource(Vulnerability.Source.NVD);
+        nvdVuln.setSeverity(Severity.HIGH);
+        qm.persist(nvdVuln);
+        qm.addVulnerability(nvdVuln, component, "none");
+
+        final var osvVuln = new Vulnerability();
+        osvVuln.setVulnId("CVE-2099-0001");
+        osvVuln.setSource(Vulnerability.Source.OSV);
+        osvVuln.setSeverity(Severity.HIGH);
+        qm.persist(osvVuln);
+        qm.addVulnerability(osvVuln, component, "none");
+
+        final byte[] vexBytes = /* language=JSON */ """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.6",
+                  "version": 1,
+                  "metadata": {
+                    "component": {
+                      "type": "application",
+                      "bom-ref": "project",
+                      "name": "acme-app",
+                      "version": "1.0.0"
+                    }
+                  },
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2099-0001",
+                      "source": { "name": "NVD" },
+                      "analysis": { "state": "not_affected", "justification": "code_not_reachable" },
+                      "affects": [{ "ref": "project" }]
+                    }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+        vexImporter.applyVex(qm, BomParserFactory.createParser(vexBytes).parse(vexBytes), project);
+
+        assertThat(qm.getAnalysis(component, nvdVuln))
+                .extracting(Analysis::getAnalysisState)
+                .isEqualTo(AnalysisState.NOT_AFFECTED);
+        assertThat(qm.getAnalysis(component, osvVuln)).isNull();
+    }
+
+    @Test
+    public void shouldSkipWhenSourcelessVulnerabilityIdIsAmbiguous() throws ParseException {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("1.0.0");
+        qm.persist(component);
+
+        final var nvdVuln = new Vulnerability();
+        nvdVuln.setVulnId("CVE-2099-0001");
+        nvdVuln.setSource(Vulnerability.Source.NVD);
+        nvdVuln.setSeverity(Severity.HIGH);
+        qm.persist(nvdVuln);
+        qm.addVulnerability(nvdVuln, component, "none");
+
+        final var osvVuln = new Vulnerability();
+        osvVuln.setVulnId("CVE-2099-0001");
+        osvVuln.setSource(Vulnerability.Source.OSV);
+        osvVuln.setSeverity(Severity.HIGH);
+        qm.persist(osvVuln);
+        qm.addVulnerability(osvVuln, component, "none");
+
+        final byte[] vexBytes = /* language=JSON */ """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.6",
+                  "version": 1,
+                  "metadata": {
+                    "component": {
+                      "type": "application",
+                      "bom-ref": "project",
+                      "name": "acme-app",
+                      "version": "1.0.0"
+                    }
+                  },
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2099-0001",
+                      "source": { "name": "Some Other Scanner" },
+                      "analysis": {
+                        "state": "not_affected",
+                        "justification": "code_not_reachable"
+                      },
+                      "affects": [
+                        { "ref": "project" }
+                      ]
+                    }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+        vexImporter.applyVex(qm, BomParserFactory.createParser(vexBytes).parse(vexBytes), project);
+
+        // Guessing either one would be wrong, so neither is analyzed.
+        assertThat(qm.getAnalysis(component, nvdVuln)).isNull();
+        assertThat(qm.getAnalysis(component, osvVuln)).isNull();
+    }
+
+    @Test
+    public void shouldSkipUnresolvableRefWhenSourceIsAbsent() throws ParseException {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("1.0.0");
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-2099-0001");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setSeverity(Severity.HIGH);
+        qm.persist(vuln);
+        qm.addVulnerability(vuln, component, "none");
+
+        final byte[] vexBytes = /* language=JSON */ """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.6",
+                  "version": 1,
+                  "metadata": {
+                    "component": {
+                      "type": "application",
+                      "bom-ref": "project",
+                      "name": "acme-app",
+                      "version": "1.0.0"
+                    }
+                  },
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2099-0001",
+                      "analysis": {
+                        "state": "not_affected",
+                        "justification": "code_not_reachable"
+                      },
+                      "affects": [
+                        { "ref": "no-such-ref" }
+                      ]
+                    }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+        vexImporter.applyVex(qm, BomParserFactory.createParser(vexBytes).parse(vexBytes), project);
+
+        assertThat(qm.getAnalysis(component, vuln)).isNull();
     }
 
     private static final String OWASP_VECTOR =
@@ -254,11 +657,11 @@ public class CycloneDXVexImporterTest extends PersistenceCapableTest {
         vexImporter.applyVex(qm, vex, project);
 
         final Analysis analysis = qm.getAnalysis(component, vuln);
-        Assertions.assertThat(analysis.getOwaspVector()).isEqualTo(OWASP_VECTOR);
-        Assertions.assertThat(analysis.getOwaspScore()).isEqualByComparingTo(new BigDecimal("7.5"));
+        assertThat(analysis.getOwaspVector()).isEqualTo(OWASP_VECTOR);
+        assertThat(analysis.getOwaspScore()).isEqualByComparingTo(new BigDecimal("7.5"));
         // An OWASP rating import must not override the finding severity; it falls back to the vulnerability.
-        Assertions.assertThat(analysis.getSeverity()).isNull();
-        Assertions.assertThat(analysis.getAnalysisComments())
+        assertThat(analysis.getSeverity()).isNull();
+        assertThat(analysis.getAnalysisComments())
                 .extracting(AnalysisComment::getComment)
                 .contains(
                         "OWASP Vector: (None) → " + OWASP_VECTOR,
@@ -311,11 +714,11 @@ public class CycloneDXVexImporterTest extends PersistenceCapableTest {
         vexImporter.applyVex(qm, vex, project);
 
         final Analysis analysis = qm.getAnalysis(component, vuln);
-        Assertions.assertThat(analysis).isNotNull();
-        Assertions.assertThat(analysis.getOwaspVector()).isEqualTo(OWASP_VECTOR);
-        Assertions.assertThat(analysis.getOwaspScore()).isEqualByComparingTo(new BigDecimal("4.2"));
-        Assertions.assertThat(analysis.getAnalysisState()).isEqualTo(AnalysisState.NOT_SET);
-        Assertions.assertThat(analysis.isSuppressed()).isFalse();
+        assertThat(analysis).isNotNull();
+        assertThat(analysis.getOwaspVector()).isEqualTo(OWASP_VECTOR);
+        assertThat(analysis.getOwaspScore()).isEqualByComparingTo(new BigDecimal("4.2"));
+        assertThat(analysis.getAnalysisState()).isEqualTo(AnalysisState.NOT_SET);
+        assertThat(analysis.isSuppressed()).isFalse();
     }
 
     @Test
@@ -365,8 +768,8 @@ public class CycloneDXVexImporterTest extends PersistenceCapableTest {
         vexImporter.applyVex(qm, vex, project);
 
         final Analysis analysis = qm.getAnalysis(component, vuln);
-        Assertions.assertThat(analysis.getOwaspVector()).isNull();
-        Assertions.assertThat(analysis.getOwaspScore()).isNull();
+        assertThat(analysis.getOwaspVector()).isNull();
+        assertThat(analysis.getOwaspScore()).isNull();
     }
 
 }

--- a/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxBomAssert.java
+++ b/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxBomAssert.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.parser.cyclonedx;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.AbstractAssert;
+
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+public class CycloneDxBomAssert extends AbstractAssert<CycloneDxBomAssert, String> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private CycloneDxBomAssert(String actual) {
+        super(actual, CycloneDxBomAssert.class);
+    }
+
+    public static CycloneDxBomAssert assertThatBom(String actual) {
+        return new CycloneDxBomAssert(actual);
+    }
+
+    public CycloneDxBomAssert isValid() {
+        isNotNull();
+
+        assertThatNoException().isThrownBy(
+                () -> CycloneDxValidator.getInstance().validate(actual.getBytes()));
+        return this;
+    }
+
+    public CycloneDxBomAssert hasUniqueBomRefs() {
+        isNotNull();
+
+        final JsonNode bom;
+        try {
+            bom = MAPPER.readTree(actual);
+        } catch (JsonProcessingException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        final var bomRefs = new ArrayList<String>();
+        collectBomRefs(bom.at("/metadata/component"), bomRefs);
+        bom.path("components").forEach(component -> collectBomRefs(component, bomRefs));
+        bom.path("services").forEach(service -> collectBomRefs(service, bomRefs));
+        bom.path("vulnerabilities").forEach(vuln -> collectBomRef(vuln, bomRefs));
+
+        assertThat(bomRefs).doesNotHaveDuplicates();
+        return this;
+    }
+
+    private static void collectBomRefs(JsonNode node, List<String> bomRefs) {
+        collectBomRef(node, bomRefs);
+        node.path("components").forEach(child -> collectBomRefs(child, bomRefs));
+        node.path("services").forEach(child -> collectBomRefs(child, bomRefs));
+    }
+
+    private static void collectBomRef(JsonNode node, List<String> bomRefs) {
+        final JsonNode bomRef = node.path("bom-ref");
+        if (bomRef.isTextual()) {
+            bomRefs.add(bomRef.asText());
+        }
+    }
+
+}

--- a/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxBomAssertTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxBomAssertTest.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.parser.cyclonedx;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.dependencytrack.parser.cyclonedx.CycloneDxBomAssert.assertThatBom;
+
+class CycloneDxBomAssertTest {
+
+    @Nested
+    class HasUniqueBomRefsTest {
+
+        @Test
+        void shouldDetectDuplicateInNestedComponent() {
+            assertThatThrownBy(() -> assertThatBom(/* language=JSON */ """
+                    {
+                      "bomFormat": "CycloneDX",
+                      "specVersion": "1.7",
+                      "metadata": {
+                        "component": {
+                          "type": "application",
+                          "bom-ref": "root"
+                        }
+                      },
+                      "components": [
+                        {
+                          "type": "library",
+                          "bom-ref": "comp-a",
+                          "components": [
+                            { "type": "library", "bom-ref": "root" }
+                          ]
+                        }
+                      ]
+                    }
+                    """).hasUniqueBomRefs())
+                    .isInstanceOf(AssertionError.class)
+                    .hasMessageContaining("root");
+        }
+
+        @Test
+        void shouldIgnoreBomRefsThatAreNotDeclarations() {
+            assertThatNoException().isThrownBy(() -> assertThatBom(/* language=JSON */ """
+                    {
+                      "bomFormat": "CycloneDX",
+                      "specVersion": "1.7",
+                      "components": [
+                        {
+                          "type": "library",
+                          "bom-ref": "comp-a",
+                          "patentAssertions": [
+                            { "bom-ref": "patent-1", "assertionType": "use", "asserter": {} }
+                          ]
+                        },
+                        {
+                          "type": "library",
+                          "bom-ref": "comp-b",
+                          "patentAssertions": [
+                            { "bom-ref": "patent-1", "assertionType": "use", "asserter": {} }
+                          ]
+                        }
+                      ]
+                    }
+                    """).hasUniqueBomRefs());
+        }
+
+    }
+
+}

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -121,6 +121,7 @@ import static org.dependencytrack.notification.NotificationTestUtil.createCatchA
 import static org.dependencytrack.notification.proto.v1.Group.GROUP_BOM_VALIDATION_FAILED;
 import static org.dependencytrack.notification.proto.v1.Level.LEVEL_ERROR;
 import static org.dependencytrack.notification.proto.v1.Scope.SCOPE_PORTFOLIO;
+import static org.dependencytrack.parser.cyclonedx.CycloneDxBomAssert.assertThatBom;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiHandle;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -492,7 +493,9 @@ class BomResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
 
         final String jsonResponse = getPlainTextBody(response);
-        assertThatNoException().isThrownBy(() -> CycloneDxValidator.getInstance().validate(jsonResponse.getBytes()));
+        assertThatBom(jsonResponse)
+                .isValid()
+                .hasUniqueBomRefs();
         assertThatJson(jsonResponse)
                 .withOptions(Option.IGNORING_ARRAY_ORDER)
                 .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
@@ -634,7 +637,9 @@ class BomResourceTest extends ResourceTest {
                 .get(Response.class);
 
         final String jsonResponse = getPlainTextBody(response);
-        assertThatNoException().isThrownBy(() -> CycloneDxValidator.getInstance().validate(jsonResponse.getBytes()));
+        assertThatBom(jsonResponse)
+                .isValid()
+                .hasUniqueBomRefs();
         assertThatJson(jsonResponse)
                 .withMatcher("component", equalTo(component.getUuid().toString()))
                 .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
@@ -766,10 +771,11 @@ class BomResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
 
         final String jsonResponse = getPlainTextBody(response);
-        assertThatNoException().isThrownBy(() -> CycloneDxValidator.getInstance().validate(jsonResponse.getBytes()));
+        assertThatBom(jsonResponse)
+                .isValid()
+                .hasUniqueBomRefs();
         assertThatJson(jsonResponse)
                 .withOptions(Option.IGNORING_ARRAY_ORDER)
-                .withMatcher("vulnUuid", equalTo(vulnerability.getUuid().toString()))
                 .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
                 .withMatcher("componentWithoutVulnUuid", equalTo(componentWithoutVuln.getUuid().toString()))
                 .withMatcher("componentWithVulnUuid", equalTo(componentWithVuln.getUuid().toString()))
@@ -846,7 +852,6 @@ class BomResourceTest extends ResourceTest {
                             ],
                             "vulnerabilities": [
                                 {
-                                    "bom-ref": "${json-unit.matches:vulnUuid}",
                                     "id": "INT-001",
                                     "source": {
                                         "name": "INTERNAL"
@@ -863,25 +868,7 @@ class BomResourceTest extends ResourceTest {
                                     "affects": [
                                         {
                                             "ref": "${json-unit.matches:componentWithVulnUuid}"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "bom-ref": "${json-unit.matches:vulnUuid}",
-                                    "id": "INT-001",
-                                    "source": {
-                                        "name": "INTERNAL"
-                                    },
-                                    "ratings": [
-                                        {
-                                            "source": {
-                                                "name": "INTERNAL"
-                                            },
-                                            "severity": "high",
-                                            "method": "other"
-                                        }
-                                    ],
-                                    "affects": [
+                                        },
                                         {
                                             "ref": "${json-unit.matches:componentWithVulnAndAnalysisUuid}"
                                         }
@@ -989,10 +976,11 @@ class BomResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
 
         final String jsonResponse = getPlainTextBody(response);
-        assertThatNoException().isThrownBy(() -> CycloneDxValidator.getInstance().validate(jsonResponse.getBytes()));
+        assertThatBom(jsonResponse)
+                .isValid()
+                .hasUniqueBomRefs();
         assertThatJson(jsonResponse)
                 .withOptions(Option.IGNORING_ARRAY_ORDER)
-                .withMatcher("vulnUuid", equalTo(vulnerability.getUuid().toString()))
                 .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
                 .withMatcher("componentWithoutVulnUuid", equalTo(componentWithoutVuln.getUuid().toString()))
                 .withMatcher("componentWithVulnUuid", equalTo(componentWithVuln.getUuid().toString()))
@@ -1056,7 +1044,6 @@ class BomResourceTest extends ResourceTest {
                             ],
                             "vulnerabilities": [
                                 {
-                                    "bom-ref": "${json-unit.matches:vulnUuid}",
                                     "id": "INT-001",
                                     "source": {
                                         "name": "INTERNAL"
@@ -1077,7 +1064,6 @@ class BomResourceTest extends ResourceTest {
                                     ]
                                 },
                                 {
-                                    "bom-ref": "${json-unit.matches:vulnUuid}",
                                     "id": "INT-001",
                                     "source": {
                                         "name": "INTERNAL"

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
@@ -18,11 +18,11 @@
  */
 package org.dependencytrack.resources.v1;
 
+import alpine.model.IConfigProperty;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthFeature;
 import com.fasterxml.jackson.core.StreamReadConstraints;
 import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import net.javacrumbs.jsonunit.core.Option;
 import org.dependencytrack.JerseyTestExtension;
@@ -37,11 +37,11 @@ import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.BomValidationMode;
 import org.dependencytrack.model.Classifier;
 import org.dependencytrack.model.Component;
+import org.dependencytrack.model.ComponentProperty;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectCollectionLogic;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
-import org.dependencytrack.parser.cyclonedx.CycloneDxValidator;
 import org.dependencytrack.persistence.command.MakeAnalysisCommand;
 import org.glassfish.jersey.inject.hk2.AbstractBinder;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
@@ -62,10 +62,10 @@ import java.util.function.Supplier;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_MODE;
 import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_TAGS_EXCLUSIVE;
 import static org.dependencytrack.model.ConfigPropertyConstants.BOM_VALIDATION_TAGS_INCLUSIVE;
+import static org.dependencytrack.parser.cyclonedx.CycloneDxBomAssert.assertThatBom;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -153,7 +153,7 @@ public class VexResourceTest extends ResourceTest {
                         .withSuppress(true));
 
         // Make componentWithoutVuln (acme-lib-a) depend on componentWithVuln (acme-lib-b)
-        componentWithoutVuln.setDirectDependencies("""
+        componentWithoutVuln.setDirectDependencies(/* language=JSON */ """
                 [
                     {"uuid": "%s"}
                 ]
@@ -161,7 +161,7 @@ public class VexResourceTest extends ResourceTest {
 
         // Make project depend on componentWithoutVuln (acme-lib-a)
         // and componentWithVulnAndAnalysis (acme-lib-c)
-        project.setDirectDependencies("""
+        project.setDirectDependencies(/* language=JSON */ """
                 [
                     {"uuid": "%s"},
                     {"uuid": "%s"}
@@ -179,13 +179,15 @@ public class VexResourceTest extends ResourceTest {
                 .get(Response.class);
         assertThat(response.getStatus()).isEqualTo(200);
         final String jsonResponse = getPlainTextBody(response);
-        assertThatNoException().isThrownBy(() -> CycloneDxValidator.getInstance().validate(jsonResponse.getBytes()));
+        assertThatBom(jsonResponse)
+                .isValid()
+                .hasUniqueBomRefs();
         assertThatJson(jsonResponse)
                 .withOptions(Option.IGNORING_ARRAY_ORDER)
-                .withMatcher("vulnAUuid", equalTo(vulnA.getUuid().toString()))
-                .withMatcher("vulnBUuid", equalTo(vulnB.getUuid().toString()))
                 .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
-                .isEqualTo("""
+                .withMatcher("componentWithVulnUuid", equalTo(componentWithVuln.getUuid().toString()))
+                .withMatcher("componentWithVulnAndAnalysisUuid", equalTo(componentWithVulnAndAnalysis.getUuid().toString()))
+                .isEqualTo(/* language=JSON */ """
                         {
                           "bomFormat": "CycloneDX",
                           "specVersion": "1.5",
@@ -212,9 +214,22 @@ public class VexResourceTest extends ResourceTest {
                               ]
                             }
                           },
+                          "components": [
+                            {
+                              "type": "library",
+                              "bom-ref": "${json-unit.matches:componentWithVulnUuid}",
+                              "name": "acme-lib-b",
+                              "version": "1.0.0"
+                            },
+                            {
+                              "type": "library",
+                              "bom-ref": "${json-unit.matches:componentWithVulnAndAnalysisUuid}",
+                              "name": "acme-lib-c",
+                              "version": "1.0.0"
+                            }
+                          ],
                           "vulnerabilities": [
                             {
-                              "bom-ref": "${json-unit.matches:vulnAUuid}",
                               "id": "INT-001",
                               "source": {
                                 "name": "INTERNAL"
@@ -230,12 +245,11 @@ public class VexResourceTest extends ResourceTest {
                               ],
                               "affects": [
                                 {
-                                  "ref": "${json-unit.matches:projectUuid}"
+                                  "ref": "${json-unit.matches:componentWithVulnUuid}"
                                 }
                               ]
                             },
                             {
-                              "bom-ref": "${json-unit.matches:vulnBUuid}",
                               "id": "INT-002",
                               "source": {
                                 "name": "INTERNAL"
@@ -257,7 +271,7 @@ public class VexResourceTest extends ResourceTest {
                               },
                               "affects": [
                                 {
-                                  "ref": "${json-unit.matches:projectUuid}"
+                                  "ref": "${json-unit.matches:componentWithVulnAndAnalysisUuid}"
                                 }
                               ]
                             }
@@ -316,7 +330,9 @@ public class VexResourceTest extends ResourceTest {
 
         assertThat(response.getStatus()).isEqualTo(200);
         final String jsonResponse = getPlainTextBody(response);
-        assertThatNoException().isThrownBy(() -> CycloneDxValidator.getInstance().validate(jsonResponse.getBytes()));
+        assertThatBom(jsonResponse)
+                .isValid()
+                .hasUniqueBomRefs();
 
         String expectedCdxVersionSpec = version.isEmpty() ? "1.5" : version;
         assertThatJson(jsonResponse, json -> json.inPath("specVersion").isEqualTo("\"" + expectedCdxVersionSpec + "\""));
@@ -352,7 +368,7 @@ public class VexResourceTest extends ResourceTest {
         project.setVersion("1.0.0");
         qm.persist(project);
 
-        final String encodedVex = Base64.getEncoder().encodeToString("""
+        final String encodedVex = Base64.getEncoder().encodeToString(/* language=JSON */ """
                 {
                   "bomFormat": "CycloneDX",
                   "specVersion": "1.2",
@@ -370,16 +386,16 @@ public class VexResourceTest extends ResourceTest {
 
         final Response response = jersey.target(V1_VEX).request()
                 .header(X_API_KEY, apiKey)
-                .put(Entity.entity("""
+                .put(Entity.json(/* language=JSON */ """
                         {
                           "projectName": "acme-app",
                           "projectVersion": "1.0.0",
                           "vex": "%s"
                         }
-                        """.formatted(encodedVex), MediaType.APPLICATION_JSON));
+                        """.formatted(encodedVex)));
 
         assertThat(response.getStatus()).isEqualTo(400);
-        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
                 {
                   "status": 400,
                   "title": "The uploaded BOM is invalid",
@@ -400,7 +416,7 @@ public class VexResourceTest extends ResourceTest {
         project.setVersion("1.0.0");
         qm.persist(project);
 
-        final String encodedVex = Base64.getEncoder().encodeToString("""
+        final String encodedVex = Base64.getEncoder().encodeToString(/* language=XML */ """
                 <?xml version="1.0"?>
                 <bom serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1" xmlns="http://cyclonedx.org/schema/bom/1.2">
                     <components>
@@ -414,16 +430,16 @@ public class VexResourceTest extends ResourceTest {
 
         final Response response = jersey.target(V1_VEX).request()
                 .header(X_API_KEY, apiKey)
-                .put(Entity.entity("""
+                .put(Entity.json(/* language=JSON */ """
                         {
                           "projectName": "acme-app",
                           "projectVersion": "1.0.0",
                           "vex": "%s"
                         }
-                        """.formatted(encodedVex), MediaType.APPLICATION_JSON));
+                        """.formatted(encodedVex)));
 
         assertThat(response.getStatus()).isEqualTo(400);
-        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
                 {
                   "status": 400,
                   "title": "The uploaded BOM is invalid",
@@ -449,16 +465,16 @@ public class VexResourceTest extends ResourceTest {
 
         final Response response = jersey.target(V1_VEX).request()
                 .header(X_API_KEY, apiKey)
-                .put(Entity.entity("""
+                .put(Entity.json(/* language=JSON */ """
                         {
                           "projectName": "acme-app",
                           "projectVersion": "1.0.0",
                           "vex": "%s"
                         }
-                        """.formatted(vex), MediaType.APPLICATION_JSON));
+                        """.formatted(vex)));
         assertThat(response.getStatus()).isEqualTo(400);
         assertThat(response.getHeaderString("Content-Type")).isEqualTo("application/problem+json");
-        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
                 {
                   "status": 400,
                   "title": "The provided JSON payload could not be mapped",
@@ -521,6 +537,91 @@ public class VexResourceTest extends ResourceTest {
     }
 
     @Test
+    public void exportVexShouldOnlyIncludeComponentIdentityTest() {
+        initializeWithPermissions(Permissions.VULNERABILITY_ANALYSIS_READ);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        project.setClassifier(Classifier.APPLICATION);
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setGroup("com.acme");
+        component.setName("acme-lib-a");
+        component.setVersion("1.0.0");
+        component.setClassifier(Classifier.LIBRARY);
+        component.setPurl("pkg:maven/com.acme/acme-lib-a@1.0.0?type=jar");
+        component.setCpe("cpe:2.3:a:acme:acme-lib-a:1.0.0:*:*:*:*:*:*:*");
+        component.setSwidTagId("swidgen-acme-lib-a");
+        component.setMd5("0cc175b9c0f1b6a831c399e269772661");
+        component.setSha1("86f7e437faa5a7fce15d1ddcb9eaeaea377667b8");
+        component.setDescription("Internal build of the Acme library");
+        component.setCopyright("Copyright (c) Acme Inc");
+        component.setLicense("Apache-2.0");
+        qm.persist(component);
+
+        final var componentProperty = new ComponentProperty();
+        componentProperty.setComponent(component);
+        componentProperty.setGroupName("internal");
+        componentProperty.setPropertyName("buildHost");
+        componentProperty.setPropertyValue("build-07.internal.acme.example");
+        componentProperty.setPropertyType(IConfigProperty.PropertyType.STRING);
+        qm.persist(componentProperty);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("INT-001");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        qm.persist(vuln);
+        qm.addVulnerability(vuln, component, "none");
+        qm.makeAnalysis(new MakeAnalysisCommand(component, vuln).withState(AnalysisState.NOT_AFFECTED));
+
+        final Response response = jersey
+                .target("%s/cyclonedx/project/%s".formatted(V1_VEX, project.getUuid()))
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(200);
+        final String jsonResponse = getPlainTextBody(response);
+        assertThatBom(jsonResponse)
+                .isValid()
+                .hasUniqueBomRefs();
+        assertThatJson(jsonResponse)
+                .withMatcher("componentUuid", equalTo(component.getUuid().toString()))
+                .inPath("components")
+                .isEqualTo(/* language=JSON */ """
+                        [
+                          {
+                            "type": "library",
+                            "bom-ref": "${json-unit.matches:componentUuid}",
+                            "group": "com.acme",
+                            "name": "acme-lib-a",
+                            "version": "1.0.0",
+                            "cpe": "cpe:2.3:a:acme:acme-lib-a:1.0.0:*:*:*:*:*:*:*",
+                            "purl": "pkg:maven/com.acme/acme-lib-a@1.0.0?type=jar",
+                            "swid": {
+                              "tagId": "swidgen-acme-lib-a",
+                              "name": "acme-lib-a",
+                              "version": "1.0.0"
+                            },
+                            "hashes": [
+                              {
+                                "alg": "MD5",
+                                "content": "0cc175b9c0f1b6a831c399e269772661"
+                              },
+                              {
+                                "alg": "SHA-1",
+                                "content": "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8"
+                              }
+                            ]
+                          }
+                        ]
+                        """);
+    }
+
+    @Test
     public void exportVexWithSameVulnAnalysisValidJsonTest() {
         initializeWithPermissions(Permissions.VULNERABILITY_ANALYSIS_READ);
 
@@ -569,12 +670,15 @@ public class VexResourceTest extends ResourceTest {
                 .get(Response.class);
         assertThat(response.getStatus()).isEqualTo(200);
         final String jsonResponse = getPlainTextBody(response);
-        assertThatNoException().isThrownBy(() -> CycloneDxValidator.getInstance().validate(jsonResponse.getBytes()));
+        assertThatBom(jsonResponse)
+                .isValid()
+                .hasUniqueBomRefs();
         assertThatJson(jsonResponse)
                 .withOptions(Option.IGNORING_ARRAY_ORDER)
-                .withMatcher("vulnUuid", equalTo(vuln.getUuid().toString()))
                 .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
-                .isEqualTo("""
+                .withMatcher("componentAUuid", equalTo(componentAWithVuln.getUuid().toString()))
+                .withMatcher("componentBUuid", equalTo(componentBWithVuln.getUuid().toString()))
+                .isEqualTo(/* language=JSON */ """
                         {
                           "bomFormat": "CycloneDX",
                           "specVersion": "1.5",
@@ -601,9 +705,22 @@ public class VexResourceTest extends ResourceTest {
                               ]
                             }
                           },
+                          "components": [
+                            {
+                              "type": "library",
+                              "bom-ref": "${json-unit.matches:componentAUuid}",
+                              "name": "acme-lib-a",
+                              "version": "1.0.0"
+                            },
+                            {
+                              "type": "library",
+                              "bom-ref": "${json-unit.matches:componentBUuid}",
+                              "name": "acme-lib-b",
+                              "version": "1.0.0"
+                            }
+                          ],
                           "vulnerabilities": [
                             {
-                              "bom-ref": "${json-unit.matches:vulnUuid}",
                               "id": "INT-001",
                               "source": {
                                 "name": "INTERNAL"
@@ -625,7 +742,10 @@ public class VexResourceTest extends ResourceTest {
                               },
                               "affects": [
                                 {
-                                  "ref": "${json-unit.matches:projectUuid}"
+                                  "ref": "${json-unit.matches:componentAUuid}"
+                                },
+                                {
+                                  "ref": "${json-unit.matches:componentBUuid}"
                                 }
                               ]
                             }
@@ -683,12 +803,15 @@ public class VexResourceTest extends ResourceTest {
                 .get(Response.class);
         assertThat(response.getStatus()).isEqualTo(200);
         final String jsonResponse = getPlainTextBody(response);
-        assertThatNoException().isThrownBy(() -> CycloneDxValidator.getInstance().validate(jsonResponse.getBytes()));
+        assertThatBom(jsonResponse)
+                .isValid()
+                .hasUniqueBomRefs();
         assertThatJson(jsonResponse)
                 .withOptions(Option.IGNORING_ARRAY_ORDER)
-                .withMatcher("vulnUuid", equalTo(vuln.getUuid().toString()))
                 .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
-                .isEqualTo("""
+                .withMatcher("componentAUuid", equalTo(componentAWithVuln.getUuid().toString()))
+                .withMatcher("componentBUuid", equalTo(componentBWithVuln.getUuid().toString()))
+                .isEqualTo(/* language=JSON */ """
                         {
                           "bomFormat": "CycloneDX",
                           "specVersion": "1.5",
@@ -715,9 +838,22 @@ public class VexResourceTest extends ResourceTest {
                               ]
                             }
                           },
+                          "components": [
+                            {
+                              "type": "library",
+                              "bom-ref": "${json-unit.matches:componentAUuid}",
+                              "name": "acme-lib-a",
+                              "version": "1.0.0"
+                            },
+                            {
+                              "type": "library",
+                              "bom-ref": "${json-unit.matches:componentBUuid}",
+                              "name": "acme-lib-b",
+                              "version": "1.0.0"
+                            }
+                          ],
                           "vulnerabilities": [
                             {
-                              "bom-ref": "${json-unit.matches:vulnUuid}",
                               "id": "INT-001",
                               "source": {
                                 "name": "INTERNAL"
@@ -739,12 +875,11 @@ public class VexResourceTest extends ResourceTest {
                               },
                               "affects": [
                                 {
-                                  "ref": "${json-unit.matches:projectUuid}"
+                                  "ref": "${json-unit.matches:componentAUuid}"
                                 }
                               ]
                             },
                             {
-                              "bom-ref": "${json-unit.matches:vulnUuid}",
                               "id": "INT-001",
                               "source": {
                                 "name": "INTERNAL"
@@ -766,7 +901,7 @@ public class VexResourceTest extends ResourceTest {
                               },
                               "affects": [
                                 {
-                                  "ref": "${json-unit.matches:projectUuid}"
+                                  "ref": "${json-unit.matches:componentBUuid}"
                                 }
                               ]
                             }
@@ -792,7 +927,7 @@ public class VexResourceTest extends ResourceTest {
         project.setVersion("1.0.0");
         qm.persist(project);
 
-        final String encodedBom = Base64.getEncoder().encodeToString("""
+        final String encodedBom = Base64.getEncoder().encodeToString(/* language=JSON */ """
                 {
                   "bomFormat": "CycloneDX",
                   "specVersion": "1.2",
@@ -810,13 +945,13 @@ public class VexResourceTest extends ResourceTest {
 
         final Response response = jersey.target(V1_VEX).request()
                 .header(X_API_KEY, apiKey)
-                .put(Entity.entity("""
+                .put(Entity.json(/* language=JSON */ """
                         {
                           "projectName": "acme-app",
                           "projectVersion": "1.0.0",
                           "vex": "%s"
                         }
-                        """.formatted(encodedBom), MediaType.APPLICATION_JSON));
+                        """.formatted(encodedBom)));
         assertThat(response.getStatus()).isEqualTo(200);
     }
 
@@ -846,7 +981,7 @@ public class VexResourceTest extends ResourceTest {
 
         qm.bind(project, List.of(qm.createTag("foo")));
 
-        final String encodedBom = Base64.getEncoder().encodeToString("""
+        final String encodedBom = Base64.getEncoder().encodeToString(/* language=JSON */ """
                 {
                   "bomFormat": "CycloneDX",
                   "specVersion": "1.2",
@@ -864,26 +999,26 @@ public class VexResourceTest extends ResourceTest {
 
         Response response = jersey.target(V1_VEX).request()
                 .header(X_API_KEY, apiKey)
-                .put(Entity.entity("""
+                .put(Entity.json(/* language=JSON */ """
                         {
                           "projectName": "acme-app",
                           "projectVersion": "1.0.0",
                           "vex": "%s"
                         }
-                        """.formatted(encodedBom), MediaType.APPLICATION_JSON));
+                        """.formatted(encodedBom)));
         assertThat(response.getStatus()).isEqualTo(400);
 
         qm.bind(project, Collections.emptyList());
 
         response = jersey.target(V1_VEX).request()
                 .header(X_API_KEY, apiKey)
-                .put(Entity.entity("""
+                .put(Entity.json(/* language=JSON */ """
                         {
                           "projectName": "acme-app",
                           "projectVersion": "1.0.0",
                           "vex": "%s"
                         }
-                        """.formatted(encodedBom), MediaType.APPLICATION_JSON));
+                        """.formatted(encodedBom)));
         assertThat(response.getStatus()).isEqualTo(200);
     }
 
@@ -913,7 +1048,7 @@ public class VexResourceTest extends ResourceTest {
 
         qm.bind(project, List.of(qm.createTag("foo")));
 
-        final String encodedBom = Base64.getEncoder().encodeToString("""
+        final String encodedBom = Base64.getEncoder().encodeToString(/* language=JSON */ """
                 {
                   "bomFormat": "CycloneDX",
                   "specVersion": "1.2",
@@ -931,26 +1066,26 @@ public class VexResourceTest extends ResourceTest {
 
         Response response = jersey.target(V1_VEX).request()
                 .header(X_API_KEY, apiKey)
-                .put(Entity.entity("""
+                .put(Entity.json(/* language=JSON */ """
                         {
                           "projectName": "acme-app",
                           "projectVersion": "1.0.0",
                           "vex": "%s"
                         }
-                        """.formatted(encodedBom), MediaType.APPLICATION_JSON));
+                        """.formatted(encodedBom)));
         assertThat(response.getStatus()).isEqualTo(200);
 
         qm.bind(project, Collections.emptyList());
 
         response = jersey.target(V1_VEX).request()
                 .header(X_API_KEY, apiKey)
-                .put(Entity.entity("""
+                .put(Entity.json(/* language=JSON */ """
                         {
                           "projectName": "acme-app",
                           "projectVersion": "1.0.0",
                           "vex": "%s"
                         }
-                        """.formatted(encodedBom), MediaType.APPLICATION_JSON));
+                        """.formatted(encodedBom)));
         assertThat(response.getStatus()).isEqualTo(400);
     }
 
@@ -964,7 +1099,7 @@ public class VexResourceTest extends ResourceTest {
         project.setCollectionLogic(ProjectCollectionLogic.AGGREGATE_DIRECT_CHILDREN);
         qm.persist(project);
 
-        final String encodedVex = Base64.getEncoder().encodeToString("""
+        final String encodedVex = Base64.getEncoder().encodeToString(/* language=JSON */ """
                 {
                   "bomFormat": "CycloneDX",
                   "specVersion": "1.5",
@@ -974,13 +1109,13 @@ public class VexResourceTest extends ResourceTest {
 
         final Response response = jersey.target(V1_VEX).request()
                 .header(X_API_KEY, apiKey)
-                .put(Entity.entity("""
+                .put(Entity.json(/* language=JSON */ """
                         {
                           "projectName": "acme-app",
                           "projectVersion": "1.0.0",
                           "vex": "%s"
                         }
-                        """.formatted(encodedVex), MediaType.APPLICATION_JSON));
+                        """.formatted(encodedVex)));
         assertThat(response.getStatus()).isEqualTo(400);
         assertThat(getPlainTextBody(response)).isEqualTo("VEX cannot be uploaded to a collection project.");
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Aligns VEX semantics with CISA guidance and tooling ecosystem:

* Includes the *identity* of affected components in VEX exports. Previously, all vulnerabilities in a VEX export referred to the project (`metadata.component`). The assumption was that VEX was inherently a product-level concept. This is not actually true, and CISA itself says to include the "subcomponents" from which a vulnerability originates. It also caused conflcits when a vulnerability affected multiple components in a project, which each component having a different analysis. Note that only component identifiers are needed for this use case, and details like licenses, properties, external references are baggage at best and leak internals at worst. So, we only include group, name, version, CPE, PURL, SWID tag, and hashes.
* No longer requires exact matches of `vulnerability.source.name` during VEX imports. No other tool does it, and enforcing this actively defeats compatibility with the broader ecosystem. We now only match on vulnerability IDs, but skip records and log a warning when more than one vulnerability matches, which should be *very* rare.
* Drops `bom-ref`s from `vulnerability` objects in VEX exports entirely. They previously caused issues with BOM ref uniqueness. Since nothing references the objects, the refs are not needed at all.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #3554
Fixes #3907
Fixes #3906
Fixes #4397
Fixes #6017

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Docs PR: https://github.com/DependencyTrack/docs/pull/234

Builds on the changes proposed in #6555.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
