### PR TITLE
Allow operators to load external JDBC drivers

### DIFF
--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -32,7 +32,6 @@
         <project.parentBaseDir>${project.basedir}/..</project.parentBaseDir>
         <maven.install.skip>true</maven.install.skip>
         <!-- Dependency Versions -->
-        <lib.cloud-sql-postgres-socket-factory.version>1.29.0</lib.cloud-sql-postgres-socket-factory.version>
         <lib.javacron.version>1.4.0</lib.javacron.version>
         <lib.micrometer-jvm-extras.version>0.3.0</lib.micrometer-jvm-extras.version>
         <lib.owasp-rr-calculator.version>1.0.1</lib.owasp-rr-calculator.version>
@@ -439,11 +438,6 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.cloud.sql</groupId>
-            <artifactId>postgres-socket-factory</artifactId>
-            <version>${lib.cloud-sql-postgres-socket-factory.version}</version>
         </dependency>
         <!-- Resilience4J -->
         <dependency>

--- a/apiserver/src/main/docker/Dockerfile
+++ b/apiserver/src/main/docker/Dockerfile
@@ -67,8 +67,9 @@ ENV TZ=Etc/UTC \
 # ${DATA_DIR} is owned by the root group, with group permissions mirroring those of the owner,
 # such that arbitrary UIDs (as used by OpenShift) can write to it.
 # ${APP_DIR} deliberately stays owned by root and read-only for the runtime user,
-# so the application can not modify the JARs it runs from.
-RUN mkdir -p ${APP_DIR} ${DATA_DIR} \
+# so the application can not modify the JARs it runs from. This includes lib-external,
+# which is left empty for users to mount their own JARs into, e.g. additional JDBC drivers.
+RUN mkdir -p ${APP_DIR}lib-external ${DATA_DIR} \
     && addgroup -S -g ${GID} dtrack \
     && adduser -S -D -G dtrack -H -h ${DATA_DIR} -g "dtrack user" -s /bin/false -u ${UID} dtrack \
     && chown -R dtrack:0 ${DATA_DIR} \
