### PR TITLE
Trigger internal analysis on internal vulnerability create/update

### DIFF
--- a/src/main/java/org/dependencytrack/event/EventSubsystemInitializer.java
+++ b/src/main/java/org/dependencytrack/event/EventSubsystemInitializer.java
@@ -52,6 +52,7 @@ import org.dependencytrack.tasks.metrics.PortfolioMetricsUpdateTask;
 import org.dependencytrack.tasks.metrics.ProjectMetricsUpdateTask;
 import org.dependencytrack.tasks.metrics.VulnerabilityMetricsUpdateTask;
 import org.dependencytrack.tasks.repositories.RepositoryMetaAnalyzerTask;
+import org.dependencytrack.tasks.scanners.InternalAnalysisTask;
 
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
@@ -111,6 +112,7 @@ public class EventSubsystemInitializer implements ServletContextListener {
         EVENT_SERVICE.subscribe(EpssMirrorEvent.class, EpssMirrorTask.class);
         EVENT_SERVICE.subscribe(TelemetrySubmissionEvent.class, TelemetrySubmissionTask.class);
         EVENT_SERVICE.subscribe(ScheduledNotificationDispatchEvent.class, ScheduledNotificationDispatchTask.class);
+        EVENT_SERVICE.subscribe(InternalAnalysisEvent.class, InternalAnalysisTask.class);
 
         EVENT_SERVICE_ST.subscribe(IndexEvent.class, IndexTask.class);
 
@@ -149,6 +151,7 @@ public class EventSubsystemInitializer implements ServletContextListener {
         EVENT_SERVICE.unsubscribe(EpssMirrorTask.class);
         EVENT_SERVICE.unsubscribe(TelemetrySubmissionTask.class);
         EVENT_SERVICE.unsubscribe(ScheduledNotificationDispatchTask.class);
+        EVENT_SERVICE.unsubscribe(InternalAnalysisTask.class);
         EVENT_SERVICE.shutdown(DRAIN_TIMEOUT_DURATION);
 
         EVENT_SERVICE_ST.unsubscribe(IndexTask.class);

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -33,6 +33,7 @@ import org.dependencytrack.model.ComponentProperty;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
+import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.resources.v1.vo.DependencyGraphResponse;
 
 import jakarta.json.Json;
@@ -43,8 +44,10 @@ import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -806,6 +809,78 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
                 pm.deletePersistent(existingProperty);
             }
         }
+    }
+
+    /**
+     * Returns candidate Components that may be affected by the given list of VulnerableSoftware.
+     * Uses tight DB-level filtering (purlType + purlName for PURL, vendor:product for CPE)
+     * so only relevant components are returned. Deduplicates across multiple VS entries.
+     *
+     * @param vsList the VulnerableSoftware entries to find candidates for
+     * @return a deduplicated list of candidate Component objects
+     */
+    @SuppressWarnings("unchecked")
+    public List<Component> getCandidateComponentsForVulnerableSoftware(final List<VulnerableSoftware> vsList) {
+        if (vsList == null || vsList.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // Use a LinkedHashSet to deduplicate while preserving order
+        final LinkedHashSet<Component> candidates = new LinkedHashSet<>();
+
+        for (final VulnerableSoftware vs : vsList) {
+            final Query<Component> query = pm.newQuery(Component.class);
+
+            if (vs.getPurlType() != null && vs.getPurlName() != null) {
+                final String purlPrefix = "pkg:" + vs.getPurlType().toLowerCase() + "/";
+                final String purlName = vs.getPurlName().toLowerCase();
+                if (vs.getPurlNamespace() != null) {
+                    final String purlNamespace = vs.getPurlNamespace().toLowerCase();
+                    query.setFilter("purl != null && purl.toLowerCase().startsWith(:prefix) && purl.toLowerCase().indexOf(:ns) >= 0 && purl.toLowerCase().indexOf(:name) >= 0");
+                    query.setNamedParameters(Map.of("prefix", purlPrefix, "ns", purlNamespace + "/", "name", purlNamespace + "/" + purlName));
+                } else {
+                    query.setFilter("purl != null && purl.toLowerCase().startsWith(:prefix) && purl.toLowerCase().indexOf(:name) >= 0");
+                    query.setNamedParameters(Map.of("prefix", purlPrefix, "name", purlName));
+                }
+            } else if (vs.getVendor() != null && vs.getProduct() != null) {
+                // CPE: filter by vendor:product substring (same as existing logic)
+                final String vendor = vs.getVendor().toLowerCase();
+                final String product = vs.getProduct().toLowerCase();
+                final String vendorProduct = ":" + vendor + ":" + product;
+                final String escapedVendorProduct = ":" + escapeCpeValue(vendor) + ":" + escapeCpeValue(product);
+                if (vendorProduct.equals(escapedVendorProduct)) {
+                    query.setFilter("cpe != null && cpe.toLowerCase().indexOf(:vendorProduct) >= 0");
+                    query.setNamedParameters(Map.of("vendorProduct", vendorProduct));
+                } else {
+                    query.setFilter("cpe != null && (cpe.toLowerCase().indexOf(:vendorProduct) >= 0 || cpe.toLowerCase().indexOf(:escapedVendorProduct) >= 0)");
+                    query.setNamedParameters(Map.of("vendorProduct", vendorProduct, "escapedVendorProduct", escapedVendorProduct));
+                }
+            } else if (vs.getPurl() != null) {
+                // Fallback: PURL exists but no parsed type/name — use broad filter
+                query.setFilter("purl != null");
+            } else if (vs.getCpe23() != null || vs.getCpe22() != null) {
+                query.setFilter("cpe != null");
+            } else {
+                continue; // No identity info — skip this VS entry
+            }
+
+            try {
+                candidates.addAll((List<Component>) query.executeList());
+            } finally {
+                query.closeAll();
+            }
+        }
+
+        return new ArrayList<>(candidates);
+    }
+
+    /**
+     * Escapes CPE 2.3 special characters with backslash.
+     * Per the CPE spec, characters like + ? * must be escaped with \ in the formatted string.
+     */
+    private static String escapeCpeValue(final String value) {
+        if (value == null) return null;
+        return value.replaceAll("([!\"#$%&'()+,/:;<=>@\\[\\]^`{|}~*?])", "\\\\$1");
     }
 
 }

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1004,6 +1004,10 @@ public class QueryManager extends AlpineQueryManager {
         return getComponentQueryManager().getAllComponents(project);
     }
 
