### PR TITLE
Decouple more API v1 endpoints from JDO models

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
@@ -42,6 +42,7 @@ import org.dependencytrack.persistence.command.MakeAnalysisCommand;
 import org.dependencytrack.resources.AbstractApiResource;
 import org.dependencytrack.resources.v1.problems.ProblemDetails;
 import org.dependencytrack.resources.v1.vo.AnalysisRequest;
+import org.dependencytrack.resources.v1.vo.AnalysisTrailResponse;
 
 import jakarta.validation.Validator;
 import jakarta.ws.rs.Consumes;
@@ -74,7 +75,7 @@ public class AnalysisResource extends AbstractApiResource {
                 @ApiResponse(
                         responseCode = "200",
                         description = "An analysis trail",
-                        content = @Content(schema = @Schema(implementation = Analysis.class))),
+                        content = @Content(schema = @Schema(implementation = AnalysisTrailResponse.class))),
                 @ApiResponse(responseCode = "401", description = "Unauthorized"),
                 @ApiResponse(
                         responseCode = "403",
@@ -143,7 +144,7 @@ public class AnalysisResource extends AbstractApiResource {
                         .entity("No analysis exists.")
                         .build();
             }
-            return Response.ok(analysis).build();
+            return Response.ok(AnalysisTrailResponse.of(analysis)).build();
         }
     }
 
@@ -159,7 +160,7 @@ public class AnalysisResource extends AbstractApiResource {
                 @ApiResponse(
                         responseCode = "200",
                         description = "The created analysis",
-                        content = @Content(schema = @Schema(implementation = Analysis.class))),
+                        content = @Content(schema = @Schema(implementation = AnalysisTrailResponse.class))),
                 @ApiResponse(responseCode = "401", description = "Unauthorized"),
                 @ApiResponse(
                         responseCode = "403",
@@ -213,7 +214,8 @@ public class AnalysisResource extends AbstractApiResource {
                         .withSuppress(request.isSuppressed())
                         .withComment(request.getComment()));
 
-                return Response.ok(qm.getObjectById(Analysis.class, analysisId)).build();
+                return Response.ok(AnalysisTrailResponse.of(qm.getObjectById(Analysis.class, analysisId)))
+                        .build();
             });
         }
     }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/LdapResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/LdapResource.java
@@ -38,6 +38,7 @@ import org.dependencytrack.model.validation.ValidUuid;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.AbstractApiResource;
 import org.dependencytrack.resources.v1.vo.MappedLdapGroupRequest;
+import org.dependencytrack.resources.v1.vo.MappedLdapGroupResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,7 +142,10 @@ public class LdapResource extends AbstractApiResource {
                                 @Content(
                                         array =
                                                 @ArraySchema(
-                                                        schema = @Schema(implementation = MappedLdapGroup.class)))),
+                                                        schema =
+                                                                @Schema(
+                                                                        implementation =
+                                                                                MappedLdapGroupResponse.class)))),
                 @ApiResponse(responseCode = "401", description = "Unauthorized"),
                 @ApiResponse(responseCode = "404", description = "The UUID of the team could not be found"),
             })
@@ -157,7 +161,9 @@ public class LdapResource extends AbstractApiResource {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final Team team = qm.getObjectByUuid(Team.class, uuid);
             if (team != null) {
-                final List<MappedLdapGroup> mappings = qm.getMappedLdapGroups(team);
+                final List<MappedLdapGroupResponse> mappings = qm.getMappedLdapGroups(team).stream()
+                        .map(MappedLdapGroupResponse::of)
+                        .toList();
                 return Response.ok(mappings).build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND)
@@ -180,7 +186,7 @@ public class LdapResource extends AbstractApiResource {
                 @ApiResponse(
                         responseCode = "200",
                         description = "The created mapping",
-                        content = @Content(schema = @Schema(implementation = MappedLdapGroup.class))),
+                        content = @Content(schema = @Schema(implementation = MappedLdapGroupResponse.class))),
                 @ApiResponse(responseCode = "401", description = "Unauthorized"),
                 @ApiResponse(responseCode = "404", description = "The UUID of the team could not be found"),
                 @ApiResponse(responseCode = "409", description = "A mapping with the same team and dn already exists")
@@ -195,7 +201,7 @@ public class LdapResource extends AbstractApiResource {
                 if (team != null) {
                     if (!qm.isMapped(team, request.getDn())) {
                         final MappedLdapGroup mapping = qm.createMappedLdapGroup(team, request.getDn());
-                        return Response.ok(mapping).build();
+                        return Response.ok(MappedLdapGroupResponse.of(mapping)).build();
                     } else {
                         return Response.status(Response.Status.CONFLICT)
                                 .entity("A mapping with the same team and dn already exists.")

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/OidcResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/OidcResource.java
@@ -38,7 +38,11 @@ import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.validation.ValidUuid;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.AbstractApiResource;
+import org.dependencytrack.resources.v1.vo.CreateOidcGroupRequest;
 import org.dependencytrack.resources.v1.vo.MappedOidcGroupRequest;
+import org.dependencytrack.resources.v1.vo.MappedOidcGroupResponse;
+import org.dependencytrack.resources.v1.vo.OidcGroupResponse;
+import org.dependencytrack.resources.v1.vo.UpdateOidcGroupRequest;
 import org.owasp.security.logging.SecurityMarkers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,13 +99,18 @@ public class OidcResource extends AbstractApiResource {
                 @ApiResponse(
                         responseCode = "200",
                         description = "A list of all groups",
-                        content = @Content(array = @ArraySchema(schema = @Schema(implementation = OidcGroup.class)))),
+                        content =
+                                @Content(
+                                        array =
+                                                @ArraySchema(
+                                                        schema = @Schema(implementation = OidcGroupResponse.class)))),
                 @ApiResponse(responseCode = "401", description = "Unauthorized")
             })
     @PermissionRequired({Permissions.Constants.ACCESS_MANAGEMENT, Permissions.Constants.ACCESS_MANAGEMENT_READ})
     public Response retrieveGroups() {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
-            final List<OidcGroup> oidcGroups = qm.getOidcGroups();
+            final List<OidcGroupResponse> oidcGroups =
+                    qm.getOidcGroups().stream().map(OidcGroupResponse::of).toList();
             return Response.ok(oidcGroups).build();
         }
     }
@@ -119,19 +128,21 @@ public class OidcResource extends AbstractApiResource {
                 @ApiResponse(
                         responseCode = "201",
                         description = "The created group",
-                        content = @Content(schema = @Schema(implementation = OidcGroup.class))),
+                        content = @Content(schema = @Schema(implementation = OidcGroupResponse.class))),
                 @ApiResponse(responseCode = "401", description = "Unauthorized")
             })
     @PermissionRequired({Permissions.Constants.ACCESS_MANAGEMENT, Permissions.Constants.ACCESS_MANAGEMENT_CREATE})
