### PR TITLE
Expose workflow run status on BOM token polling endpoint

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -38,10 +38,11 @@ import org.cyclonedx.Version;
 import org.cyclonedx.exception.GeneratorException;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.auth.ProjectAccess;
+import org.dependencytrack.common.pagination.SortDirection;
 import org.dependencytrack.dex.engine.api.DexEngine;
-import org.dependencytrack.dex.engine.api.WorkflowRunStatus;
+import org.dependencytrack.dex.engine.api.WorkflowRunMetadata;
 import org.dependencytrack.dex.engine.api.request.CreateWorkflowRunRequest;
-import org.dependencytrack.dex.engine.api.request.ExistsWorkflowRunRequest;
+import org.dependencytrack.dex.engine.api.request.ListWorkflowRunsRequest;
 import org.dependencytrack.filestorage.api.FileStorage;
 import org.dependencytrack.filestorage.proto.v1.FileMetadata;
 import org.dependencytrack.model.BomValidationMode;
@@ -975,17 +976,21 @@ public class BomResource extends AbstractApiResource {
                     String uuid) {
         final UUID token = UUID.fromString(uuid);
 
-        final boolean isProcessing;
-        if (dexEngine.existsRun(new ExistsWorkflowRunRequest(
-                WorkflowRunStatus.NON_TERMINAL_STATUSES, Map.of(WF_LABEL_BOM_UPLOAD_TOKEN, token.toString())))) {
-            isProcessing = true;
-        } else {
-            final var runMetadata = dexEngine.getRunMetadataById(token);
-            isProcessing = runMetadata != null && !runMetadata.status().isTerminal();
-        }
+        final var page = dexEngine.listRuns(new ListWorkflowRunsRequest()
+                .withLabels(Map.of(WF_LABEL_BOM_UPLOAD_TOKEN, token.toString()))
+                .withSortBy(ListWorkflowRunsRequest.SortBy.CREATED_AT)
+                .withSortDirection(SortDirection.DESC)
+                .withLimit(1));
+        final WorkflowRunMetadata runMetadata =
+                !page.items().isEmpty() ? page.items().getFirst() : dexEngine.getRunMetadataById(token);
 
         final var response = new IsTokenBeingProcessedResponse();
-        response.setProcessing(isProcessing);
+        if (runMetadata != null) {
+            response.setProcessing(!runMetadata.status().isTerminal());
+            response.setStatus(IsTokenBeingProcessedResponse.Status.of(runMetadata.status()));
+        } else {
+            response.setProcessing(false);
+        }
         return Response.ok(response).build();
     }
 

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/EventResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/EventResource.java
@@ -27,10 +27,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.dependencytrack.common.pagination.SortDirection;
 import org.dependencytrack.dex.engine.api.DexEngine;
 import org.dependencytrack.dex.engine.api.WorkflowRunMetadata;
-import org.dependencytrack.dex.engine.api.WorkflowRunStatus;
-import org.dependencytrack.dex.engine.api.request.ExistsWorkflowRunRequest;
+import org.dependencytrack.dex.engine.api.request.ListWorkflowRunsRequest;
 import org.dependencytrack.model.validation.ValidUuid;
 import org.dependencytrack.resources.AbstractApiResource;
 import org.dependencytrack.resources.v1.vo.IsTokenBeingProcessedResponse;
@@ -100,27 +100,27 @@ public class EventResource extends AbstractApiResource {
                     @ValidUuid
                     String uuid) {
         final UUID token = UUID.fromString(uuid);
-
-        final boolean isProcessing;
-        if (hasNonTerminalDexRun(token)) {
-            isProcessing = true;
-        } else {
-            isProcessing = false;
-        }
+        final WorkflowRunMetadata runMetadata = resolveRunByToken(token);
 
         final var response = new IsTokenBeingProcessedResponse();
-        response.setProcessing(isProcessing);
+        if (runMetadata != null) {
+            response.setProcessing(!runMetadata.status().isTerminal());
+            response.setStatus(IsTokenBeingProcessedResponse.Status.of(runMetadata.status()));
+        } else {
+            response.setProcessing(false);
+        }
         return Response.ok(response).build();
     }
 
