### PR TITLE
Fix PURLs without version being submitted for analysis

### DIFF
--- a/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzer.java
+++ b/vuln-analysis/checkmarx/src/main/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzer.java
@@ -221,6 +221,11 @@ final class CheckmarxVulnAnalyzer implements VulnAnalyzer {
 
             try {
                 final var purl = new PackageURL(component.getPurl());
+                if (purl.getVersion() == null) {
+                    LOGGER.debug("PURL '{}' has no version; Skipping", component.getPurl());
+                    continue;
+                }
+
                 // Lowercase PURL coordinates for consistent cache keys
                 bomRefsByPurl
                         .computeIfAbsent(purl.getCoordinates().toLowerCase(), _ -> new HashSet<>())
@@ -245,7 +250,8 @@ final class CheckmarxVulnAnalyzer implements VulnAnalyzer {
             if (bomRefs == null) {
                 LOGGER.warn("""
                         Received vulnerabilities for PURL '{}', but no component \
-                        with this PURL was submitted for analysis""", purl);
+                        with this PURL was submitted for analysis\
+                        """, purl);
                 continue;
             }
 

--- a/vuln-analysis/checkmarx/src/test/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerTest.java
+++ b/vuln-analysis/checkmarx/src/test/java/org/dependencytrack/vulnanalysis/checkmarx/CheckmarxVulnAnalyzerTest.java
@@ -254,6 +254,22 @@ class CheckmarxVulnAnalyzerTest {
     }
 
     @Test
+    void shouldNotAnalyzeComponentWithVersionlessPurl() throws Exception {
+        final var bom = Bom.newBuilder()
+                .addComponents(Component.newBuilder()
+                        .setBomRef("1")
+                        .setName("acme-lib")
+                        .setPurl("pkg:maven/org.acme/acme-lib")
+                        .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThat(vdr).isEqualTo(Bom.getDefaultInstance());
+
+        verify(0, postRequestedFor(anyUrl()));
+    }
+
+    @Test
     void shouldNotAnalyzeComponentWithoutPurl() throws Exception {
         final var bom = Bom.newBuilder()
                 .addComponents(Component.newBuilder()

--- a/vuln-analysis/oss-index/src/main/java/org/dependencytrack/vulnanalysis/ossindex/OssIndexVulnAnalyzer.java
+++ b/vuln-analysis/oss-index/src/main/java/org/dependencytrack/vulnanalysis/ossindex/OssIndexVulnAnalyzer.java
@@ -178,6 +178,12 @@ final class OssIndexVulnAnalyzer implements VulnAnalyzer {
             try {
                 final var purl = new PackageURL(component.getPurl());
                 if (!SUPPORTED_PURL_TYPES.contains(purl.getType())) {
+                    LOGGER.debug(
+                            "Type '{}' of PURL '{}' is not supported; Skipping", purl.getType(), component.getPurl());
+                    continue;
+                }
+                if (purl.getVersion() == null) {
+                    LOGGER.debug("PURL '{}' has no version; Skipping", component.getPurl());
                     continue;
                 }
 

--- a/vuln-analysis/oss-index/src/test/java/org/dependencytrack/vulnanalysis/ossindex/OssIndexVulnAnalyzerTest.java
+++ b/vuln-analysis/oss-index/src/test/java/org/dependencytrack/vulnanalysis/ossindex/OssIndexVulnAnalyzerTest.java
@@ -228,6 +228,22 @@ class OssIndexVulnAnalyzerTest {
     }
 
     @Test
+    void shouldNotAnalyzeComponentWithVersionlessPurl() throws Exception {
+        final var bom = Bom.newBuilder()
+                .addComponents(Component.newBuilder()
+                        .setBomRef("1")
+                        .setName("acme-lib")
+                        .setPurl("pkg:maven/org.acme/acme-lib")
+                        .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThat(vdr).isEqualTo(Bom.getDefaultInstance());
+
+        verify(0, postRequestedFor(anyUrl()));
+    }
+
+    @Test
     void shouldNotAnalyzeComponentWithoutPurl() throws Exception {
         final var bom = Bom.newBuilder()
                 .addComponents(Component.newBuilder()

--- a/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzer.java
+++ b/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzer.java
@@ -167,6 +167,12 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
             try {
                 final var purl = new PackageURL(component.getPurl());
                 if (!SUPPORTED_PURL_TYPES.contains(purl.getType())) {
+                    LOGGER.debug(
+                            "Type '{}' of PURL '{}' is not supported; Skipping", purl.getType(), component.getPurl());
+                    continue;
+                }
+                if (purl.getVersion() == null) {
+                    LOGGER.debug("PURL '{}' has no version; Skipping", component.getPurl());
                     continue;
                 }
 

--- a/vuln-analysis/snyk/src/test/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzerTest.java
+++ b/vuln-analysis/snyk/src/test/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzerTest.java
@@ -264,6 +264,22 @@ class SnykVulnAnalyzerTest {
     }
 
     @Test
+    void shouldNotAnalyzeComponentWithVersionlessPurl() throws Exception {
+        final var bom = Bom.newBuilder()
+                .addComponents(Component.newBuilder()
+                        .setBomRef("1")
+                        .setName("acme-lib")
+                        .setPurl("pkg:maven/org.acme/acme-lib")
+                        .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThat(vdr).isEqualTo(Bom.getDefaultInstance());
+
+        verify(0, postRequestedFor(anyUrl()));
+    }
+
+    @Test
     void shouldNotAnalyzeComponentWithoutPurl() throws Exception {
         final var bom = Bom.newBuilder()
                 .addComponents(Component.newBuilder()


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes PURLs without version being submitted for analysis.

Without version there's nothing to base a vulnerability analysis on, and OSS Index even fails when presented with such a PURL.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #6767

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
