### PR TITLE
Propose OAuth2 Proxy authentication

### DIFF
--- a/docs/adr/040-oauth2-proxy-authentication.md
+++ b/docs/adr/040-oauth2-proxy-authentication.md
@@ -129,9 +129,15 @@ same short-lived bearer session used by other login methods.
 
 The ID token must pass the standard checks defined by [OpenID Connect Core] and already performed
 by Dependency-Track. These include issuer, signature, expiration, and audience validation. A new
-`dt.oauth2-proxy.client-id` setting must match the client identifier used by OAuth2 Proxy. It is
-the expected audience for the forwarded ID token. A token issued to a different client of the
-same identity provider will be rejected.
+`dt.auth-proxy.client-id` setting must match the client identifier used by the reverse proxy that
+forwards the ID token. It is the expected audience for the forwarded ID token. A token issued to
+a different client of the same identity provider will be rejected.
+
+The setting is named generically because the exchange validates a forwarded ID token and does not
+depend on which reverse proxy provides it. OAuth2 Proxy is the reference implementation for the
+first version: other reverse proxies that can inject a bearer ID token into
+`X-Forwarded-ID-Token` should work with the same validation path, but only the OAuth2 Proxy
+configuration is documented and validated.
 
 Native Dependency-Track OIDC continues to use `dt.oidc.client-id`. The two login paths can be
 enabled together and can use different client registrations, but both registrations must use the

--- a/docs/adr/040-oauth2-proxy-authentication.md
+++ b/docs/adr/040-oauth2-proxy-authentication.md
@@ -10,24 +10,51 @@ server validates the tokens, creates or finds an OIDC user, and returns a Depend
 session.
 
 Some deployments put [OAuth2 Proxy] in front of every application. OAuth2 Proxy authenticates
-the browser before a request reaches the application. When it uses an OIDC provider, it can pass
-the access token or ID token to the upstream application. Starting another OIDC flow in the
-Dependency-Track frontend gives the user a second login step.
+the browser before a request reaches the application. These deployments use the proxy to apply
+the same access policy to every application. Starting another OIDC flow in the Dependency-Track
+frontend adds another redirect and makes the proxy session separate from the application login.
 
-OAuth2 Proxy can also pass the authenticated username, email, and groups in HTTP headers. These
+The existing Dependency-Track OIDC flow remains the default. It gives Dependency-Track its own
+OIDC client and does not depend on a proxy credential. The integration in this decision is only
+for deployments that require an OAuth2 Proxy session to initiate the application session.
+
+OAuth2 Proxy can pass the authenticated username, email, and groups in HTTP headers. These
 identity headers are not signed. A client can forge them if it can bypass the proxy, or if the
 proxy preserves values supplied by the client. Accepting them as credentials would make the
-deployment network part of the authentication mechanism.
+deployment network the only authentication boundary.
 
-The frontend and REST API use a Dependency-Track bearer session after login. Passing an OIDC ID
-token to the upstream in the `Authorization` header conflicts with this session because both use
-the same header. The browser also cannot read a header that the proxy adds to its request. A
-server-side exchange is therefore required even when the existing OIDC validation is reused.
+OAuth2 Proxy can also pass the provider access token or ID token to the upstream application.
+Calling the OIDC UserInfo endpoint proves that an access token is accepted by that endpoint. It
+does not prove that the token was issued for Dependency-Track. An access token issued to another
+client of the same identity provider could therefore be accepted by the existing UserInfo path.
+Using an access token as a Dependency-Track credential would require resource server validation,
+including a Dependency-Track audience. That is broader than reusing the existing OIDC login.
+
+An OIDC ID token has the client identifier in its audience. Dependency-Track already validates
+the ID token issuer, signature, expiration, and audience. The OAuth2 Proxy client identifier can
+therefore be configured as the Dependency-Track OIDC client identifier and used as a
+cryptographic boundary between clients of the same identity provider.
+
+The frontend and REST API use a Dependency-Track bearer session after login. OAuth2 Proxy's
+stable direct-upstream option puts the ID token in the `Authorization` header. This conflicts
+with the Dependency-Track session because both use the same header. The browser also cannot read
+a header that the proxy adds to its request. A separate header and a server-side exchange are
+therefore required.
 
 This decision addresses interactive users opening the Dependency-Track dashboard. Authentication
 for service and robot accounts is tracked separately in [issue 7055] and [issue 7056].
 
 ### Possible Solutions
+
+#### Use native Dependency-Track OIDC behind OAuth2 Proxy
+
+OAuth2 Proxy can authenticate the gateway request, then the frontend can start the existing
+Dependency-Track OIDC authorization flow. An existing identity provider session can complete the
+second flow without another credential prompt.
+
+This keeps an independent application authentication boundary and uses only standard OIDC
+behavior. It still requires a Dependency-Track browser flow, redirect URI, and client
+configuration. It also does not use the OAuth2 Proxy session as the application login event.
 
 #### Exchange trusted identity headers for a Dependency-Track session
 
@@ -41,23 +68,26 @@ user provisioning and team synchronization behavior.
 #### Validate an access token forwarded by OAuth2 Proxy
 
 OAuth2 Proxy can pass the provider access token in the `X-Forwarded-Access-Token` header. The API
-server can use the existing OIDC UserInfo validation, user provisioning, team synchronization,
-and session creation behavior.
+server can call the existing OIDC UserInfo endpoint and reuse the returned user claims.
 
-This does not trust plain identity headers and does not require another user type. OAuth2 Proxy's
-existing client registration can be reused. However, the provider must support OIDC, and the API
-server must be able to access OIDC discovery and the UserInfo endpoint.
+This does not prove that the access token is intended for Dependency-Track. Correct resource
+server support must validate a Dependency-Track audience, signature, issuer, token type, and
+expiration as described by the [OAuth 2.0 JWT access token profile]. It must also define scopes
+for API authorization. These requirements apply to both human and machine clients and are
+tracked separately.
 
 #### Validate an ID token forwarded by OAuth2 Proxy
 
-The API server can validate a forwarded ID token with the existing OIDC issuer, audience, and
-signature checks. This avoids a UserInfo request when the token contains all required claims.
+The API server can validate a forwarded ID token with the existing OIDC issuer, audience,
+signature, and expiration checks. The audience binds the token to the configured OAuth2 Proxy
+client instead of only trusting the network path. The resulting identity can reuse the normal
+OIDC user, provisioning, team synchronization, and session behavior.
 
-OAuth2 Proxy's stable direct-upstream option sends the ID token in the `Authorization` header.
-This would overwrite the Dependency-Track session on later requests. A separate header requires
-structured OAuth2 Proxy configuration or an additional reverse proxy. Access token refresh also
-does not guarantee that the stored ID token is replaced. This makes the option less portable for
-the first version.
+The ID token must use a separate header so it does not replace the Dependency-Track session in
+`Authorization`. Direct-upstream deployments need OAuth2 Proxy's structured header injection.
+NGINX `auth_request` deployments can remap the ID token from the authentication response. The ID
+token must contain every claim required by the configured username and team synchronization
+settings.
 
 #### Authenticate every API request from proxy headers
 
@@ -70,7 +100,7 @@ harder to define.
 
 ## Decision
 
-We will validate an access token forwarded by OAuth2 Proxy and exchange it for a normal
+We will validate an ID token forwarded by OAuth2 Proxy and exchange it for a normal
 Dependency-Track session. The integration will only support OAuth2 Proxy deployments backed by
 an OIDC provider. It will only authenticate interactive users.
 
@@ -79,13 +109,13 @@ sequenceDiagram
     participant Browser
     participant Proxy as OAuth2 Proxy
     participant API as Dependency-Track API
-    participant IdP as OIDC UserInfo
+    participant IdP as OIDC Provider
 
     Browser->>Proxy: Request dashboard
     Proxy->>Proxy: Authenticate browser
-    Proxy->>API: Session exchange with forwarded access token
-    API->>IdP: Validate token and load claims
-    IdP-->>API: OIDC user claims
+    Proxy->>API: Session exchange with forwarded ID token
+    API->>IdP: Load OIDC discovery and signing keys
+    API->>API: Validate issuer, signature, expiry, and audience
     API-->>Proxy: Dependency-Track session
     Proxy-->>Browser: Dependency-Track session
     Browser->>Proxy: API request with Dependency-Track session
