### PR TITLE
Expose vulnerability analysis to CEL policy expressions

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyEngine.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyEngine.java
@@ -80,6 +80,7 @@ import static org.dependencytrack.policy.cel.CelPolicyTypes.TYPE_LICENSE;
 import static org.dependencytrack.policy.cel.CelPolicyTypes.TYPE_LICENSE_GROUP;
 import static org.dependencytrack.policy.cel.CelPolicyTypes.TYPE_PROJECT;
 import static org.dependencytrack.policy.cel.CelPolicyTypes.TYPE_VULNERABILITY;
+import static org.dependencytrack.policy.cel.CelPolicyTypes.TYPE_VULNERABILITY_ANALYSIS;
 
 public final class CelPolicyEngine {
 
@@ -236,6 +237,21 @@ public final class CelPolicyEngine {
             vulnIdsByComponentId = Map.of();
         }
 
+        // Analyses are per-finding, whereas vulnerability protos are de-duplicated per
+        // project. They are thus merged into per-component copies further below, and only
+        // when a policy actually accesses them.
+        final Map<Long, Map<Long, Vulnerability.Analysis>> analysesByComponentId;
+        if (requirements.getOrDefault(TYPE_VULNERABILITY, Set.of()).contains("analysis")
+                && !vulnIdsByComponentId.isEmpty()) {
+            analysesByComponentId = withJdbiHandle(handle -> new CelPolicyDao(handle)
+                    .fetchAllAnalyses(
+                            projectId,
+                            vulnIdsByComponentId.keySet(),
+                            requirements.getOrDefault(TYPE_VULNERABILITY_ANALYSIS, Set.of())));
+        } else {
+            analysesByComponentId = Map.of();
+        }
+
         final var violationsByComponentId = new HashMap<Long, List<PolicyViolation>>();
         final Timestamp protoNow = Timestamps.now();
 
@@ -249,8 +265,22 @@ public final class CelPolicyEngine {
 
             final List<Vulnerability> protoVulns;
             if (requirements.containsKey(TYPE_VULNERABILITY)) {
+                final Map<Long, Vulnerability.Analysis> analysesByVulnId =
+                        analysesByComponentId.getOrDefault(componentId, Map.of());
                 protoVulns = vulnIdsByComponentId.getOrDefault(componentId, Set.of()).stream()
-                        .map(protoVulnById::get)
+                        .map(vulnId -> {
+                            final Vulnerability protoVuln = protoVulnById.get(vulnId);
+                            if (protoVuln == null) {
+                                return null;
+                            }
+                            final Vulnerability.Analysis protoAnalysis = analysesByVulnId.get(vulnId);
+                            if (protoAnalysis == null) {
+                                return protoVuln;
+                            }
+                            return protoVuln.toBuilder()
+                                    .setAnalysis(protoAnalysis)
+                                    .build();
+                        })
                         .filter(Objects::nonNull)
                         .toList();
             } else {

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyTypes.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyTypes.java
@@ -51,6 +51,8 @@ public final class CelPolicyTypes {
     public static final CelType TYPE_VULNERABILITIES = ListType.create(TYPE_VULNERABILITY);
     public static final CelType TYPE_VULNERABILITY_ALIAS =
             StructTypeReference.create(Vulnerability.Alias.getDescriptor().getFullName());
+    public static final CelType TYPE_VULNERABILITY_ANALYSIS =
+            StructTypeReference.create(Vulnerability.Analysis.getDescriptor().getFullName());
     public static final CelType TYPE_VERSION_DISTANCE =
             StructTypeReference.create(VersionDistance.getDescriptor().getFullName());
 

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
@@ -55,6 +55,7 @@ import static org.dependencytrack.policy.cel.persistence.CelPolicyFieldMappingRe
 import static org.dependencytrack.policy.cel.persistence.CelPolicyFieldMappingRegistry.LICENSE_GROUP_FIELDS;
 import static org.dependencytrack.policy.cel.persistence.CelPolicyFieldMappingRegistry.PROJECT_FIELDS;
 import static org.dependencytrack.policy.cel.persistence.CelPolicyFieldMappingRegistry.PROJECT_PROPERTY_FIELDS;
+import static org.dependencytrack.policy.cel.persistence.CelPolicyFieldMappingRegistry.VULNERABILITY_ANALYSIS_FIELDS;
 import static org.dependencytrack.policy.cel.persistence.CelPolicyFieldMappingRegistry.VULNERABILITY_FIELDS;
 import static org.dependencytrack.policy.cel.persistence.CelPolicyFieldMappingRegistry.selectColumns;
 
@@ -272,6 +273,49 @@ public final class CelPolicyDao {
                 .reduceResultSet(new HashMap<>(), (accumulator, rs, ctx) -> {
                     final long dbId = rs.getLong("db_id");
                     accumulator.put(dbId, licenseRowMapper.map(rs, ctx));
+                    return accumulator;
+                });
+    }
+
+    /**
+     * Fetches the {@link Vulnerability.Analysis} of each finding in the given project.
+     *
+     * <p>Analyses are keyed by component, then by vulnerability, because the same
+     * vulnerability can be analyzed differently on each component it affects.
+     *
+     * <p>Suppressed findings are not evaluated, so their analyses are not fetched.
+     *
+     * @param projectId ID of the project to fetch analyses for
+     * @param componentIds IDs of the components to fetch analyses for
+     * @param protoFieldNames Names of the {@link Vulnerability.Analysis} fields to fetch
+     * @return Analyses, grouped by component ID and vulnerability ID
+     */
+    public Map<Long, Map<Long, Vulnerability.Analysis>> fetchAllAnalyses(
+            long projectId, Collection<Long> componentIds, Collection<String> protoFieldNames) {
+        final List<String> fetchColumns = new ArrayList<>();
+        fetchColumns.add("a.\"COMPONENT_ID\" AS component_id");
+        fetchColumns.add("a.\"VULNERABILITY_ID\" AS vulnerability_id");
+        fetchColumns.addAll(selectColumns(VULNERABILITY_ANALYSIS_FIELDS, protoFieldNames));
+
+        final var analysisRowMapper = new CelPolicyVulnerabilityAnalysisRowMapper();
+        return jdbiHandle
+                .createQuery(/* language=InjectedFreeMarker */ """
+                        <#-- @ftlvariable name="fetchColumns" type="java.util.Collection<String>" -->
+                        SELECT ${fetchColumns?join(", ")}
+                          FROM "ANALYSIS" AS a
+                         WHERE a."PROJECT_ID" = :projectId
+                           AND a."COMPONENT_ID" = ANY(:componentIds)
+                           AND a."SUPPRESSED" IS NOT TRUE
+                        """)
+                .define("fetchColumns", fetchColumns)
+                .bind("projectId", projectId)
+                .bindArray("componentIds", Long.class, componentIds)
+                .reduceResultSet(new HashMap<>(), (accumulator, rs, ctx) -> {
+                    final long componentId = rs.getLong("component_id");
+                    final long vulnerabilityId = rs.getLong("vulnerability_id");
+                    accumulator
+                            .computeIfAbsent(componentId, k -> new HashMap<>())
+                            .put(vulnerabilityId, analysisRowMapper.map(rs, ctx));
                     return accumulator;
                 });
     }

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyFieldMappingRegistry.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyFieldMappingRegistry.java
@@ -95,6 +95,12 @@ public final class CelPolicyFieldMappingRegistry {
             new FieldMapping("epss_score", "ep.\"SCORE\""),
             new FieldMapping("epss_percentile", "ep.\"PERCENTILE\""));
 
+    static final List<FieldMapping> VULNERABILITY_ANALYSIS_FIELDS = List.of(
+            new FieldMapping("state", "a.\"STATE\""),
+            new FieldMapping("justification", "a.\"JUSTIFICATION\""),
+            new FieldMapping("response", "a.\"RESPONSE\""),
+            new FieldMapping("details", "a.\"DETAILS\""));
+
     static final List<FieldMapping> LICENSE_FIELDS = List.of(
             new FieldMapping("uuid", "l.\"UUID\""),
             new FieldMapping("id", "l.\"LICENSEID\""),

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyVulnerabilityAnalysisRowMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyVulnerabilityAnalysisRowMapper.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.policy.cel.persistence;
+
+import org.dependencytrack.proto.policy.v1.Vulnerability;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.dependencytrack.persistence.jdbi.mapping.RowMapperUtil.maybeSet;
+
+public final class CelPolicyVulnerabilityAnalysisRowMapper implements RowMapper<Vulnerability.Analysis> {
+
+    @Override
+    public Vulnerability.Analysis map(ResultSet rs, StatementContext ctx) throws SQLException {
+        final Vulnerability.Analysis.Builder builder = Vulnerability.Analysis.newBuilder();
+        maybeSet(rs, "state", ResultSet::getString, builder::setState);
+        maybeSet(rs, "justification", ResultSet::getString, builder::setJustification);
+        maybeSet(rs, "response", ResultSet::getString, builder::setResponse);
+        maybeSet(rs, "details", ResultSet::getString, builder::setDetails);
+        return builder.build();
+    }
+}

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
@@ -22,6 +22,7 @@ import alpine.model.IConfigProperty;
 import com.github.packageurl.PackageURL;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.kevdatasource.api.KevAssertion;
+import org.dependencytrack.model.AnalysisResponse;
 import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.Bom;
 import org.dependencytrack.model.Classifier;
@@ -3040,5 +3041,197 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
 
         assertThat(qm.getAllPolicyViolations(projectUntagged)).hasSize(1);
         assertThat(qm.getAllPolicyViolations(projectTagged)).isEmpty();
+    }
+
+    @Test
+    void shouldEvaluateVulnerabilityAnalysisPerComponent() throws Exception {
+        final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
+        qm.createPolicyCondition(
+                policy,
+                PolicyCondition.Subject.EXPRESSION,
+                PolicyCondition.Operator.MATCHES,
+                """
+                vulns.exists(v, has(v.analysis) && v.analysis.state == "EXPLOITABLE")
+                """,
+                PolicyViolation.Type.SECURITY);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var componentExploitable = new Component();
+        componentExploitable.setProject(project);
+        componentExploitable.setName("acme-lib-a");
+        qm.persist(componentExploitable);
+
+        final var componentUntriaged = new Component();
+        componentUntriaged.setProject(project);
+        componentUntriaged.setName("acme-lib-b");
+        qm.persist(componentUntriaged);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-001");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setSeverity(Severity.HIGH);
+        qm.persist(vuln);
+
+        // The same vulnerability on both components, analyzed on only one of them.
+        // Vulnerability protos are de-duplicated per project, so the analysis must not
+        // leak from one component to the other.
+        qm.addVulnerability(vuln, componentExploitable, "internal");
+        qm.addVulnerability(vuln, componentUntriaged, "internal");
+
+        qm.makeAnalysis(new MakeAnalysisCommand(componentExploitable, vuln)
+                .withState(AnalysisState.EXPLOITABLE)
+                .withResponse(AnalysisResponse.WILL_NOT_FIX)
+                .withDetails("accepted risk"));
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+
+        assertThat(qm.getAllPolicyViolations(componentExploitable)).hasSize(1);
+        assertThat(qm.getAllPolicyViolations(componentUntriaged)).isEmpty();
+    }
+
+    @Test
+    void shouldEvaluateUntriagedVulnerabilitiesViaAnalysis() throws Exception {
+        final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
+        qm.createPolicyCondition(
+                policy,
+                PolicyCondition.Subject.EXPRESSION,
+                PolicyCondition.Operator.MATCHES,
+                """
+                vulns.exists(v, !has(v.analysis) || v.analysis.state in ["NOT_SET", "IN_TRIAGE"])
+                """,
+                PolicyViolation.Type.SECURITY);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var componentUntriaged = new Component();
+        componentUntriaged.setProject(project);
+        componentUntriaged.setName("acme-lib-a");
+        qm.persist(componentUntriaged);
+
+        final var componentInTriage = new Component();
+        componentInTriage.setProject(project);
+        componentInTriage.setName("acme-lib-b");
+        qm.persist(componentInTriage);
+
+        final var componentResolved = new Component();
+        componentResolved.setProject(project);
+        componentResolved.setName("acme-lib-c");
+        qm.persist(componentResolved);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-001");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setSeverity(Severity.HIGH);
+        qm.persist(vuln);
+
+        qm.addVulnerability(vuln, componentUntriaged, "internal");
+        qm.addVulnerability(vuln, componentInTriage, "internal");
+        qm.addVulnerability(vuln, componentResolved, "internal");
+
+        qm.makeAnalysis(new MakeAnalysisCommand(componentInTriage, vuln).withState(AnalysisState.IN_TRIAGE));
+        qm.makeAnalysis(new MakeAnalysisCommand(componentResolved, vuln).withState(AnalysisState.RESOLVED));
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+
+        assertThat(qm.getAllPolicyViolations(componentUntriaged)).hasSize(1);
+        assertThat(qm.getAllPolicyViolations(componentInTriage)).hasSize(1);
+        assertThat(qm.getAllPolicyViolations(componentResolved)).isEmpty();
+    }
+
+    @Test
+    void shouldEvaluateAnalysisResponseAndDetails() throws Exception {
+        final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
+        qm.createPolicyCondition(
+                policy,
+                PolicyCondition.Subject.EXPRESSION,
+                PolicyCondition.Operator.MATCHES,
+                """
+                vulns.exists(v, has(v.analysis) && v.analysis.state == "EXPLOITABLE"
+                    && (!has(v.analysis.response) || v.analysis.response == "NOT_SET"
+                        || size(v.analysis.details) == 0))
+                """,
+                PolicyViolation.Type.SECURITY);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var componentUndocumented = new Component();
+        componentUndocumented.setProject(project);
+        componentUndocumented.setName("acme-lib-a");
+        qm.persist(componentUndocumented);
+
+        final var componentDocumented = new Component();
+        componentDocumented.setProject(project);
+        componentDocumented.setName("acme-lib-b");
+        qm.persist(componentDocumented);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-001");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setSeverity(Severity.HIGH);
+        qm.persist(vuln);
+
+        qm.addVulnerability(vuln, componentUndocumented, "internal");
+        qm.addVulnerability(vuln, componentDocumented, "internal");
+
+        qm.makeAnalysis(new MakeAnalysisCommand(componentUndocumented, vuln).withState(AnalysisState.EXPLOITABLE));
+        qm.makeAnalysis(new MakeAnalysisCommand(componentDocumented, vuln)
+                .withState(AnalysisState.EXPLOITABLE)
+                .withResponse(AnalysisResponse.WILL_NOT_FIX)
+                .withDetails("risk accepted by security board"));
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+
+        assertThat(qm.getAllPolicyViolations(componentUndocumented)).hasSize(1);
+        assertThat(qm.getAllPolicyViolations(componentDocumented)).isEmpty();
+    }
+
+    @Test
+    void shouldEvaluateAnalysisPresenceWithoutAccessingFields() throws Exception {
+        final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
+        qm.createPolicyCondition(
+                policy,
+                PolicyCondition.Subject.EXPRESSION,
+                PolicyCondition.Operator.MATCHES,
+                """
+                vulns.exists(v, has(v.analysis))
+                """,
+                PolicyViolation.Type.SECURITY);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var componentAnalyzed = new Component();
+        componentAnalyzed.setProject(project);
+        componentAnalyzed.setName("acme-lib-a");
+        qm.persist(componentAnalyzed);
+
+        final var componentUnanalyzed = new Component();
+        componentUnanalyzed.setProject(project);
+        componentUnanalyzed.setName("acme-lib-b");
+        qm.persist(componentUnanalyzed);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-001");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setSeverity(Severity.HIGH);
+        qm.persist(vuln);
+
+        qm.addVulnerability(vuln, componentAnalyzed, "internal");
+        qm.addVulnerability(vuln, componentUnanalyzed, "internal");
+
+        qm.makeAnalysis(new MakeAnalysisCommand(componentAnalyzed, vuln).withState(AnalysisState.RESOLVED));
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+
+        assertThat(qm.getAllPolicyViolations(componentAnalyzed)).hasSize(1);
+        assertThat(qm.getAllPolicyViolations(componentUnanalyzed)).isEmpty();
     }
 }

--- a/proto/src/main/proto/org/dependencytrack/policy/v1/policy.proto
+++ b/proto/src/main/proto/org/dependencytrack/policy/v1/policy.proto
@@ -195,9 +195,23 @@ message Vulnerability {
   // Whether the vulnerability is known to be exploited.
   bool is_kev = 37;
 
+  // The analysis of this vulnerability for the component being evaluated.
+  // Not set when the finding has not been analyzed yet.
+  //
+  // Note that suppressed findings are not evaluated at all, so this will never
+  // describe a suppressed analysis.
+  optional Analysis analysis = 38;
+
   message Alias {
     string id = 1;
     string source = 2;
+  }
+
+  message Analysis {
+    string state = 1;
+    optional string justification = 2;
+    optional string response = 3;
+    optional string details = 4;
   }
 }
 


### PR DESCRIPTION
### Description

Policy expressions can only see portfolio global vulnerability fields today, with no access to a finding's analysis. So checks like "fail if any finding is still untriaged", or "fail if a finding is EXPLOITABLE without a documented response", cannot be written as policies and have to be done outside the policy model against GET /api/v1/finding/project/{uuid}.

Added a Vulnerability.Analysis message with state, justification, response and details, so both expressions from the issue work as written:

```
vulns.exists(v, !has(v.analysis) || v.analysis.state in ["NOT_SET", "IN_TRIAGE"])
```

```
vulns.exists(v, has(v.analysis) && v.analysis.state == "EXPLOITABLE"
    && (!has(v.analysis.response) || v.analysis.response == "NOT_SET"
        || size(v.analysis.details) == 0))
```

### Addressed Issue

Fixes https://github.com/DependencyTrack/dependency-track/issues/6990

### Additional Details

Analyses are keyed by project, component and vulnerability, but protoVulnById de-duplicates vulnerability protos per project. So a shared proto cannot carry an analysis, since the same CVE on two components can be analyzed differently. I fetch analyses into a component to vulnerability map and merge them into per component copies of the proto. shouldEvaluateVulnerabilityAnalysisPerComponent covers this and fails if the proto is shared.

Both the query and the merge only happen when an expression actually selects analysis, following the existing shouldFetchEpss pattern. CelPolicyAstAnalyzer keys accessed fields by operand type, so v.analysis.state gives "analysis" under Vulnerability and "state" under Vulnerability.Analysis. The first gates the fetch, the second selects only the columns needed. Policies that do not use analysis are unaffected.

I did not expose SUPPRESSED. fetchAllComponentsVulnerabilities already excludes suppressed findings, so it would always be false. Can add it if you disagree.

One thing I ran into and left alone: policy evaluation runs from EvalProjectPoliciesActivity inside AnalyzeProjectWorkflow, which is triggered by BOM upload and by the scheduled portfolio analysis. AnalysisResource#updateAnalysis does not trigger it. So an untriaged policy keeps reporting a violation after someone triages the finding, until the next BOM upload or scheduled run. For the release gating use case in the issue that is a real gap, but re-triggering on analysis changes has its own concurrency and debouncing questions, so I kept it out of this PR. Can open a follow up issue, or fold it in here if you prefer.

### Checklist

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [X] This PR implements an enhancement, and I have provided tests to verify that it works as intended

Left the documentation box unchecked, the expression reference is in the docs repo. Will raise a PR there once the field shape is settled here.
