### PR TITLE
Decouple API v1 DELETE endpoints from JDO models

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/NotificationRuleResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/NotificationRuleResource.java
@@ -54,6 +54,7 @@ import org.dependencytrack.resources.v1.problems.InvalidNotificationFilterExpres
 import org.dependencytrack.resources.v1.problems.ProblemDetails;
 import org.dependencytrack.resources.v1.vo.CreateNotificationRuleRequest;
 import org.dependencytrack.resources.v1.vo.CreateScheduledNotificationRuleRequest;
+import org.dependencytrack.resources.v1.vo.DeleteNotificationRuleRequest;
 import org.dependencytrack.resources.v1.vo.UpdateNotificationRuleRequest;
 import org.owasp.security.logging.SecurityMarkers;
 import org.slf4j.Logger;
@@ -404,10 +405,10 @@ public class NotificationRuleResource extends AbstractApiResource {
                 @ApiResponse(responseCode = "404", description = "The UUID of the notification rule could not be found")
             })
     @PermissionRequired({Permissions.Constants.SYSTEM_CONFIGURATION, Permissions.Constants.SYSTEM_CONFIGURATION_DELETE})
-    public Response deleteNotificationRule(NotificationRule jsonRule) {
+    public Response deleteNotificationRule(DeleteNotificationRuleRequest request) {
         try (final var qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
-                final NotificationRule rule = qm.getObjectByUuid(NotificationRule.class, jsonRule.getUuid());
+                final NotificationRule rule = qm.getObjectByUuid(NotificationRule.class, request.uuid());
                 if (rule != null) {
                     qm.delete(rule);
                     return Response.status(Response.Status.NO_CONTENT).build();

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
@@ -44,6 +44,7 @@ import org.dependencytrack.resources.AbstractApiResource;
 import org.dependencytrack.resources.v1.openapi.PaginatedApi;
 import org.dependencytrack.resources.v1.problems.ProblemDetails;
 import org.dependencytrack.resources.v1.problems.TeamAlreadyExistsProblemDetails;
+import org.dependencytrack.resources.v1.vo.DeleteTeamRequest;
 import org.dependencytrack.resources.v1.vo.TeamSelfResponse;
 import org.dependencytrack.resources.v1.vo.VisibleTeams;
 import org.owasp.security.logging.SecurityMarkers;
@@ -245,10 +246,10 @@ public class TeamResource extends AbstractApiResource {
                 @ApiResponse(responseCode = "404", description = "The team could not be found")
             })
     @PermissionRequired({Permissions.Constants.ACCESS_MANAGEMENT, Permissions.Constants.ACCESS_MANAGEMENT_DELETE})
-    public Response deleteTeam(Team jsonTeam) {
+    public Response deleteTeam(DeleteTeamRequest request) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
-                final Team team = qm.getObjectByUuid(Team.class, jsonTeam.getUuid(), Team.FetchGroup.ALL.name());
+                final Team team = qm.getObjectByUuid(Team.class, request.uuid(), Team.FetchGroup.ALL.name());
                 if (team != null) {
                     final String teamName = team.getName();
                     qm.delete(team);

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/UserResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/UserResource.java
@@ -49,6 +49,7 @@ import org.dependencytrack.notification.NotificationModelConverter;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.AbstractApiResource;
 import org.dependencytrack.resources.v1.problems.ProblemDetails;
+import org.dependencytrack.resources.v1.vo.DeleteUserRequest;
 import org.dependencytrack.resources.v1.vo.TeamsSetRequest;
 import org.owasp.security.logging.SecurityMarkers;
 import org.slf4j.Logger;
@@ -564,16 +565,16 @@ public class UserResource extends AbstractApiResource {
                 @ApiResponse(responseCode = "404", description = "The user could not be found")
             })
     @PermissionRequired({Permissions.Constants.ACCESS_MANAGEMENT, Permissions.Constants.ACCESS_MANAGEMENT_DELETE})
-    public Response deleteLdapUser(LdapUser jsonUser) {
+    public Response deleteLdapUser(DeleteUserRequest request) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
-                final LdapUser user = qm.getLdapUser(jsonUser.getUsername());
+                final LdapUser user = qm.getLdapUser(request.username());
                 if (user != null) {
                     new JdoNotificationEmitter(qm)
                             .emit(createUserDeletedNotification(NotificationModelConverter.convert(user)));
                     qm.delete(user);
                     super.logSecurityEvent(
-                            LOGGER, SecurityMarkers.SECURITY_AUDIT, "LDAP user deleted: " + jsonUser.getUsername());
+                            LOGGER, SecurityMarkers.SECURITY_AUDIT, "LDAP user deleted: " + request.username());
                     return Response.status(Response.Status.NO_CONTENT).build();
                 } else {
                     return Response.status(Response.Status.NOT_FOUND)
@@ -733,16 +734,16 @@ public class UserResource extends AbstractApiResource {
                 @ApiResponse(responseCode = "404", description = "The user could not be found")
             })
     @PermissionRequired({Permissions.Constants.ACCESS_MANAGEMENT, Permissions.Constants.ACCESS_MANAGEMENT_DELETE})
-    public Response deleteManagedUser(ManagedUser jsonUser) {
+    public Response deleteManagedUser(DeleteUserRequest request) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
-                final ManagedUser user = qm.getManagedUser(jsonUser.getUsername());
+                final ManagedUser user = qm.getManagedUser(request.username());
                 if (user != null) {
                     new JdoNotificationEmitter(qm)
                             .emit(createUserDeletedNotification(NotificationModelConverter.convert(user)));
                     qm.delete(user);
                     super.logSecurityEvent(
-                            LOGGER, SecurityMarkers.SECURITY_AUDIT, "Managed user deleted: " + jsonUser.getUsername());
+                            LOGGER, SecurityMarkers.SECURITY_AUDIT, "Managed user deleted: " + request.username());
                     return Response.status(Response.Status.NO_CONTENT).build();
                 } else {
                     return Response.status(Response.Status.NOT_FOUND)
@@ -816,10 +817,10 @@ public class UserResource extends AbstractApiResource {
                 @ApiResponse(responseCode = "404", description = "The user could not be found")
             })
     @PermissionRequired({Permissions.Constants.ACCESS_MANAGEMENT, Permissions.Constants.ACCESS_MANAGEMENT_DELETE})
-    public Response deleteOidcUser(final OidcUser jsonUser) {
+    public Response deleteOidcUser(final DeleteUserRequest request) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             return qm.callInTransaction(() -> {
-                final OidcUser user = qm.getOidcUser(jsonUser.getUsername());
+                final OidcUser user = qm.getOidcUser(request.username());
                 if (user != null) {
                     new JdoNotificationEmitter(qm)
                             .emit(createUserDeletedNotification(NotificationModelConverter.convert(user)));
@@ -827,7 +828,7 @@ public class UserResource extends AbstractApiResource {
                     super.logSecurityEvent(
                             LOGGER,
                             SecurityMarkers.SECURITY_AUDIT,
-                            "OpenID Connect user deleted: " + jsonUser.getUsername());
+                            "OpenID Connect user deleted: " + request.username());
                     return Response.status(Response.Status.NO_CONTENT).build();
                 } else {
                     return Response.status(Response.Status.NOT_FOUND)

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/DeleteNotificationRuleRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/DeleteNotificationRuleRequest.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.jspecify.annotations.NullMarked;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+/// @since 5.2.0
+@NullMarked
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DeleteNotificationRuleRequest(
+        @NotNull
+        @Schema(description = "UUID of the notification rule to delete", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID uuid) {}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/DeleteTeamRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/DeleteTeamRequest.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.jspecify.annotations.NullMarked;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+/// @since 5.2.0
+@NullMarked
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DeleteTeamRequest(
+        @NotNull @Schema(description = "UUID of the team to delete", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID uuid) {}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/DeleteUserRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/DeleteUserRequest.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.jspecify.annotations.NullMarked;
+
+import jakarta.validation.constraints.NotBlank;
+
+/// @since 5.2.0
+@NullMarked
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DeleteUserRequest(
+        @NotBlank @Schema(description = "Username of the user to delete", requiredMode = Schema.RequiredMode.REQUIRED)
+        String username) {}

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
@@ -279,14 +279,34 @@ class NotificationRuleResourceTest extends ResourceTest {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_DELETE);
         NotificationRule rule = qm.createNotificationRule(
                 "Rule 1", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
-        rule.setName("Example Rule");
         Response response = jersey.target(V1_NOTIFICATION_RULE)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true) // HACK
-                .method("DELETE", Entity.entity(rule, MediaType.APPLICATION_JSON)); // HACK
-        // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
+                // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
+                .method("DELETE", Entity.json(/* language=JSON */ """
+                        {
+                          "uuid": "%s"
+                        }
+                        """.formatted(rule.getUuid())));
         Assertions.assertEquals(204, response.getStatus(), 0);
+    }
+
+    @Test
+    void deleteNotificationRuleWithUnknownUuidTest() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_DELETE);
+
+        final Response response = jersey.target(V1_NOTIFICATION_RULE)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method("DELETE", Entity.json(/* language=JSON */ """
+                        {
+                          "uuid": "d6b6bb50-4d9f-4a56-a68a-1b2a2b7f8e5b"
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(getPlainTextBody(response)).isEqualTo("The UUID of the notification rule could not be found.");
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
@@ -344,8 +344,12 @@ public class TeamResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true) // HACK
-                .method("DELETE", Entity.entity(team, MediaType.APPLICATION_JSON)); // HACK
-        // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
+                // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
+                .method("DELETE", Entity.json(/* language=JSON */ """
+                        {
+                          "uuid": "%s"
+                        }
+                        """.formatted(team.getUuid())));
         org.junit.jupiter.api.Assertions.assertEquals(204, response.getStatus(), 0);
     }
 
@@ -375,9 +379,30 @@ public class TeamResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true) // HACK
-                .method("DELETE", Entity.entity(team, MediaType.APPLICATION_JSON)); // HACK
-        // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
+                // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
+                .method("DELETE", Entity.json(/* language=JSON */ """
+                        {
+                          "uuid": "%s"
+                        }
+                        """.formatted(team.getUuid())));
         org.junit.jupiter.api.Assertions.assertEquals(204, response.getStatus(), 0);
+    }
+
+    @Test
+    public void deleteTeamWithUnknownUuidTest() {
+        initializeWithPermissions(Permissions.ACCESS_MANAGEMENT_DELETE);
+
+        final Response response = jersey.target(V1_TEAM)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method("DELETE", Entity.json(/* language=JSON */ """
+                        {
+                          "uuid": "d6b6bb50-4d9f-4a56-a68a-1b2a2b7f8e5b"
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(getPlainTextBody(response)).isEqualTo("The team could not be found.");
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/UserResourceAuthenticatedTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/UserResourceAuthenticatedTest.java
@@ -295,14 +295,16 @@ class UserResourceAuthenticatedTest extends ResourceTest {
         createCatchAllNotificationRule(qm, NotificationScope.SYSTEM);
 
         qm.createLdapUser("blackbeard");
-        LdapUser user = new LdapUser();
-        user.setUsername("blackbeard");
         Response response = jersey.target(V1_USER + "/ldap")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true) // HACK
-                .method("DELETE", Entity.entity(user, MediaType.APPLICATION_JSON)); // HACK
-        // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
+                // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
+                .method("DELETE", Entity.json(/* language=JSON */ """
+                        {
+                          "username": "blackbeard"
+                        }
+                        """));
         Assertions.assertEquals(204, response.getStatus(), 0);
 
         assertThat(qm.getNotificationOutbox()).satisfiesExactly(notification -> {
@@ -312,6 +314,23 @@ class UserResourceAuthenticatedTest extends ResourceTest {
             assertThat(notification.getTitle()).isEqualTo("User Deleted");
             assertThat(notification.getContent()).isEqualTo("User blackbeard was deleted");
         });
+    }
+
+    @Test
+    void deleteLdapUserWithUnknownUsernameTest() {
+        initializeWithPermissions(Permissions.ACCESS_MANAGEMENT_DELETE);
+
+        final Response response = jersey.target(V1_USER + "/ldap")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method("DELETE", Entity.json(/* language=JSON */ """
+                        {
+                          "username": "does-not-exist"
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(getPlainTextBody(response)).isEqualTo("The user could not be found.");
     }
 
     @Test
@@ -590,6 +609,23 @@ class UserResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
+    void deleteManagedUserWithUnknownUsernameTest() {
+        initializeWithPermissions(Permissions.ACCESS_MANAGEMENT_DELETE);
+
+        final Response response = jersey.target(V1_USER + "/managed")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method("DELETE", Entity.json(/* language=JSON */ """
+                        {
+                          "username": "does-not-exist"
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(getPlainTextBody(response)).isEqualTo("The user could not be found.");
+    }
+
+    @Test
     void deleteManagedUserTest() {
         initializeWithPermissions(Permissions.ACCESS_MANAGEMENT_DELETE);
 
@@ -603,14 +639,16 @@ class UserResourceAuthenticatedTest extends ResourceTest {
                 false,
                 false,
                 false);
-        ManagedUser user = new ManagedUser();
-        user.setUsername("blackbeard");
         Response response = jersey.target(V1_USER + "/managed")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true) // HACK
-                .method("DELETE", Entity.entity(user, MediaType.APPLICATION_JSON)); // HACK
-        // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
+                // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
+                .method("DELETE", Entity.json(/* language=JSON */ """
+                        {
+                          "username": "blackbeard"
+                        }
+                        """));
         Assertions.assertEquals(204, response.getStatus(), 0);
 
         assertThat(qm.getNotificationOutbox()).satisfiesExactly(notification -> {
@@ -670,15 +708,34 @@ class UserResourceAuthenticatedTest extends ResourceTest {
         initializeWithPermissions(Permissions.ACCESS_MANAGEMENT_DELETE);
 
         qm.createOidcUser("blackbeard");
-        OidcUser user = new OidcUser();
-        user.setUsername("blackbeard");
         Response response = jersey.target(V1_USER + "/oidc")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true) // HACK
-                .method("DELETE", Entity.entity(user, MediaType.APPLICATION_JSON)); // HACK
-        // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
+                // Hack: Workaround to https://github.com/eclipse-ee4j/jersey/issues/3798
+                .method("DELETE", Entity.json(/* language=JSON */ """
+                        {
+                          "username": "blackbeard"
+                        }
+                        """));
         Assertions.assertEquals(204, response.getStatus(), 0);
+    }
+
+    @Test
+    void deleteOidcUserWithUnknownUsernameTest() {
+        initializeWithPermissions(Permissions.ACCESS_MANAGEMENT_DELETE);
+
+        final Response response = jersey.target(V1_USER + "/oidc")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method("DELETE", Entity.json(/* language=JSON */ """
+                        {
+                          "username": "does-not-exist"
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(getPlainTextBody(response)).isEqualTo("The user could not be found.");
     }
 
     @Test

--- a/apiserver/src/test/resources/archunit_store/3e49066c-46b2-40c2-8473-ce4276c1ba12
+++ b/apiserver/src/test/resources/archunit_store/3e49066c-46b2-40c2-8473-ce4276c1ba12
@@ -1,6 +1,5 @@
 org.dependencytrack.resources.v1.ComponentResource.createComponent(java.lang.String, org.dependencytrack.model.Component) accepts JDO model class org.dependencytrack.model.Component as request body
 org.dependencytrack.resources.v1.ComponentResource.updateComponent(org.dependencytrack.model.Component) accepts JDO model class org.dependencytrack.model.Component as request body
-org.dependencytrack.resources.v1.NotificationRuleResource.deleteNotificationRule(org.dependencytrack.model.NotificationRule) accepts JDO model class org.dependencytrack.model.NotificationRule as request body
 org.dependencytrack.resources.v1.OidcResource.createGroup(alpine.model.OidcGroup) accepts JDO model class alpine.model.OidcGroup as request body
 org.dependencytrack.resources.v1.OidcResource.updateGroup(alpine.model.OidcGroup) accepts JDO model class alpine.model.OidcGroup as request body
 org.dependencytrack.resources.v1.PolicyResource.createPolicy(org.dependencytrack.model.Policy) accepts JDO model class org.dependencytrack.model.Policy as request body
@@ -11,14 +10,10 @@ org.dependencytrack.resources.v1.ProjectResource.updateProject(org.dependencytra
 org.dependencytrack.resources.v1.ServiceResource.createService(java.lang.String, org.dependencytrack.model.ServiceComponent) accepts JDO model class org.dependencytrack.model.ServiceComponent as request body
 org.dependencytrack.resources.v1.ServiceResource.updateService(org.dependencytrack.model.ServiceComponent) accepts JDO model class org.dependencytrack.model.ServiceComponent as request body
 org.dependencytrack.resources.v1.TeamResource.createTeam(alpine.model.Team) accepts JDO model class alpine.model.Team as request body
-org.dependencytrack.resources.v1.TeamResource.deleteTeam(alpine.model.Team) accepts JDO model class alpine.model.Team as request body
 org.dependencytrack.resources.v1.TeamResource.updateTeam(alpine.model.Team) accepts JDO model class alpine.model.Team as request body
 org.dependencytrack.resources.v1.UserResource.createLdapUser(alpine.model.LdapUser) accepts JDO model class alpine.model.LdapUser as request body
 org.dependencytrack.resources.v1.UserResource.createManagedUser(alpine.model.ManagedUser) accepts JDO model class alpine.model.ManagedUser as request body
 org.dependencytrack.resources.v1.UserResource.createOidcUser(alpine.model.OidcUser) accepts JDO model class alpine.model.OidcUser as request body
-org.dependencytrack.resources.v1.UserResource.deleteLdapUser(alpine.model.LdapUser) accepts JDO model class alpine.model.LdapUser as request body
-org.dependencytrack.resources.v1.UserResource.deleteManagedUser(alpine.model.ManagedUser) accepts JDO model class alpine.model.ManagedUser as request body
-org.dependencytrack.resources.v1.UserResource.deleteOidcUser(alpine.model.OidcUser) accepts JDO model class alpine.model.OidcUser as request body
 org.dependencytrack.resources.v1.UserResource.updateManagedUser(alpine.model.ManagedUser) accepts JDO model class alpine.model.ManagedUser as request body
 org.dependencytrack.resources.v1.UserResource.updateSelf(alpine.model.ManagedUser) accepts JDO model class alpine.model.ManagedUser as request body
 org.dependencytrack.resources.v1.VulnerabilityResource.createVulnerability(org.dependencytrack.model.Vulnerability) accepts JDO model class org.dependencytrack.model.Vulnerability as request body


### PR DESCRIPTION

### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Refactors multiple DELETE endpoints in API v1 that previously accepted full JDO models as request body. This coupled persistence classes to the public API contract and polluted the corresponding OpenAPI docs.


### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
