### PR TITLE
Make the Trivy API token optional

### DIFF
--- a/vuln-analysis/trivy/src/main/java/org/dependencytrack/vulnanalysis/trivy/TrivyVulnAnalyzer.java
+++ b/vuln-analysis/trivy/src/main/java/org/dependencytrack/vulnanalysis/trivy/TrivyVulnAnalyzer.java
@@ -329,14 +329,17 @@ final class TrivyVulnAnalyzer implements VulnAnalyzer {
     }
 
     private byte[] sendProtobufRequest(String url, byte[] body) throws InterruptedException {
-        final var request = HttpRequest.newBuilder()
+        final HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                 .uri(java.net.URI.create(url))
                 .header("Accept", "application/protobuf")
                 .header("Content-Type", "application/protobuf")
-                .header(TOKEN_HEADER, apiToken)
                 .timeout(Duration.ofSeconds(30))
-                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
-                .build();
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body));
+        // Trivy servers only require a token when one was configured with --token.
+        if (apiToken != null) {
+            requestBuilder.header(TOKEN_HEADER, apiToken);
+        }
+        final HttpRequest request = requestBuilder.build();
 
         final HttpResponse<byte[]> response;
         try {

--- a/vuln-analysis/trivy/src/main/java/org/dependencytrack/vulnanalysis/trivy/TrivyVulnAnalyzerFactory.java
+++ b/vuln-analysis/trivy/src/main/java/org/dependencytrack/vulnanalysis/trivy/TrivyVulnAnalyzerFactory.java
@@ -107,9 +107,6 @@ final class TrivyVulnAnalyzerFactory implements VulnAnalyzerFactory, RuntimeConf
                     if (config.getApiUrl() == null) {
                         throw new InvalidRuntimeConfigException("No API URL provided");
                     }
-                    if (config.getApiToken() == null) {
-                        throw new InvalidRuntimeConfigException("No API token provided");
-                    }
                 });
     }
 }

--- a/vuln-analysis/trivy/src/test/java/org/dependencytrack/vulnanalysis/trivy/TrivyVulnAnalyzerFactoryTest.java
+++ b/vuln-analysis/trivy/src/test/java/org/dependencytrack/vulnanalysis/trivy/TrivyVulnAnalyzerFactoryTest.java
@@ -18,12 +18,35 @@
  */
 package org.dependencytrack.vulnanalysis.trivy;
 
+import org.dependencytrack.plugin.api.RuntimeConfigurable;
+import org.dependencytrack.plugin.config.RuntimeConfigMapper;
 import org.dependencytrack.plugin.testing.AbstractExtensionFactoryTest;
 import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 class TrivyVulnAnalyzerFactoryTest extends AbstractExtensionFactoryTest<VulnAnalyzer, TrivyVulnAnalyzerFactory> {
 
     TrivyVulnAnalyzerFactoryTest() {
         super(TrivyVulnAnalyzerFactory.class);
+    }
+
+    @Test
+    void shouldAcceptConfigWithoutApiToken() {
+        // Trivy servers do not require a token unless one was configured with --token,
+        // so a deployment can legitimately have no token to provide.
+        final var config = new TrivyVulnAnalyzerConfigV1()
+                .withEnabled(true)
+                .withApiUrl(URI.create("http://localhost:8080"))
+                .withIgnoreUnfixed(false)
+                .withScanLibrary(true)
+                .withScanOs(false);
+
+        assertThatNoException()
+                .isThrownBy(() -> RuntimeConfigMapper.getInstance()
+                        .validate(config, ((RuntimeConfigurable) factory).runtimeConfigSpec()));
     }
 }


### PR DESCRIPTION
### Description

Trivy servers only require a token when one was configured with --token, so a deployment can legitimately have none to provide. The analyzer rejected any configuration without one, which makes a stock Trivy server unusable with Dependency-Track.

### Addressed Issue

Fixes https://github.com/DependencyTrack/dependency-track/issues/4843

### Additional Details

On v5 the effect is worse than not being able to save the settings. The validation throws while the analyzer is being enabled, and getApplicableAnalyzers calls isEnabled on every analyzer during prepare-vuln-analysis, so the activity fails terminally after its retries and the project gets no results from any analyzer, not just Trivy.

I hit this by accident while setting up a local Trivy server. With Trivy enabled and no token, prepare-vuln-analysis failed 6 times and the project ended up with zero findings even though the internal analyzer was enabled:

```
org.dependencytrack.plugin.api.config.InvalidRuntimeConfigException: No API token provided
    at TrivyVulnAnalyzerFactory.lambda$runtimeConfigSpec$0(TrivyVulnAnalyzerFactory.java:111)
    at TrivyVulnAnalyzerFactory.isEnabled(TrivyVulnAnalyzerFactory.java:84)
    at PrepareVulnAnalysisActivity.getApplicableAnalyzers(PrepareVulnAnalysisActivity.java:122)
...
Activity failed; Failing task terminally after 6 attempt(s) [activityName=prepare-vuln-analysis]
```

v4 handled this by skipping the analyzer, TrivyAnalysisTask logged "No API token provided; Skipping" and carried on.

Verified against a stock `trivy server` with no token. Before the change the workflow failed terminally with no findings. After it, the same setup returns findings attributed to trivy, including CVE-2021-44228 on log4j-core 2.14.1, and prepare-vuln-analysis no longer fails.

That one analyzer's invalid configuration can take down analysis for every analyzer seems worth looking at separately, this PR only removes the most likely trigger. #6572 was a similar case of prepare-vuln-analysis failing terminally and leaving projects without any results. Happy to raise that as its own issue if useful.

### Checklist

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [X] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~[ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~[ ] This PR introduces changes to the database model, and I have updated the migration changelog accordingly~
- [ ] This PR introduces new or alters existing behavior, and I have updated the documentation accordingly

The documentation box is unchecked, the Trivy configuration docs live in the docs repo. Will raise a PR there if the token should be documented as optional.