+    public List<Component> getCandidateComponentsForVulnerableSoftware(final List<VulnerableSoftware> vsList) {
+        return getComponentQueryManager().getCandidateComponentsForVulnerableSoftware(vsList);
+    }
+
     public PaginatedResult getComponents(final Project project, final boolean includeMetrics) {
         return getComponentQueryManager().getComponents(project, includeMetrics);
     }

--- a/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.resources.v1;
 
+import alpine.event.framework.Event;
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
 import alpine.server.resources.AlpineResource;
@@ -45,12 +46,14 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.event.InternalAnalysisEvent;
 import org.dependencytrack.model.AffectedVersionAttribution;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.Cwe;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.VulnerabilityAnalysisLevel;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.model.validation.ValidUuid;
 import org.dependencytrack.parser.common.resolver.CweResolver;
@@ -379,7 +382,8 @@ public class VulnerabilityResource extends AlpineResource {
                 }
                 recalculateScoresAndSeverityFromVectors(jsonVulnerability);
                 jsonVulnerability.setSource(Vulnerability.Source.INTERNAL);
-                return qm.callInTransaction(() -> {
+                final List<Component> candidates = qm.getCandidateComponentsForVulnerableSoftware(vsList);
+                final Response response = qm.callInTransaction(() -> {
                     final Vulnerability persistentVuln = qm.createVulnerability(jsonVulnerability, true);
                     qm.synchronizeVulnerableSoftware(persistentVuln, vsList, Vulnerability.Source.INTERNAL);
                     if (persistentVuln.getVulnerableSoftware() != null && !persistentVuln.getVulnerableSoftware().isEmpty()) {
@@ -390,6 +394,13 @@ public class VulnerabilityResource extends AlpineResource {
                     }
                     return Response.status(Response.Status.CREATED).entity(persistentVuln).build();
                 });
+                // Analyze candidate components right away so findings for the new vulnerability
+                // appear immediately, rather than after the next BOM upload or scheduled
+                // portfolio analysis.
+                if (!candidates.isEmpty()) {
+                    Event.dispatch(new InternalAnalysisEvent(candidates, VulnerabilityAnalysisLevel.ON_DEMAND));
+                }
+                return response;
             } else {
                 return Response.status(Response.Status.CONFLICT).entity("A vulnerability with the specified vulnId already exists.").build();
             }
@@ -463,7 +474,8 @@ public class VulnerabilityResource extends AlpineResource {
                     }
                 }
                 recalculateScoresAndSeverityFromVectors(jsonVuln);
-                return qm.callInTransaction(() -> {
+                final List<Component> candidates = qm.getCandidateComponentsForVulnerableSoftware(vsList);
+                final Response response = qm.callInTransaction(() -> {
                     final Vulnerability persistentVuln = qm.updateVulnerability(jsonVuln, true);
                     qm.synchronizeVulnerableSoftware(persistentVuln, vsList, Vulnerability.Source.INTERNAL);
                     if (persistentVuln.getVulnerableSoftware() != null && !persistentVuln.getVulnerableSoftware().isEmpty()) {
@@ -474,6 +486,12 @@ public class VulnerabilityResource extends AlpineResource {
                     }
                     return Response.ok(persistentVuln).build();
                 });
+                // Re-analyze candidate components so updated affected-version ranges are
+                // reflected in findings immediately.
+                if (!candidates.isEmpty()) {
+                    Event.dispatch(new InternalAnalysisEvent(candidates, VulnerabilityAnalysisLevel.ON_DEMAND));
+                }
+                return response;
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The vulnerability could not be found.").build();
             }

--- a/src/test/java/org/dependencytrack/persistence/ComponentQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ComponentQueryManagerTest.java
@@ -1,0 +1,168 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence;
+
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.VulnerableSoftware;
+import org.dependencytrack.tasks.scanners.InternalAnalysisTask;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ComponentQueryManagerTest extends PersistenceCapableTest {
+
+    private Project project;
+
+    private Component createComponent(final String name, final String version, final String purl, final String cpe) {
+        if (project == null) {
+            project = qm.createProject("acme-app", null, "1.0.0", null, null, null, true, false);
+        }
+        final var component = new Component();
+        component.setProject(project);
+        component.setName(name);
+        component.setVersion(version);
+        component.setPurl(purl);
+        component.setCpe(cpe);
+        return qm.createComponent(component, false);
+    }
+
+    private VulnerableSoftware createPurlVulnerableSoftware(final String type, final String namespace, final String name) {
+        final var vs = new VulnerableSoftware();
+        vs.setPurlType(type);
+        vs.setPurlNamespace(namespace);
+        vs.setPurlName(name);
+        vs.setVulnerable(true);
+        return qm.persist(vs);
+    }
+
+    @Test
+    void getCandidateComponentsReturnsEmptyListForNullOrEmptyInput() {
+        assertThat(qm.getCandidateComponentsForVulnerableSoftware(null)).isEmpty();
+        assertThat(qm.getCandidateComponentsForVulnerableSoftware(Collections.emptyList())).isEmpty();
+    }
+
+    @Test
+    void getCandidateComponentsMatchesByPurlTypeNamespaceAndName() {
+        final Component matching = createComponent("jackson-databind", "2.13.0",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.0", null);
+        createComponent("other-lib", "1.0.0",
+                "pkg:maven/com.acme/other-lib@1.0.0", null);
+
+        final VulnerableSoftware vs = createPurlVulnerableSoftware("maven", "com.fasterxml.jackson.core", "jackson-databind");
+
+        final List<Component> candidates = qm.getCandidateComponentsForVulnerableSoftware(List.of(vs));
+        assertThat(candidates).hasSize(1);
+        assertThat(candidates.get(0).getId()).isEqualTo(matching.getId());
+    }
+
+    @Test
+    void getCandidateComponentsMatchesByPurlWithoutNamespace() {
+        final Component matching = createComponent("lodash", "4.17.20",
+                "pkg:npm/lodash@4.17.20", null);
+        createComponent("express", "4.18.0",
+                "pkg:npm/express@4.18.0", null);
+
+        final VulnerableSoftware vs = createPurlVulnerableSoftware("npm", null, "lodash");
+
+        final List<Component> candidates = qm.getCandidateComponentsForVulnerableSoftware(List.of(vs));
+        assertThat(candidates).hasSize(1);
+        assertThat(candidates.get(0).getId()).isEqualTo(matching.getId());
+    }
+
+    @Test
+    void getCandidateComponentsMatchesByCpeVendorAndProduct() {
+        final Component matching = createComponent("openssl", "1.1.1",
+                null, "cpe:2.3:a:openssl:openssl:1.1.1:*:*:*:*:*:*:*");
+        createComponent("nginx", "1.20.0",
+                null, "cpe:2.3:a:nginx:nginx:1.20.0:*:*:*:*:*:*:*");
+
+        final var vs = new VulnerableSoftware();
+        vs.setCpe23("cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*");
+        vs.setVendor("openssl");
+        vs.setProduct("openssl");
+        vs.setVulnerable(true);
+        qm.persist(vs);
+
+        final List<Component> candidates = qm.getCandidateComponentsForVulnerableSoftware(List.of(vs));
+        assertThat(candidates).hasSize(1);
+        assertThat(candidates.get(0).getId()).isEqualTo(matching.getId());
+    }
+
+    @Test
+    void getCandidateComponentsDeduplicatesAcrossEntries() {
+        final Component component = createComponent("jackson-databind", "2.13.0",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.0", null);
+
+        final VulnerableSoftware vs1 = createPurlVulnerableSoftware("maven", "com.fasterxml.jackson.core", "jackson-databind");
+        final VulnerableSoftware vs2 = createPurlVulnerableSoftware("maven", "com.fasterxml.jackson.core", "jackson-databind");
+
+        final List<Component> candidates = qm.getCandidateComponentsForVulnerableSoftware(List.of(vs1, vs2));
+        assertThat(candidates).hasSize(1);
+        assertThat(candidates.get(0).getId()).isEqualTo(component.getId());
+    }
+
+    @Test
+    void getCandidateComponentsSkipsEntriesWithoutIdentity() {
+        createComponent("jackson-databind", "2.13.0",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.0", null);
+
+        final var vs = new VulnerableSoftware();
+        vs.setVulnerable(true);
+        qm.persist(vs);
+
+        assertThat(qm.getCandidateComponentsForVulnerableSoftware(List.of(vs))).isEmpty();
+    }
+
+    @Test
+    void candidateComponentsAnalyzedByInternalAnalyzerProduceFindings() {
+        // Documents the full flow triggered when an INTERNAL vulnerability is created or
+        // updated via the REST API: candidate components are resolved and dispatched to
+        // the internal analyzer, which performs the precise version-range matching.
+        final Component component = createComponent("jackson-databind", "2.13.0",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.0", null);
+
+        var vs = new VulnerableSoftware();
+        vs.setPurlType("maven");
+        vs.setPurlNamespace("com.fasterxml.jackson.core");
+        vs.setPurlName("jackson-databind");
+        vs.setVersionEndExcluding("2.13.1");
+        vs.setVulnerable(true);
+        vs = qm.persist(vs);
+
+        var vulnerability = new Vulnerability();
+        vulnerability.setVulnId("INT-2026-001");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability = qm.createVulnerability(vulnerability, false);
+        vulnerability.setVulnerableSoftware(List.of(vs));
+
+        final List<Component> candidates = qm.getCandidateComponentsForVulnerableSoftware(List.of(vs));
+        assertThat(candidates).hasSize(1);
+
+        new InternalAnalysisTask().analyze(candidates);
+
+        assertThat(qm.getAllVulnerabilities(component)).hasSize(1);
+        assertThat(qm.getAllVulnerabilities(component).get(0).getVulnId()).isEqualTo("INT-2026-001");
+    }
+}


### PR DESCRIPTION
### Description
Findings for INTERNAL vulnerabilities are currently only produced when components are
re-analyzed — on BOM upload or during the scheduled portfolio analysis. Creating or
updating an internal vulnerability has no immediate effect: findings appear silently
up to a day later, with no feedback if the affected-component identifiers match
nothing in the portfolio.

Creating or updating an INTERNAL vulnerability now resolves candidate components via
targeted queries and dispatches an `InternalAnalysisEvent` for just those candidates.
The existing internal analyzer performs the precise identity and version-range
matching, so results are identical to those of the scheduled analysis — they just
appear immediately.

### Addressed Issue
fixes #7030

### Additional Details
- `ComponentQueryManager.getCandidateComponentsForVulnerableSoftware` narrows
  candidates at the DB level (PURL type/namespace/name; CPE vendor:product substring,
  matching both escaped and unescaped stored forms) and deduplicates across entries.
- `InternalAnalysisTask` is subscribed to `InternalAnalysisEvent` in
  `EventSubsystemInitializer` to make the dispatch effective — analyzers were
  previously only invoked inline by `VulnerabilityAnalysisTask`. Aware of the TODO
  about moving away from `Subscriber#inform`; happy to switch to direct invocation
  if preferred.
- Companion frontend PR: will follow shortly and be linked here.
- Note: touches the same methods as open PR #6639 (non-overlapping lines).

### Checklist
- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations