### PR TITLE
dex: Avoid unnecessary allocations during history replay

### DIFF
--- a/dex/api/src/main/java/org/dependencytrack/dex/api/RetryPolicy.java
+++ b/dex/api/src/main/java/org/dependencytrack/dex/api/RetryPolicy.java
@@ -31,6 +31,9 @@ public record RetryPolicy(
         Duration maxDelay,
         int maxAttempts) {
 
+    private static final RetryPolicy DEFAULT =
+            new RetryPolicy(Duration.ofSeconds(5), 1.5, 0.3, Duration.ofMinutes(30), 6);
+
     public RetryPolicy {
         requireNonNull(initialDelay, "initialDelay must not be null");
         if (initialDelay.isZero() || initialDelay.isNegative()) {
@@ -52,7 +55,7 @@ public record RetryPolicy(
     }
 
     public static RetryPolicy ofDefault() {
-        return new RetryPolicy(Duration.ofSeconds(5), 1.5, 0.3, Duration.ofMinutes(30), 6);
+        return DEFAULT;
     }
 
     public static RetryPolicy fromProto(final org.dependencytrack.dex.proto.common.v1.RetryPolicy protoPolicy) {

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowContextImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowContextImpl.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.dex.engine;
 
 import com.google.protobuf.DebugFormat;
+import com.google.protobuf.Timestamp;
 import org.dependencytrack.dex.api.Activity;
 import org.dependencytrack.dex.api.ActivityHandle;
 import org.dependencytrack.dex.api.Awaitable;
@@ -105,13 +106,12 @@ final class WorkflowContextImpl<A, R> implements WorkflowContext<A> {
     private final Logger logger;
     private int currentEventIndex;
     private int currentEventId;
-    private @Nullable Instant currentTime;
+    private @Nullable Timestamp currentTime;
     private @Nullable A argument;
     private boolean isInSideEffect;
     private boolean isReplaying;
     private boolean isSuspended;
     private @Nullable String customStatus;
-    private int randomCounter;
 
     WorkflowContextImpl(
             final UUID runId,
@@ -173,7 +173,7 @@ final class WorkflowContextImpl<A, R> implements WorkflowContext<A> {
             throw new IllegalStateException("currentTime was not initialized");
         }
 
-        return currentTime;
+        return toInstant(currentTime);
     }
 
     @Override
@@ -473,7 +473,7 @@ final class WorkflowContextImpl<A, R> implements WorkflowContext<A> {
     }
 
     private void onWorkflowTaskStarted(final WorkflowEvent event) {
-        currentTime = toInstant(event.getTimestamp());
+        currentTime = event.getTimestamp();
     }
 
     private void onRunCreated(final WorkflowEvent event) {


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

dex: Avoid unnecessary allocations during history replay.

Stops converting the timestamp of every event from Proto `Timestamp` to Java `Instant` during replay. Only convert lazily when the timestamp is requested in workflow code.

Stops allocating new `RetryPolicy` objects for `RetryPolicy#ofDefault`. Gets called for every activity invocation, including during history replay. Use a constant instead.

Note these are not big memory hogs, they're just unnecessary and avoidable waste.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
