### PR TITLE
Expose patched versions to CEL policy expressions

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyFieldMappingRegistry.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyFieldMappingRegistry.java
@@ -92,6 +92,7 @@ public final class CelPolicyFieldMappingRegistry {
             new FieldMapping("owasp_rr_vector", "v.\"OWASPRRVECTOR\""),
             new FieldMapping("cwes", "STRING_TO_ARRAY(v.\"CWES\", ',')"),
             new FieldMapping("aliases", "CAST(JSONB_VULN_ALIASES(v.\"SOURCE\", v.\"VULNID\") AS TEXT)"),
+            new FieldMapping("patched_versions", "v.\"PATCHEDVERSIONS\""),
             new FieldMapping("epss_score", "ep.\"SCORE\""),
             new FieldMapping("epss_percentile", "ep.\"PERCENTILE\""));
 

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyVulnerabilityRowMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyVulnerabilityRowMapper.java
@@ -87,6 +87,7 @@ public final class CelPolicyVulnerabilityRowMapper implements RowMapper<Vulnerab
         maybeSet(rs, "cwes", CelPolicyVulnerabilityRowMapper::maybeConvertCwes, builder::addAllCwes);
         maybeSet(rs, "aliases", CelPolicyVulnerabilityRowMapper::maybeConvertAliases, builder::addAllAliases);
         maybeSet(rs, "is_kev", ResultSet::getBoolean, builder::setIsKev);
+        maybeSet(rs, "patched_versions", ResultSet::getString, builder::setPatchedVersions);
         builder.setSeverity(computeSeverity(builder).name());
 
         return builder.build();

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
@@ -2880,4 +2880,53 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
         assertThat(qm.getAllPolicyViolations(componentUnsuppressed)).hasSize(1);
         assertThat(qm.getAllPolicyViolations(componentSuppressed)).isEmpty();
     }
+
+    @Test
+    void shouldEvaluateVulnerabilityPatchedVersions() throws Exception {
+        // Flag findings that can actually be remediated by upgrading.
+        final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
+        qm.createPolicyCondition(
+                policy,
+                PolicyCondition.Subject.EXPRESSION,
+                PolicyCondition.Operator.MATCHES,
+                """
+                vulns.exists(v, v.patched_versions != "")
+                """,
+                PolicyViolation.Type.SECURITY);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var componentPatchable = new Component();
+        componentPatchable.setProject(project);
+        componentPatchable.setName("acme-lib-a");
+        qm.persist(componentPatchable);
+
+        final var componentUnpatchable = new Component();
+        componentUnpatchable.setProject(project);
+        componentUnpatchable.setName("acme-lib-b");
+        qm.persist(componentUnpatchable);
+
+        final var vulnPatchable = new Vulnerability();
+        vulnPatchable.setVulnId("CVE-001");
+        vulnPatchable.setSource(Vulnerability.Source.NVD);
+        vulnPatchable.setSeverity(Severity.HIGH);
+        vulnPatchable.setPatchedVersions("1.2.3");
+        qm.persist(vulnPatchable);
+
+        final var vulnUnpatchable = new Vulnerability();
+        vulnUnpatchable.setVulnId("CVE-002");
+        vulnUnpatchable.setSource(Vulnerability.Source.NVD);
+        vulnUnpatchable.setSeverity(Severity.HIGH);
+        qm.persist(vulnUnpatchable);
+
+        qm.addVulnerability(vulnPatchable, componentPatchable, "internal");
+        qm.addVulnerability(vulnUnpatchable, componentUnpatchable, "internal");
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+
+        assertThat(qm.getAllPolicyViolations(componentPatchable)).hasSize(1);
+        assertThat(qm.getAllPolicyViolations(componentUnpatchable)).isEmpty();
+    }
 }

--- a/proto/src/main/proto/org/dependencytrack/policy/v1/policy.proto
+++ b/proto/src/main/proto/org/dependencytrack/policy/v1/policy.proto
@@ -195,6 +195,10 @@ message Vulnerability {
   // Whether the vulnerability is known to be exploited.
   bool is_kev = 37;
 
+  // Versions in which the vulnerability is fixed, as reported by the source.
+  // Empty when the source did not report a fixed version.
+  string patched_versions = 40;
+
   message Alias {
     string id = 1;
     string source = 2;


### PR DESCRIPTION
### Description

Policies cannot tell apart vulnerabilities that can be remediated by upgrading from those with no fix available, so SLA style policies end up treating both the same even when there is nothing to upgrade to.

The data is already there, VULNERABILITY.PATCHEDVERSIONS is populated by the data sources, it just is not reachable from an expression. This exposes it:

```
vulns.exists(v, v.patched_versions != "")
```

### Addressed Issue

Fixes https://github.com/DependencyTrack/dependency-track/issues/5731

### Additional Details

This is a plain vulnerability level field, so it needs nothing beyond a proto field, a field mapping and a row mapper line. It is only selected when an expression uses it, like the other fields.

I used field number 40 because 38 and 39 are taken by #7173 and #7177, so the three do not clash whichever order they land in.

This replaces #5202, which was raised against master before the v5 restructure and added a dedicated PolicyEvaluator class, an extension point that no longer exists.

One thing worth noting for whoever picks this up, PATCHEDVERSIONS is a free-form string from the source, not a parsed version range, so an expression can test whether a fix exists but cannot reliably compare it against the component version. That felt like the right scope for this issue, which asks for patchable versus non-patchable.

### Checklist

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [X] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~[ ] This PR introduces changes to the database model, and I have updated the migration changelog accordingly~
- [ ] This PR introduces new or alters existing behavior, and I have updated the documentation accordingly

The documentation box is unchecked, the expression reference lives in the docs repo. Will raise a PR there once agreed.