-    private boolean hasNonTerminalDexRun(UUID token) {
-        final boolean hasNonTerminalByLabel = dexEngine.existsRun(new ExistsWorkflowRunRequest(
-                WorkflowRunStatus.NON_TERMINAL_STATUSES, Map.of(WF_LABEL_BOM_UPLOAD_TOKEN, token.toString())));
-        if (hasNonTerminalByLabel) {
-            return true;
+    private WorkflowRunMetadata resolveRunByToken(final UUID token) {
+        final var page = dexEngine.listRuns(new ListWorkflowRunsRequest()
+                .withLabels(Map.of(WF_LABEL_BOM_UPLOAD_TOKEN, token.toString()))
+                .withSortBy(ListWorkflowRunsRequest.SortBy.CREATED_AT)
+                .withSortDirection(SortDirection.DESC)
+                .withLimit(1));
+        if (!page.items().isEmpty()) {
+            return page.items().getFirst();
         }
-
-        final WorkflowRunMetadata runMetadata = dexEngine.getRunMetadataById(token);
-        return runMetadata != null && !runMetadata.status().isTerminal();
+        return dexEngine.getRunMetadataById(token);
     }
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/IsTokenBeingProcessedResponse.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/IsTokenBeingProcessedResponse.java
@@ -18,10 +18,14 @@
  */
 package org.dependencytrack.resources.v1.vo;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.dependencytrack.dex.engine.api.WorkflowRunStatus;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class IsTokenBeingProcessedResponse implements Serializable {
 
     private static final long serialVersionUID = -7592468766586686855L;
@@ -29,11 +33,43 @@ public class IsTokenBeingProcessedResponse implements Serializable {
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean processing;
 
+    @Schema(
+            nullable = true,
+            description = "The processing status associated with the token. "
+                    + "Null when no processing is associated with the token.")
+    @Nullable
+    private Status status;
+
     public void setProcessing(Boolean processing) {
         this.processing = processing;
     }
 
     public Boolean getProcessing() {
         return this.processing;
+    }
+
+    public void setStatus(@Nullable Status status) {
+        this.status = status;
+    }
+
+    @Nullable
+    public Status getStatus() {
+        return this.status;
+    }
+
+    public enum Status {
+        PENDING,
+        RUNNING,
+        COMPLETED,
+        FAILED;
+
+        public static Status of(final WorkflowRunStatus runStatus) {
+            return switch (runStatus) {
+                case CREATED, SUSPENDED -> PENDING;
+                case RUNNING -> RUNNING;
+                case COMPLETED -> COMPLETED;
+                case CANCELLED, FAILED -> FAILED;
+            };
+        }
     }
 }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -37,10 +37,11 @@ import org.cyclonedx.parsers.XmlParser;
 import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.common.pagination.Page;
 import org.dependencytrack.dex.engine.api.DexEngine;
 import org.dependencytrack.dex.engine.api.WorkflowRunMetadata;
 import org.dependencytrack.dex.engine.api.WorkflowRunStatus;
-import org.dependencytrack.dex.engine.api.request.ExistsWorkflowRunRequest;
+import org.dependencytrack.dex.engine.api.request.ListWorkflowRunsRequest;
 import org.dependencytrack.filestorage.api.FileStorage;
 import org.dependencytrack.filestorage.memory.MemoryFileStorage;
 import org.dependencytrack.model.AnalysisResponse;
@@ -2626,8 +2627,23 @@ class BomResourceTest extends ResourceTest {
     void shouldReportTokenBeingProcessedWhenDexRunExistsByLabel() {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
 
-        doReturn(null).when(DEX_ENGINE_MOCK).getRunMetadataById(any());
-        doReturn(true).when(DEX_ENGINE_MOCK).existsRun(any(ExistsWorkflowRunRequest.class));
+        final var runMetadata = new WorkflowRunMetadata(
+                UUID.randomUUID(),
+                null,
+                "import-bom",
+                1,
+                null,
+                "default",
+                WorkflowRunStatus.RUNNING,
+                null,
+                0,
+                null,
+                null,
+                java.time.Instant.now(),
+                java.time.Instant.now(),
+                null,
+                null);
+        doReturn(new Page<>(List.of(runMetadata))).when(DEX_ENGINE_MOCK).listRuns(any(ListWorkflowRunsRequest.class));
 
         final Response response = jersey.target(V1_BOM + "/token/2ff20ad6-587c-4db6-8788-cca7a9b0dc1b")
                 .request()
@@ -2636,7 +2652,8 @@ class BomResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
                 {
-                  "processing": true
+                  "processing": true,
+                  "status": "RUNNING"
                 }
                 """);
     }
@@ -2662,7 +2679,7 @@ class BomResourceTest extends ResourceTest {
                 java.time.Instant.now(),
                 null,
                 null);
-        doReturn(false).when(DEX_ENGINE_MOCK).existsRun(any(ExistsWorkflowRunRequest.class));
+        doReturn(new Page<>(List.of())).when(DEX_ENGINE_MOCK).listRuns(any(ListWorkflowRunsRequest.class));
         doReturn(runMetadata).when(DEX_ENGINE_MOCK).getRunMetadataById(runId);
 
         final Response response = jersey.target(V1_BOM + "/token/" + runId)
@@ -2672,7 +2689,8 @@ class BomResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
                 {
-                  "processing": true
+                  "processing": true,
+                  "status": "RUNNING"
                 }
                 """);
     }
@@ -2681,8 +2699,8 @@ class BomResourceTest extends ResourceTest {
     void shouldReportTokenNotBeingProcessed() {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
 
+        doReturn(new Page<>(List.of())).when(DEX_ENGINE_MOCK).listRuns(any(ListWorkflowRunsRequest.class));
         doReturn(null).when(DEX_ENGINE_MOCK).getRunMetadataById(any());
-        doReturn(false).when(DEX_ENGINE_MOCK).existsRun(any(ExistsWorkflowRunRequest.class));
 
         final Response response = jersey.target(V1_BOM + "/token/089dcdbe-31cf-489a-a8f3-0743ea7f3cc5")
                 .request()

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/EventResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/EventResourceTest.java
@@ -23,10 +23,11 @@ import alpine.server.filters.AuthFeature;
 import org.apache.http.HttpStatus;
 import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
+import org.dependencytrack.common.pagination.Page;
 import org.dependencytrack.dex.engine.api.DexEngine;
 import org.dependencytrack.dex.engine.api.WorkflowRunMetadata;
 import org.dependencytrack.dex.engine.api.WorkflowRunStatus;
-import org.dependencytrack.dex.engine.api.request.ExistsWorkflowRunRequest;
+import org.dependencytrack.dex.engine.api.request.ListWorkflowRunsRequest;
 import org.glassfish.jersey.inject.hk2.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.AfterEach;
@@ -37,6 +38,7 @@ import org.mockito.Mockito;
 import jakarta.ws.rs.core.Response;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
@@ -84,7 +86,7 @@ class EventResourceTest extends ResourceTest {
                 Instant.now(),
                 null,
                 null);
-        doReturn(false).when(DEX_ENGINE_MOCK).existsRun(any(ExistsWorkflowRunRequest.class));
+        doReturn(new Page<>(List.of())).when(DEX_ENGINE_MOCK).listRuns(any(ListWorkflowRunsRequest.class));
         doReturn(runMetadata).when(DEX_ENGINE_MOCK).getRunMetadataById(runId);
 
         final Response response = jersey.target(V1_EVENT + "/token/6214c0c2-660c-4615-8b3a-174a64e4abe4")
@@ -94,17 +96,31 @@ class EventResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
                 {
-                  "processing": true
+                  "processing": true,
+                  "status": "RUNNING"
                 }
                 """);
     }
 
     @Test
     void isTokenBeingProcessedDexRunByLabelTest() {
-        final var bomUploadToken = UUID.fromString("2ff20ad6-587c-4db6-8788-cca7a9b0dc1b");
-
-        doReturn(null).when(DEX_ENGINE_MOCK).getRunMetadataById(bomUploadToken);
-        doReturn(true).when(DEX_ENGINE_MOCK).existsRun(any(ExistsWorkflowRunRequest.class));
+        final var runMetadata = new WorkflowRunMetadata(
+                UUID.randomUUID(),
+                null,
+                "import-bom",
+                1,
+                null,
+                "default",
+                WorkflowRunStatus.RUNNING,
+                null,
+                0,
+                null,
+                null,
+                Instant.now(),
+                Instant.now(),
+                null,
+                null);
+        doReturn(new Page<>(List.of(runMetadata))).when(DEX_ENGINE_MOCK).listRuns(any(ListWorkflowRunsRequest.class));
 
         final Response response = jersey.target(V1_EVENT + "/token/2ff20ad6-587c-4db6-8788-cca7a9b0dc1b")
                 .request()
@@ -113,15 +129,49 @@ class EventResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
                 {
-                  "processing": true
+                  "processing": true,
+                  "status": "RUNNING"
+                }
+                """);
+    }
+
+    @Test
+    void isTokenBeingProcessedFailedTest() {
+        final var runMetadata = new WorkflowRunMetadata(
+                UUID.randomUUID(),
+                null,
+                "import-bom",
+                1,
+                null,
+                "default",
+                WorkflowRunStatus.FAILED,
+                null,
+                0,
+                null,
+                null,
+                Instant.now(),
+                Instant.now(),
+                null,
+                Instant.now());
+        doReturn(new Page<>(List.of(runMetadata))).when(DEX_ENGINE_MOCK).listRuns(any(ListWorkflowRunsRequest.class));
+
+        final Response response = jersey.target(V1_EVENT + "/token/2ff20ad6-587c-4db6-8788-cca7a9b0dc1b")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "processing": false,
+                  "status": "FAILED"
                 }
                 """);
     }
 
     @Test
     void isTokenBeingProcessedNotExistsTest() {
+        doReturn(new Page<>(List.of())).when(DEX_ENGINE_MOCK).listRuns(any(ListWorkflowRunsRequest.class));
         doReturn(null).when(DEX_ENGINE_MOCK).getRunMetadataById(any());
-        doReturn(false).when(DEX_ENGINE_MOCK).existsRun(any(ExistsWorkflowRunRequest.class));
 
         final Response response = jersey.target(V1_EVENT + "/token/089dcdbe-31cf-489a-a8f3-0743ea7f3cc5")
                 .request()


### PR DESCRIPTION
### Description

Fixes the BOM upload token polling endpoints (`GET /v1/bom/token/{uuid}` and `GET /v1/event/token/{uuid}`) so they now expose the actual processing status of the associated workflow run instead of silently reporting only a boolean `processing` flag. The response now includes a `status` field using a dedicated, consumer-facing `IsTokenBeingProcessedResponse.Status` enum (`PENDING`, `RUNNING`, `COMPLETED`, `FAILED`), decoupled from the internal `WorkflowRunStatus` used by the workflow engine. Additionally, the underlying `listRuns` lookups by BOM upload token now specify an explicit sort order (`CREATED_AT` descending) to ensure deterministic results when multiple runs share the same label.

### Addressed Issue

Relates to #1665

### Additional Details

- Introduced `IsTokenBeingProcessedResponse.Status`, a dedicated enum mirroring the pattern used in `VulnDataSourceMirrorService.MirrorStatus.Status`, to avoid leaking internal `WorkflowRunStatus` semantics (and the word "workflow") into the public API surface.
- `Status.of(WorkflowRunStatus)` maps: `CREATED` / `SUSPENDED` -> `PENDING`, `RUNNING` -> `RUNNING`, `COMPLETED` -> `COMPLETED`, `CANCELLED` / `FAILED` -> `FAILED`.
- Added explicit `.withSortBy(CREATED_AT)` + `.withSortDirection(DESC)` to the `listRuns` calls in `BomResource` and `EventResource` for deterministic run resolution.
- Verified manually: a corrupted BOM upload yields `{"processing": false, "status": "FAILED"}`, and a valid BOM upload yields `{"processing": false, "status": "COMPLETED"}` once processing completes.
- Rebasing onto latest upstream `main` to resolve a merge conflict caused by a concurrent unrelated refactor of the same endpoint.

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`