-    public Response createGroup(final OidcGroup jsonGroup) {
+    public Response createGroup(final CreateOidcGroupRequest request) {
         final Validator validator = super.getValidator();
-        failOnValidationError(validator.validateProperty(jsonGroup, "name"));
+        failOnValidationError(validator.validateProperty(request, "name"));
 
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
-            if (qm.getOidcGroup(jsonGroup.getName()) == null) {
-                final OidcGroup group = qm.createOidcGroup(jsonGroup.getName());
+            if (qm.getOidcGroup(request.name()) == null) {
+                final OidcGroup group = qm.createOidcGroup(request.name());
                 super.logSecurityEvent(LOGGER, SecurityMarkers.SECURITY_AUDIT, "Group created: " + group.getName());
-                return Response.status(Response.Status.CREATED).entity(group).build();
+                return Response.status(Response.Status.CREATED)
+                        .entity(OidcGroupResponse.of(group))
+                        .build();
             } else {
                 return Response.status(Response.Status.CONFLICT)
                         .entity("A group with the same name already exists. Cannot create new group")
@@ -153,22 +164,21 @@ public class OidcResource extends AbstractApiResource {
                 @ApiResponse(
                         responseCode = "200",
                         description = "The updated group",
-                        content = @Content(schema = @Schema(implementation = OidcGroup.class))),
+                        content = @Content(schema = @Schema(implementation = OidcGroupResponse.class))),
                 @ApiResponse(responseCode = "401", description = "Unauthorized")
             })
     @PermissionRequired({Permissions.Constants.ACCESS_MANAGEMENT, Permissions.Constants.ACCESS_MANAGEMENT_UPDATE})
-    public Response updateGroup(final OidcGroup jsonGroup) {
+    public Response updateGroup(final UpdateOidcGroupRequest request) {
         final Validator validator = super.getValidator();
-        failOnValidationError(
-                validator.validateProperty(jsonGroup, "uuid"), validator.validateProperty(jsonGroup, "name"));
+        failOnValidationError(validator.validateProperty(request, "uuid"), validator.validateProperty(request, "name"));
 
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
-            OidcGroup oidcGroup = qm.getObjectByUuid(OidcGroup.class, jsonGroup.getUuid());
+            OidcGroup oidcGroup = qm.getObjectByUuid(OidcGroup.class, request.uuid());
             if (oidcGroup != null) {
-                oidcGroup.setName(jsonGroup.getName());
+                oidcGroup.setName(request.name());
                 oidcGroup = qm.updateOidcGroup(oidcGroup);
                 super.logSecurityEvent(LOGGER, SecurityMarkers.SECURITY_AUDIT, "Group updated: " + oidcGroup.getName());
-                return Response.ok(oidcGroup).build();
+                return Response.ok(OidcGroupResponse.of(oidcGroup)).build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND)
                         .entity("An OpenID Connect group with the specified UUID does not exists.")
@@ -272,7 +282,7 @@ public class OidcResource extends AbstractApiResource {
                 @ApiResponse(
                         responseCode = "200",
                         description = "The created mapping",
-                        content = @Content(schema = @Schema(implementation = MappedOidcGroup.class))),
+                        content = @Content(schema = @Schema(implementation = MappedOidcGroupResponse.class))),
                 @ApiResponse(responseCode = "401", description = "Unauthorized"),
                 @ApiResponse(responseCode = "404", description = "The UUID of the team or group could not be found"),
                 @ApiResponse(
@@ -308,9 +318,11 @@ public class OidcResource extends AbstractApiResource {
                             LOGGER,
                             SecurityMarkers.SECURITY_AUDIT,
                             "Mapping created for group " + group.getName() + " and team " + team.getName());
-                    return Response.ok(mappedOidcGroup).build();
+                    return Response.ok(MappedOidcGroupResponse.of(mappedOidcGroup))
+                            .build();
                 } else {
-                    return Response.ok(existingMapping).build();
+                    return Response.ok(MappedOidcGroupResponse.of(existingMapping))
+                            .build();
                 }
             });
         }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/TagResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/TagResource.java
@@ -40,6 +40,7 @@ import org.dependencytrack.resources.v1.openapi.PaginatedApi;
 import org.dependencytrack.resources.v1.problems.ProblemDetails;
 import org.dependencytrack.resources.v1.problems.TagOperationProblemDetails;
 import org.dependencytrack.resources.v1.vo.TagListResponseItem;
+import org.dependencytrack.resources.v1.vo.TagResponse;
 import org.dependencytrack.resources.v1.vo.TaggedCollectionProjectListResponseItem;
 import org.dependencytrack.resources.v1.vo.TaggedNotificationRuleListResponseItem;
 import org.dependencytrack.resources.v1.vo.TaggedPolicyListResponseItem;
@@ -473,7 +474,7 @@ public class TagResource extends AbstractApiResource {
                                         name = TOTAL_COUNT_HEADER,
                                         description = "The total number of tags",
                                         schema = @Schema(format = "integer")),
-                        content = @Content(array = @ArraySchema(schema = @Schema(implementation = Tag.class)))),
+                        content = @Content(array = @ArraySchema(schema = @Schema(implementation = TagResponse.class)))),
                 @ApiResponse(responseCode = "401", description = "Unauthorized")
             })
     @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
