### PR TITLE
Run spotless:apply after Maven release plugin modifies them POM

### DIFF
--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -686,7 +686,7 @@
                         <phase>prepare-package</phase>
                         <configuration>
                             <target>
-                                <copy file="${project.build.directory}/bom.json" tofile="${project.build.outputDirectory}/static/.well-known/sbom" />
+                                <copy file="${project.build.directory}/bom.json" tofile="${project.build.outputDirectory}/static/.well-known/sbom"/>
                             </target>
                             <skip>${cyclonedx.skip}</skip>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -798,8 +798,8 @@
                         <pushChanges>true</pushChanges>
                         <localCheckout>true</localCheckout>
                         <releaseProfiles>quick</releaseProfiles>
-                        <preparationGoals>clean verify -Pquick</preparationGoals>
-                        <completionGoals>clean</completionGoals>
+                        <preparationGoals>clean verify spotless:apply -Pquick</preparationGoals>
+                        <completionGoals>clean spotless:apply</completionGoals>
                         <signTag>false</signTag>
                     </configuration>
                 </plugin>
@@ -836,17 +836,17 @@
                         <phase>validate</phase>
                         <configuration>
                             <rules>
-                                <banDuplicatePomDependencyVersions />
-                                <reactorModuleConvergence />
+                                <banDuplicatePomDependencyVersions/>
+                                <reactorModuleConvergence/>
                                 <requireJavaVersion>
                                     <version>[25,)</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>[3.9,)</version>
                                 </requireMavenVersion>
-                                <requireNoRepositories />
-                                <requirePluginVersions />
-                                <requireUpperBoundDeps />
+                                <requireNoRepositories/>
+                                <requirePluginVersions/>
+                                <requireUpperBoundDeps/>
                             </rules>
                         </configuration>
                     </execution>
@@ -866,9 +866,9 @@
                         <importOrder>
                             <order>,jakarta,javax|java,\#</order>
                         </importOrder>
-                        <removeUnusedImports />
-                        <forbidWildcardImports />
-                        <forbidModuleImports />
+                        <removeUnusedImports/>
+                        <forbidWildcardImports/>
+                        <forbidModuleImports/>
                     </java>
                     <pom>
                         <licenseHeader>

--- a/support/v4-migrator/pom.xml
+++ b/support/v4-migrator/pom.xml
@@ -132,7 +132,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>org.dependencytrack.v4migrator.V4Migrator</mainClass>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
                         </configuration>
                     </execution>
@@ -148,7 +148,7 @@
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <excludes combine.self="override" />
+                            <excludes combine.self="override"/>
                             <includes>
                                 <include>**/*Test.java</include>
                                 <include>**/*IT.java</include>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Runs spotless:apply after Maven release plugin modifies them POM.

Prevents `make lint-java` from failing after release.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
