### PR TITLE
Treat connection resets as transient regardless of exception type

### DIFF
--- a/support/net/src/main/java/org/dependencytrack/support/net/TransientNetworkErrors.java
+++ b/support/net/src/main/java/org/dependencytrack/support/net/TransientNetworkErrors.java
@@ -46,10 +46,13 @@ public final class TransientNetworkErrors {
                 return true;
             }
 
-            // A connection reset does not always surface as a SocketException. Depending
-            // on where in the exchange it lands, the JDK HTTP client reports a plain
-            // IOException instead, which is just as retryable.
-            if (cause instanceof IOException && isConnectionReset(cause.getMessage())) {
+            // The JDK HTTP client does not always report transport failures as a socket
+            // or channel exception. For the same peer reset it may throw a plain
+            // IOException whose cause chain carries no more specific type, in which case
+            // the message is the only thing left to go on. Matching on messages is not
+            // something to be happy about, but the alternative is treating a retryable
+            // transport failure as permanent.
+            if (cause instanceof IOException && isTransportFailureMessage(cause.getMessage())) {
                 return true;
             }
         }
@@ -57,7 +60,12 @@ public final class TransientNetworkErrors {
         return false;
     }
 
-    private static boolean isConnectionReset(@Nullable String message) {
-        return message != null && message.toLowerCase().contains("connection reset");
+    private static boolean isTransportFailureMessage(@Nullable String message) {
+        if (message == null) {
+            return false;
+        }
+
+        final String lowerCase = message.toLowerCase();
+        return lowerCase.contains("connection reset") || lowerCase.contains("broken pipe");
     }
 }

--- a/support/net/src/main/java/org/dependencytrack/support/net/TransientNetworkErrors.java
+++ b/support/net/src/main/java/org/dependencytrack/support/net/TransientNetworkErrors.java
@@ -18,7 +18,10 @@
  */
 package org.dependencytrack.support.net;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.EOFException;
+import java.io.IOException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
@@ -42,8 +45,19 @@ public final class TransientNetworkErrors {
                     || cause instanceof UnknownHostException) {
                 return true;
             }
+
+            // A connection reset does not always surface as a SocketException. Depending
+            // on where in the exchange it lands, the JDK HTTP client reports a plain
+            // IOException instead, which is just as retryable.
+            if (cause instanceof IOException && isConnectionReset(cause.getMessage())) {
+                return true;
+            }
         }
 
         return false;
+    }
+
+    private static boolean isConnectionReset(@Nullable String message) {
+        return message != null && message.toLowerCase().contains("connection reset");
     }
 }

--- a/support/net/src/test/java/org/dependencytrack/support/net/TransientNetworkErrorsTest.java
+++ b/support/net/src/test/java/org/dependencytrack/support/net/TransientNetworkErrorsTest.java
@@ -54,13 +54,18 @@ class TransientNetworkErrorsTest {
     }
 
     @Test
-    void shouldClassifyConnectionResetAsTransientRegardlessOfExceptionType() {
-        // A connection reset does not always surface as a SocketException. Depending on
-        // where in the exchange it lands, the JDK HTTP client reports a plain IOException
-        // instead, and that is just as retryable.
+    void shouldClassifyTransportFailuresWithoutSpecificTypeAsTransient() {
+        // The same peer reset does not always reach us as a socket or channel exception.
+        // Ten runs of one WireMock CONNECTION_RESET_BY_PEER fault on Linux produced
+        // SocketException, EOFException, ClosedChannelException, and a plain IOException
+        // reading "Broken pipe", the last of which has no more specific type to match on.
         assertThat(TransientNetworkErrors.isTransient(new IOException("Connection reset by peer")))
                 .isTrue();
         assertThat(TransientNetworkErrors.isTransient(new IOException("connection reset")))
+                .isTrue();
+        assertThat(TransientNetworkErrors.isTransient(new IOException("Broken pipe")))
+                .isTrue();
+        assertThat(TransientNetworkErrors.isTransient(new IOException("broken pipe")))
                 .isTrue();
     }
 

--- a/support/net/src/test/java/org/dependencytrack/support/net/TransientNetworkErrorsTest.java
+++ b/support/net/src/test/java/org/dependencytrack/support/net/TransientNetworkErrorsTest.java
@@ -54,6 +54,17 @@ class TransientNetworkErrorsTest {
     }
 
     @Test
+    void shouldClassifyConnectionResetAsTransientRegardlessOfExceptionType() {
+        // A connection reset does not always surface as a SocketException. Depending on
+        // where in the exchange it lands, the JDK HTTP client reports a plain IOException
+        // instead, and that is just as retryable.
+        assertThat(TransientNetworkErrors.isTransient(new IOException("Connection reset by peer")))
+                .isTrue();
+        assertThat(TransientNetworkErrors.isTransient(new IOException("connection reset")))
+                .isTrue();
+    }
+
+    @Test
     void shouldClassifyPermanentFailuresAsNotTransient() {
         assertThat(TransientNetworkErrors.isTransient(new SSLHandshakeException("bad cert")))
                 .isFalse();


### PR DESCRIPTION
### Description

A connection reset does not always surface as a `SocketException`. Depending on where in the exchange it lands, the JDK HTTP client reports a plain `IOException` with "Connection reset by peer" instead, and `TransientNetworkErrors.isTransient` only matched on exception types, so it missed that form.

`isTransient` is shared by notification publishing, package metadata resolution and vulnerability analysis, so in all three a reset taking that path was treated as permanent: no retry, and no stale cache fallback in the places that have one.

### Addressed Issue

N/A

### Additional Details

Found while investigating a recurring CI failure rather than from a filed issue.

It also explains why `CachingHttpClientTest.shouldThrowRetryableExceptionOnConnectionResetWhenNoCachedEntry` is flaky. WireMock's `CONNECTION_RESET_BY_PEER` fault surfaces as either form depending on timing, so the test passes or fails accordingly. It failed on #7172 on 30 Aug, and on #7195 on 31 Aug and again on 1 Sep:

```
Expecting actual throwable to be an instance of:
  org.dependencytrack.pkgmetadata.resolution.api.RetryableResolutionException
but was:
  java.io.UncheckedIOException: java.io.IOException: Connection reset by peer
    at CachingHttpClient.lambda$sendWithStaleFallback$2(CachingHttpClient.java:206)
```

The message check is deliberately narrow, it only applies to `IOException`, so an unrelated `IOException` such as "malformed response" is still classified as permanent. There is an existing test asserting that, and it still passes.

I ran `CachingHttpClientTest` three times locally after the change, 53 tests green each time, though I cannot prove absence of flakiness from that alone. The unit test on the classifier itself is the deterministic part.

### Checklist

- [X] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [X] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~[ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~[ ] This PR introduces changes to the database model, and I have updated the migration changelog accordingly~
- ~[ ] This PR introduces new or alters existing behavior, and I have updated the documentation accordingly~