@@ -487,7 +488,9 @@ public class TagResource extends AbstractApiResource {
                     final String uuid) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final PaginatedResult result = qm.getTagsForPolicy(uuid);
-            return Response.ok(result.getObjects())
+            final List<TagResponse> tags =
+                    result.getList(Tag.class).stream().map(TagResponse::of).toList();
+            return Response.ok(tags)
                     .header(TOTAL_COUNT_HEADER, result.getTotal())
                     .build();
         }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/AnalysisTrailResponse.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/AnalysisTrailResponse.java
@@ -1,0 +1,125 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.dependencytrack.model.Analysis;
+import org.dependencytrack.model.AnalysisComment;
+import org.dependencytrack.model.AnalysisJustification;
+import org.dependencytrack.model.AnalysisResponse;
+import org.dependencytrack.model.AnalysisState;
+import org.dependencytrack.model.Severity;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.List;
+
+/// @since 5.2.0
+@NullMarked
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record AnalysisTrailResponse(
+        @Schema(description = "The state of the analysis decision", requiredMode = Schema.RequiredMode.REQUIRED)
+        AnalysisState analysisState,
+
+        @Schema(description = "The justification of the analysis decision") @Nullable
+        AnalysisJustification analysisJustification,
+
+        @Schema(description = "The vendor response to the vulnerability") @Nullable
+        AnalysisResponse analysisResponse,
+
+        @Schema(description = "Free-form details of the analysis decision") @Nullable
+        String analysisDetails,
+
+        @Schema(description = "Audit trail of analysis comments", requiredMode = Schema.RequiredMode.REQUIRED)
+        List<Comment> analysisComments,
+
+        @JsonProperty("isSuppressed")
+        @Schema(description = "Whether the finding is suppressed", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean isSuppressed,
+
+        @Schema(description = "Severity assigned by the analysis") @Nullable
+        Severity severity,
+
+        @Schema(description = "CVSS v2 vector assigned by the analysis") @Nullable
+        String cvssV2Vector,
+
+        @Schema(description = "CVSS v2 score assigned by the analysis") @Nullable
+        BigDecimal cvssV2Score,
+
+        @Schema(description = "CVSS v3 vector assigned by the analysis") @Nullable
+        String cvssV3Vector,
+
+        @Schema(description = "CVSS v3 score assigned by the analysis") @Nullable
+        BigDecimal cvssV3Score,
+
+        @Schema(description = "CVSS v4 vector assigned by the analysis") @Nullable
+        String cvssV4Vector,
+
+        @Schema(description = "CVSS v4 score assigned by the analysis") @Nullable
+        BigDecimal cvssV4Score,
+
+        @Schema(description = "OWASP Risk Rating vector assigned by the analysis") @Nullable
+        String owaspVector,
+
+        @Schema(description = "OWASP Risk Rating score assigned by the analysis") @Nullable
+        BigDecimal owaspScore) {
+
+    public static AnalysisTrailResponse of(Analysis analysis) {
+        final List<AnalysisComment> jdoComments = analysis.getAnalysisComments();
+        final List<Comment> comments =
+                jdoComments != null ? jdoComments.stream().map(Comment::of).toList() : List.of();
+
+        return new AnalysisTrailResponse(
+                analysis.getAnalysisState(),
+                analysis.getAnalysisJustification(),
+                analysis.getAnalysisResponse(),
+                analysis.getAnalysisDetails(),
+                comments,
+                analysis.isSuppressed(),
+                analysis.getSeverity(),
+                analysis.getCvssV2Vector(),
+                analysis.getCvssV2Score(),
+                analysis.getCvssV3Vector(),
+                analysis.getCvssV3Score(),
+                analysis.getCvssV4Vector(),
+                analysis.getCvssV4Score(),
+                analysis.getOwaspVector(),
+                analysis.getOwaspScore());
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Comment(
+            @Schema(description = "Timestamp the comment was recorded at", requiredMode = Schema.RequiredMode.REQUIRED)
+            Date timestamp,
+
+            @Schema(description = "The comment text", requiredMode = Schema.RequiredMode.REQUIRED)
+            String comment,
+
+            @Schema(description = "Identifier of the user who wrote the comment") @Nullable
+            String commenter) {
+
+        public static Comment of(AnalysisComment jdo) {
+            return new Comment(jdo.getTimestamp(), jdo.getComment(), jdo.getCommenter());
+        }
+    }
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/CreateOidcGroupRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/CreateOidcGroupRequest.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.jspecify.annotations.NullMarked;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/// @since 5.2.0
+@NullMarked
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CreateOidcGroupRequest(
+        @NotBlank
+        @Size(min = 1, max = 255)
+        @Pattern(regexp = "[\\P{Cc}]+", message = "The name must not contain control characters")
+        @Schema(description = "Name of the group to create", requiredMode = Schema.RequiredMode.REQUIRED)
+        String name) {}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/MappedLdapGroupResponse.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/MappedLdapGroupResponse.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import alpine.model.MappedLdapGroup;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.UUID;
+
+/// @since 5.2.0
+@NullMarked
+public record MappedLdapGroupResponse(
+        @Schema(
+                description = "Distinguished name of the mapped LDAP group",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        String dn,
+
+        @Schema(description = "UUID of the mapping", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID uuid) {
+
+    public static MappedLdapGroupResponse of(MappedLdapGroup mapping) {
+        return new MappedLdapGroupResponse(mapping.getDn(), mapping.getUuid());
+    }
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/MappedOidcGroupResponse.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/MappedOidcGroupResponse.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import alpine.model.MappedOidcGroup;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.UUID;
+
+/// @since 5.2.0
+@NullMarked
+public record MappedOidcGroupResponse(
+        @Schema(description = "The mapped group", requiredMode = Schema.RequiredMode.REQUIRED)
+        OidcGroupResponse group,
+
+        @Schema(description = "UUID of the mapping", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID uuid) {
+
+    public static MappedOidcGroupResponse of(MappedOidcGroup mapping) {
+        return new MappedOidcGroupResponse(OidcGroupResponse.of(mapping.getGroup()), mapping.getUuid());
+    }
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/OidcGroupResponse.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/OidcGroupResponse.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import alpine.model.OidcGroup;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.UUID;
+
+/// @since 5.2.0
+@NullMarked
+public record OidcGroupResponse(
+        @Schema(description = "UUID of the group", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID uuid,
+
+        @Schema(description = "Name of the group", requiredMode = Schema.RequiredMode.REQUIRED)
+        String name) {
+
+    public static OidcGroupResponse of(OidcGroup group) {
+        return new OidcGroupResponse(group.getUuid(), group.getName());
+    }
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/TagResponse.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/TagResponse.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.dependencytrack.model.Tag;
+import org.jspecify.annotations.NullMarked;
+
+/// @since 5.2.0
+@NullMarked
+public record TagResponse(
+        @Schema(description = "Name of the tag", requiredMode = Schema.RequiredMode.REQUIRED)
+        String name) {
+
+    public static TagResponse of(Tag tag) {
+        return new TagResponse(tag.getName());
+    }
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/UpdateOidcGroupRequest.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/UpdateOidcGroupRequest.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.jspecify.annotations.NullMarked;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+/// @since 5.2.0
+@NullMarked
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record UpdateOidcGroupRequest(
+        @NotNull @Schema(description = "UUID of the group to update", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID uuid,
+
+        @NotBlank
+        @Size(min = 1, max = 255)
+        @Pattern(regexp = "[\\P{Cc}]+", message = "The name must not contain control characters")
+        @Schema(description = "New name of the group", requiredMode = Schema.RequiredMode.REQUIRED)
+        String name) {}

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
@@ -26,6 +26,7 @@ import org.apache.http.HttpStatus;
 import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.Analysis;
 import org.dependencytrack.model.AnalysisJustification;
 import org.dependencytrack.model.AnalysisResponse;
 import org.dependencytrack.model.AnalysisState;
@@ -51,6 +52,7 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import java.math.BigDecimal;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
@@ -111,18 +113,85 @@ class AnalysisResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
 
-        final JsonObject responseJson = parseJsonObject(response);
-        assertThat(responseJson).isNotNull();
-        assertThat(responseJson.getString("analysisState")).isEqualTo(AnalysisState.NOT_AFFECTED.name());
-        assertThat(responseJson.getString("analysisJustification"))
-                .isEqualTo(AnalysisJustification.CODE_NOT_REACHABLE.name());
-        assertThat(responseJson.getString("analysisResponse")).isEqualTo(AnalysisResponse.WILL_NOT_FIX.name());
-        assertThat(responseJson.getString("analysisDetails")).isEqualTo("Analysis details here");
-        assertThat(responseJson.getJsonArray("analysisComments")).hasSize(1);
-        assertThat(responseJson.getJsonArray("analysisComments").getJsonObject(0))
-                .hasFieldOrPropertyWithValue("comment", Json.createValue("Analysis comment here"))
-                .hasFieldOrPropertyWithValue("commenter", Json.createValue("Jane Doe"));
-        assertThat(responseJson.getBoolean("isSuppressed")).isTrue();
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "analysisState": "NOT_AFFECTED",
+                  "analysisJustification": "CODE_NOT_REACHABLE",
+                  "analysisResponse": "WILL_NOT_FIX",
+                  "analysisDetails": "Analysis details here",
+                  "analysisComments": [
+                    {
+                      "timestamp": "${json-unit.any-number}",
+                      "comment": "Analysis comment here",
+                      "commenter": "Jane Doe"
+                    }
+                  ],
+                  "isSuppressed": true
+                }
+                """);
+    }
+
+    @Test
+    void retrieveAnalysisWithSeverityAndScoresTest() {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
+
+        var component = new Component();
+        component.setProject(project);
+        component.setName("Acme Component");
+        component.setVersion("1.0");
+        component = qm.createComponent(component, false);
+
+        var vulnerability = new Vulnerability();
+        vulnerability.setVulnId("INT-001");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.HIGH);
+        vulnerability.setComponents(List.of(component));
+        vulnerability = qm.createVulnerability(vulnerability);
+
+        qm.makeAnalysis(new MakeAnalysisCommand(component, vulnerability)
+                .withState(AnalysisState.EXPLOITABLE)
+                .withOwasp("OWASP/K9:M1:O0:Z2/D1:X1:W1:L1/C1:I1:A1:T1/F1:R1:S1:P1/", new BigDecimal("4.5"))
+                .withOptions(EnumSet.of(
+                        MakeAnalysisCommand.Option.OMIT_AUDIT_TRAIL, MakeAnalysisCommand.Option.OMIT_NOTIFICATION)));
+
+        final Analysis analysis = qm.getAnalysis(component, vulnerability);
+        analysis.setSeverity(Severity.MEDIUM);
+        analysis.setCvssV2Vector("AV:N/AC:L/Au:N/C:P/I:P/A:P");
+        analysis.setCvssV2Score(new BigDecimal("7.5"));
+        analysis.setCvssV3Vector("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
+        analysis.setCvssV3Score(new BigDecimal("9.8"));
+        analysis.setCvssV4Vector("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N");
+        analysis.setCvssV4Score(new BigDecimal("9.3"));
+        qm.persist(analysis);
+
+        final Response response = jersey.target(V1_ANALYSIS)
+                .queryParam("project", project.getUuid())
+                .queryParam("component", component.getUuid())
+                .queryParam("vulnerability", vulnerability.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "analysisState": "EXPLOITABLE",
+                  "analysisJustification": "NOT_SET",
+                  "analysisResponse": "NOT_SET",
+                  "analysisComments": [],
+                  "isSuppressed": false,
+                  "severity": "MEDIUM",
+                  "cvssV2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                  "cvssV2Score": 7.5,
+                  "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                  "cvssV3Score": 9.8,
+                  "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+                  "cvssV4Score": 9.3,
+                  "owaspVector": "OWASP/K9:M1:O0:Z2/D1:X1:W1:L1/C1:I1:A1:T1/F1:R1:S1:P1/",
+                  "owaspScore": 4.5
+                }
+                """);
     }
 
     @Test
@@ -381,33 +450,47 @@ class AnalysisResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
 
-        final JsonObject responseJson = parseJsonObject(response);
-        assertThat(responseJson).isNotNull();
-        assertThat(responseJson.getString("analysisState")).isEqualTo(AnalysisState.NOT_AFFECTED.name());
-        assertThat(responseJson.getString("analysisJustification"))
-                .isEqualTo(AnalysisJustification.CODE_NOT_REACHABLE.name());
-        assertThat(responseJson.getString("analysisResponse")).isEqualTo(AnalysisResponse.WILL_NOT_FIX.name());
-        assertThat(responseJson.getString("analysisDetails")).isEqualTo("Analysis details here");
-        assertThat(responseJson.getJsonArray("analysisComments")).hasSize(6);
-        assertThat(responseJson.getJsonArray("analysisComments").getJsonObject(0))
-                .hasFieldOrPropertyWithValue("comment", Json.createValue("Analysis: NOT_SET → NOT_AFFECTED"))
-                .hasFieldOrPropertyWithValue("commenter", Json.createValue("Test Users"));
-        assertThat(responseJson.getJsonArray("analysisComments").getJsonObject(1))
-                .hasFieldOrPropertyWithValue("comment", Json.createValue("Justification: NOT_SET → CODE_NOT_REACHABLE"))
-                .hasFieldOrPropertyWithValue("commenter", Json.createValue("Test Users"));
-        assertThat(responseJson.getJsonArray("analysisComments").getJsonObject(2))
-                .hasFieldOrPropertyWithValue("comment", Json.createValue("Vendor Response: NOT_SET → WILL_NOT_FIX"))
-                .hasFieldOrPropertyWithValue("commenter", Json.createValue("Test Users"));
-        assertThat(responseJson.getJsonArray("analysisComments").getJsonObject(3))
-                .hasFieldOrPropertyWithValue("comment", Json.createValue("Details: Analysis details here"))
-                .hasFieldOrPropertyWithValue("commenter", Json.createValue("Test Users"));
-        assertThat(responseJson.getJsonArray("analysisComments").getJsonObject(4))
-                .hasFieldOrPropertyWithValue("comment", Json.createValue("Suppressed"))
-                .hasFieldOrPropertyWithValue("commenter", Json.createValue("Test Users"));
-        assertThat(responseJson.getJsonArray("analysisComments").getJsonObject(5))
-                .hasFieldOrPropertyWithValue("comment", Json.createValue("Analysis comment here"))
-                .hasFieldOrPropertyWithValue("commenter", Json.createValue("Test Users"));
-        assertThat(responseJson.getBoolean("isSuppressed")).isTrue();
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "analysisState": "NOT_AFFECTED",
+                  "analysisJustification": "CODE_NOT_REACHABLE",
+                  "analysisResponse": "WILL_NOT_FIX",
+                  "analysisDetails": "Analysis details here",
+                  "analysisComments": [
+                    {
+                      "timestamp": "${json-unit.any-number}",
+                      "comment": "Analysis: NOT_SET → NOT_AFFECTED",
+                      "commenter": "Test Users"
+                    },
+                    {
+                      "timestamp": "${json-unit.any-number}",
+                      "comment": "Justification: NOT_SET → CODE_NOT_REACHABLE",
+                      "commenter": "Test Users"
+                    },
+                    {
+                      "timestamp": "${json-unit.any-number}",
+                      "comment": "Vendor Response: NOT_SET → WILL_NOT_FIX",
+                      "commenter": "Test Users"
+                    },
+                    {
+                      "timestamp": "${json-unit.any-number}",
+                      "comment": "Details: Analysis details here",
+                      "commenter": "Test Users"
+                    },
+                    {
+                      "timestamp": "${json-unit.any-number}",
+                      "comment": "Suppressed",
+                      "commenter": "Test Users"
+                    },
+                    {
+                      "timestamp": "${json-unit.any-number}",
+                      "comment": "Analysis comment here",
+                      "commenter": "Test Users"
+                    }
+                  ],
+                  "isSuppressed": true
+                }
+                """);
 
         assertThat(qm.getNotificationOutbox()).satisfiesExactly(notification -> {
             assertThat(notification.getScope()).isEqualTo(SCOPE_PORTFOLIO);

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/LdapResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/LdapResourceTest.java
@@ -30,13 +30,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import java.util.UUID;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 public class LdapResourceTest extends ResourceTest {
 
@@ -71,12 +71,18 @@ public class LdapResourceTest extends ResourceTest {
                 .get(Response.class);
         Assertions.assertEquals(200, response.getStatus(), 0);
         Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
-        JsonArray json = parseJsonArray(response);
-        Assertions.assertNotNull(json);
-        Assertions.assertEquals(2, json.size());
-        Assertions.assertEquals(
-                "CN=Developers,OU=R&D,O=Acme", json.getJsonObject(0).getString("dn"));
-        Assertions.assertEquals("CN=QA,OU=R&D,O=Acme", json.getJsonObject(1).getString("dn"));
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                [
+                  {
+                    "dn": "CN=Developers,OU=R&D,O=Acme",
+                    "uuid": "${json-unit.any-string}"
+                  },
+                  {
+                    "dn": "CN=QA,OU=R&D,O=Acme",
+                    "uuid": "${json-unit.any-string}"
+                  }
+                ]
+                """);
     }
 
     @Test
@@ -91,9 +97,12 @@ public class LdapResourceTest extends ResourceTest {
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
         Assertions.assertEquals(200, response.getStatus(), 0);
         Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
-        JsonObject json = parseJsonObject(response);
-        Assertions.assertNotNull(json);
-        Assertions.assertEquals("CN=Administrators,OU=R&D,O=Acme", json.getString("dn"));
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "dn": "CN=Administrators,OU=R&D,O=Acme",
+                  "uuid": "${json-unit.any-string}"
+                }
+                """);
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/OidcResourceAuthenticatedTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/OidcResourceAuthenticatedTest.java
@@ -32,13 +32,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import java.util.UUID;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class OidcResourceAuthenticatedTest extends ResourceTest {
@@ -61,10 +61,14 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
                 .get();
 
         assertThat(response.getStatus()).isEqualTo(200);
-
-        final JsonArray jsonGroups = parseJsonArray(response);
-        assertThat(jsonGroups).hasSize(1);
-        assertThat(jsonGroups.getJsonObject(0).getString("name")).isEqualTo("groupName");
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                [
+                  {
+                    "uuid": "${json-unit.any-string}",
+                    "name": "groupName"
+                  }
+                ]
+                """);
     }
 
     @Test
@@ -95,11 +99,12 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
                 .put(Entity.entity(oidcGroup, MediaType.APPLICATION_JSON));
 
         assertThat(response.getStatus()).isEqualTo(201);
-
-        final JsonObject group = parseJsonObject(response);
-        assertThat(group.getJsonObject("id")).isNull();
-        assertThat(group.getString("uuid")).isNotEmpty();
-        assertThat(group.getString("name")).isEqualTo("groupName");
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "uuid": "${json-unit.any-string}",
+                  "name": "groupName"
+                }
+                """);
     }
 
     @Test
@@ -150,10 +155,13 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
                 .post(Entity.entity(jsonGroup, MediaType.APPLICATION_JSON));
 
         assertThat(response.getStatus()).isEqualTo(200);
-
-        final JsonObject groupObject = parseJsonObject(response);
-        assertThat(groupObject.getString("uuid")).isEqualTo(jsonGroup.getUuid().toString());
-        assertThat(groupObject.getString("name")).isEqualTo("newGroupName");
+        assertThatJson(getPlainTextBody(response))
+                .isEqualTo(/* language=JSON */ """
+                {
+                  "uuid": "%s",
+                  "name": "newGroupName"
+                }
+                """.formatted(existingGroup.getUuid()));
     }
 
     @Test
@@ -329,12 +337,15 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
 
         assertThat(response.getStatus()).isEqualTo(200);
-
-        final JsonObject mapping = parseJsonObject(response);
-        assertThat(mapping.getJsonObject("id")).isNull();
-        assertThat(mapping.getString("uuid")).isNotEmpty();
-        assertThat(mapping.getJsonObject("team")).isNull();
-        assertThat(mapping.getJsonObject("group")).isNotNull();
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "group": {
+                    "uuid": "%s",
+                    "name": "groupName"
+                  },
+                  "uuid": "${json-unit.any-string}"
+                }
+                """.formatted(group.getUuid()));
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
@@ -1556,11 +1556,16 @@ class TagResourceTest extends ResourceTest {
 
         Assertions.assertEquals(200, response.getStatus());
         Assertions.assertEquals(String.valueOf(2), response.getHeaderString(TOTAL_COUNT_HEADER));
-        json = parseJsonArray(response);
-        Assertions.assertNotNull(json);
-        Assertions.assertEquals(2, json.size());
-        Assertions.assertEquals("tag 1", json.getJsonObject(0).getString("name"));
-        Assertions.assertEquals("tag 4", json.getJsonObject(1).getString("name"));
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                [
+                  {
+                    "name": "tag 1"
+                  },
+                  {
+                    "name": "tag 4"
+                  }
+                ]
+                """);
     }
 
     @Test

--- a/apiserver/src/test/resources/archunit_store/3e49066c-46b2-40c2-8473-ce4276c1ba12
+++ b/apiserver/src/test/resources/archunit_store/3e49066c-46b2-40c2-8473-ce4276c1ba12
@@ -1,7 +1,5 @@
 org.dependencytrack.resources.v1.ComponentResource.createComponent(java.lang.String, org.dependencytrack.model.Component) accepts JDO model class org.dependencytrack.model.Component as request body
 org.dependencytrack.resources.v1.ComponentResource.updateComponent(org.dependencytrack.model.Component) accepts JDO model class org.dependencytrack.model.Component as request body
-org.dependencytrack.resources.v1.OidcResource.createGroup(alpine.model.OidcGroup) accepts JDO model class alpine.model.OidcGroup as request body
-org.dependencytrack.resources.v1.OidcResource.updateGroup(alpine.model.OidcGroup) accepts JDO model class alpine.model.OidcGroup as request body
 org.dependencytrack.resources.v1.PolicyResource.createPolicy(org.dependencytrack.model.Policy) accepts JDO model class org.dependencytrack.model.Policy as request body
 org.dependencytrack.resources.v1.PolicyResource.updatePolicy(org.dependencytrack.model.Policy) accepts JDO model class org.dependencytrack.model.Policy as request body
 org.dependencytrack.resources.v1.ProjectResource.createProject(org.dependencytrack.model.Project) accepts JDO model class org.dependencytrack.model.Project as request body

--- a/apiserver/src/test/resources/archunit_store/67305ac9-6039-403a-8a4c-ada073ef9b6d
+++ b/apiserver/src/test/resources/archunit_store/67305ac9-6039-403a-8a4c-ada073ef9b6d
@@ -1,5 +1,3 @@
-org.dependencytrack.resources.v1.AnalysisResource.retrieveAnalysis(java.lang.String, java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.Analysis as Swagger response schema
-org.dependencytrack.resources.v1.AnalysisResource.updateAnalysis(org.dependencytrack.resources.v1.vo.AnalysisRequest) declares JDO model class org.dependencytrack.model.Analysis as Swagger response schema
 org.dependencytrack.resources.v1.ComponentResource.createComponent(java.lang.String, org.dependencytrack.model.Component) declares JDO model class org.dependencytrack.model.Component as Swagger response schema
 org.dependencytrack.resources.v1.ComponentResource.getAllComponents(java.lang.String, boolean, boolean) declares JDO model class org.dependencytrack.model.Component as Swagger response schema
 org.dependencytrack.resources.v1.ComponentResource.getComponentByHash(java.lang.String) declares JDO model class org.dependencytrack.model.Component as Swagger response schema
@@ -7,8 +5,6 @@ org.dependencytrack.resources.v1.ComponentResource.getComponentByIdentity(java.l
 org.dependencytrack.resources.v1.ComponentResource.getComponentByUuid(java.lang.String, boolean) declares JDO model class org.dependencytrack.model.Component as Swagger response schema
 org.dependencytrack.resources.v1.ComponentResource.getOccurrences(java.util.UUID) declares JDO model class org.dependencytrack.model.ComponentOccurrence as Swagger response schema
 org.dependencytrack.resources.v1.ComponentResource.updateComponent(org.dependencytrack.model.Component) declares JDO model class org.dependencytrack.model.Component as Swagger response schema
-org.dependencytrack.resources.v1.LdapResource.addMapping(org.dependencytrack.resources.v1.vo.MappedLdapGroupRequest) declares JDO model class alpine.model.MappedLdapGroup as Swagger response schema
-org.dependencytrack.resources.v1.LdapResource.retrieveLdapGroups(java.lang.String) declares JDO model class alpine.model.MappedLdapGroup as Swagger response schema
 org.dependencytrack.resources.v1.NotificationRuleResource.addProjectToRule(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
 org.dependencytrack.resources.v1.NotificationRuleResource.addTeamToRule(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
 org.dependencytrack.resources.v1.NotificationRuleResource.createNotificationRule(org.dependencytrack.resources.v1.vo.CreateNotificationRuleRequest) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
@@ -17,11 +13,7 @@ org.dependencytrack.resources.v1.NotificationRuleResource.getAllNotificationRule
 org.dependencytrack.resources.v1.NotificationRuleResource.removeProjectFromRule(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
 org.dependencytrack.resources.v1.NotificationRuleResource.removeTeamFromRule(java.lang.String, java.lang.String) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
 org.dependencytrack.resources.v1.NotificationRuleResource.updateNotificationRule(org.dependencytrack.resources.v1.vo.UpdateNotificationRuleRequest) declares JDO model class org.dependencytrack.model.NotificationRule as Swagger response schema
-org.dependencytrack.resources.v1.OidcResource.addMapping(org.dependencytrack.resources.v1.vo.MappedOidcGroupRequest) declares JDO model class alpine.model.MappedOidcGroup as Swagger response schema
-org.dependencytrack.resources.v1.OidcResource.createGroup(alpine.model.OidcGroup) declares JDO model class alpine.model.OidcGroup as Swagger response schema
-org.dependencytrack.resources.v1.OidcResource.retrieveGroups() declares JDO model class alpine.model.OidcGroup as Swagger response schema
 org.dependencytrack.resources.v1.OidcResource.retrieveTeamsMappedToGroup(java.lang.String) declares JDO model class alpine.model.Team as Swagger response schema
-org.dependencytrack.resources.v1.OidcResource.updateGroup(alpine.model.OidcGroup) declares JDO model class alpine.model.OidcGroup as Swagger response schema
 org.dependencytrack.resources.v1.PermissionResource.addPermissionToTeam(java.lang.String, java.lang.String) declares JDO model class alpine.model.Team as Swagger response schema
 org.dependencytrack.resources.v1.PermissionResource.addPermissionToUser(java.lang.String, java.lang.String) declares JDO model class alpine.model.User as Swagger response schema
 org.dependencytrack.resources.v1.PermissionResource.removePermissionFromTeam(java.lang.String, java.lang.String) declares JDO model class alpine.model.Team as Swagger response schema
@@ -47,7 +39,6 @@ org.dependencytrack.resources.v1.ServiceResource.createService(java.lang.String,
 org.dependencytrack.resources.v1.ServiceResource.getAllServices(java.lang.String) declares JDO model class org.dependencytrack.model.ServiceComponent as Swagger response schema
 org.dependencytrack.resources.v1.ServiceResource.getServiceByUuid(java.lang.String) declares JDO model class org.dependencytrack.model.ServiceComponent as Swagger response schema
 org.dependencytrack.resources.v1.ServiceResource.updateService(org.dependencytrack.model.ServiceComponent) declares JDO model class org.dependencytrack.model.ServiceComponent as Swagger response schema
-org.dependencytrack.resources.v1.TagResource.getTagsForPolicy(java.lang.String) declares JDO model class org.dependencytrack.model.Tag as Swagger response schema
 org.dependencytrack.resources.v1.TeamResource.createTeam(alpine.model.Team) declares JDO model class alpine.model.Team as Swagger response schema
 org.dependencytrack.resources.v1.TeamResource.generateApiKey(java.lang.String) declares JDO model class alpine.model.ApiKey as Swagger response schema
 org.dependencytrack.resources.v1.TeamResource.getTeam(java.lang.String) declares JDO model class alpine.model.Team as Swagger response schema


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Refactors multiple endpoints in API v1 that previously accepted full JDO models as request body. This coupled persistence classes to the public API contract and polluted the corresponding OpenAPI docs.

The endpoints in this batch are all simple and low-risk, with good pre-existing test coverage.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
