### PR TITLE
Fix incorrect equality of data classification and external reference types

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/DataClassification.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/DataClassification.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonView;
 
 import java.io.Serializable;
+import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * Model class for tracking data classification
@@ -34,21 +36,11 @@ public class DataClassification implements Serializable {
 
     private static final long serialVersionUID = -1969199685989611696L;
 
-    public static enum Direction {
-        INBOUND("inbound"),
-        OUTBOUND("outbound"),
-        BI_DIRECTIONAL("bi-directional"),
-        UNKNOWN("unknown");
-
-        private final String name;
-
-        public String getDirectionName() {
-            return this.name;
-        }
-
-        private Direction(String name) {
-            this.name = name;
-        }
+    public enum Direction {
+        INBOUND,
+        OUTBOUND,
+        BI_DIRECTIONAL,
+        UNKNOWN;
     }
 
     @JsonView(JsonViews.MetadataTools.class)
@@ -56,6 +48,14 @@ public class DataClassification implements Serializable {
 
     @JsonView(JsonViews.MetadataTools.class)
     private String name;
+
+    public DataClassification() {
+    }
+
+    public DataClassification(Direction direction, String name) {
+        this.direction = direction;
+        this.name = name;
+    }
 
     public Direction getDirection() {
         return direction;
@@ -72,4 +72,28 @@ public class DataClassification implements Serializable {
     public void setName(String name) {
         this.name = name;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof final DataClassification that)) {
+            return false;
+        }
+
+        return direction == that.direction
+                && Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(direction, name);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", DataClassification.class.getSimpleName() + "[", "]")
+                .add("direction=" + direction)
+                .add("name='" + name + "'")
+                .toString();
+    }
+
 }

--- a/apiserver/src/main/java/org/dependencytrack/model/ExternalReference.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/ExternalReference.java
@@ -26,7 +26,10 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+
 import java.io.Serializable;
+import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * Model class for tracking external references.
@@ -52,6 +55,15 @@ public class ExternalReference implements Serializable {
     @JsonView(JsonViews.MetadataTools.class)
     private String comment;
 
+    public ExternalReference() {
+    }
+
+    public ExternalReference(org.cyclonedx.model.ExternalReference.Type type, String url, String comment) {
+        this.type = type;
+        this.url = url;
+        this.comment = comment;
+    }
+
     public org.cyclonedx.model.ExternalReference.Type getType() {
         return type;
     }
@@ -75,4 +87,30 @@ public class ExternalReference implements Serializable {
     public void setComment(String comment) {
         this.comment = comment;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof final ExternalReference that)) {
+            return false;
+        }
+
+        return type == that.type
+                && Objects.equals(url, that.url)
+                && Objects.equals(comment, that.comment);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, url, comment);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ExternalReference.class.getSimpleName() + "[", "]")
+                .add("type=" + type)
+                .add("url='" + url + "'")
+                .add("comment='" + comment + "'")
+                .toString();
+    }
+
 }

