### PR TITLE
docs: point README CI badges at main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ capabilities of Software Bill of Materials (SBOM).
 [![Docker Pulls](https://img.shields.io/docker/pulls/dependencytrack/apiserver?logo=docker&logoColor=white&label=docker%20pulls&color=2496ED)](https://hub.docker.com/r/dependencytrack/apiserver)
 [![License](https://img.shields.io/badge/license-Apache--2.0-4c1?logo=apache&logoColor=white)](LICENSE.txt)
 
-[![Build](https://img.shields.io/github/actions/workflow/status/DependencyTrack/dependency-track/ci-build.yaml?branch=master&logo=githubactions&logoColor=white&label=build)](https://github.com/DependencyTrack/dependency-track/actions/workflows/ci-build.yaml)
-[![Tests](https://img.shields.io/github/actions/workflow/status/DependencyTrack/dependency-track/ci-test.yaml?branch=master&logo=githubactions&logoColor=white&label=tests)](https://github.com/DependencyTrack/dependency-track/actions/workflows/ci-test.yaml)
+[![Build](https://img.shields.io/github/actions/workflow/status/DependencyTrack/dependency-track/ci-build.yaml?branch=main&logo=githubactions&logoColor=white&label=build)](https://github.com/DependencyTrack/dependency-track/actions/workflows/ci-build.yaml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/DependencyTrack/dependency-track/ci-test.yaml?branch=main&logo=githubactions&logoColor=white&label=tests)](https://github.com/DependencyTrack/dependency-track/actions/workflows/ci-test.yaml)
 [![E2E Tests](https://img.shields.io/github/actions/workflow/status/DependencyTrack/dependency-track/ci-test-e2e.yaml?logo=githubactions&logoColor=white&label=e2e%20tests)](https://github.com/DependencyTrack/dependency-track/actions/workflows/ci-test-e2e.yaml)
 [![Coverage](https://img.shields.io/codacy/coverage/b2ecd06dab57438a9a55bc4a71c5a8ce?logo=codacy&logoColor=white&label=coverage)](https://app.codacy.com/gh/DependencyTrack/dependency-track/dashboard)
 


### PR DESCRIPTION
### Description

Point the README Build and Tests CI badges at the `main` branch instead of the legacy `master` branch so the badge status reflects the repository's current default branch.

### Addressed Issue

N/A

### Additional Details

The `ci-build.yaml` and `ci-test.yaml` workflows run on the `main` branch (alongside feature and release branches). The Build/Tests badges were still querying `branch=master`, while the adjacent E2E badge already uses the default branch. This change only updates badge query URLs and does not alter runtime behavior.

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [ ] ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [ ] ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations