### PR TITLE
Ignore letters appended to numeric version parts in VersionDistance

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/VersionDistance.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/VersionDistance.java
@@ -80,8 +80,8 @@ public class VersionDistance implements Comparable<VersionDistance>, Serializabl
             "^(?:(?<" + GROUP_EPOCH + ">.*):)?"
                     // Version part: at least major version (numeric), optionally minor (numeric)
                     // or patch (numeric) version. Ignore the rest.
-                    + "v?(?<" + GROUP_MAJOR + ">\\d+[a-z]*)?(?:\\.(?<" + GROUP_MINOR + ">\\d+[a-z]*))?(?:\\.(?<"
-                    + GROUP_PATCH + ">\\d+[a-z]*))?"
+                    + "v?(?<" + GROUP_MAJOR + ">\\d+)?[a-z]*(?:\\.(?<" + GROUP_MINOR + ">\\d+)?[a-z]*)?(?:\\.(?<"
+                    + GROUP_PATCH + ">\\d+)?[a-z]*)?"
                     // Build numbers, labels and build metadata.
                     + ".*$",
             Pattern.CASE_INSENSITIVE);

--- a/apiserver/src/test/java/org/dependencytrack/model/VersionDistanceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/model/VersionDistanceTest.java
@@ -130,6 +130,11 @@ public class VersionDistanceTest {
     @Test
     public void testGetVersionDistanceWithLetterSuffixedVersionParts() {
         assertEquals(new VersionDistance("0.0.0"), VersionDistance.getVersionDistance("1.2.3a", "1.2.3"));
+
+        // A part that is entirely non-numeric is skipped rather than ending the match,
+        // so the parts after it are still recognised. Previously everything from the
+        // non-numeric part onwards was ignored, and "1.abc.3" was read as "1.0.0".
+        assertEquals(new VersionDistance("0.0.3"), VersionDistance.getVersionDistance("1.abc.3", "1.0.0"));
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/model/VersionDistanceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/model/VersionDistanceTest.java
@@ -118,10 +118,18 @@ public class VersionDistanceTest {
         // optional build numbers are ignored:
         assertEquals(new VersionDistance("0.0.0"), VersionDistance.getVersionDistance("0.0.0.1", "0.0.0.5"));
 
+        // letters appended to a numeric version part are ignored, like build numbers above:
+        assertEquals(new VersionDistance("0.2.?"), VersionDistance.getVersionDistance("1a.2.3", "1"));
+        assertEquals(new VersionDistance("0.2.?"), VersionDistance.getVersionDistance("1.2a.3", "1"));
+        assertEquals(new VersionDistance("0.2.?"), VersionDistance.getVersionDistance("1.2.3a", "1"));
+
+        // a non-numeric epoch is still invalid:
         assertThrows(NumberFormatException.class, () -> VersionDistance.getVersionDistance("a:", "1"));
-        assertThrows(NumberFormatException.class, () -> VersionDistance.getVersionDistance("1a.2.3", "1"));
-        assertThrows(NumberFormatException.class, () -> VersionDistance.getVersionDistance("1.2a.3", "1"));
-        assertThrows(NumberFormatException.class, () -> VersionDistance.getVersionDistance("1.2.3a", "1"));
+    }
+
+    @Test
+    public void testGetVersionDistanceWithLetterSuffixedVersionParts() {
+        assertEquals(new VersionDistance("0.0.0"), VersionDistance.getVersionDistance("1.2.3a", "1.2.3"));
     }
 
     @Test


### PR DESCRIPTION
### Description

Fixed a NumberFormatException in VersionDistance when a version part has letters appended to it, e.g. 1.2.3a. VERSION_PATTERN captures parts as \d+[a-z]*, so the group comes out as "3a", and parseVersion passes that straight to Integer.parseInt.

### Addressed Issue

Fixes https://github.com/DependencyTrack/dependency-track/issues/3230

### Additional Details

The handling is inconsistent today. A part that is only letters, like the "f" in "1.f", never matches the group at all, so it is treated as 0. This is already asserted by getVersionDistance("1.f", "3.4.0"). But a digit followed by letters does match, and then fails to parse.

The comments on the pattern say the version part is numeric and the rest is ignored, and appended build numbers like 0.0.0.1 are already ignored, so letters were probably meant to be tolerated as well. Moved the [a-z]* outside the capture groups so only the numeric part is captured.

Epoch is left as .* so a non-numeric epoch still fails, and DISTANCE_PATTERN is untouched, so an invalid distance like {"major": "1a"} is still rejected.

Two behaviour changes worth calling out.

Moving the letters outside the capture groups also means a version part with no digits at all no longer ends the match. "1.abc.3" used to be read as 1.0.0, because everything from ".abc" onwards was ignored, and is now read as 1.0.3. That seems more correct to me, but it is a change beyond the reported defect, so I added a test pinning it. Happy to keep the old behaviour there if you would rather.

The second is that this changes behaviour that is currently asserted. The three assertThrows cases for 1a.2.3, 1.2a.3 and 1.2.3a now parse, and I replaced them with assertEquals. The a: epoch case still asserts a throw. If you would rather go the other way and reject letters everywhere, including "1.f", I can rework it.

### Checklist

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [X] This PR fixes a defect, and I have provided tests to verify that the fix is effective

