### PR TITLE
Define display names for all extensions

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/notification/DefaultNotificationPublisherInitializer.java
+++ b/apiserver/src/main/java/org/dependencytrack/notification/DefaultNotificationPublisherInitializer.java
@@ -20,7 +20,6 @@ package org.dependencytrack.notification;
 
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
-import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.notification.api.publishing.NotificationPublisher;
 import org.dependencytrack.notification.api.publishing.NotificationPublisherFactory;
 import org.dependencytrack.notification.api.templating.NotificationTemplate;
@@ -61,7 +60,7 @@ public final class DefaultNotificationPublisherInitializer implements ServletCon
         final var publishers = new ArrayList<org.dependencytrack.model.NotificationPublisher>(extensionFactories.size());
         for (final var extensionFactory : extensionFactories) {
             final var publisher = new org.dependencytrack.model.NotificationPublisher();
-            publisher.setName(StringUtils.capitalize(extensionFactory.extensionName()));
+            publisher.setName(extensionFactory.displayName());
             publisher.setDescription("Default %s publisher".formatted(publisher.getName()));
             publisher.setExtensionName(extensionFactory.extensionName());
             publisher.setDefaultPublisher(true);

--- a/apiserver/src/test/java/org/dependencytrack/kevdatasource/MirrorKevDataSourceActivityTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/kevdatasource/MirrorKevDataSourceActivityTest.java
@@ -31,6 +31,7 @@ import org.dependencytrack.persistence.jdbi.JdbiFactory;
 import org.dependencytrack.plugin.api.ServiceRegistry;
 import org.dependencytrack.plugin.runtime.PluginManager;
 import org.dependencytrack.proto.internal.workflow.v1.MirrorKevDataSourceArg;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -215,12 +216,17 @@ class MirrorKevDataSourceActivityTest extends PersistenceCapableTest {
         }
 
         @Override
-        public String extensionName() {
+        public @NonNull String extensionName() {
             return name;
         }
 
         @Override
-        public Class<? extends KevDataSource> extensionClass() {
+        public @NonNull String displayName() {
+            return name;
+        }
+
+        @Override
+        public @NonNull Class<? extends KevDataSource> extensionClass() {
             return TestKevDataSource.class;
         }
 
@@ -230,11 +236,11 @@ class MirrorKevDataSourceActivityTest extends PersistenceCapableTest {
         }
 
         @Override
-        public void init(ServiceRegistry serviceRegistry) {
+        public void init(@NonNull ServiceRegistry serviceRegistry) {
         }
 
         @Override
-        public KevDataSource create() {
+        public @NonNull KevDataSource create() {
             return dataSourceSupplier.get();
         }
 
@@ -254,12 +260,17 @@ class MirrorKevDataSourceActivityTest extends PersistenceCapableTest {
         }
 
         @Override
-        public String extensionName() {
+        public @NonNull String extensionName() {
             return name;
         }
 
         @Override
-        public Class<? extends KevDataSource> extensionClass() {
+        public @NonNull String displayName() {
+            return name;
+        }
+
+        @Override
+        public @NonNull Class<? extends KevDataSource> extensionClass() {
             return TestKevDataSource.class;
         }
 
@@ -269,11 +280,11 @@ class MirrorKevDataSourceActivityTest extends PersistenceCapableTest {
         }
 
         @Override
-        public void init(ServiceRegistry serviceRegistry) {
+        public void init(@NonNull ServiceRegistry serviceRegistry) {
         }
 
         @Override
-        public KevDataSource create() {
+        public @NonNull KevDataSource create() {
             throw new UnsupportedOperationException();
         }
 

--- a/apiserver/src/test/java/org/dependencytrack/pkgmetadata/MockPackageMetadataResolverPlugin.java
+++ b/apiserver/src/test/java/org/dependencytrack/pkgmetadata/MockPackageMetadataResolverPlugin.java
@@ -95,6 +95,11 @@ final class MockPackageMetadataResolverPlugin implements Plugin {
         }
 
         @Override
+        public @NonNull String displayName() {
+            return "Mock";
+        }
+
+        @Override
         public @NonNull Class<? extends PackageMetadataResolver> extensionClass() {
             return MockPackageMetadataResolver.class;
         }
@@ -104,7 +109,7 @@ final class MockPackageMetadataResolverPlugin implements Plugin {
         }
 
         @Override
-        public PackageMetadataResolver create() {
+        public @NonNull PackageMetadataResolver create() {
             return new MockPackageMetadataResolver(resolveFnRef, lastSeenPriorRef);
         }
 

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
@@ -166,8 +166,8 @@ class NotificationPublisherResourceTest extends ResourceTest {
                             "uuid": "${json-unit.any-string}"
                           },
                           {
-                            "name": "Msteams",
-                            "description": "Default Msteams publisher",
+                            "name": "Microsoft Teams",
+                            "description": "Default Microsoft Teams publisher",
                             "extensionName": "msteams",
                             "template": "${json-unit.any-string}",
                             "templateMimeType": "${json-unit.any-string}",

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/ExtensionsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/ExtensionsResourceTest.java
@@ -148,7 +148,7 @@ class ExtensionsResourceTest extends ResourceTest {
                     },
                     {
                       "name": "non-configurable-extension",
-                      "display_name": "non-configurable-extension",
+                      "display_name": "Non-configurable Extension",
                       "configurable": false,
                       "testable": false
                     }
@@ -623,7 +623,7 @@ class ExtensionsResourceTest extends ResourceTest {
         }
 
         @Override
-        public RuntimeConfigSpec runtimeConfigSpec() {
+        public @NonNull RuntimeConfigSpec runtimeConfigSpec() {
             final var defaultConfig = new DummyRuntimeConfig("test", null);
             return RuntimeConfigSpec.of(
                     defaultConfig,
@@ -651,11 +651,11 @@ class ExtensionsResourceTest extends ResourceTest {
         }
 
         @Override
-        public void init(ServiceRegistry serviceRegistry) {
+        public void init(@NonNull ServiceRegistry serviceRegistry) {
         }
 
         @Override
-        public DummyExtensionPoint create() {
+        public @NonNull DummyExtensionPoint create() {
             return new DummyExtension();
         }
 
@@ -664,12 +664,17 @@ class ExtensionsResourceTest extends ResourceTest {
     private static class NonConfigurableExtensionFactory implements ExtensionFactory<DummyExtensionPoint> {
 
         @Override
-        public String extensionName() {
+        public @NonNull String extensionName() {
             return "non-configurable-extension";
         }
 
         @Override
-        public Class<? extends DummyExtensionPoint> extensionClass() {
+        public @NonNull String displayName() {
+            return "Non-configurable Extension";
+        }
+
+        @Override
+        public @NonNull Class<? extends DummyExtensionPoint> extensionClass() {
             return DummyExtension.class;
         }
 
@@ -679,11 +684,11 @@ class ExtensionsResourceTest extends ResourceTest {
         }
 
         @Override
-        public void init(ServiceRegistry serviceRegistry) {
+        public void init(@NonNull ServiceRegistry serviceRegistry) {
         }
 
         @Override
-        public DummyExtensionPoint create() {
+        public @NonNull DummyExtensionPoint create() {
             return new DummyExtension();
         }
 
@@ -700,7 +705,12 @@ class ExtensionsResourceTest extends ResourceTest {
         }
 
         @Override
-        public Class<? extends DummyExtensionPoint> extensionClass() {
+        public @NonNull String displayName() {
+            return "Testable Extension";
+        }
+
+        @Override
+        public @NonNull Class<? extends DummyExtensionPoint> extensionClass() {
             return DummyExtension.class;
         }
 
@@ -710,16 +720,16 @@ class ExtensionsResourceTest extends ResourceTest {
         }
 
         @Override
-        public void init(ServiceRegistry serviceRegistry) {
+        public void init(@NonNull ServiceRegistry serviceRegistry) {
         }
 
         @Override
-        public DummyExtensionPoint create() {
+        public @NonNull DummyExtensionPoint create() {
             return new DummyExtension();
         }
 
         @Override
-        public ExtensionTestResult test(@Nullable RuntimeConfig runtimeConfig) {
+        public @NonNull ExtensionTestResult test(@Nullable RuntimeConfig runtimeConfig) {
             final var testConfig = (TestableRuntimeConfig) runtimeConfig;
             if ("PASSED".equals(testConfig.outcome())) {
                 return ExtensionTestResult.ofChecks("name").pass("name");
@@ -729,7 +739,7 @@ class ExtensionsResourceTest extends ResourceTest {
         }
 
         @Override
-        public @Nullable RuntimeConfigSpec runtimeConfigSpec() {
+        public @NonNull RuntimeConfigSpec runtimeConfigSpec() {
             final var defaultConfig = new TestableRuntimeConfig(null);
             return RuntimeConfigSpec.of(
                     defaultConfig,
@@ -757,12 +767,17 @@ class ExtensionsResourceTest extends ResourceTest {
     private static class ExtensionWithValidatorFactory implements ExtensionFactory<DummyExtensionPoint>, RuntimeConfigurable, Testable {
 
         @Override
-        public String extensionName() {
+        public @NonNull String extensionName() {
             return "extension-with-validator";
         }
 
         @Override
-        public Class<? extends DummyExtensionPoint> extensionClass() {
+        public @NonNull String displayName() {
+            return "Extension With Validator";
+        }
+
+        @Override
+        public @NonNull Class<? extends DummyExtensionPoint> extensionClass() {
             return DummyExtension.class;
         }
 
@@ -772,11 +787,11 @@ class ExtensionsResourceTest extends ResourceTest {
         }
 
         @Override
-        public void init(ServiceRegistry serviceRegistry) {
+        public void init(@NonNull ServiceRegistry serviceRegistry) {
         }
 
         @Override
-        public @Nullable RuntimeConfigSpec runtimeConfigSpec() {
+        public @NonNull RuntimeConfigSpec runtimeConfigSpec() {
             final var defaultConfig = new TestableRuntimeConfig(null);
             return RuntimeConfigSpec.of(
                     defaultConfig,
@@ -804,12 +819,12 @@ class ExtensionsResourceTest extends ResourceTest {
         }
 
         @Override
-        public ExtensionTestResult test(@Nullable RuntimeConfig runtimeConfig) {
+        public @NonNull ExtensionTestResult test(@Nullable RuntimeConfig runtimeConfig) {
             return ExtensionTestResult.ofChecks("name").pass("name");
         }
 
         @Override
-        public DummyExtensionPoint create() {
+        public @NonNull DummyExtensionPoint create() {
             return new DummyExtension();
         }
 

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/KevDataSourcesResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/KevDataSourcesResourceTest.java
@@ -456,6 +456,11 @@ class KevDataSourcesResourceTest extends ResourceTest {
         }
 
         @Override
+        public @NonNull String displayName() {
+            return name;
+        }
+
+        @Override
         public @NonNull Class<? extends KevDataSource> extensionClass() {
             return DummyKevDataSource.class;
         }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/VulnDataSourcesResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/VulnDataSourcesResourceTest.java
@@ -42,6 +42,7 @@ import org.dependencytrack.vulndatasource.VulnDataSourceMirrorService;
 import org.dependencytrack.vulndatasource.api.VulnDataSource;
 import org.dependencytrack.vulndatasource.api.VulnDataSourceFactory;
 import org.glassfish.jersey.inject.hk2.AbstractBinder;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -386,12 +387,17 @@ class VulnDataSourcesResourceTest extends ResourceTest {
         }
 
         @Override
-        public String extensionName() {
+        public @NonNull String extensionName() {
             return name;
         }
 
         @Override
-        public Class<? extends VulnDataSource> extensionClass() {
+        public @NonNull String displayName() {
+            return name;
+        }
+
+        @Override
+        public @NonNull Class<? extends VulnDataSource> extensionClass() {
             return DummyVulnDataSource.class;
         }
 
@@ -401,7 +407,7 @@ class VulnDataSourcesResourceTest extends ResourceTest {
         }
 
         @Override
-        public void init(final ServiceRegistry serviceRegistry) {
+        public void init(@NonNull ServiceRegistry serviceRegistry) {
         }
 
         @Override
@@ -410,7 +416,7 @@ class VulnDataSourcesResourceTest extends ResourceTest {
         }
 
         @Override
-        public VulnDataSource create() {
+        public @NonNull VulnDataSource create() {
             throw new UnsupportedOperationException();
         }
 

--- a/apiserver/src/test/java/org/dependencytrack/vulnanalysis/MockVulnAnalyzerPlugin.java
+++ b/apiserver/src/test/java/org/dependencytrack/vulnanalysis/MockVulnAnalyzerPlugin.java
@@ -80,6 +80,11 @@ public final class MockVulnAnalyzerPlugin implements Plugin {
         }
 
         @Override
+        public @NonNull String displayName() {
+            return "Mock";
+        }
+
+        @Override
         public @NonNull Class<? extends VulnAnalyzer> extensionClass() {
             return MockVulnAnalyzer.class;
         }

--- a/apiserver/src/test/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivityTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivityTest.java
@@ -33,6 +33,7 @@ import org.dependencytrack.plugin.runtime.PluginManager;
 import org.dependencytrack.proto.internal.workflow.v1.MirrorVulnDataSourceArg;
 import org.dependencytrack.vulndatasource.api.VulnDataSource;
 import org.dependencytrack.vulndatasource.api.VulnDataSourceFactory;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -1617,12 +1618,17 @@ class MirrorVulnDataSourceActivityTest extends PersistenceCapableTest {
         }
 
         @Override
-        public String extensionName() {
+        public @NonNull String extensionName() {
             return name;
         }
 
         @Override
-        public Class<? extends VulnDataSource> extensionClass() {
+        public @NonNull String displayName() {
+            return name;
+        }
+
+        @Override
+        public @NonNull Class<? extends VulnDataSource> extensionClass() {
             return TestVulnDataSource.class;
         }
 
@@ -1632,11 +1638,11 @@ class MirrorVulnDataSourceActivityTest extends PersistenceCapableTest {
         }
 
         @Override
-        public void init(ServiceRegistry serviceRegistry) {
+        public void init(@NonNull ServiceRegistry serviceRegistry) {
         }
 
         @Override
-        public VulnDataSource create() {
+        public @NonNull VulnDataSource create() {
             return dataSourceSupplier.get();
         }
 
@@ -1670,12 +1676,17 @@ class MirrorVulnDataSourceActivityTest extends PersistenceCapableTest {
         }
 
         @Override
-        public String extensionName() {
+        public @NonNull String extensionName() {
             return name;
         }
 
         @Override
-        public Class<? extends VulnDataSource> extensionClass() {
+        public @NonNull String displayName() {
+            return name;
+        }
+
+        @Override
+        public @NonNull Class<? extends VulnDataSource> extensionClass() {
             return TestVulnDataSource.class;
         }
 
@@ -1685,11 +1696,11 @@ class MirrorVulnDataSourceActivityTest extends PersistenceCapableTest {
         }
 
         @Override
-        public void init(ServiceRegistry serviceRegistry) {
+        public void init(@NonNull ServiceRegistry serviceRegistry) {
         }
 
         @Override
-        public VulnDataSource create() {
+        public @NonNull VulnDataSource create() {
             throw new UnsupportedOperationException();
         }
 

--- a/e2e/src/test/java/org/dependencytrack/e2e/BomProcessedNotificationDelayedE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/BomProcessedNotificationDelayedE2ET.java
@@ -74,7 +74,7 @@ class BomProcessedNotificationDelayedE2ET extends AbstractE2ET {
 
         // Find the webhook notification publisher.
         final NotificationPublisher webhookPublisher = publishers.stream()
-                .filter(publisher -> publisher.name().equals("Webhook"))
+                .filter(publisher -> publisher.extensionName().equals("webhook"))
                 .findAny()
                 .orElseThrow(() -> new AssertionError("Unable to find webhook notification publisher"));
 

--- a/e2e/src/test/java/org/dependencytrack/e2e/BomUploadProcessingE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/BomUploadProcessingE2ET.java
@@ -112,7 +112,7 @@ class BomUploadProcessingE2ET extends AbstractE2ET {
 
         // Find the webhook notification publisher.
         final NotificationPublisher webhookPublisher = publishers.stream()
-                .filter(publisher -> publisher.name().equals("Webhook"))
+                .filter(publisher -> publisher.extensionName().equals("webhook"))
                 .findAny()
                 .orElseThrow(() -> new AssertionError("Unable to find webhook notification publisher"));
 

--- a/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
@@ -381,7 +381,7 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
 
         // Find the webhook notification publisher.
         final NotificationPublisher webhookPublisher = publishers.stream()
-                .filter(publisher -> publisher.name().equals("Webhook"))
+                .filter(publisher -> publisher.extensionName().equals("webhook"))
                 .findAny()
                 .orElseThrow(() -> new AssertionError("Unable to find webhook notification publisher"));
 

--- a/migration/src/main/resources/org/dependencytrack/migration/V202608261121__rename_msteams_notification_publisher.sql
+++ b/migration/src/main/resources/org/dependencytrack/migration/V202608261121__rename_msteams_notification_publisher.sql
@@ -1,0 +1,11 @@
+UPDATE "NOTIFICATIONPUBLISHER"
+   SET "NAME" = 'Microsoft Teams'
+     , "DESCRIPTION" = 'Default Microsoft Teams publisher'
+ WHERE "EXTENSION_NAME" = 'msteams'
+   AND "DEFAULT_PUBLISHER" IS TRUE
+   -- There's a UNIQUE index on "NAME", make sure to not violate that.
+   AND NOT EXISTS (
+     SELECT 1
+       FROM "NOTIFICATIONPUBLISHER" AS other
+      WHERE other."NAME" = 'Microsoft Teams'
+   );

--- a/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/console/ConsoleNotificationPublisherFactory.java
+++ b/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/console/ConsoleNotificationPublisherFactory.java
@@ -50,6 +50,11 @@ public final class ConsoleNotificationPublisherFactory implements NotificationPu
     }
 
     @Override
+    public String displayName() {
+        return "Console";
+    }
+
+    @Override
     public Class<? extends NotificationPublisher> extensionClass() {
         return ConsoleNotificationPublisher.class;
     }

--- a/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/email/EmailNotificationPublisherFactory.java
+++ b/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/email/EmailNotificationPublisherFactory.java
@@ -78,6 +78,11 @@ public final class EmailNotificationPublisherFactory implements NotificationPubl
     }
 
     @Override
+    public String displayName() {
+        return "Email";
+    }
+
+    @Override
     public Class<? extends NotificationPublisher> extensionClass() {
         return EmailNotificationPublisher.class;
     }

--- a/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/jira/JiraNotificationPublisherFactory.java
+++ b/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/jira/JiraNotificationPublisherFactory.java
@@ -47,6 +47,11 @@ public final class JiraNotificationPublisherFactory implements NotificationPubli
     }
 
     @Override
+    public String displayName() {
+        return "Jira";
+    }
+
+    @Override
     public Class<? extends NotificationPublisher> extensionClass() {
         return JiraNotificationPublisher.class;
     }

--- a/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/kafka/KafkaNotificationPublisherFactory.java
+++ b/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/kafka/KafkaNotificationPublisherFactory.java
@@ -91,6 +91,11 @@ public final class KafkaNotificationPublisherFactory implements NotificationPubl
     }
 
     @Override
+    public String displayName() {
+        return "Kafka";
+    }
+
+    @Override
     public Class<? extends NotificationPublisher> extensionClass() {
         return KafkaNotificationPublisher.class;
     }

--- a/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/mattermost/MattermostNotificationPublisherFactory.java
+++ b/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/mattermost/MattermostNotificationPublisherFactory.java
@@ -45,6 +45,11 @@ public final class MattermostNotificationPublisherFactory implements Notificatio
     }
 
     @Override
+    public String displayName() {
+        return "Mattermost";
+    }
+
+    @Override
     public Class<? extends NotificationPublisher> extensionClass() {
         return MattermostNotificationPublisher.class;
     }

--- a/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/msteams/MsTeamsNotificationPublisherFactory.java
+++ b/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/msteams/MsTeamsNotificationPublisherFactory.java
@@ -45,6 +45,11 @@ public final class MsTeamsNotificationPublisherFactory implements NotificationPu
     }
 
     @Override
+    public String displayName() {
+        return "Microsoft Teams";
+    }
+
+    @Override
     public Class<? extends NotificationPublisher> extensionClass() {
         return MsTeamsNotificationPublisher.class;
     }

--- a/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/slack/SlackNotificationPublisherFactory.java
+++ b/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/slack/SlackNotificationPublisherFactory.java
@@ -45,6 +45,11 @@ public final class SlackNotificationPublisherFactory implements NotificationPubl
     }
 
     @Override
+    public String displayName() {
+        return "Slack";
+    }
+
+    @Override
     public Class<? extends NotificationPublisher> extensionClass() {
         return SlackNotificationPublisher.class;
     }

--- a/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/webex/WebexNotificationPublisherFactory.java
+++ b/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/webex/WebexNotificationPublisherFactory.java
@@ -45,6 +45,11 @@ public final class WebexNotificationPublisherFactory implements NotificationPubl
     }
 
     @Override
+    public String displayName() {
+        return "Webex";
+    }
+
+    @Override
     public Class<? extends NotificationPublisher> extensionClass() {
         return WebexNotificationPublisher.class;
     }

--- a/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/webhook/WebhookNotificationPublisherFactory.java
+++ b/notification/publishing/src/main/java/org/dependencytrack/notification/publishing/webhook/WebhookNotificationPublisherFactory.java
@@ -45,6 +45,11 @@ public final class WebhookNotificationPublisherFactory implements NotificationPu
     }
 
     @Override
+    public String displayName() {
+        return "Webhook";
+    }
+
+    @Override
     public Class<? extends NotificationPublisher> extensionClass() {
         return WebhookNotificationPublisher.class;
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolverFactory.java
@@ -45,6 +45,11 @@ public final class CargoPackageMetadataResolverFactory implements PackageMetadat
     }
 
     @Override
+    public String displayName() {
+        return "Cargo";
+    }
+
+    @Override
     public Class<? extends PackageMetadataResolver> extensionClass() {
         return CargoPackageMetadataResolver.class;
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/composer/ComposerPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/composer/ComposerPackageMetadataResolverFactory.java
@@ -45,6 +45,11 @@ public final class ComposerPackageMetadataResolverFactory implements PackageMeta
     }
 
     @Override
+    public String displayName() {
+        return "Composer";
+    }
+
+    @Override
     public Class<? extends PackageMetadataResolver> extensionClass() {
         return ComposerPackageMetadataResolver.class;
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cpan/CpanPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cpan/CpanPackageMetadataResolverFactory.java
@@ -45,6 +45,11 @@ public final class CpanPackageMetadataResolverFactory implements PackageMetadata
     }
 
     @Override
+    public String displayName() {
+        return "CPAN";
+    }
+
+    @Override
     public Class<? extends PackageMetadataResolver> extensionClass() {
         return CpanPackageMetadataResolver.class;
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gem/GemPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gem/GemPackageMetadataResolverFactory.java
@@ -45,6 +45,11 @@ public final class GemPackageMetadataResolverFactory implements PackageMetadataR
     }
 
     @Override
+    public String displayName() {
+        return "RubyGems";
+    }
+
+    @Override
     public Class<? extends PackageMetadataResolver> extensionClass() {
         return GemPackageMetadataResolver.class;
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/github/GithubPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/github/GithubPackageMetadataResolverFactory.java
@@ -45,6 +45,11 @@ public final class GithubPackageMetadataResolverFactory implements PackageMetada
     }
 
     @Override
+    public String displayName() {
+        return "GitHub";
+    }
+
+    @Override
     public Class<? extends PackageMetadataResolver> extensionClass() {
         return GithubPackageMetadataResolver.class;
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gomodules/GoModulesPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gomodules/GoModulesPackageMetadataResolverFactory.java
@@ -45,6 +45,11 @@ public final class GoModulesPackageMetadataResolverFactory implements PackageMet
     }
 
     @Override
+    public String displayName() {
+        return "Go Modules";
+    }
+
+    @Override
     public Class<? extends PackageMetadataResolver> extensionClass() {
         return GoModulesPackageMetadataResolver.class;
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/hackage/HackagePackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/hackage/HackagePackageMetadataResolverFactory.java
@@ -45,6 +45,11 @@ public final class HackagePackageMetadataResolverFactory implements PackageMetad
     }
 
     @Override
+    public String displayName() {
+        return "Hackage";
+    }
+
+    @Override
     public Class<? extends PackageMetadataResolver> extensionClass() {
         return HackagePackageMetadataResolver.class;
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/hex/HexPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/hex/HexPackageMetadataResolverFactory.java
@@ -45,6 +45,11 @@ public final class HexPackageMetadataResolverFactory implements PackageMetadataR
     }
 
     @Override
+    public String displayName() {
+        return "Hex";
+    }
+
+    @Override
     public Class<? extends PackageMetadataResolver> extensionClass() {
         return HexPackageMetadataResolver.class;
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolverFactory.java
@@ -43,6 +43,11 @@ public final class MavenPackageMetadataResolverFactory implements PackageMetadat
     }
 
     @Override
+    public String displayName() {
+        return "Maven";
+    }
+
+    @Override
     public Class<? extends PackageMetadataResolver> extensionClass() {
         return MavenPackageMetadataResolver.class;
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nixpkgs/NixpkgsPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nixpkgs/NixpkgsPackageMetadataResolverFactory.java
@@ -44,6 +44,11 @@ public final class NixpkgsPackageMetadataResolverFactory implements PackageMetad
     }
 
     @Override
+    public String displayName() {
+        return "Nixpkgs";
+    }
+
+    @Override
     public Class<? extends PackageMetadataResolver> extensionClass() {
         return NixpkgsPackageMetadataResolver.class;
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/npm/NpmPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/npm/NpmPackageMetadataResolverFactory.java
@@ -46,6 +46,11 @@ public final class NpmPackageMetadataResolverFactory implements PackageMetadataR
     }
 
     @Override
+    public String displayName() {
+        return "npm";
+    }
+
+    @Override
     public Class<? extends PackageMetadataResolver> extensionClass() {
         return NpmPackageMetadataResolver.class;
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nuget/NugetPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nuget/NugetPackageMetadataResolverFactory.java
@@ -45,6 +45,11 @@ public final class NugetPackageMetadataResolverFactory implements PackageMetadat
     }
 
     @Override
+    public String displayName() {
+        return "NuGet";
+    }
+
+    @Override
     public Class<? extends PackageMetadataResolver> extensionClass() {
         return NugetPackageMetadataResolver.class;
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/pypi/PypiPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/pypi/PypiPackageMetadataResolverFactory.java
@@ -46,6 +46,11 @@ public final class PypiPackageMetadataResolverFactory implements PackageMetadata
     }
 
     @Override
+    public String displayName() {
+        return "PyPI";
+    }
+
+    @Override
     public Class<? extends PackageMetadataResolver> extensionClass() {
         return PypiPackageMetadataResolver.class;
     }

--- a/plugin/api/src/main/java/org/dependencytrack/plugin/api/ExtensionFactory.java
+++ b/plugin/api/src/main/java/org/dependencytrack/plugin/api/ExtensionFactory.java
@@ -34,12 +34,10 @@ public interface ExtensionFactory<T extends ExtensionPoint> extends Closeable {
     String extensionName();
 
     /**
-     * @return Human-readable name of the extension, for display purposes. Defaults to {@link #extensionName()}.
+     * @return Human-readable name of the extension, for display purposes.
      * @since 5.1.0
      */
-    default String displayName() {
-        return extensionName();
-    }
+    String displayName();
 
     /**
      * @return {@link Class} of the extension.

--- a/plugin/runtime/src/test/java/org/dependencytrack/plugin/runtime/DummyTestExtensionFactory.java
+++ b/plugin/runtime/src/test/java/org/dependencytrack/plugin/runtime/DummyTestExtensionFactory.java
@@ -33,6 +33,11 @@ class DummyTestExtensionFactory implements ExtensionFactory<@NonNull TestExtensi
     }
 
     @Override
+    public @NonNull String displayName() {
+        return DummyTestExtension.NAME;
+    }
+
+    @Override
     public @NonNull Class<? extends TestExtensionPoint> extensionClass() {
         return DummyTestExtension.class;
     }

--- a/plugin/testing/src/main/java/org/dependencytrack/plugin/testing/AbstractExtensionFactoryTest.java
+++ b/plugin/testing/src/main/java/org/dependencytrack/plugin/testing/AbstractExtensionFactoryTest.java
@@ -68,6 +68,11 @@ public abstract class AbstractExtensionFactoryTest<T extends ExtensionPoint, U e
     }
 
     @Test
+    void shouldDefineDisplayName() {
+        assertThat(factory.displayName()).isNotBlank();
+    }
+
+    @Test
     void shouldDefineExtensionClass() {
         assertThat(factory.extensionClass()).isNotNull();
     }

--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerFactory.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerFactory.java
@@ -49,6 +49,11 @@ public final class CheckmarxVulnAnalyzerFactory implements VulnAnalyzerFactory, 
     }
 
     @Override
+    public String displayName() {
+        return "Checkmarx SCA";
+    }
+
+    @Override
     public Class<? extends VulnAnalyzer> extensionClass() {
         return CheckmarxVulnAnalyzer.class;
     }

--- a/vuln-analysis/internal/src/main/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzerFactory.java
+++ b/vuln-analysis/internal/src/main/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzerFactory.java
@@ -58,6 +58,11 @@ final class InternalVulnAnalyzerFactory implements VulnAnalyzerFactory, RuntimeC
     }
 
     @Override
+    public String displayName() {
+        return "Internal";
+    }
+
+    @Override
     public Class<? extends VulnAnalyzer> extensionClass() {
         return InternalVulnAnalyzer.class;
     }

--- a/vuln-analysis/oss-index/src/main/java/org/dependencytrack/vulnanalysis/ossindex/OssIndexVulnAnalyzerFactory.java
+++ b/vuln-analysis/oss-index/src/main/java/org/dependencytrack/vulnanalysis/ossindex/OssIndexVulnAnalyzerFactory.java
@@ -70,6 +70,11 @@ final class OssIndexVulnAnalyzerFactory implements VulnAnalyzerFactory, RuntimeC
     }
 
     @Override
+    public String displayName() {
+        return "Sonatype OSS Index";
+    }
+
+    @Override
     public Class<? extends VulnAnalyzer> extensionClass() {
         return OssIndexVulnAnalyzer.class;
     }

--- a/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzerFactory.java
+++ b/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzerFactory.java
@@ -55,6 +55,11 @@ final class SnykVulnAnalyzerFactory implements VulnAnalyzerFactory, RuntimeConfi
     }
 
     @Override
+    public String displayName() {
+        return "Snyk";
+    }
+
+    @Override
     public Class<? extends VulnAnalyzer> extensionClass() {
         return SnykVulnAnalyzer.class;
     }

--- a/vuln-analysis/trivy/src/main/java/org/dependencytrack/vulnanalysis/trivy/TrivyVulnAnalyzerFactory.java
+++ b/vuln-analysis/trivy/src/main/java/org/dependencytrack/vulnanalysis/trivy/TrivyVulnAnalyzerFactory.java
@@ -44,6 +44,11 @@ final class TrivyVulnAnalyzerFactory implements VulnAnalyzerFactory, RuntimeConf
     }
 
     @Override
+    public String displayName() {
+        return "Trivy";
+    }
+
+    @Override
     public Class<? extends VulnAnalyzer> extensionClass() {
         return TrivyVulnAnalyzer.class;
     }

--- a/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzerFactory.java
+++ b/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzerFactory.java
@@ -53,6 +53,11 @@ final class VulnDbVulnAnalyzerFactory implements VulnAnalyzerFactory, RuntimeCon
     }
 
     @Override
+    public String displayName() {
+        return "VulnDB";
+    }
+
+    @Override
     public Class<? extends VulnAnalyzer> extensionClass() {
         return VulnDbVulnAnalyzer.class;
     }

--- a/vuln-data-source/github/src/main/java/org/dependencytrack/vulndatasource/github/GitHubVulnDataSourceFactory.java
+++ b/vuln-data-source/github/src/main/java/org/dependencytrack/vulndatasource/github/GitHubVulnDataSourceFactory.java
@@ -58,6 +58,11 @@ final class GitHubVulnDataSourceFactory implements VulnDataSourceFactory, Runtim
     }
 
     @Override
+    public String displayName() {
+        return "GitHub Advisories";
+    }
+
+    @Override
     public Class<? extends VulnDataSource> extensionClass() {
         return GitHubVulnDataSource.class;
     }

--- a/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSourceFactory.java
+++ b/vuln-data-source/jvn/src/main/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSourceFactory.java
@@ -71,6 +71,11 @@ final class JvnVulnDataSourceFactory implements VulnDataSourceFactory, RuntimeCo
     }
 
     @Override
+    public String displayName() {
+        return "JVN iPedia";
+    }
+
+    @Override
     public Class<? extends VulnDataSource> extensionClass() {
         return JvnVulnDataSource.class;
     }

--- a/vuln-data-source/jvn/src/test/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSourceFactoryTest.java
+++ b/vuln-data-source/jvn/src/test/java/org/dependencytrack/vulndatasource/jvn/JvnVulnDataSourceFactoryTest.java
@@ -16,12 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-package org.dependencytrack.e2e.api.model;
+package org.dependencytrack.vulndatasource.jvn;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.dependencytrack.plugin.testing.AbstractExtensionFactoryTest;
+import org.dependencytrack.vulndatasource.api.VulnDataSource;
 
-import java.util.UUID;
+class JvnVulnDataSourceFactoryTest extends AbstractExtensionFactoryTest<VulnDataSource, JvnVulnDataSourceFactory> {
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-public record NotificationPublisher(UUID uuid, String name, String extensionName) {
+    protected JvnVulnDataSourceFactoryTest() {
+        super(JvnVulnDataSourceFactory.class);
+    }
 }

--- a/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdVulnDataSourceFactory.java
+++ b/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdVulnDataSourceFactory.java
@@ -72,6 +72,11 @@ final class NvdVulnDataSourceFactory implements VulnDataSourceFactory, RuntimeCo
     }
 
     @Override
+    public String displayName() {
+        return "NVD";
+    }
+
+    @Override
     public Class<? extends VulnDataSource> extensionClass() {
         return NvdVulnDataSource.class;
     }

--- a/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSourceFactory.java
+++ b/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSourceFactory.java
@@ -52,6 +52,11 @@ final class OsvVulnDataSourceFactory implements VulnDataSourceFactory, RuntimeCo
     }
 
     @Override
+    public String displayName() {
+        return "OSV";
+    }
+
+    @Override
     public Class<? extends VulnDataSource> extensionClass() {
         return OsvVulnDataSource.class;
     }


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Defines display names for all extensions.

Overrides `ExtensionFactory#displayName` for all extensions. The method was introduced for KEV data sources but never applied broadly.

Performs a small DB migration to rename the MS Teams default publisher, since its seeded name changes from `Msteams` to `Microsoft Teams`.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