@@ -93,62 +123,84 @@ sequenceDiagram
 ```
 
 The API server will extend the version 1 login API with a session exchange endpoint. The endpoint
-will read the access token from `X-Forwarded-Access-Token`. It will not accept a token from the
-request body. It will pass the token to the existing OIDC authentication path and issue the same
-short-lived bearer session used by other login methods.
+will read a bearer ID token from `X-Forwarded-ID-Token`. It will not accept a token from the
+request body. It will pass the token to the existing OIDC ID token validation path and issue the
+same short-lived bearer session used by other login methods.
 
-The API server must have OIDC enabled and configured for the same issuer used by OAuth2 Proxy.
-Existing username claim, user provisioning, default team, and team synchronization settings will
-apply. The frontend OIDC client settings can remain empty because the frontend will not start an
-OIDC flow for this integration.
+The ID token must pass the standard checks defined by [OpenID Connect Core] and already performed
+by Dependency-Track. These include issuer, signature, expiration, and audience validation. The
+configured `dt.oidc.client-id` must match the client identifier used by OAuth2 Proxy. A token
+issued to a different client of the same identity provider will be rejected.
 
-Users authenticated through the exchange will be normal OIDC users. No proxy-specific user type,
+The first version will not authenticate from a forwarded access token and will not call UserInfo
+during the exchange. The ID token must contain the subject, configured username claim, and the
+configured teams claim when team synchronization is enabled. Supporting providers that only
+return required claims from UserInfo is outside the first version.
+
+Users authenticated through the exchange will be normal OIDC users. Existing user provisioning,
+default team, team synchronization, and session settings will apply. No proxy-specific user type,
 database discriminator, migration, or access management API will be added.
 
 The frontend will attempt the exchange when it has no Dependency-Track session, before it displays
 the login choices. A successful exchange will run the existing permission check and open the
-requested page. A response indicating that no forwarded access token is available will continue
-to the existing local, LDAP, or OIDC login options.
+requested page. A response indicating that no forwarded ID token is available will continue to
+the existing local, LDAP, or OIDC login options.
 
-Operators must configure OAuth2 Proxy to replace `X-Forwarded-Access-Token` values supplied by
-clients. In direct-upstream mode, this is provided by `--pass-access-token`, as described in the
-[OAuth2 Proxy header options]. In NGINX `auth_request` mode, OAuth2 Proxy must use both
-`--pass-access-token` and `--set-xauthrequest`. NGINX must then copy the token from the
-authentication response into the expected upstream header, as shown in the
-[OAuth2 Proxy NGINX integration]. Operators must also prevent clients from bypassing OAuth2
-Proxy. Dependency-Track will not use forwarded username or email headers as credentials.
+OAuth2 Proxy must remove any `X-Forwarded-ID-Token` value supplied by a client and set its own
+value. Direct-upstream deployments must use [OAuth2 Proxy structured configuration] with
+`injectRequestHeaders`, the session `id_token` claim, and `preserveRequestValue: false`. The
+header value must use the `Bearer` scheme. This structured configuration is currently an alpha
+OAuth2 Proxy feature.
 
-The forwarded provider token will not use the `Authorization` header. That header remains
-available for the Dependency-Track session after the exchange.
+In [OAuth2 Proxy NGINX integration] using `auth_request`, OAuth2 Proxy can use
+`--set-authorization-header` to return the ID token in the authentication response. NGINX must
+copy that value to `X-Forwarded-ID-Token` for the Dependency-Track upstream and must replace any
+client value. The stable direct-upstream `--pass-authorization-header` option documented under
+[OAuth2 Proxy header options] is not supported because it would replace the Dependency-Track
+session in `Authorization` on every request.
+
+Operators must still prevent clients from bypassing OAuth2 Proxy. This preserves gateway access
+policy and prevents unauthenticated requests from reaching the application. Identity integrity
+does not rely only on that network rule because Dependency-Track also validates the forwarded ID
+token. Dependency-Track will not use forwarded username, email, or group headers as credentials.
 
 API keys remain a Dependency-Track authentication method, but this decision does not define how
-machine clients authenticate to OAuth2 Proxy. Deployments that require gateway authentication for
-machine traffic must address it separately. The session exchange will not accept API keys as
-proxy credentials.
+machine clients authenticate to OAuth2 Proxy. Deployments that require OAuth 2.0 access tokens
+for machine traffic need native resource server support. That work remains separate.
 
 ## Consequences
 
-* Users authenticated by OAuth2 Proxy can open the dashboard without a second login action.
+* Users authenticated by OAuth2 Proxy can open the dashboard without starting a second OIDC flow.
 * The API server reuses its OIDC users, provisioning, team synchronization, permissions, and
   sessions. No new user type or database migration is required.
-* The integration only works when OAuth2 Proxy uses an OIDC provider and forwards an access token
-  that the provider accepts at its UserInfo endpoint.
-* The API server needs network access to OIDC discovery and UserInfo. This may not meet deployment
-  policies that prohibit applications from contacting the identity provider.
-* The access token crosses the proxy-to-API boundary. Both components must use a protected network
+* Dependency-Track validates the ID token issuer, signature, expiration, and audience. A plain
+  forwarded identity header or an access token for another client is not sufficient to log in.
+* The configured Dependency-Track OIDC client identifier must match the OAuth2 Proxy client
+  identifier. The same client registration can be reused.
+* Every claim required for the Dependency-Track OIDC profile must be present in the ID token.
+  Providers that only expose those claims through UserInfo are not supported by the first version.
+* The API server needs network access to OIDC discovery and signing keys. It does not need to call
+  UserInfo during a proxy session exchange.
+* Direct-upstream deployments depend on OAuth2 Proxy's alpha structured header configuration.
+  NGINX `auth_request` deployments require explicit header remapping.
+* The ID token crosses the proxy-to-API boundary. Both components must use a protected network
   path, and neither component may log the token.
-* OAuth2 Proxy must refresh its access token before it expires. NGINX `auth_request` deployments
-  must also return refreshed session cookies to the browser.
+* OAuth2 Proxy must provide an unexpired ID token whenever a new Dependency-Track session is
+  needed. If OAuth2 Proxy does not refresh the stored ID token, the user must authenticate with
+  the proxy again after it expires.
 * Existing API key validation is unchanged, but OAuth2 Proxy may reject machine requests before
   they reach the API server. Service account and workload identity support remain separate work.
 * The API server and frontend changes must be released together for automatic login. Older
   frontends will continue to show the normal login page.
 * Logging out of Dependency-Track only deletes the local session. If the OAuth2 Proxy session is
-  still active, opening the login page can create a new local session. A gateway-wide logout flow
-  is outside the scope of this decision.
+  still active and has a valid ID token, opening the login page can create a new local session. A
+  gateway-wide logout flow is outside the scope of this decision.
 
 [OAuth2 Proxy]: https://oauth2-proxy.github.io/oauth2-proxy/
 [OAuth2 Proxy header options]: https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/#header-options
+[OAuth2 Proxy structured configuration]: https://oauth2-proxy.github.io/oauth2-proxy/configuration/alpha-config/
 [OAuth2 Proxy NGINX integration]: https://oauth2-proxy.github.io/oauth2-proxy/configuration/integrations/nginx/
+[OpenID Connect Core]: https://openid.net/specs/openid-connect-core-1_0.html
+[OAuth 2.0 JWT access token profile]: https://www.rfc-editor.org/rfc/rfc9068.html
 [issue 7055]: https://github.com/DependencyTrack/dependency-track/issues/7055
 [issue 7056]: https://github.com/DependencyTrack/dependency-track/issues/7056

--- a/docs/adr/040-oauth2-proxy-authentication.md
+++ b/docs/adr/040-oauth2-proxy-authentication.md
@@ -1,0 +1,107 @@
+| Status   | Date       | Author(s)                              |
+|:---------|:-----------|:---------------------------------------|
+| Proposed | 2026-08-28 | [@jjj-n](https://github.com/jjj-n)     |
+
+## Context
+
+Dependency-Track supports local, LDAP, and OpenID Connect (OIDC) login. The frontend starts
+the OIDC flow and sends the resulting tokens to the API server. The API server then creates a
+Dependency-Track session. This works when Dependency-Track is the OIDC client.
+
+Some deployments put [OAuth2 Proxy] in front of every application. The gateway authenticates
+the browser before a request reaches an application. It can pass the authenticated user, email,
+and groups to the upstream application in HTTP headers. Repeating the OIDC flow in the
+Dependency-Track frontend gives the user a second login step. It also requires a separate OIDC
+client registration and direct access from Dependency-Track to the identity provider.
+
+Headers from an authentication proxy are security assertions. They are not signed. A client can
+forge them when it can reach the API server without the gateway, or when the gateway preserves
+headers supplied by the client. Proxy authentication therefore needs an explicit trust boundary.
+
+Dependency-Track authorization is based on persistent users, teams, and permissions. Its
+frontend and REST API use a Dependency-Track bearer session after login. API keys must continue
+to work for automated clients.
+
+### Possible Solutions
+
+#### Exchange trusted proxy headers for a Dependency-Track session
+
+The frontend can call a session exchange endpoint when it has no Dependency-Track session. The
+endpoint can use identity headers added by OAuth2 Proxy. It can create or find a local proxy user
+and return a normal Dependency-Track session.
+
+This option works with every identity provider supported by OAuth2 Proxy. It also keeps the
+existing authorization and session model. However, the API server must trust the gateway and the
+deployment must prevent direct access to the API server.
+
+#### Validate a token forwarded by OAuth2 Proxy
+
+OAuth2 Proxy can forward an access token or OIDC ID token. Dependency-Track can validate that
+token with its existing OIDC support before it creates a session.
+
+This option does not trust plain identity headers. However, it only works for providers and
+tokens that Dependency-Track can validate through OIDC. It may require another client
+registration, access to the identity provider, and provider-specific claim configuration. It
+does not solve the general proxy authentication use case.
+
+#### Authenticate every API request from proxy headers
+
+The API server can treat proxy headers as credentials on every request. This avoids a session
+exchange.
+
+This option conflicts with the frontend's current session flow. It also mixes proxy identity,
+API keys, and session bearer tokens in the common authentication filter. Logout and direct API
+access become harder to define.
+
+## Decision
+
+We will exchange trusted OAuth2 Proxy identity headers for a normal Dependency-Track session.
+The integration will be disabled by default.
+
+The API server will extend the existing version 1 login API with a session exchange endpoint.
+This is an extension of the existing login contract, not a new authentication method for every
+REST endpoint. The endpoint will have these properties:
+
+* It will only accept identity when proxy authentication is enabled.
+* It will read the user and email values from configurable header names. The defaults will
+  match the `X-Forwarded-*` request headers emitted by OAuth2 Proxy.
+* It will reject a request when the user header is missing or empty.
+* It will create or find a persistent proxy user. A username that already belongs to another
+  user type will be rejected.
+* It will issue the same short-lived bearer session used by other login methods. Later API
+  requests will use that session and the existing authorization filters.
+* It will not accept passwords, access tokens, or ID tokens from the browser.
+
+Proxy users will be a distinct user type in the shared user model. This keeps their origin clear
+and avoids treating an unverified proxy assertion as an OIDC identity. Proxy users will use the
+existing team and permission model. User provisioning will be opt-in. Operators can assign
+default teams to newly provisioned users. Administrators can change team membership through the
+existing access management API. Dynamic group synchronization is outside the first version.
+
+The frontend will attempt the proxy session exchange before it displays the login choices. A
+successful exchange will run the existing permission check and open the requested page. When
+proxy authentication is disabled, the frontend will continue with the current local, LDAP, or
+OIDC login flow.
+
+The deployment is part of the trust boundary. Operators must configure the gateway to replace
+the selected identity headers, not preserve values sent by clients. They must also prevent
+clients from reaching the API server without the gateway. The configuration documentation will
+include examples for direct upstream mode and NGINX `auth_request` mode.
+
+## Consequences
+
+* Users authenticated by OAuth2 Proxy can open the dashboard without a second login action.
+* OAuth2 Proxy can use OIDC or another provider. Dependency-Track does not need to validate or
+  store the provider's token.
+* Existing API key clients and Dependency-Track sessions keep their current behavior.
+* The API server still controls authorization through users, teams, and permissions.
+* A new persistent user discriminator and a database migration are required.
+* The API server and frontend changes must be released together for seamless login. Older
+  frontends will continue to show the normal login page.
+* A bad gateway configuration can allow identity spoofing. Enabling this feature asserts that
+  the gateway headers and the network path to the API server are trusted.
+* Logging out of Dependency-Track only deletes the local session. The OAuth2 Proxy session may
+  create a new local session when the login page loads again. A gateway-wide logout flow is
+  outside the scope of this decision.
+
+[OAuth2 Proxy]: https://oauth2-proxy.github.io/oauth2-proxy/

--- a/docs/adr/040-oauth2-proxy-authentication.md
+++ b/docs/adr/040-oauth2-proxy-authentication.md
@@ -32,8 +32,8 @@ including a Dependency-Track audience. That is broader than reusing the existing
 
 An OIDC ID token has the client identifier in its audience. Dependency-Track already validates
 the ID token issuer, signature, expiration, and audience. The OAuth2 Proxy client identifier can
-therefore be configured as the Dependency-Track OIDC client identifier and used as a
-cryptographic boundary between clients of the same identity provider.
+therefore be configured as the expected audience and used as a cryptographic boundary between
+clients of the same identity provider.
 
 The frontend and REST API use a Dependency-Track bearer session after login. OAuth2 Proxy's
 stable direct-upstream option puts the ID token in the `Authorization` header. This conflicts
@@ -79,9 +79,9 @@ tracked separately.
 #### Validate an ID token forwarded by OAuth2 Proxy
 
 The API server can validate a forwarded ID token with the existing OIDC issuer, audience,
-signature, and expiration checks. The audience binds the token to the configured OAuth2 Proxy
-client instead of only trusting the network path. The resulting identity can reuse the normal
-OIDC user, provisioning, team synchronization, and session behavior.
+signature, and expiration checks. The audience binds the token to the separately configured
+OAuth2 Proxy client instead of only trusting the network path. The resulting identity can reuse
+the normal OIDC user, provisioning, team synchronization, and session behavior.
 
 The ID token must use a separate header so it does not replace the Dependency-Track session in
 `Authorization`. Direct-upstream deployments need OAuth2 Proxy's structured header injection.
@@ -128,14 +128,22 @@ request body. It will pass the token to the existing OIDC ID token validation pa
 same short-lived bearer session used by other login methods.
 
 The ID token must pass the standard checks defined by [OpenID Connect Core] and already performed
-by Dependency-Track. These include issuer, signature, expiration, and audience validation. The
-configured `dt.oidc.client-id` must match the client identifier used by OAuth2 Proxy. A token
-issued to a different client of the same identity provider will be rejected.
+by Dependency-Track. These include issuer, signature, expiration, and audience validation. A new
+`dt.oauth2-proxy.client-id` setting must match the client identifier used by OAuth2 Proxy. It is
+the expected audience for the forwarded ID token. A token issued to a different client of the
+same identity provider will be rejected.
+
+Native Dependency-Track OIDC continues to use `dt.oidc.client-id`. The two login paths can be
+enabled together and can use different client registrations, but both registrations must use the
+provider configured by `dt.oidc.issuer`. This avoids requiring a public browser client and the
+OAuth2 Proxy client to share a registration.
 
 The first version will not authenticate from a forwarded access token and will not call UserInfo
 during the exchange. The ID token must contain the subject, configured username claim, and the
-configured teams claim when team synchronization is enabled. Supporting providers that only
-return required claims from UserInfo is outside the first version.
+configured teams claim when team synchronization is enabled. If a required claim is absent, the
+exchange will fail rather than construct an incomplete profile or synchronize an empty team list.
+An explicitly present empty teams claim remains valid and removes mapped team memberships.
+Supporting providers that only return required claims from UserInfo is outside the first version.
 
 Users authenticated through the exchange will be normal OIDC users. Existing user provisioning,
 default team, team synchronization, and session settings will apply. No proxy-specific user type,
@@ -175,10 +183,11 @@ for machine traffic need native resource server support. That work remains separ
   sessions. No new user type or database migration is required.
 * Dependency-Track validates the ID token issuer, signature, expiration, and audience. A plain
   forwarded identity header or an access token for another client is not sufficient to log in.
-* The configured Dependency-Track OIDC client identifier must match the OAuth2 Proxy client
-  identifier. The same client registration can be reused.
+* OAuth2 Proxy and native Dependency-Track OIDC have separate client identifier settings and may
+  use different client registrations with the same issuer.
 * Every claim required for the Dependency-Track OIDC profile must be present in the ID token.
-  Providers that only expose those claims through UserInfo are not supported by the first version.
+  A missing required claim fails the exchange. Providers that only expose those claims through
+  UserInfo are not supported by the first version.
 * The API server needs network access to OIDC discovery and signing keys. It does not need to call
   UserInfo during a proxy session exchange.
 * Direct-upstream deployments depend on OAuth2 Proxy's alpha structured header configuration.

--- a/docs/adr/040-oauth2-proxy-authentication.md
+++ b/docs/adr/040-oauth2-proxy-authentication.md
@@ -1,107 +1,154 @@
-| Status   | Date       | Author(s)                              |
-|:---------|:-----------|:---------------------------------------|
-| Proposed | 2026-08-28 | [@jjj-n](https://github.com/jjj-n)     |
+| Status   | Date       | Author(s)                          |
+|:---------|:-----------|:-----------------------------------|
+| Proposed | 2026-08-28 | [@jjj-n](https://github.com/jjj-n) |
 
 ## Context
 
-Dependency-Track supports local, LDAP, and OpenID Connect (OIDC) login. The frontend starts
-the OIDC flow and sends the resulting tokens to the API server. The API server then creates a
-Dependency-Track session. This works when Dependency-Track is the OIDC client.
+Dependency-Track supports local, LDAP, and OpenID Connect (OIDC) login. For OIDC login, the
+frontend starts the authorization flow and sends the resulting tokens to the API server. The API
+server validates the tokens, creates or finds an OIDC user, and returns a Dependency-Track
+session.
 
-Some deployments put [OAuth2 Proxy] in front of every application. The gateway authenticates
-the browser before a request reaches an application. It can pass the authenticated user, email,
-and groups to the upstream application in HTTP headers. Repeating the OIDC flow in the
-Dependency-Track frontend gives the user a second login step. It also requires a separate OIDC
-client registration and direct access from Dependency-Track to the identity provider.
+Some deployments put [OAuth2 Proxy] in front of every application. OAuth2 Proxy authenticates
+the browser before a request reaches the application. When it uses an OIDC provider, it can pass
+the access token or ID token to the upstream application. Starting another OIDC flow in the
+Dependency-Track frontend gives the user a second login step.
 
-Headers from an authentication proxy are security assertions. They are not signed. A client can
-forge them when it can reach the API server without the gateway, or when the gateway preserves
-headers supplied by the client. Proxy authentication therefore needs an explicit trust boundary.
+OAuth2 Proxy can also pass the authenticated username, email, and groups in HTTP headers. These
+identity headers are not signed. A client can forge them if it can bypass the proxy, or if the
+proxy preserves values supplied by the client. Accepting them as credentials would make the
+deployment network part of the authentication mechanism.
 
-Dependency-Track authorization is based on persistent users, teams, and permissions. Its
-frontend and REST API use a Dependency-Track bearer session after login. API keys must continue
-to work for automated clients.
+The frontend and REST API use a Dependency-Track bearer session after login. Passing an OIDC ID
+token to the upstream in the `Authorization` header conflicts with this session because both use
+the same header. The browser also cannot read a header that the proxy adds to its request. A
+server-side exchange is therefore required even when the existing OIDC validation is reused.
+
+This decision addresses interactive users opening the Dependency-Track dashboard. Authentication
+for service and robot accounts is tracked separately in [issue 7055] and [issue 7056].
 
 ### Possible Solutions
 
-#### Exchange trusted proxy headers for a Dependency-Track session
+#### Exchange trusted identity headers for a Dependency-Track session
 
-The frontend can call a session exchange endpoint when it has no Dependency-Track session. The
-endpoint can use identity headers added by OAuth2 Proxy. It can create or find a local proxy user
-and return a normal Dependency-Track session.
+The frontend can call a session exchange endpoint. The endpoint can trust identity headers added
+by OAuth2 Proxy, then create or find a dedicated proxy user.
 
-This option works with every identity provider supported by OAuth2 Proxy. It also keeps the
-existing authorization and session model. However, the API server must trust the gateway and the
-deployment must prevent direct access to the API server.
+This works with non-OIDC providers. However, it requires strict network isolation or another way
+to authenticate the proxy. It also introduces another user type and duplicates existing OIDC
+user provisioning and team synchronization behavior.
 
-#### Validate a token forwarded by OAuth2 Proxy
+#### Validate an access token forwarded by OAuth2 Proxy
 
-OAuth2 Proxy can forward an access token or OIDC ID token. Dependency-Track can validate that
-token with its existing OIDC support before it creates a session.
+OAuth2 Proxy can pass the provider access token in the `X-Forwarded-Access-Token` header. The API
+server can use the existing OIDC UserInfo validation, user provisioning, team synchronization,
+and session creation behavior.
 
-This option does not trust plain identity headers. However, it only works for providers and
-tokens that Dependency-Track can validate through OIDC. It may require another client
-registration, access to the identity provider, and provider-specific claim configuration. It
-does not solve the general proxy authentication use case.
+This does not trust plain identity headers and does not require another user type. OAuth2 Proxy's
+existing client registration can be reused. However, the provider must support OIDC, and the API
+server must be able to access OIDC discovery and the UserInfo endpoint.
+
+#### Validate an ID token forwarded by OAuth2 Proxy
+
+The API server can validate a forwarded ID token with the existing OIDC issuer, audience, and
+signature checks. This avoids a UserInfo request when the token contains all required claims.
+
+OAuth2 Proxy's stable direct-upstream option sends the ID token in the `Authorization` header.
+This would overwrite the Dependency-Track session on later requests. A separate header requires
+structured OAuth2 Proxy configuration or an additional reverse proxy. Access token refresh also
+does not guarantee that the stored ID token is replaced. This makes the option less portable for
+the first version.
 
 #### Authenticate every API request from proxy headers
 
 The API server can treat proxy headers as credentials on every request. This avoids a session
 exchange.
 
-This option conflicts with the frontend's current session flow. It also mixes proxy identity,
-API keys, and session bearer tokens in the common authentication filter. Logout and direct API
-access become harder to define.
+This conflicts with the existing frontend session flow. It also mixes proxy identity, API keys,
+and session bearer tokens in the common authentication path. Logout and direct API access become
+harder to define.
 
 ## Decision
 
-We will exchange trusted OAuth2 Proxy identity headers for a normal Dependency-Track session.
-The integration will be disabled by default.
+We will validate an access token forwarded by OAuth2 Proxy and exchange it for a normal
+Dependency-Track session. The integration will only support OAuth2 Proxy deployments backed by
+an OIDC provider. It will only authenticate interactive users.
 
-The API server will extend the existing version 1 login API with a session exchange endpoint.
-This is an extension of the existing login contract, not a new authentication method for every
-REST endpoint. The endpoint will have these properties:
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant Proxy as OAuth2 Proxy
+    participant API as Dependency-Track API
+    participant IdP as OIDC UserInfo
 
-* It will only accept identity when proxy authentication is enabled.
-* It will read the user and email values from configurable header names. The defaults will
-  match the `X-Forwarded-*` request headers emitted by OAuth2 Proxy.
-* It will reject a request when the user header is missing or empty.
-* It will create or find a persistent proxy user. A username that already belongs to another
-  user type will be rejected.
-* It will issue the same short-lived bearer session used by other login methods. Later API
-  requests will use that session and the existing authorization filters.
-* It will not accept passwords, access tokens, or ID tokens from the browser.
+    Browser->>Proxy: Request dashboard
+    Proxy->>Proxy: Authenticate browser
+    Proxy->>API: Session exchange with forwarded access token
+    API->>IdP: Validate token and load claims
+    IdP-->>API: OIDC user claims
+    API-->>Proxy: Dependency-Track session
+    Proxy-->>Browser: Dependency-Track session
+    Browser->>Proxy: API request with Dependency-Track session
+    Proxy->>API: API request with Dependency-Track session
+```
 
-Proxy users will be a distinct user type in the shared user model. This keeps their origin clear
-and avoids treating an unverified proxy assertion as an OIDC identity. Proxy users will use the
-existing team and permission model. User provisioning will be opt-in. Operators can assign
-default teams to newly provisioned users. Administrators can change team membership through the
-existing access management API. Dynamic group synchronization is outside the first version.
+The API server will extend the version 1 login API with a session exchange endpoint. The endpoint
+will read the access token from `X-Forwarded-Access-Token`. It will not accept a token from the
+request body. It will pass the token to the existing OIDC authentication path and issue the same
+short-lived bearer session used by other login methods.
 
-The frontend will attempt the proxy session exchange before it displays the login choices. A
-successful exchange will run the existing permission check and open the requested page. When
-proxy authentication is disabled, the frontend will continue with the current local, LDAP, or
-OIDC login flow.
+The API server must have OIDC enabled and configured for the same issuer used by OAuth2 Proxy.
+Existing username claim, user provisioning, default team, and team synchronization settings will
+apply. The frontend OIDC client settings can remain empty because the frontend will not start an
+OIDC flow for this integration.
 
-The deployment is part of the trust boundary. Operators must configure the gateway to replace
-the selected identity headers, not preserve values sent by clients. They must also prevent
-clients from reaching the API server without the gateway. The configuration documentation will
-include examples for direct upstream mode and NGINX `auth_request` mode.
+Users authenticated through the exchange will be normal OIDC users. No proxy-specific user type,
+database discriminator, migration, or access management API will be added.
+
+The frontend will attempt the exchange when it has no Dependency-Track session, before it displays
+the login choices. A successful exchange will run the existing permission check and open the
+requested page. A response indicating that no forwarded access token is available will continue
+to the existing local, LDAP, or OIDC login options.
+
+Operators must configure OAuth2 Proxy to replace `X-Forwarded-Access-Token` values supplied by
+clients. In direct-upstream mode, this is provided by `--pass-access-token`, as described in the
+[OAuth2 Proxy header options]. In NGINX `auth_request` mode, OAuth2 Proxy must use both
+`--pass-access-token` and `--set-xauthrequest`. NGINX must then copy the token from the
+authentication response into the expected upstream header, as shown in the
+[OAuth2 Proxy NGINX integration]. Operators must also prevent clients from bypassing OAuth2
+Proxy. Dependency-Track will not use forwarded username or email headers as credentials.
+
+The forwarded provider token will not use the `Authorization` header. That header remains
+available for the Dependency-Track session after the exchange.
+
+API keys remain a Dependency-Track authentication method, but this decision does not define how
+machine clients authenticate to OAuth2 Proxy. Deployments that require gateway authentication for
+machine traffic must address it separately. The session exchange will not accept API keys as
+proxy credentials.
 
 ## Consequences
 
 * Users authenticated by OAuth2 Proxy can open the dashboard without a second login action.
-* OAuth2 Proxy can use OIDC or another provider. Dependency-Track does not need to validate or
-  store the provider's token.
-* Existing API key clients and Dependency-Track sessions keep their current behavior.
-* The API server still controls authorization through users, teams, and permissions.
-* A new persistent user discriminator and a database migration are required.
-* The API server and frontend changes must be released together for seamless login. Older
+* The API server reuses its OIDC users, provisioning, team synchronization, permissions, and
+  sessions. No new user type or database migration is required.
+* The integration only works when OAuth2 Proxy uses an OIDC provider and forwards an access token
+  that the provider accepts at its UserInfo endpoint.
+* The API server needs network access to OIDC discovery and UserInfo. This may not meet deployment
+  policies that prohibit applications from contacting the identity provider.
+* The access token crosses the proxy-to-API boundary. Both components must use a protected network
+  path, and neither component may log the token.
+* OAuth2 Proxy must refresh its access token before it expires. NGINX `auth_request` deployments
+  must also return refreshed session cookies to the browser.
+* Existing API key validation is unchanged, but OAuth2 Proxy may reject machine requests before
+  they reach the API server. Service account and workload identity support remain separate work.
+* The API server and frontend changes must be released together for automatic login. Older
   frontends will continue to show the normal login page.
-* A bad gateway configuration can allow identity spoofing. Enabling this feature asserts that
-  the gateway headers and the network path to the API server are trusted.
-* Logging out of Dependency-Track only deletes the local session. The OAuth2 Proxy session may
-  create a new local session when the login page loads again. A gateway-wide logout flow is
-  outside the scope of this decision.
+* Logging out of Dependency-Track only deletes the local session. If the OAuth2 Proxy session is
+  still active, opening the login page can create a new local session. A gateway-wide logout flow
+  is outside the scope of this decision.
 
 [OAuth2 Proxy]: https://oauth2-proxy.github.io/oauth2-proxy/
+[OAuth2 Proxy header options]: https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/#header-options
+[OAuth2 Proxy NGINX integration]: https://oauth2-proxy.github.io/oauth2-proxy/configuration/integrations/nginx/
+[issue 7055]: https://github.com/DependencyTrack/dependency-track/issues/7055
+[issue 7056]: https://github.com/DependencyTrack/dependency-track/issues/7056


### PR DESCRIPTION
### Description

Proposes optional support for deployments where an OIDC-backed OAuth2 Proxy authenticates
incoming browser requests before they reach Dependency-Track.

The revised design treats the OAuth2 Proxy ID token as the credential. OAuth2 Proxy forwards it
in a separate `X-Forwarded-ID-Token` header, and Dependency-Track validates it through the
existing OIDC ID token path. Validation includes the issuer, signature, expiration, and audience.
A new `dt.auth-proxy.client-id` setting declares the expected audience and must match the
OAuth2 Proxy client identifier, so a token issued to another client of the same identity provider
cannot be exchanged for a Dependency-Track session.

Native OIDC continues to use `dt.oidc.client-id`. The native and proxy login paths may coexist
with different client registrations, but both must use the configured `dt.oidc.issuer` in the
first version.

The integration does not trust forwarded username, email, or group headers. It also does not
authenticate from a forwarded access token or rely on UserInfo as proof that a token was issued
for Dependency-Track. Users remain normal OIDC users and reuse existing provisioning, team
synchronization, permissions, and session behavior. The configured username claim, and the teams
claim when team synchronization is enabled, must be present in the ID token. A missing required
claim fails the exchange rather than synchronizing an incomplete profile.