--- a/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
@@ -187,11 +187,11 @@ public class ModelConverter {
         project.setCpe(trimToNull(cdxComponent.getCpe()));
         project.setExternalReferences(convertExternalReferences(cdxComponent.getExternalReferences()));
 
-        List<OrganizationalContact> contacts = new ArrayList<>();
+        final List<OrganizationalContact> contacts = new ArrayList<>();
         if (cdxComponent.getAuthor() != null) {
-            contacts.add(new OrganizationalContact() {{
-                setName(cdxComponent.getAuthor());
-            }});
+            final var author = new OrganizationalContact();
+            author.setName(cdxComponent.getAuthor());
+            contacts.add(author);
         }
         if (cdxComponent.getAuthors() != null) {
             contacts.addAll(convertCdxContacts(cdxComponent.getAuthors()));
@@ -238,11 +238,11 @@ public class ModelConverter {
         component.setExternalReferences(convertExternalReferences(cdxComponent.getExternalReferences()));
         component.setProperties(convertToComponentProperties(cdxComponent.getProperties()));
 
-        List<OrganizationalContact> contacts = new ArrayList<>();
+        final List<OrganizationalContact> contacts = new ArrayList<>();
         if (cdxComponent.getAuthor() != null) {
-            contacts.add(new OrganizationalContact() {{
-                setName(cdxComponent.getAuthor());
-            }});
+            final var author = new OrganizationalContact();
+            author.setName(cdxComponent.getAuthor());
+            contacts.add(author);
         }
         if (cdxComponent.getAuthors() != null) {
             contacts.addAll(convertCdxContacts(cdxComponent.getAuthors()));

--- a/apiserver/src/test/java/org/dependencytrack/model/DataClassificationTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/model/DataClassificationTest.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.model;
+
+import org.dependencytrack.model.DataClassification.Direction;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class DataClassificationTest {
+
+    private static Stream<Arguments> equalsAndHashCodeShouldCompareByValue() {
+        return Stream.of(
+                arguments(
+                        new DataClassification(Direction.INBOUND, "public"),
+                        new DataClassification(Direction.INBOUND, "public"),
+                        true),
+                arguments(
+                        new DataClassification(null, null),
+                        new DataClassification(null, null),
+                        true),
+                arguments(
+                        new DataClassification(Direction.INBOUND, "public"),
+                        new DataClassification(Direction.OUTBOUND, "public"),
+                        false),
+                arguments(
+                        new DataClassification(Direction.INBOUND, "public"),
+                        new DataClassification(Direction.INBOUND, "private"),
+                        false),
+                arguments(
+                        new DataClassification(Direction.INBOUND, "public"),
+                        new DataClassification(null, "public"),
+                        false),
+                arguments(
+                        new DataClassification(Direction.INBOUND, "public"),
+                        new DataClassification(Direction.INBOUND, null),
+                        false));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void equalsAndHashCodeShouldCompareByValue(
+            DataClassification left,
+            DataClassification right,
+            boolean expectEqual) {
+        if (expectEqual) {
+            assertThat(left).isEqualTo(right);
+            assertThat(right).isEqualTo(left);
+            assertThat(left).hasSameHashCodeAs(right);
+        } else {
+            assertThat(left).isNotEqualTo(right);
+            assertThat(right).isNotEqualTo(left);
+            assertThat(left.hashCode()).isNotEqualTo(right.hashCode());
+        }
+    }
+
+    @Test
+    void equalsShouldBeReflexive() {
+        final DataClassification dataClassification = new DataClassification(Direction.INBOUND, "public");
+
+        assertThat(dataClassification).isEqualTo(dataClassification);
+    }
+
+    @Test
+    void equalsShouldNotMatchNullOrOtherTypes() {
+        final DataClassification dataClassification = new DataClassification(Direction.INBOUND, "public");
+
+        assertThat(dataClassification).isNotEqualTo(null);
+        assertThat(dataClassification).isNotEqualTo("public");
+    }
+
+}

--- a/apiserver/src/test/java/org/dependencytrack/model/ExternalReferenceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/model/ExternalReferenceTest.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.model;
+
+import org.cyclonedx.model.ExternalReference.Type;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class ExternalReferenceTest {
+
+    private static Stream<Arguments> equalsAndHashCodeShouldCompareByValue() {
+        return Stream.of(
+                arguments(
+                        new ExternalReference(Type.WEBSITE, "https://example.com", "comment"),
+                        new ExternalReference(Type.WEBSITE, "https://example.com", "comment"),
+                        true),
+                arguments(
+                        new ExternalReference(null, null, null),
+                        new ExternalReference(null, null, null),
+                        true),
+                arguments(
+                        new ExternalReference(Type.WEBSITE, "https://example.com", "comment"),
+                        new ExternalReference(Type.VCS, "https://example.com", "comment"),
+                        false),
+                arguments(
+                        new ExternalReference(Type.WEBSITE, "https://example.com", "comment"),
+                        new ExternalReference(Type.WEBSITE, "https://example.org", "comment"),
+                        false),
+                arguments(
+                        new ExternalReference(Type.WEBSITE, "https://example.com", "comment"),
+                        new ExternalReference(Type.WEBSITE, "https://example.com", "other comment"),
+                        false),
+                arguments(
+                        new ExternalReference(Type.WEBSITE, "https://example.com", "comment"),
+                        new ExternalReference(null, "https://example.com", "comment"),
+                        false),
+                arguments(
+                        new ExternalReference(Type.WEBSITE, "https://example.com", "comment"),
+                        new ExternalReference(Type.WEBSITE, null, "comment"),
+                        false),
+                arguments(
+                        new ExternalReference(Type.WEBSITE, "https://example.com", "comment"),
+                        new ExternalReference(Type.WEBSITE, "https://example.com", null),
+                        false));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void equalsAndHashCodeShouldCompareByValue(
+            ExternalReference left,
+            ExternalReference right,
+            boolean expectEqual) {
+        if (expectEqual) {
+            assertThat(left).isEqualTo(right);
+            assertThat(right).isEqualTo(left);
+            assertThat(left).hasSameHashCodeAs(right);
+        } else {
+            assertThat(left).isNotEqualTo(right);
+            assertThat(right).isNotEqualTo(left);
+            assertThat(left.hashCode()).isNotEqualTo(right.hashCode());
+        }
+    }
+
+    @Test
+    void equalsShouldBeReflexive() {
+        final ExternalReference externalReference =
+                new ExternalReference(Type.WEBSITE, "https://example.com", "comment");
+
+        assertThat(externalReference).isEqualTo(externalReference);
+    }
+
+    @Test
+    void equalsShouldNotMatchNullOrOtherTypes() {
+        final ExternalReference externalReference =
+                new ExternalReference(Type.WEBSITE, "https://example.com", "comment");
+
+        assertThat(externalReference).isNotEqualTo(null);
+        assertThat(externalReference).isNotEqualTo("https://example.com");
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes incorrect equality of data classification and external reference types.

Implements `equals` and `hashCode` for the `DataClassification` and `ExternalReference` classes.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Both types are involved in change detection of components and services during BOM imports. They were previously compared by identity, causing them to erroneously be considered "changed".

Also fixes a similar issue for comparisons of `OrganizationalContact`, which was caused by object instances to be created using the `{{ set... }}` notation. It turns out this notation creates anonymous classes, which then fail `equals` checks due to type mismatches. Bummer.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
