### PR TITLE
Make Dockerfile more layer cache friendly

### DIFF
--- a/.github/workflows/_meta-build.yaml
+++ b/.github/workflows/_meta-build.yaml
@@ -84,6 +84,16 @@ jobs:
           path: |-
             apiserver/target/dependency-track-apiserver-dist.tar.gz
 
+      - name: Upload Container Image Context
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag=v7.0.1
+        with:
+          name: container-context
+          retention-days: 1
+          path: |-
+            apiserver/target/dependency-track-apiserver.jar
+            apiserver/target/lib/
+            apiserver/target/lib-internal/
+
       - name: Upload BOM
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag=v7.0.1
         with:
@@ -127,8 +137,8 @@ jobs:
         include:
           - name: apiserver
             context: apiserver
-            artifact: assembled-dist
-            prepare-cmd: tar xzf apiserver/target/dependency-track-apiserver-dist.tar.gz -C apiserver/target
+            artifact: container-context
+            prepare-cmd: ":" # no-op
           - name: v4-migrator
             context: support/v4-migrator
             artifact: v4-migrator-jar

--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -40,6 +40,7 @@
                 <execution artifactId="maven-dependency-plugin">
                     <execIds>
                         <execId>copy-dependencies</execId>
+                        <execId>copy-internal-dependencies</execId>
                     </execIds>
                 </execution>
                 <execution artifactId="jacoco-maven-plugin">

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ MVND := $(shell command -v mvnd 2>/dev/null)
 ifeq ($(MVND),)
 	MVND := $(MVN)
 endif
+MVN_NO_BUILDCACHE := -Dmaven.build.cache.enabled=false
 
 ifdef CI
 	MVN_FLAGS := -B
@@ -74,11 +75,11 @@ install:
 .PHONY: install
 
 lint-java:
-	$(MVND) $(MVN_FLAGS) -q -Dmaven.build.cache.enabled=false validate
+	$(MVND) $(MVN_FLAGS) $(MVN_NO_BUILDCACHE) -q validate
 .PHONY: lint-java
 
 format-java:
-	$(MVND) $(MVN_FLAGS) -q -Dmaven.build.cache.enabled=false spotless:apply
+	$(MVND) $(MVN_FLAGS) $(MVN_NO_BUILDCACHE) -q spotless:apply
 .PHONY: format-java
 
 lint-migrations:
@@ -145,7 +146,7 @@ test:
 
 test-single:
 	$(MVND) $(MVN_FLAGS) test \
-		-Dmaven.build.cache.enabled=false \
+		$(MVN_NO_BUILDCACHE) \
 		-Dspotless.check.skip \
 		-Dcyclonedx.skip \
 		-pl "$(MODULE)" \
@@ -189,11 +190,11 @@ apiserver-dev-remove-containers:
 .PHONY: apiserver-dev-remove-containers
 
 test-e2e: build-image
-	$(MVND) $(MVN_FLAGS) -pl e2e -DskipE2E=false verify
+	$(MVND) $(MVN_FLAGS) $(MVN_NO_BUILDCACHE) -pl e2e -DskipE2E=false verify
 .PHONY: test-e2e
 
 clean:
-	$(MVND) $(MVN_FLAGS) -q -Dmaven.build.cache.enabled=false clean
+	$(MVND) $(MVN_FLAGS) $(MVN_NO_BUILDCACHE) -q clean
 .PHONY: clean
 
 clean-build-cache:

--- a/apiserver/.dockerignore
+++ b/apiserver/.dockerignore
@@ -8,4 +8,5 @@ src/
 target/
 !target/*.jar
 !target/lib/*.jar
+!target/lib-internal/*.jar
 /*.md

--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -715,6 +715,19 @@
                         <configuration>
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
                             <includeScope>runtime</includeScope>
+                            <excludeGroupIds>org.dependencytrack</excludeGroupIds>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-internal-dependencies</id>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib-internal</outputDirectory>
+                            <includeScope>runtime</includeScope>
+                            <includeGroupIds>org.dependencytrack</includeGroupIds>
                         </configuration>
                     </execution>
                 </executions>

--- a/apiserver/src/main/assembly/dist.xml
+++ b/apiserver/src/main/assembly/dist.xml
@@ -35,5 +35,9 @@
             <directory>${project.build.directory}/lib</directory>
             <outputDirectory>lib</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/lib-internal</directory>
+            <outputDirectory>lib</outputDirectory>
+        </fileSet>
     </fileSets>
 </assembly>

--- a/apiserver/src/main/docker/Dockerfile
+++ b/apiserver/src/main/docker/Dockerfile
@@ -29,7 +29,7 @@ FROM eclipse-temurin:25.0.4_7-jdk-alpine@sha256:09349d79941fd53bb3d487b393ca118d
 WORKDIR /work
 
 COPY --chmod=755 ./src/main/docker/create-jre.sh ./
-COPY ./target/lib/ ./lib/
+COPY ./target/lib/ ./target/lib-internal/ ./lib/
 COPY ./target/dependency-track-apiserver.jar ./
 
 RUN ./create-jre.sh -i ./dependency-track-apiserver.jar -o ./jre
@@ -80,6 +80,7 @@ USER ${UID}:0
 
 COPY --from=jre-build /work/jre ${JAVA_HOME}
 COPY ./target/lib/ ./lib/
+COPY ./target/lib-internal/ ./lib/
 COPY ./target/dependency-track-apiserver.jar ./src/main/docker/logback-json.xml ./
 
 ENTRYPOINT ["/sbin/tini", "--"]


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Makes Dockerfile more layer cache friendly.

Copies 3rd party and 1st party dependencies in separate steps, such that the large 3rd party copy can be reused across image versions that only touch 1st party code, which is the vast majority of builds. 3rd party libs account for ~90MB so this should also reduce storage requirements in container registries quite a bit.

Tested and verified that this benefit still holds true when using a single `COPY` statement.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