@@ -95,7 +96,7 @@ CMD [ \
         --enable-native-access=ALL-UNNAMED \
         --sun-misc-unsafe-memory-access=allow \
         -Djdk.http.auth.tunneling.disabledSchemes= \
-        -cp 'dependency-track-apiserver.jar:lib/*' \
+        -cp 'dependency-track-apiserver.jar:lib/*:lib-external/*' \
         org.dependencytrack.Application \
         -context ${CONTEXT}" \
 ]

--- a/common/datasource/src/main/java/org/dependencytrack/common/datasource/DataSourceFactory.java
+++ b/common/datasource/src/main/java/org/dependencytrack/common/datasource/DataSourceFactory.java
@@ -20,8 +20,8 @@ package org.dependencytrack.common.datasource;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.util.DriverDataSource;
 import io.micrometer.core.instrument.Metrics;
-import org.postgresql.ds.PGSimpleDataSource;
 
 import javax.sql.DataSource;
 import java.io.IOException;
@@ -29,6 +29,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -73,25 +74,20 @@ final class DataSourceFactory {
             return new HikariDataSource(hikariConfig);
         }
 
-        final var dataSource = new PGSimpleDataSource();
-
-        // NB: These properties must be set BEFORE setUrl is called,
-        // as the driver only then loops over all properties and applies
-        // them to the URL. Setting the URL first would cause these
-        // properties to no-op.
-        dataSource.setApplicationName(appName);
+        final var properties = new Properties();
+        properties.setProperty("ApplicationName", appName);
+        properties.setProperty("reWriteBatchedInserts", "true");
+        properties.setProperty("tcpKeepAlive", "true");
         config.getConnectionTimeoutMillis()
                 .map(TimeUnit.MILLISECONDS::toSeconds)
-                .map(Math::toIntExact)
-                .ifPresent(dataSource::setConnectTimeout);
-        dataSource.setReWriteBatchedInserts(true);
-        dataSource.setTcpKeepAlive(true);
+                .ifPresent(seconds -> properties.setProperty("connectTimeout", Long.toString(seconds)));
 
-        dataSource.setUrl(config.getUrl());
-        config.getUsername().ifPresent(dataSource::setUser);
-        getPassword(config).ifPresent(dataSource::setPassword);
-
-        return dataSource;
+        return new DriverDataSource(
+                config.getUrl(),
+                /* driverClassName */ null,
+                properties,
+                config.getUsername().orElse(null),
+                getPassword(config).orElse(null));
     }
 
     private static Optional<String> getPassword(DataSourceConfig config) {

--- a/common/datasource/src/test/java/org/dependencytrack/common/datasource/DataSourceRegistryTest.java
+++ b/common/datasource/src/test/java/org/dependencytrack/common/datasource/DataSourceRegistryTest.java
@@ -27,19 +27,23 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.postgresql.ds.PGSimpleDataSource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Properties;
+import java.util.logging.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -72,7 +76,7 @@ class DataSourceRegistryTest {
     }
 
     @Test
-    void shouldCreateSimpleDataSourceWhenPoolIsDisabled() throws SQLException {
+    void shouldCreateUnpooledDataSourceWhenPoolIsDisabled() throws SQLException {
         MemoryConfigSource.setProperties(Map.ofEntries(
                 Map.entry("dt.datasource.url", postgresContainer.getJdbcUrl()),
                 Map.entry("dt.datasource.username", postgresContainer.getUsername()),
@@ -80,7 +84,11 @@ class DataSourceRegistryTest {
                 Map.entry("dt.datasource.pool.enabled", "false")));
 
         final DataSource dataSource = registry.getDefault();
-        assertThat(dataSource.isWrapperFor(PGSimpleDataSource.class)).isTrue();
+        assertThat(dataSource.isWrapperFor(HikariDataSource.class)).isFalse();
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            assertThat(statement.execute("SELECT 1")).isTrue();
+        }
     }
 
     @Test
@@ -257,5 +265,74 @@ class DataSourceRegistryTest {
         MemoryConfigSource.setProperties(validConfig);
 
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(() -> registry.getDefault());
+    }
+
+    @Test
+    void shouldSupportNonPostgresJdbcUrlWhenPoolIsDisabled() throws SQLException {
+        final var driver = new DelegatingDriver();
+        DriverManager.registerDriver(driver);
+        try {
+            MemoryConfigSource.setProperties(Map.ofEntries(
+                    Map.entry("dt.datasource.url", DelegatingDriver.rewriteUrl(postgresContainer.getJdbcUrl())),
+                    Map.entry("dt.datasource.username", postgresContainer.getUsername()),
+                    Map.entry("dt.datasource.password", postgresContainer.getPassword()),
+                    Map.entry("dt.datasource.pool.enabled", "false")));
+
+            final DataSource dataSource = registry.getDefault();
+            try (Connection connection = dataSource.getConnection();
+                    Statement statement = connection.createStatement()) {
+                assertThat(statement.execute("SELECT 1")).isTrue();
+            }
+        } finally {
+            DriverManager.deregisterDriver(driver);
+        }
+    }
+
+    private static final class DelegatingDriver implements Driver {
+
+        private static final String PREFIX = "jdbc:dtrack-test:";
+
+        @Override
+        public Connection connect(String url, Properties info) throws SQLException {
+            return acceptsURL(url) ? DriverManager.getConnection(restoreUrl(url), info) : null;
+        }
+
+        @Override
+        public boolean acceptsURL(String url) {
+            return url != null && url.startsWith(PREFIX);
+        }
+
+        @Override
+        public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) {
+            return new DriverPropertyInfo[0];
+        }
+
+        @Override
+        public int getMajorVersion() {
+            return 1;
+        }
+
+        @Override
+        public int getMinorVersion() {
+            return 0;
+        }
+
+        @Override
+        public boolean jdbcCompliant() {
+            return false;
+        }
+
+        @Override
+        public Logger getParentLogger() {
+            return Logger.getLogger(DelegatingDriver.class.getName());
+        }
+
+        private static String rewriteUrl(String postgresJdbcUrl) {
+            return PREFIX + postgresJdbcUrl.substring("jdbc:postgresql:".length());
+        }
+
+        private static String restoreUrl(String url) {
+            return "jdbc:postgresql:" + url.substring(PREFIX.length());
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,6 @@
         <lib.eclipse-angus.version>2.0.5</lib.eclipse-angus.version>
         <lib.errorprone.version>2.50.0</lib.errorprone.version>
         <lib.flyway.version>13.3.0</lib.flyway.version>
-        <lib.google-http-client.version>2.2.0</lib.google-http-client.version>
         <lib.greenmail.version>2.1.12</lib.greenmail.version>
         <lib.guava.version>33.7.1-jre</lib.guava.version>
         <lib.hamcrest.version>3.0</lib.hamcrest.version>
@@ -301,11 +300,6 @@
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
                 <version>${lib.errorprone.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.http-client</groupId>
-                <artifactId>google-http-client</artifactId>
-                <version>${lib.google-http-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.icegreen</groupId>


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Allows operators to load external JDBC drivers.

Adds a new `libs-external` directory in the container image, notably NOT writable by the application user, where operators can mount 3rd party libraries into, such as the AWS JDBC driver.

Refactors data source creation to no longer hardcode a driver implementation. The appropriate driver is now picked based on the JDBC URL alone, which enables usage of `jdbc:aws-wrapper:postgresql:` etc.

Also removes the direct dependency to Google's `postgres-socket-factory`. Operators relying on it will need to acquire a fat far (https://github.com/googlecloudplatform/cloud-sql-jdbc-socket-factory#building-the-drivers) and mount it into the container just like AWS users. For us, removal of this dependency means ~10MB and ~20 JARs less to worry about.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #6524

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
