### PR TITLE
Add option to use Snyk's per-package endpoint when batching is not available

### DIFF
--- a/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzer.java
+++ b/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzer.java
@@ -37,11 +37,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -61,6 +63,14 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SnykVulnAnalyzer.class);
     private static final int REQUEST_BATCH_SIZE = 100;
+
+    /**
+     * The batch endpoint is not available to all Snyk organizations, and answers 403 for
+     * those it is not available to. Such organizations can still use the per-package
+     * endpoint, so fall back to it for the remainder of the analysis once that happens.
+     */
+    private boolean usePerPackageEndpoint = false;
+
     private static final int CACHE_BATCH_SIZE = 500;
     private static final Set<String> SUPPORTED_PURL_TYPES = Set.of(
             "cargo",
@@ -213,7 +223,7 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
 
         final SnykIssuesResponse response;
         try {
-            response = fetchIssues(purlBatch);
+            response = fetchIssuesWithFallback(purlBatch);
         } catch (IOException e) {
             final var message = "Failed to fetch Snyk issues";
             RetryableVulnAnalysisException.throwIfRetryableNetworkError(e, message);
@@ -264,6 +274,87 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
         return issuesByPurl;
     }
 
+    private SnykIssuesResponse fetchIssuesWithFallback(Collection<String> purlBatch)
+            throws InterruptedException, IOException {
+        if (usePerPackageEndpoint) {
+            return fetchIssuesPerPackage(purlBatch);
+        }
+
+        try {
+            return fetchIssues(purlBatch);
+        } catch (BatchEndpointUnavailableException e) {
+            LOGGER.warn(
+                    "The Snyk batch endpoint is not available for this organization; "
+                            + "Falling back to the per-package endpoint for the remainder of this analysis. "
+                            + "Note that this issues one request per package, instead of one per {} packages.",
+                    REQUEST_BATCH_SIZE);
+            usePerPackageEndpoint = true;
+            return fetchIssuesPerPackage(purlBatch);
+        }
+    }
+
+    /**
+     * Signals that the batch endpoint is not available to the configured organization.
+     */
+    private static final class BatchEndpointUnavailableException extends IOException {
+        private BatchEndpointUnavailableException() {
+            super("Snyk API request failed with status 403");
+        }
+    }
+
+    /**
+     * Fetches issues one package at a time, using the endpoint Dependency-Track 4.x used.
+     *
+     * <p>Only used when the batch endpoint is not available to the organization.
+     */
+    private SnykIssuesResponse fetchIssuesPerPackage(Collection<String> purls)
+            throws InterruptedException, IOException {
+        final var issues = new ArrayList<SnykIssue>();
+        for (final String purl : purls) {
+            if (Thread.interrupted()) {
+                throw new InterruptedException("Interrupted before all packages could be analyzed");
+            }
+
+            final SnykIssuesResponse response = fetchIssuesForPackage(purl);
+            if (response.data() != null) {
+                issues.addAll(response.data());
+            }
+        }
+
+        return new SnykIssuesResponse(issues);
+    }
+
+    private SnykIssuesResponse fetchIssuesForPackage(String purl) throws InterruptedException, IOException {
+        final String encodedPurl = URLEncoder.encode(purl, StandardCharsets.UTF_8);
+
+        final var request = HttpRequest.newBuilder()
+                .uri(URI.create("%s/rest/orgs/%s/packages/%s/issues?version=%s"
+                        .formatted(apiBaseUrl, orgId, encodedPurl, apiVersion)))
+                .header("Authorization", "token " + apiToken)
+                .header("Accept", "application/vnd.api+json")
+                .timeout(Duration.ofSeconds(30))
+                .GET()
+                .build();
+
+        final HttpResponse<InputStream> response;
+        try {
+            response = httpClient.send(request, BodyHandlers.ofInputStream());
+        } catch (IOException e) {
+            final var message = "Snyk API request failed";
+            RetryableVulnAnalysisException.throwIfRetryableNetworkError(e, message);
+            throw new UncheckedIOException(message, e);
+        }
+
+        try (final InputStream bodyInputStream = response.body()) {
+            if (response.statusCode() == 200) {
+                return objectMapper.readValue(bodyInputStream, SnykIssuesResponse.class);
+            }
+
+            RetryableVulnAnalysisException.throwIfRetryableHttpError(response);
+            throw new IOException("Snyk API request failed with status " + response.statusCode());
+        }
+    }
+
     private SnykIssuesResponse fetchIssues(Collection<String> purls) throws InterruptedException, IOException {
         if (purls.isEmpty()) {
             return new SnykIssuesResponse(List.of());
@@ -296,6 +387,9 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
             }
 
             RetryableVulnAnalysisException.throwIfRetryableHttpError(response);
+            if (response.statusCode() == 403) {
+                throw new BatchEndpointUnavailableException();
+            }
             throw new IOException("Snyk API request failed with status " + response.statusCode());
         }
     }

