### PR TITLE
Expose vulnerability attribution date to CEL policy expressions

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyEngine.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyEngine.java
@@ -57,6 +57,7 @@ import org.dependencytrack.proto.policy.v1.Vulnerability;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -236,6 +237,18 @@ public final class CelPolicyEngine {
             vulnIdsByComponentId = Map.of();
         }
 
+        // Attributions are per-finding, whereas vulnerability protos are de-duplicated per
+        // project. They are thus merged into per-component copies further below, and only
+        // when a policy actually accesses them.
+        final Map<Long, Map<Long, Instant>> attributionsByComponentId;
+        if (requirements.getOrDefault(TYPE_VULNERABILITY, Set.of()).contains("attributed_on")
+                && !vulnIdsByComponentId.isEmpty()) {
+            attributionsByComponentId = withJdbiHandle(
+                    handle -> new CelPolicyDao(handle).fetchAllAttributions(projectId, vulnIdsByComponentId.keySet()));
+        } else {
+            attributionsByComponentId = Map.of();
+        }
+
         final var violationsByComponentId = new HashMap<Long, List<PolicyViolation>>();
         final Timestamp protoNow = Timestamps.now();
 
@@ -249,8 +262,22 @@ public final class CelPolicyEngine {
 
             final List<Vulnerability> protoVulns;
             if (requirements.containsKey(TYPE_VULNERABILITY)) {
+                final Map<Long, Instant> attributionsByVulnId =
+                        attributionsByComponentId.getOrDefault(componentId, Map.of());
                 protoVulns = vulnIdsByComponentId.getOrDefault(componentId, Set.of()).stream()
-                        .map(protoVulnById::get)
+                        .map(vulnId -> {
+                            final Vulnerability protoVuln = protoVulnById.get(vulnId);
+                            if (protoVuln == null) {
+                                return null;
+                            }
+                            final Instant attributedOn = attributionsByVulnId.get(vulnId);
+                            if (attributedOn == null) {
+                                return protoVuln;
+                            }
+                            return protoVuln.toBuilder()
+                                    .setAttributedOn(Timestamps.fromMillis(attributedOn.toEpochMilli()))
+                                    .build();
+                        })
                         .filter(Objects::nonNull)
                         .toList();
             } else {

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
@@ -31,6 +31,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.sql.ResultSet;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -272,6 +273,42 @@ public final class CelPolicyDao {
                 .reduceResultSet(new HashMap<>(), (accumulator, rs, ctx) -> {
                     final long dbId = rs.getLong("db_id");
                     accumulator.put(dbId, licenseRowMapper.map(rs, ctx));
+                    return accumulator;
+                });
+    }
+
+    /**
+     * Fetches the attribution timestamp of each finding in the given project.
+     *
+     * <p>Like analyses, attributions are per-finding: the same vulnerability can have been
+     * attributed to different components at different times.
+     *
+     * @param projectId ID of the project to fetch attributions for
+     * @param componentIds IDs of the components to fetch attributions for
+     * @return Attribution timestamps, grouped by component ID and vulnerability ID
+     */
+    public Map<Long, Map<Long, Instant>> fetchAllAttributions(long projectId, Collection<Long> componentIds) {
+        return jdbiHandle
+                .createQuery("""
+                        SELECT "COMPONENT_ID" AS component_id
+                             , "VULNERABILITY_ID" AS vulnerability_id
+                             , "ATTRIBUTED_ON" AS attributed_on
+                          FROM "FINDINGATTRIBUTION"
+                         WHERE "PROJECT_ID" = :projectId
+                           AND "COMPONENT_ID" = ANY(:componentIds)
+                           AND "DELETED_AT" IS NULL
+                        """)
+                .bind("projectId", projectId)
+                .bindArray("componentIds", Long.class, componentIds)
+                .reduceResultSet(new HashMap<>(), (accumulator, rs, ctx) -> {
+                    final long componentId = rs.getLong("component_id");
+                    final long vulnerabilityId = rs.getLong("vulnerability_id");
+                    final Timestamp attributedOn = rs.getTimestamp("attributed_on");
+                    if (attributedOn != null) {
+                        accumulator
+                                .computeIfAbsent(componentId, k -> new HashMap<>())
+                                .put(vulnerabilityId, attributedOn.toInstant());
+                    }
                     return accumulator;
                 });
     }

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
@@ -3041,4 +3041,55 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
         assertThat(qm.getAllPolicyViolations(projectUntagged)).hasSize(1);
         assertThat(qm.getAllPolicyViolations(projectTagged)).isEmpty();
     }
+
+    @Test
+    void shouldEvaluateVulnerabilityAttributedOn() throws Exception {
+        final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
+        qm.createPolicyCondition(
+                policy,
+                PolicyCondition.Subject.EXPRESSION,
+                PolicyCondition.Operator.MATCHES,
+                """
+                vulns.exists(v, v.attributed_on < timestamp("2020-01-01T00:00:00Z"))
+                """,
+                PolicyViolation.Type.SECURITY);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var componentOld = new Component();
+        componentOld.setProject(project);
+        componentOld.setName("acme-lib-a");
+        qm.persist(componentOld);
+
+        final var componentRecent = new Component();
+        componentRecent.setProject(project);
+        componentRecent.setName("acme-lib-b");
+        qm.persist(componentRecent);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-001");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setSeverity(Severity.HIGH);
+        qm.persist(vuln);
+
+        qm.addVulnerability(vuln, componentOld, "internal");
+        qm.addVulnerability(vuln, componentRecent, "internal");
+
+        // Backdate the attribution of one component only. The same vulnerability is
+        // attributed to both, so the value must not leak between them.
+        useJdbiHandle(handle -> handle.createUpdate("""
+                        UPDATE "FINDINGATTRIBUTION"
+                           SET "ATTRIBUTED_ON" = TIMESTAMPTZ '2015-01-01T00:00:00Z'
+                         WHERE "COMPONENT_ID" = :componentId
+                        """)
+                .bind("componentId", componentOld.getId())
+                .execute());
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+
+        assertThat(qm.getAllPolicyViolations(componentOld)).hasSize(1);
+        assertThat(qm.getAllPolicyViolations(componentRecent)).isEmpty();
+    }
 }

--- a/proto/src/main/proto/org/dependencytrack/policy/v1/policy.proto
+++ b/proto/src/main/proto/org/dependencytrack/policy/v1/policy.proto
@@ -195,6 +195,10 @@ message Vulnerability {
   // Whether the vulnerability is known to be exploited.
   bool is_kev = 37;
 
+  // When this vulnerability was first attributed to the component being evaluated.
+  // Not set when the finding has no active attribution.
+  optional google.protobuf.Timestamp attributed_on = 39;
+
   message Alias {
     string id = 1;
     string source = 2;


### PR DESCRIPTION
### Description

Policy expressions cannot see when a vulnerability was attributed to a component, so there is no way to write a policy about how long a finding has been sitting there, for example flagging findings that have not been triaged within a given timeframe.

This adds attributed_on to the vulnerability type:

```
vulns.exists(v, v.attributed_on < now - duration("720h"))
```

### Addressed Issue

Fixes https://github.com/DependencyTrack/dependency-track/issues/3629

### Additional Details

Attributions are keyed by project, component and vulnerability, whereas protoVulnById de-duplicates vulnerability protos per project. The same vulnerability can therefore carry a different attribution date on each component it affects, so the value cannot live on the shared proto. Attributions are merged into per-component copies instead, and both the query and the merge only run when an expression actually selects the field, following the existing shouldFetchEpss pattern. Attributions with DELETED_AT set are excluded, matching the other finding queries.

I used field number 39 rather than 38 on purpose. #7173 uses 38 for a similar per-finding field, so leaving it free means the two do not clash whichever one lands first. They both touch the same block in CelPolicyEngine, so there will be a small conflict to resolve in whichever goes second, happy to rebase.

This replaces #4998, which was raised against master before the v5 restructure and added a dedicated PolicyEvaluator class, an extension point that no longer exists.

Worth mentioning what the issue actually asks for. #3629 wants to flag vulnerabilities that have not been triaged within a timeframe, which needs the attribution date and the analysis state together. With #7173 that becomes:

```
vulns.exists(v, v.attributed_on < now - duration("720h")
    && (!has(v.analysis) || v.analysis.state in ["NOT_SET", "IN_TRIAGE"]))
```

This PR on its own covers the attribution date half.

### Checklist

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [X] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~[ ] This PR introduces changes to the database model, and I have updated the migration changelog accordingly~
- [ ] This PR introduces new or alters existing behavior, and I have updated the documentation accordingly

The documentation box is unchecked, the expression reference lives in the docs repo. Will raise a PR there once the field shape is agreed.
