### PR TITLE
Tweak apiserver Dockerfile

### DIFF
--- a/apiserver/src/main/docker/Dockerfile
+++ b/apiserver/src/main/docker/Dockerfile
@@ -45,7 +45,7 @@ ARG GID
 
 ENV TZ=Etc/UTC \
     # JVM Options that are passed at runtime by default
-    JAVA_OPTIONS="-XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseCompactObjectHeaders -XX:MaxGCPauseMillis=250 -XX:MaxRAMPercentage=80.0" \
+    JAVA_OPTIONS="-XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseCompactObjectHeaders -XX:MaxGCPauseMillis=250 -XX:MaxRAMPercentage=80.0 -XX:+ExitOnOutOfMemoryError" \
     # JVM Options that can be passed at runtime, while maintaining also those set in JAVA_OPTIONS.
     # e.g. EXTRA_JAVA_OPTIONS="-Dlogback.configurationFile=logback-json.xml"
     EXTRA_JAVA_OPTIONS="" \
@@ -63,20 +63,24 @@ ENV TZ=Etc/UTC \
 
 # Create the directories where the JAR will be deployed to (${APP_DIR}) and Dependency-Track will store its data (${DATA_DIR})
 # Create a user and assign home directory to a ${DATA_DIR}
-# Ensure UID 1000 & GID 1000 own all the needed directories
+#
+# ${DATA_DIR} is owned by the root group, with group permissions mirroring those of the owner,
+# such that arbitrary UIDs (as used by OpenShift) can write to it.
+# ${APP_DIR} deliberately stays owned by root and read-only for the runtime user,
+# so the application can not modify the JARs it runs from.
 RUN mkdir -p ${APP_DIR} ${DATA_DIR} \
     && addgroup -S -g ${GID} dtrack \
     && adduser -S -D -G dtrack -H -h ${DATA_DIR} -g "dtrack user" -s /bin/false -u ${UID} dtrack \
-    && chown -R dtrack:0 ${DATA_DIR} ${APP_DIR} \
-    && chmod -R g=u ${DATA_DIR} ${APP_DIR} \
-    && apk add --no-cache curl gcompat tini tzdata
+    && chown -R dtrack:0 ${DATA_DIR} \
+    && chmod -R g=u ${DATA_DIR} \
+    && apk add --no-cache gcompat tini
 
 WORKDIR ${APP_DIR}
-USER ${UID}
+USER ${UID}:0
 
-COPY --from=jre-build --chown=${UID}:0 /work/jre ${JAVA_HOME}
-COPY --chown=${UID}:0 ./target/lib/ ./lib/
-COPY --chown=${UID}:0 ./target/dependency-track-apiserver.jar ./src/main/docker/logback-json.xml ./
+COPY --from=jre-build /work/jre ${JAVA_HOME}
+COPY ./target/lib/ ./lib/
+COPY ./target/dependency-track-apiserver.jar ./src/main/docker/logback-json.xml ./
 
 ENTRYPOINT ["/sbin/tini", "--"]
 
@@ -96,13 +100,12 @@ CMD [ \
 ]
 
 # Specify which ports Dependency-Track listens on
-EXPOSE 8080
-EXPOSE 9000
+EXPOSE 8080 9000
 
 # Health check against the management port
 HEALTHCHECK --interval=30s --start-period=60s --timeout=5s CMD [ \
     "/bin/sh", "-c", \
-    "curl -f -s --max-time 3 --noproxy '*' -o /dev/null http://127.0.0.1:9000/health" \
+    "wget -q -Y off -T 3 -O /dev/null http://127.0.0.1:9000/health" \
 ]
 
 # metadata labels
@@ -112,7 +115,8 @@ LABEL \
     org.opencontainers.image.description="Dependency-Track is an intelligent Component Analysis platform" \
     org.opencontainers.image.version="${APP_VERSION}" \
     org.opencontainers.image.url="https://dependencytrack.org/" \
+    org.opencontainers.image.documentation="https://docs.dependencytrack.org/" \
     org.opencontainers.image.source="https://github.com/DependencyTrack/dependency-track" \
     org.opencontainers.image.revision="${COMMIT_SHA}" \
     org.opencontainers.image.licenses="Apache-2.0" \
-    maintainer="steve.springett@owasp.org"
+    org.opencontainers.image.authors="The Dependency-Track Authors"

--- a/apiserver/src/main/docker/create-jre.sh
+++ b/apiserver/src/main/docker/create-jre.sh
@@ -19,7 +19,7 @@
 
 set -eo pipefail
 
-function printHelp() {
+printHelp() {
   echo "Create a minimal Java Runtime Environment (JRE) using jlink."
   echo ""
   echo "Usage: ${0} [-i <INPUT_JAR_FILE>] [-o <OUTPUT_DIR>]"
@@ -69,11 +69,17 @@ jdeps \
   --class-path "lib/*" \
   --print-module-deps \
   --ignore-missing-deps \
-  --multi-release 21 \
+  --multi-release 25 \
   "${input_jar}" \
   > module-deps.txt
 
-module_deps="$(cat module-deps.txt),${static_module_deps}"
+# Modules that jdeps detects, but that are not needed at runtime.
+#   jdk.jdi: Referenced by Javassist's HotSwapper debugging utility, which is never used.
+#            It requires jdk.jdwp.agent, i.e. keeping it would ship a JDWP debugging
+#            agent in a production runtime. Javassist itself is required by jersey-hk2.
+excluded_module_deps='jdk.jdi'
+
+module_deps="$(tr ',' '\n' < module-deps.txt | grep -vxF "${excluded_module_deps}" | tr '\n' ',')${static_module_deps}"
 echo "[+] identified module dependencies: ${module_deps}"
 
 echo "[+] creating jre at ${output_dir}"


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Tweak apiserver Dockerfile:

* Adds `-XX:+ExitOnOutOfMemoryError` as default Java option so an instance experiencing OOMs gets caught as dead by orchestrators like k8s.
* Changes GID from `1000` to `0` to better align with the stated goal of supporting OpenShift.
* Drops `curl` dependency in favor of `wget` which already ships with busybox. Removes ~5MB from the base image layer.
* Drops `tzdata` dependency, turns out the JRE ships its own timezone data file.
* Replaces deprecated `maintainer` OCI label.

Also removes the `jdk.jdi` module from the minimal JRE assembled during image builds. See code comment for details.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