Native Dependency-Track OIDC remains the default. This integration is limited to interactive
users in deployments that require the OAuth2 Proxy session to initiate the application session.
Service accounts and workload identity federation remain separate work in #7055 and #7056.

### Addressed Issue

Related to #7141

### Additional Details

The ADR compares five approaches:

- Use native Dependency-Track OIDC behind OAuth2 Proxy.
- Exchange trusted proxy identity headers for a Dependency-Track session.
- Validate an access token forwarded by OAuth2 Proxy.
- Validate an ID token forwarded by OAuth2 Proxy.
- Authenticate every API request directly from proxy headers.

It proposes the ID token exchange because it reuses Dependency-Track's existing OIDC model while
retaining cryptographic issuer, signature, expiration, and audience validation. The ID token uses
a separate header so `Authorization` remains available for the Dependency-Track session.

Implementation pull requests will follow after the ADR is accepted.

### Checklist

- [x] I have read and understand the contributing guidelines
- [x] ~~This PR fixes a defect, and I have provided tests~~
- [x] ~~This PR implements an enhancement, and I have provided tests~~
- [x] ~~This PR introduces changes to the database model~~
- [x] ~~This PR introduces new or alters existing behavior~~
- [x] This PR is a substantial change, and I have added an ADR under `docs/adr/`
