### PR TITLE
Fix BOM import change detection of JSON and array values

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
@@ -19,6 +19,8 @@
 package org.dependencytrack.tasks;
 
 import alpine.persistence.ScopedCustomization;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.cyclonedx.exception.ParseException;
@@ -70,7 +72,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.time.Instant;
 import java.util.UUID;
@@ -425,7 +426,7 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
             final Project project,
             final ProjectMetadata projectMetadata
     ) {
-        final Query<Project> query = qm.getPersistenceManager().newQuery(Project.class);
+        final Query<@Nullable Project> query = qm.getPersistenceManager().newQuery(Project.class);
         query.setFilter("uuid == :uuid");
         query.setParameters(ctx.project.getUuid());
 
@@ -508,7 +509,7 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
                 .collect(Collectors.toMap(
                         component -> new ComponentIdentity(component, /* excludeUuid */ true),
                         Function.identity(),
-                        (previous, duplicate) -> {
+                        (previous, _) -> {
                             LOGGER.warn("""
                                     More than one existing component matches the identity %s; \
                                     Proceeding with first match, others will be deleted\
@@ -704,12 +705,12 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
                         is not one of them; Graph will be incomplete because it is not possible to determine its root\
                         """.formatted(dependencyGraph.size()));
             }
-            final String directDependenciesJson = resolveDependenciesJson(
+            final ArrayNode directDependencies = resolveDependencies(
                     List.of(project.getBomRef()),
                     sourceBomRef -> sourceBomRef.equals(project.getBomRef()) ? directDependencyBomRefs : null,
                     identitiesByBomRef);
-            if (!Objects.equals(directDependenciesJson, project.getDirectDependencies())) {
-                project.setDirectDependencies(directDependenciesJson);
+            if (!matchesPersistedJson(project.getDirectDependencies(), directDependencies)) {
+                project.setDirectDependencies(directDependencies != null ? directDependencies.toString() : null);
             }
         } else {
             // Make sure we don't retain stale data from previous BOM uploads.
@@ -725,10 +726,11 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
             }
 
             assertPersistent(component, "Component must be persistent");
-            final String mergedDirectDependenciesJson = resolveMergedDirectDependenciesJson(
+            final ArrayNode mergedDirectDependencies = resolveMergedDirectDependencies(
                     component, dependencyGraph, identitiesByBomRef, bomRefsByIdentity);
-            if (!Objects.equals(mergedDirectDependenciesJson, component.getDirectDependencies())) {
-                component.setDirectDependencies(mergedDirectDependenciesJson);
+            if (!matchesPersistedJson(component.getDirectDependencies(), mergedDirectDependencies)) {
+                component.setDirectDependencies(
+                        mergedDirectDependencies != null ? mergedDirectDependencies.toString() : null);
             }
         }
     }
@@ -761,26 +763,24 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
      * look up with {@code new ComponentIdentity(component, true)} — same structural key as at consumption, same pattern
      * as matching existing rows in {@link #processComponents}.
      */
-    private @Nullable String resolveMergedDirectDependenciesJson(
-            final Component component,
-            final MultiValuedMap<String, String> dependencyGraph,
-            final Map<String, ComponentIdentity> identitiesByBomRef,
-            final MultiValuedMap<ComponentIdentity, String> bomRefsByIdentity
-    ) {
+    private @Nullable ArrayNode resolveMergedDirectDependencies(
+            Component component,
+            MultiValuedMap<String, String> dependencyGraph,
+            Map<String, ComponentIdentity> identitiesByBomRef,
+            MultiValuedMap<ComponentIdentity, String> bomRefsByIdentity) {
         final Collection<String> sourceBomRefs = bomRefsByIdentity.get(
                 new ComponentIdentity(component, /* excludeUuid */ true));
         if (sourceBomRefs == null || sourceBomRefs.isEmpty()) {
             return null;
         }
 
-        return resolveDependenciesJson(sourceBomRefs, dependencyGraph::get, identitiesByBomRef);
+        return resolveDependencies(sourceBomRefs, dependencyGraph::get, identitiesByBomRef);
     }
 
-    private @Nullable String resolveDependenciesJson(
-            final Collection<String> sourceBomRefs,
-            final Function<String, Collection<String>> directDependencyBomRefsProvider,
-            final Map<String, ComponentIdentity> identitiesByBomRef
-    ) {
+    private @Nullable ArrayNode resolveDependencies(
+            @Nullable Collection<String> sourceBomRefs,
+            Function<String, @Nullable Collection<String>> directDependencyBomRefsProvider,
+            Map<String, ComponentIdentity> identitiesByBomRef) {
         if (sourceBomRefs == null || sourceBomRefs.isEmpty()) {
             return null;
         }
@@ -819,7 +819,25 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
             }
         }
 
-        return jsonDependencies.isEmpty() ? null : jsonDependencies.toString();
+        return jsonDependencies.isEmpty() ? null : jsonDependencies;
+    }
+
+    private static boolean matchesPersistedJson(
+            @Nullable String persistedJson,
+            @Nullable ArrayNode resolved) {
+        if (persistedJson == null || resolved == null) {
+            return persistedJson == null && resolved == null;
+        }
+
+        // NB: String equality is not sufficient here, because persistedJson is retrieved
+        // from a JSONB column, which normalizes whitespace and key order.
+        // Such values would never match the ones we resolved for the new BOM.
+        try {
+            return Mappers.jsonMapper().readTree(persistedJson).equals(resolved);
+        } catch (JsonProcessingException e) {
+            LOGGER.warn("Failed to parse persisted direct dependencies; Assuming they changed", e);
+            return false;
+        }
     }
 
     private static long deleteComponentsById(final QueryManager qm, final Collection<Long> componentIds) {

--- a/apiserver/src/main/java/org/dependencytrack/util/PersistenceUtil.java
+++ b/apiserver/src/main/java/org/dependencytrack/util/PersistenceUtil.java
@@ -25,13 +25,10 @@ import javax.jdo.JDOHelper;
 import javax.jdo.ObjectState;
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static java.util.Collections.unmodifiableMap;
 import static javax.jdo.ObjectState.HOLLOW_PERSISTENT_NONTRANSACTIONAL;
 import static javax.jdo.ObjectState.PERSISTENT_CLEAN;
 import static javax.jdo.ObjectState.PERSISTENT_DIRTY;
@@ -46,43 +43,17 @@ public final class PersistenceUtil {
     public record Diff(Object before, Object after) {
     }
 
-    public static final class Differ<T> {
-
-        private final T existingObject;
-        private final T newObject;
-        private final Map<String, Diff> diffs;
-
-        public Differ(final T existingObject, final T newObject) {
-            this.existingObject = existingObject;
-            this.newObject = newObject;
-            this.diffs = new HashMap<>();
-        }
-
-        public <V> boolean applyIfChanged(final String fieldName, final Function<T, V> getter, final Consumer<V> setter) {
-            final V existingValue = getter.apply(existingObject);
-            final V newValue = getter.apply(newObject);
-
-            if (!Objects.equals(existingValue, newValue)) {
-                diffs.put(fieldName, new Diff(existingValue, newValue));
-                setter.accept(newValue);
-                return true;
-            }
-
-            return false;
-        }
-
-        public Map<String, Diff> getDiffs() {
-            return unmodifiableMap(diffs);
-        }
-
-    }
-
-    public static <T, V> boolean applyIfChanged(final T existingObject, final T newObject,
-                                                final Function<T, V> getter, final Consumer<V> setter) {
+    public static <T, V> boolean applyIfChanged(
+            T existingObject,
+            T newObject,
+            Function<T, V> getter,
+            Consumer<V> setter) {
         final V existingValue = getter.apply(existingObject);
         final V newValue = getter.apply(newObject);
 
-        if (!Objects.equals(existingValue, newValue)) {
+        // NB: Not using equals here, as it compares arrays by identity rather
+        // than comparing their elements.
+        if (!Objects.deepEquals(existingValue, newValue)) {
             setter.accept(newValue);
             return true;
         }

--- a/apiserver/src/test/java/org/dependencytrack/PersistenceCapableTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/PersistenceCapableTest.java
@@ -19,6 +19,8 @@
 package org.dependencytrack;
 
 import alpine.server.auth.PasswordService;
+import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+import org.datanucleus.management.FactoryStatistics;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.testing.database.TestDatabaseExtension;
 import org.junit.jupiter.api.AfterEach;
@@ -52,6 +54,12 @@ public abstract class PersistenceCapableTest {
         }
 
         qm.close();
+    }
+
+    protected FactoryStatistics getPmfStatistics() {
+        return ((JDOPersistenceManagerFactory) qm.getPersistenceManager().getPersistenceManagerFactory())
+                .getNucleusContext()
+                .getStatistics();
     }
 
 }

--- a/apiserver/src/test/java/org/dependencytrack/tasks/ImportBomActivityTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/ImportBomActivityTest.java
@@ -24,8 +24,6 @@ import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
-import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
-import org.datanucleus.management.FactoryStatistics;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.dex.api.failure.TerminalApplicationFailureException;
 import org.dependencytrack.dex.engine.api.DexEngine;
@@ -433,11 +431,7 @@ class ImportBomActivityTest extends PersistenceCapableTest {
         final var bomFileMetadata = storeBomFile("bom-bloated.json");
         final var bomUploadToken = UUID.randomUUID();
 
-        final FactoryStatistics pmfStatistics =
-                ((JDOPersistenceManagerFactory) qm.getPersistenceManager().getPersistenceManagerFactory())
-                        .getNucleusContext()
-                        .getStatistics();
-        final int objectUpdatesBefore = pmfStatistics.getNumberOfObjectUpdates();
+        final int objectUpdatesBefore = getPmfStatistics().getNumberOfObjectUpdates();
 
         activity.execute(null, buildArg(project, bomFileMetadata, bomUploadToken));
 
@@ -446,7 +440,7 @@ class ImportBomActivityTest extends PersistenceCapableTest {
         // dependencies into an insert *and* an update, which leads to thousands of additional
         // database round trips on a BOM this size. Only the project row should be updated.
         // If this assertion fails, something in the import logic is causing premature flushes.
-        assertThat(pmfStatistics.getNumberOfObjectUpdates() - objectUpdatesBefore)
+        assertThat(getPmfStatistics().getNumberOfObjectUpdates() - objectUpdatesBefore)
                 .as("BOM import must not update components after inserting them")
                 .isLessThan(100);
 
@@ -515,6 +509,158 @@ class ImportBomActivityTest extends PersistenceCapableTest {
             // Ensure the expected amount of components is present.
             assertThat(qm.getAllComponents(project)).hasSize(1756);
         }
+    }
+
+    @Test
+    void informWithUnchangedComponentsReimportTest() throws Exception {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final byte[] bomBytes = /* language=JSON */ """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.4",
+                  "version": 1,
+                  "metadata": {
+                    "component": {
+                      "bom-ref": "root",
+                      "type": "application",
+                      "name": "acme-app"
+                    }
+                  },
+                  "components": [
+                    {
+                      "bom-ref": "a",
+                      "type": "library",
+                      "name": "acme-lib-a",
+                      "version": "1.0.0",
+                      "purl": "pkg:maven/com.acme/acme-lib-a@1.0.0",
+                      "author": "Acme Inc",
+                      "externalReferences": [
+                        { "type": "website", "url": "https://example.com", "comment": "homepage" }
+                      ]
+                    },
+                    {
+                      "bom-ref": "b",
+                      "type": "library",
+                      "name": "acme-lib-b",
+                      "version": "1.0.0",
+                      "purl": "pkg:maven/com.acme/acme-lib-b@1.0.0"
+                    }
+                  ],
+                  "dependencies": [
+                    { "ref": "root", "dependsOn": [ "a" ] },
+                    { "ref": "a", "dependsOn": [ "b" ] }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+
+        activity.execute(null, buildArg(project, storeBomFile(bomBytes), UUID.randomUUID()));
+        assertBomProcessedNotification();
+        assertThat(qm.getAllComponents(project)).hasSize(2);
+
+        final int objectUpdatesBefore = getPmfStatistics().getNumberOfObjectUpdates();
+
+        activity.execute(null, buildArg(project, storeBomFile(bomBytes), UUID.randomUUID()));
+        assertBomProcessedNotification();
+
+        // Only the project should be updated, nothing else.
+        assertThat(getPmfStatistics().getNumberOfObjectUpdates() - objectUpdatesBefore)
+                .as("re-import of an unchanged BOM must not update components")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void informWithUnchangedServiceReimportTest() throws Exception {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final byte[] bomBytes = /* language=JSON */ """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.4",
+                  "version": 1,
+                  "services": [
+                    {
+                      "bom-ref": "acme-service@2.0.0",
+                      "name": "acme-service",
+                      "version": "2.0.0",
+                      "endpoints": [ "https://example.com/api" ],
+                      "externalReferences": [
+                        { "type": "website", "url": "https://example.com" }
+                      ],
+                      "data": [
+                        { "flow": "inbound", "classification": "public" }
+                      ]
+                    }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+
+        activity.execute(null, buildArg(project, storeBomFile(bomBytes), UUID.randomUUID()));
+        assertBomProcessedNotification();
+
+        final int objectUpdatesBefore = getPmfStatistics().getNumberOfObjectUpdates();
+
+        activity.execute(null, buildArg(project, storeBomFile(bomBytes), UUID.randomUUID()));
+        assertBomProcessedNotification();
+
+        // Only the project should be updated, nothing else.
+        assertThat(getPmfStatistics().getNumberOfObjectUpdates() - objectUpdatesBefore)
+                .as("re-import of an unchanged BOM must not update the service")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void informWithChangedDependencyGraphReimportTest() throws Exception {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final String bomTemplate = /* language=JSON */ """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.4",
+                  "version": 1,
+                  "metadata": {
+                    "component": { "bom-ref": "root", "type": "application", "name": "acme-app" }
+                  },
+                  "components": [
+                    { "bom-ref": "a", "type": "library", "name": "a", "version": "1.0.0", "purl": "pkg:maven/com.example/a@1.0.0" },
+                    { "bom-ref": "b", "type": "library", "name": "b", "version": "1.0.0", "purl": "pkg:maven/com.example/b@1.0.0" },
+                    { "bom-ref": "c", "type": "library", "name": "c", "version": "1.0.0", "purl": "pkg:maven/com.example/c@1.0.0" }
+                  ],
+                  "dependencies": [
+                    { "ref": "root", "dependsOn": [ "a" ] },
+                    { "ref": "a", "dependsOn": [ "%s" ] }
+                  ]
+                }
+                """;
+
+        activity.execute(null, buildArg(project, storeBomFile(bomTemplate.formatted("b").getBytes(StandardCharsets.UTF_8)), UUID.randomUUID()));
+        assertBomProcessedNotification();
+
+        activity.execute(null, buildArg(project, storeBomFile(bomTemplate.formatted("c").getBytes(StandardCharsets.UTF_8)), UUID.randomUUID()));
+        assertBomProcessedNotification();
+
+        qm.getPersistenceManager().evictAll();
+        final List<Component> components = qm.getAllComponents(project);
+        final Component aComponent = components.stream()
+                .filter(component -> "a".equals(component.getName()))
+                .findFirst()
+                .orElseThrow();
+        final Component cComponent = components.stream()
+                .filter(component -> "c".equals(component.getName()))
+                .findFirst()
+                .orElseThrow();
+
+        final JsonArray directDependencies =
+                Json.createReader(new StringReader(aComponent.getDirectDependencies())).readArray();
+        assertThat(directDependencies).hasSize(1);
+        assertThat(directDependencies.getJsonObject(0).getString("uuid"))
+                .isEqualTo(cComponent.getUuid().toString());
     }
 
     @Test // https://github.com/DependencyTrack/dependency-track/issues/2859
@@ -1293,7 +1439,7 @@ class ImportBomActivityTest extends PersistenceCapableTest {
         qm.getPersistenceManager().evictAll();
         assertThat(qm.getAllComponents(project)).satisfiesExactly(
                 component -> assertThat(component.getName()).isEqualTo("acme-lib-retained"));
-        
+
         assertThat(qm.getPersistenceManager().newQuery(ComponentProperty.class).executeList()).isEmpty();
         assertThat(qm.getPersistenceManager().newQuery(ComponentOccurrence.class).executeList()).isEmpty();
     }

--- a/apiserver/src/test/java/org/dependencytrack/util/PersistenceUtilTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/util/PersistenceUtilTest.java
@@ -20,16 +20,12 @@ package org.dependencytrack.util;
 
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Project;
-import org.dependencytrack.util.PersistenceUtil.Diff;
-import org.dependencytrack.util.PersistenceUtil.Differ;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.jdo.PersistenceManager;
 import javax.jdo.Transaction;
-import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.dependencytrack.util.PersistenceUtil.assertNonPersistent;
@@ -130,49 +126,6 @@ public class PersistenceUtilTest extends PersistenceCapableTest {
 
         assertThatNoException()
                 .isThrownBy(() -> assertNonPersistent(pm.detachCopy(project), null));
-    }
-
-    @Test
-    public void testDifferWithChanges() {
-        final var projectA = new Project();
-        projectA.setName("acme-app-a");
-        projectA.setVersion("1.0.0");
-        projectA.setDescription("identicalDescription");
-
-        final var projectB = new Project();
-        projectB.setName("acme-app-b");
-        projectB.setVersion("2.0.0");
-        projectB.setDescription("identicalDescription");
-
-        final var differ = new Differ<>(projectA, projectB);
-        assertThat(differ.applyIfChanged("name", Project::getName, projectB::setName)).isTrue();
-        assertThat(differ.applyIfChanged("version", Project::getVersion, projectB::setVersion)).isTrue();
-        assertThat(differ.applyIfChanged("description", Project::getDescription, projectB::setDescription)).isFalse();
-
-        assertThat(differ.getDiffs()).containsOnly(
-                Map.entry("name", new Diff("acme-app-a", "acme-app-b")),
-                Map.entry("version", new Diff("1.0.0", "2.0.0"))
-        );
-    }
-
-    @Test
-    public void testDifferWithoutChanges() {
-        final var projectA = new Project();
-        projectA.setName("acme-app-a");
-        projectA.setVersion("1.0.0");
-        projectA.setDescription("identicalDescription");
-
-        final var projectB = new Project();
-        projectB.setName("acme-app-a");
-        projectB.setVersion("1.0.0");
-        projectB.setDescription("identicalDescription");
-
-        final var differ = new Differ<>(projectA, projectB);
-        assertThat(differ.applyIfChanged("name", Project::getName, projectB::setName)).isFalse();
-        assertThat(differ.applyIfChanged("version", Project::getVersion, projectB::setVersion)).isFalse();
-        assertThat(differ.applyIfChanged("description", Project::getDescription, projectB::setDescription)).isFalse();
-
-        assertThat(differ.getDiffs()).isEmpty();
     }
 
 }


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes JSON values being compared by String equality, which could never match given DB values come from normalized JSONB columns. This caused `directDependencies` fields to always be considered changed. Doing semantic comparison of JSON nodes instead.

Fixes `PersistenceUtil#applyIfChanged` firing for arrays with equal elements. Turns out `Objects#equals` doesn't compare array values, it compares array identity. Bit when comparing `ServiceComponent#endpoints` fields.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