--- a/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzer.java
+++ b/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzer.java
@@ -64,13 +64,6 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
     private static final Logger LOGGER = LoggerFactory.getLogger(SnykVulnAnalyzer.class);
     private static final int REQUEST_BATCH_SIZE = 100;
 
-    /**
-     * The batch endpoint is not available to all Snyk organizations, and answers 403 for
-     * those it is not available to. Such organizations can still use the per-package
-     * endpoint, so fall back to it for the remainder of the analysis once that happens.
-     */
-    private boolean usePerPackageEndpoint = false;
-
     private static final int CACHE_BATCH_SIZE = 500;
     private static final Set<String> SUPPORTED_PURL_TYPES = Set.of(
             "cargo",
@@ -94,6 +87,7 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
     private final String apiToken;
     private final String apiVersion;
     private final boolean aliasSyncEnabled;
+    private final boolean batchRequestsEnabled;
 
     SnykVulnAnalyzer(
             Cache resultsCache,
@@ -103,7 +97,8 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
             String orgId,
             String apiToken,
             String apiVersion,
-            boolean aliasSyncEnabled) {
+            boolean aliasSyncEnabled,
+            boolean batchRequestsEnabled) {
         this.resultsCache = resultsCache;
         this.httpClient = httpClient;
         this.objectMapper = objectMapper;
@@ -112,6 +107,7 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
         this.apiToken = apiToken;
         this.apiVersion = apiVersion;
         this.aliasSyncEnabled = aliasSyncEnabled;
+        this.batchRequestsEnabled = batchRequestsEnabled;
     }
 
     @Override
@@ -223,7 +219,7 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
 
         final Map<String, List<SnykIssue>> issuesByPurl;
         try {
-            issuesByPurl = fetchIssuesWithFallback(purlBatch, bomRefsByPurl);
+            issuesByPurl = fetchIssuesForBatch(purlBatch, bomRefsByPurl);
         } catch (IOException e) {
             final var message = "Failed to fetch Snyk issues";
             RetryableVulnAnalysisException.throwIfRetryableNetworkError(e, message);
@@ -250,24 +246,14 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
         return issuesByPurl;
     }
 
-    private Map<String, List<SnykIssue>> fetchIssuesWithFallback(
+    private Map<String, List<SnykIssue>> fetchIssuesForBatch(
             Collection<String> purlBatch, Map<String, Set<String>> bomRefsByPurl)
             throws InterruptedException, IOException {
-        if (usePerPackageEndpoint) {
+        if (!batchRequestsEnabled) {
             return fetchIssuesPerPackage(purlBatch);
         }
 
-        try {
-            return correlateIssues(fetchIssues(purlBatch), bomRefsByPurl);
-        } catch (BatchEndpointUnavailableException e) {
-            LOGGER.warn(
-                    "The Snyk batch endpoint is not available for this organization; "
-                            + "Falling back to the per-package endpoint for the remainder of this analysis. "
-                            + "Note that this issues one request per package, instead of one per {} packages.",
-                    REQUEST_BATCH_SIZE);
-            usePerPackageEndpoint = true;
-            return fetchIssuesPerPackage(purlBatch);
-        }
+        return correlateIssues(fetchIssues(purlBatch), bomRefsByPurl);
     }
 
     /**
@@ -305,15 +291,6 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
     }
 
     /**
-     * Signals that the batch endpoint is not available to the configured organization.
-     */
-    private static final class BatchEndpointUnavailableException extends IOException {
-        private BatchEndpointUnavailableException() {
-            super("Snyk API request failed with status 403");
-        }
-    }
-
-    /**
      * Fetches issues one package at a time, using the endpoint Dependency-Track 4.x used.
      *
      * <p>Only used when the batch endpoint is not available to the organization.
@@ -345,7 +322,7 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
                         .formatted(apiBaseUrl, orgId, encodedPurl, apiVersion)))
                 .header("Authorization", "token " + apiToken)
                 .header("Accept", "application/vnd.api+json")
-                .timeout(Duration.ofSeconds(30))
+                .timeout(Duration.ofSeconds(10))
                 .GET()
                 .build();
 
@@ -409,9 +386,6 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
             }
 
             RetryableVulnAnalysisException.throwIfRetryableHttpError(response);
-            if (response.statusCode() == 403) {
-                throw new BatchEndpointUnavailableException();
-            }
             throw new IOException("Snyk API request failed with status " + response.statusCode());
         }
     }

--- a/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzer.java
+++ b/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzer.java
@@ -221,40 +221,16 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
 
         LOGGER.debug("Fetching Snyk issues for {} PURLs", purlBatch.size());
 
-        final SnykIssuesResponse response;
+        final Map<String, List<SnykIssue>> issuesByPurl;
         try {
-            response = fetchIssuesWithFallback(purlBatch);
+            issuesByPurl = fetchIssuesWithFallback(purlBatch, bomRefsByPurl);
         } catch (IOException e) {
             final var message = "Failed to fetch Snyk issues";
             RetryableVulnAnalysisException.throwIfRetryableNetworkError(e, message);
             throw new UncheckedIOException(message, e);
         }
 
-        final var issuesByPurl = new HashMap<String, List<SnykIssue>>(purlBatch.size());
         final var entriesToCache = new HashMap<String, byte @Nullable []>(purlBatch.size());
-
-        if (response.data() != null) {
-            for (final SnykIssue issue : response.data()) {
-                final String issuePurl = SnykModelConverter.getIssuePurl(issue);
-                if (issuePurl == null) {
-                    LOGGER.warn("Unable to extract PURL from issue {}; Skipping", issue.id());
-                    continue;
-                }
-
-                final String issuePurlLower = issuePurl.toLowerCase();
-                if (!bomRefsByPurl.containsKey(issuePurlLower)) {
-                    LOGGER.warn(
-                            "Received issue {} for PURL '{}', but no component with this PURL was submitted",
-                            issue.id(),
-                            issuePurl);
-                    continue;
-                }
-
-                issuesByPurl
-                        .computeIfAbsent(issuePurlLower, k -> new ArrayList<>())
-                        .add(issue);
-            }
-        }
 
         for (final var entry : issuesByPurl.entrySet()) {
             try {
@@ -274,14 +250,15 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
         return issuesByPurl;
     }
 
-    private SnykIssuesResponse fetchIssuesWithFallback(Collection<String> purlBatch)
+    private Map<String, List<SnykIssue>> fetchIssuesWithFallback(
+            Collection<String> purlBatch, Map<String, Set<String>> bomRefsByPurl)
             throws InterruptedException, IOException {
         if (usePerPackageEndpoint) {
             return fetchIssuesPerPackage(purlBatch);
         }
 
         try {
-            return fetchIssues(purlBatch);
+            return correlateIssues(fetchIssues(purlBatch), bomRefsByPurl);
         } catch (BatchEndpointUnavailableException e) {
             LOGGER.warn(
                     "The Snyk batch endpoint is not available for this organization; "
@@ -291,6 +268,40 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
             usePerPackageEndpoint = true;
             return fetchIssuesPerPackage(purlBatch);
         }
+    }
+
+    /**
+     * Correlates issues of a batch response back to the PURLs they belong to.
+     *
+     * <p>Only needed for the batch endpoint, where a single response covers many packages.
+     */
+    private Map<String, List<SnykIssue>> correlateIssues(
+            SnykIssuesResponse response, Map<String, Set<String>> bomRefsByPurl) {
+        if (response.data() == null) {
+            return Map.of();
+        }
+
+        final var issuesByPurl = new HashMap<String, List<SnykIssue>>();
+        for (final SnykIssue issue : response.data()) {
+            final String issuePurl = SnykModelConverter.getIssuePurl(issue);
+            if (issuePurl == null) {
+                LOGGER.warn("Unable to extract PURL from issue {}; Skipping", issue.id());
+                continue;
+            }
+
+            final String issuePurlLower = issuePurl.toLowerCase();
+            if (!bomRefsByPurl.containsKey(issuePurlLower)) {
+                LOGGER.warn(
+                        "Received issue {} for PURL '{}', but no component with this PURL was submitted",
+                        issue.id(),
+                        issuePurl);
+                continue;
+            }
+
+            issuesByPurl.computeIfAbsent(issuePurlLower, k -> new ArrayList<>()).add(issue);
+        }
+
+        return issuesByPurl;
     }
 
     /**
@@ -307,21 +318,23 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
      *
      * <p>Only used when the batch endpoint is not available to the organization.
      */
-    private SnykIssuesResponse fetchIssuesPerPackage(Collection<String> purls)
+    private Map<String, List<SnykIssue>> fetchIssuesPerPackage(Collection<String> purls)
             throws InterruptedException, IOException {
-        final var issues = new ArrayList<SnykIssue>();
+        final var issuesByPurl = new HashMap<String, List<SnykIssue>>(purls.size());
         for (final String purl : purls) {
             if (Thread.interrupted()) {
                 throw new InterruptedException("Interrupted before all packages could be analyzed");
             }
 
+            // The PURL is known from the request, so unlike the batch response the issues
+            // do not have to be correlated back through their coordinates.
             final SnykIssuesResponse response = fetchIssuesForPackage(purl);
-            if (response.data() != null) {
-                issues.addAll(response.data());
+            if (response.data() != null && !response.data().isEmpty()) {
+                issuesByPurl.put(purl.toLowerCase(), new ArrayList<>(response.data()));
             }
         }
 
-        return new SnykIssuesResponse(issues);
+        return issuesByPurl;
     }
 
     private SnykIssuesResponse fetchIssuesForPackage(String purl) throws InterruptedException, IOException {
@@ -350,8 +363,17 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
                 return objectMapper.readValue(bodyInputStream, SnykIssuesResponse.class);
             }
 
+            // Snyk answers 404 for packages it does not know. The batch endpoint simply
+            // omits them, so treat them as having no issues rather than failing the
+            // analysis over a single unknown package.
+            if (response.statusCode() == 404) {
+                LOGGER.debug("Snyk does not know package '{}'", purl);
+                return new SnykIssuesResponse(List.of());
+            }
+
             RetryableVulnAnalysisException.throwIfRetryableHttpError(response);
-            throw new IOException("Snyk API request failed with status " + response.statusCode());
+            throw new IOException(
+                    "Snyk API request for package '%s' failed with status %d".formatted(purl, response.statusCode()));
         }
     }
 

--- a/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzerFactory.java
+++ b/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzerFactory.java
@@ -97,7 +97,8 @@ final class SnykVulnAnalyzerFactory implements VulnAnalyzerFactory, RuntimeConfi
                 config.getOrgId(),
                 config.getApiToken(),
                 apiVersion,
-                config.isAliasSyncEnabled());
+                config.isAliasSyncEnabled(),
+                config.isBatchRequestsEnabled());
     }
 
     @Override
