### PR TITLE
Fix excessive UPDATEs being issued during BOM import

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
@@ -401,6 +401,11 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
                 processDependencyGraph(qm, persistentProject, bom.dependencyGraph(), persistentComponentsByIdentity,
                         bom.identitiesByBomRef(), bom.bomRefsByIdentity());
 
+                // NB: This is supposed to be the *only* flush for the *entire* BOM.
+                // The logic leading up to this intentionally doesn't trigger flushes to prevent
+                // excessive DB round-trips and table bloat.
+                qm.getPersistenceManager().flush();
+
                 recordBomImport(ctx, qm, persistentProject);
 
                 qm.seedPackageMetadataResolution(persistentProject);
@@ -593,12 +598,7 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
             return idsOfComponentsToDelete.contains(component.getId());
         });
 
-        qm.getPersistenceManager().flush();
-
-        final long componentsDeleted = deleteComponentsById(qm, idsOfComponentsToDelete);
-        if (componentsDeleted > 0) {
-            qm.getPersistenceManager().flush();
-        }
+        deleteComponentsById(qm, idsOfComponentsToDelete);
 
         return persistentComponentByIdentity;
     }
@@ -621,7 +621,7 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
                 .collect(Collectors.toMap(
                         service -> new ComponentIdentity(service, /* excludeUuid */ true),
                         Function.identity(),
-                        (previous, duplicate) -> {
+                        (previous, _) -> {
                             LOGGER.warn("""
                                     More than one existing service matches the identity %s; \
                                     Proceeding with first match, others will be deleted\
@@ -681,12 +681,7 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
             return idsOfServicesToDelete.contains(service.getId());
         });
 
-        qm.getPersistenceManager().flush();
-
-        final long servicesDeleted = deleteServicesById(qm, idsOfServicesToDelete);
-        if (servicesDeleted > 0) {
-            qm.getPersistenceManager().flush();
-        }
+        deleteServicesById(qm, idsOfServicesToDelete);
 
         return persistentServiceByIdentity;
     }
@@ -715,13 +710,11 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
                     identitiesByBomRef);
             if (!Objects.equals(directDependenciesJson, project.getDirectDependencies())) {
                 project.setDirectDependencies(directDependenciesJson);
-                qm.getPersistenceManager().flush();
             }
         } else {
             // Make sure we don't retain stale data from previous BOM uploads.
             if (project.getDirectDependencies() != null) {
                 project.setDirectDependencies(null);
-                qm.getPersistenceManager().flush();
             }
         }
 
@@ -738,8 +731,6 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
                 component.setDirectDependencies(mergedDirectDependenciesJson);
             }
         }
-
-        qm.getPersistenceManager().flush();
     }
 
     private static void recordBomImport(final ProcessingContext ctx, final QueryManager qm, final Project project) {

--- a/apiserver/src/test/java/org/dependencytrack/tasks/ImportBomActivityTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/ImportBomActivityTest.java
@@ -24,6 +24,8 @@ import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
+import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+import org.datanucleus.management.FactoryStatistics;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.dex.api.failure.TerminalApplicationFailureException;
 import org.dependencytrack.dex.engine.api.DexEngine;
@@ -430,7 +432,24 @@ class ImportBomActivityTest extends PersistenceCapableTest {
 
         final var bomFileMetadata = storeBomFile("bom-bloated.json");
         final var bomUploadToken = UUID.randomUUID();
+
+        final FactoryStatistics pmfStatistics =
+                ((JDOPersistenceManagerFactory) qm.getPersistenceManager().getPersistenceManagerFactory())
+                        .getNucleusContext()
+                        .getStatistics();
+        final int objectUpdatesBefore = pmfStatistics.getNumberOfObjectUpdates();
+
         activity.execute(null, buildArg(project, bomFileMetadata, bomUploadToken));
+
+        // Components must be inserted with their direct dependencies already assigned.
+        // Flushing before the dependency graph is resolved turns every component that has
+        // dependencies into an insert *and* an update, which leads to thousands of additional
+        // database round trips on a BOM this size. Only the project row should be updated.
+        // If this assertion fails, something in the import logic is causing premature flushes.
+        assertThat(pmfStatistics.getNumberOfObjectUpdates() - objectUpdatesBefore)
+                .as("BOM import must not update components after inserting them")
+                .isLessThan(100);
+
         assertBomProcessedNotification();
 
         assertThat(qm.getNotificationOutbox())


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes excessive UPDATEs being issued during BOM import.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

The import logic separates the processing of components and services from the processing of the dependency graph. It previously flushed pending changes to the database between these two phases, which led to UPDATE statements being issued for every component with direct dependencies.

This change reorders when changes are flushed with the goal to delay flushing until *after* the dependency graph has been processed, thus saving thousands of DB round-trips and lots of table bloat for large BOMs.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