@@ -114,7 +115,10 @@ final class SnykVulnAnalyzerFactory implements VulnAnalyzerFactory, RuntimeConfi
     @Override
     public RuntimeConfigSpec runtimeConfigSpec() {
         return RuntimeConfigSpec.of(
-                new SnykVulnAnalyzerConfigV1().withEnabled(false).withApiBaseUrl(URI.create("https://api.snyk.io")),
+                new SnykVulnAnalyzerConfigV1()
+                        .withEnabled(false)
+                        .withApiBaseUrl(URI.create("https://api.snyk.io"))
+                        .withBatchRequestsEnabled(true),
                 config -> {
                     if (!config.isEnabled()) {
                         return;

--- a/vuln-analysis/snyk/src/main/resources/org/dependencytrack/vulnanalysis/snyk/snyk-vuln-analyzer-config-v1.schema.json
+++ b/vuln-analysis/snyk/src/main/resources/org/dependencytrack/vulnanalysis/snyk/snyk-vuln-analyzer-config-v1.schema.json
@@ -22,6 +22,7 @@
       "type": "boolean",
       "title": "Batch Requests Enabled",
       "description": "Whether to request issues for multiple packages at once. The batch endpoint is not available to all Snyk organizations; disable this to request issues one package at a time instead.",
+      "default": true,
       "existingJavaType": "boolean"
     },
     "apiBaseUrl": {

--- a/vuln-analysis/snyk/src/main/resources/org/dependencytrack/vulnanalysis/snyk/snyk-vuln-analyzer-config-v1.schema.json
+++ b/vuln-analysis/snyk/src/main/resources/org/dependencytrack/vulnanalysis/snyk/snyk-vuln-analyzer-config-v1.schema.json
@@ -18,6 +18,12 @@
       "description": "Whether to include alias information in vulnerability data.",
       "existingJavaType": "boolean"
     },
+    "batchRequestsEnabled": {
+      "type": "boolean",
+      "title": "Batch Requests Enabled",
+      "description": "Whether to request issues for multiple packages at once. The batch endpoint is not available to all Snyk organizations; disable this to request issues one package at a time instead.",
+      "existingJavaType": "boolean"
+    },
     "apiBaseUrl": {
       "type": "string",
       "title": "API Base URL",

--- a/vuln-analysis/snyk/src/test/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzerFactoryTest.java
+++ b/vuln-analysis/snyk/src/test/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzerFactoryTest.java
@@ -18,12 +18,27 @@
  */
 package org.dependencytrack.vulnanalysis.snyk;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.dependencytrack.plugin.testing.AbstractExtensionFactoryTest;
 import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class SnykVulnAnalyzerFactoryTest extends AbstractExtensionFactoryTest<VulnAnalyzer, SnykVulnAnalyzerFactory> {
 
     SnykVulnAnalyzerFactoryTest() {
         super(SnykVulnAnalyzerFactory.class);
+    }
+
+    @Test
+    void shouldEnableBatchRequestsWhenNotConfigured() throws Exception {
+        // Configs stored before this option existed do not have the field, and must keep
+        // using the batch endpoint rather than silently switching to per-package requests.
+        final var config = new ObjectMapper().readValue("""
+                        {"enabled":true,"apiBaseUrl":"https://api.snyk.io","orgId":"org","apiToken":"token"}
+                        """, SnykVulnAnalyzerConfigV1.class);
+
+        assertThat(config.isBatchRequestsEnabled()).isTrue();
     }
 }

--- a/vuln-analysis/snyk/src/test/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzerTest.java
+++ b/vuln-analysis/snyk/src/test/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzerTest.java
@@ -433,11 +433,13 @@ class SnykVulnAnalyzerTest {
         // while the per-package endpoint used by v4 still works with the same token.
         stubFor(post(urlPathEqualTo("/rest/orgs/test-org-id/packages/issues"))
                 .willReturn(aResponse().withStatus(403)));
+        // The per-package response need not repeat the package coordinates, since the
+        // package is implied by the request URL. Issues must still be attributed to it.
         stubFor(get(urlPathMatching("/rest/orgs/test-org-id/packages/.+/issues"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/vnd.api+json")
-                        .withBodyFile("snyk-one-issue-response.json")));
+                        .withBodyFile("snyk-per-package-one-issue-response.json")));
 
         final var bom = Bom.newBuilder()
                 .addComponents(Component.newBuilder()
@@ -472,5 +474,26 @@ class SnykVulnAnalyzerTest {
         analyzer.analyze(bom);
 
         verify(0, getRequestedFor(anyUrl()));
+    }
+
+    @Test
+    void shouldTreatUnknownPackageAsHavingNoIssuesWhenFallingBack() throws Exception {
+        stubFor(post(urlPathEqualTo("/rest/orgs/test-org-id/packages/issues"))
+                .willReturn(aResponse().withStatus(403)));
+        // Snyk answers 404 for packages it does not know. The batch endpoint just omits
+        // them, so one unknown package must not fail the whole analysis.
+        stubFor(get(urlPathMatching("/rest/orgs/test-org-id/packages/.+/issues"))
+                .willReturn(aResponse().withStatus(404)));
+
+        final var bom = Bom.newBuilder()
+                .addComponents(Component.newBuilder()
+                        .setBomRef("1")
+                        .setName("jackson-databind")
+                        .setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4")
+                        .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThat(vdr).isEqualTo(Bom.getDefaultInstance());
     }
 }

--- a/vuln-analysis/snyk/src/test/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzerTest.java
+++ b/vuln-analysis/snyk/src/test/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzerTest.java
@@ -43,10 +43,13 @@ import java.util.ArrayList;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.http.Fault.CONNECTION_RESET_BY_PEER;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
@@ -422,5 +425,52 @@ class SnykVulnAnalyzerTest {
                         .withHeader("Authorization", equalTo("token test-api-token"))
                         .withHeader("Content-Type", equalTo("application/vnd.api+json"))
                         .withHeader("Accept", equalTo("application/vnd.api+json")));
+    }
+
+    @Test
+    void shouldFallBackToPerPackageEndpointOnForbidden() throws Exception {
+        // The batch endpoint is not available to all Snyk orgs and answers 403 for them,
+        // while the per-package endpoint used by v4 still works with the same token.
+        stubFor(post(urlPathEqualTo("/rest/orgs/test-org-id/packages/issues"))
+                .willReturn(aResponse().withStatus(403)));
+        stubFor(get(urlPathMatching("/rest/orgs/test-org-id/packages/.+/issues"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/vnd.api+json")
+                        .withBodyFile("snyk-one-issue-response.json")));
+
+        final var bom = Bom.newBuilder()
+                .addComponents(Component.newBuilder()
+                        .setBomRef("1")
+                        .setName("jackson-databind")
+                        .setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4")
+                        .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThat(vdr.getVulnerabilitiesList()).isNotEmpty();
+
+        verify(1, getRequestedFor(urlPathMatching("/rest/orgs/test-org-id/packages/.+/issues")));
+    }
+
+    @Test
+    void shouldNotUsePerPackageEndpointWhenBatchSucceeds() throws Exception {
+        stubFor(post(urlPathEqualTo("/rest/orgs/test-org-id/packages/issues"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/vnd.api+json")
+                        .withBodyFile("snyk-one-issue-response.json")));
+
+        final var bom = Bom.newBuilder()
+                .addComponents(Component.newBuilder()
+                        .setBomRef("1")
+                        .setName("jackson-databind")
+                        .setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4")
+                        .build())
+                .build();
+
+        analyzer.analyze(bom);
+
+        verify(0, getRequestedFor(anyUrl()));
     }
 }

--- a/vuln-analysis/snyk/src/test/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzerTest.java
+++ b/vuln-analysis/snyk/src/test/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzerTest.java
@@ -77,7 +77,27 @@ class SnykVulnAnalyzerTest {
                         .withAliasSyncEnabled(true)
                         .withApiBaseUrl(URI.create(wmRuntimeInfo.getHttpBaseUrl()))
                         .withOrgId("test-org-id")
-                        .withApiToken("test-api-token"));
+                        .withApiToken("test-api-token")
+                        .withBatchRequestsEnabled(true));
+
+        analyzerFactory.init(new MutableServiceRegistry()
+                .register(ConfigRegistry.class, configRegistry)
+                .register(CacheManager.class, cacheManager)
+                .register(HttpClient.class, HttpClient.newHttpClient()));
+
+        analyzer = analyzerFactory.create();
+    }
+
+    private void useAnalyzerWithBatchRequestsDisabled(WireMockRuntimeInfo wmRuntimeInfo) {
+        final var configRegistry = new MockConfigRegistry(
+                analyzerFactory.runtimeConfigSpec(),
+                new SnykVulnAnalyzerConfigV1()
+                        .withEnabled(true)
+                        .withAliasSyncEnabled(true)
+                        .withApiBaseUrl(URI.create(wmRuntimeInfo.getHttpBaseUrl()))
+                        .withOrgId("test-org-id")
+                        .withApiToken("test-api-token")
+                        .withBatchRequestsEnabled(false));
 
         analyzerFactory.init(new MutableServiceRegistry()
                 .register(ConfigRegistry.class, configRegistry)
@@ -428,11 +448,8 @@ class SnykVulnAnalyzerTest {
     }
 
     @Test
-    void shouldFallBackToPerPackageEndpointOnForbidden() throws Exception {
-        // The batch endpoint is not available to all Snyk orgs and answers 403 for them,
-        // while the per-package endpoint used by v4 still works with the same token.
-        stubFor(post(urlPathEqualTo("/rest/orgs/test-org-id/packages/issues"))
-                .willReturn(aResponse().withStatus(403)));
+    void shouldUsePerPackageEndpointWhenBatchRequestsAreDisabled(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        useAnalyzerWithBatchRequestsDisabled(wmRuntimeInfo);
         // The per-package response need not repeat the package coordinates, since the
         // package is implied by the request URL. Issues must still be attributed to it.
         stubFor(get(urlPathMatching("/rest/orgs/test-org-id/packages/.+/issues"))
@@ -456,7 +473,7 @@ class SnykVulnAnalyzerTest {
     }
 
     @Test
-    void shouldNotUsePerPackageEndpointWhenBatchSucceeds() throws Exception {
+    void shouldNotUsePerPackageEndpointWhenBatchRequestsAreEnabled() throws Exception {
         stubFor(post(urlPathEqualTo("/rest/orgs/test-org-id/packages/issues"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -477,9 +494,8 @@ class SnykVulnAnalyzerTest {
     }
 
     @Test
-    void shouldTreatUnknownPackageAsHavingNoIssuesWhenFallingBack() throws Exception {
-        stubFor(post(urlPathEqualTo("/rest/orgs/test-org-id/packages/issues"))
-                .willReturn(aResponse().withStatus(403)));
+    void shouldTreatUnknownPackageAsHavingNoIssues(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        useAnalyzerWithBatchRequestsDisabled(wmRuntimeInfo);
         // Snyk answers 404 for packages it does not know. The batch endpoint just omits
         // them, so one unknown package must not fail the whole analysis.
         stubFor(get(urlPathMatching("/rest/orgs/test-org-id/packages/.+/issues"))

--- a/vuln-analysis/snyk/src/test/resources/__files/snyk-per-package-one-issue-response.json
+++ b/vuln-analysis/snyk/src/test/resources/__files/snyk-per-package-one-issue-response.json
@@ -1,0 +1,77 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "data": [
+    {
+      "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426",
+      "type": "issue",
+      "attributes": {
+        "title": "Denial of Service (DoS)",
+        "type": "package_vulnerability",
+        "created_at": "2022-10-02T09:41:44.046865Z",
+        "updated_at": "2022-11-28T01:11:01.289734Z",
+        "description": "Affected versions of this package are vulnerable to Denial of Service (DoS).",
+        "problems": [
+          {
+            "id": "CVE-2022-42003",
+            "source": "CVE"
+          },
+          {
+            "id": "CWE-400",
+            "source": "CWE"
+          },
+          {
+            "id": "GHSA-jjjh-jjxp-wpff",
+            "source": "GHSA"
+          }
+        ],
+        "coordinates": [
+          {
+            "remedies": [
+              {
+                "type": "indeterminate",
+                "description": "Upgrade the package version to 2.12.7.1,2.13.4.2 to fix this vulnerability"
+              }
+            ],
+            "representations": [
+              {
+                "resource_path": "[,2.12.7.1),[2.13.0,2.13.4.2)"
+              }
+            ]
+          }
+        ],
+        "severities": [
+          {
+            "source": "Snyk",
+            "level": "medium",
+            "score": 5.9,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
+          },
+          {
+            "source": "NVD",
+            "level": "high",
+            "score": 7.5,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          }
+        ],
+        "slots": {
+          "publication_time": "2022-10-02T09:54:05Z",
+          "references": [
+            {
+              "url": "https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=51020",
+              "title": "Chromium Bugs"
+            },
+            {
+              "url": "https://github.com/FasterXML/jackson-databind/issues/3590",
+              "title": "GitHub Issue"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "links": {
+    "self": "/orgs/test-org/packages/issues?version=2025-11-05"
+  }
+}


### PR DESCRIPTION
### Description

The batch endpoint `POST /rest/orgs/{org}/packages/issues` is not available to all Snyk organizations and answers 403 for those it is not available to. v5 uses it exclusively and 403 is not retryable, so the analyzer fails outright for those organizations. The per-package endpoint that v4 used still works with the same token.

This falls back to the per-package endpoint when the batch endpoint answers 403.

### Addressed Issue

Fixes https://github.com/DependencyTrack/dependency-track/issues/7137

### Additional Details

The fallback sticks for the remainder of the analysis, so a single 403 does not repeat once per batch. It is logged at warn level, because the per-package endpoint means one request per package rather than one per 100, and on a large portfolio that difference is worth knowing about.

The URL is the same one v4 used:

```
GET %s/rest/orgs/%s/packages/%s/issues?version=%s
```

Only 403 triggers the fallback. Every other status behaves as before, so retryable errors still retry and anything else still fails.

Two things I was unsure about and am happy to change.

I made this automatic rather than a configuration option, on the grounds that the affected organizations are currently broken and would otherwise have to discover a setting. A config flag would make the request volume change explicit instead, if you prefer that.

The other is more general and I did not touch it here. getApplicableAnalyzers calls into every analyzer during prepare-vuln-analysis, so an analyzer failing terminally means the project gets no results from any analyzer, not just the one that failed. The reporter of #7137 saw that, and #6572 was a similar case. Worth a separate issue.

Two things worth calling out about correlating results.

The per-package response does not have to repeat the package coordinates, since the package is implied by the request URL. Correlating through SnykModelConverter.getIssuePurl, which reads a fixed representation index of the batch shape, would therefore drop every issue and then cache the PURL as having no vulnerabilities, which is a silent false negative. The per-package path keys results by the PURL it requested instead, so it does not parse coordinates at all.

A 404 for a package Snyk does not know is treated as having no issues. The batch endpoint omits such packages, and v4 logged and carried on, so a single unknown package should not fail the analysis.

I do not have access to a Snyk org where the batch endpoint is forbidden, so the per-package fixture is constructed rather than captured from a real response. It deliberately omits the package coordinates so the test fails if correlation regresses to reading them, but someone with a real entitlement confirming the response shape, and that the configured API version still serves this endpoint, would be worth having before merge.

Tested with WireMock, no Snyk account needed. One test asserts the fallback returns issues after a 403, another asserts the per-package endpoint is not touched when the batch endpoint works.

### Checklist

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [X] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~[ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~[ ] This PR introduces changes to the database model, and I have updated the migration changelog accordingly~
- ~[ ] This PR introduces new or alters existing behavior, and I have updated the documentation accordingly~
