### PR TITLE
Add `analyzer_identity` in `NEW_VULNERABILITY` notifications

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -155,6 +155,7 @@ public interface NotificationSubjectDao extends SqlObject {
                  , STRING_TO_ARRAY(v."CWES", ',') AS "vulnCwes"
                  , JSONB_VULN_ALIASES(v."SOURCE", v."VULNID") AS "vulnAliasesJson"
                  , <@sql.isKevColumn vulnSource='v."SOURCE"' vulnId='v."VULNID"'/> AS "vulnIsKev"
+                 , fa."ANALYZERIDENTITY" AS "vulnAnalyzerIdentity"
               FROM UNNEST(:componentIds, :vulnerabilityIds)
                 AS req(component_id, vulnerability_id)
              INNER JOIN "COMPONENTS_VULNERABILITIES" AS cv
@@ -166,6 +167,9 @@ public interface NotificationSubjectDao extends SqlObject {
                 ON p."ID" = c."PROJECT_ID"
              INNER JOIN "VULNERABILITY" AS v
                 ON v."ID" = req.vulnerability_id
+             INNER JOIN "FINDINGATTRIBUTION" AS fa
+                ON fa."COMPONENT_ID" = req.component_id
+               AND fa."VULNERABILITY_ID" = req.vulnerability_id
               LEFT JOIN "ANALYSIS" AS a
                 ON a."COMPONENT_ID" = req.component_id
                AND a."VULNERABILITY_ID" = req.vulnerability_id

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -172,9 +172,7 @@ public interface NotificationSubjectDao extends SqlObject {
                  FROM "FINDINGATTRIBUTION" AS fa
                 WHERE c."ID" = fa."COMPONENT_ID"
                   AND v."ID" = fa."VULNERABILITY_ID"
-                  AND fa."DELETED_AT" IS NULL
-                ORDER BY fa."DELETED_AT" DESC NULLS FIRST
-                       , fa."ID"
+                ORDER BY fa."ID"
                 LIMIT 1
              ) AS fa ON TRUE
               LEFT JOIN "ANALYSIS" AS a

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -167,9 +167,16 @@ public interface NotificationSubjectDao extends SqlObject {
                 ON p."ID" = c."PROJECT_ID"
              INNER JOIN "VULNERABILITY" AS v
                 ON v."ID" = req.vulnerability_id
-             INNER JOIN "FINDINGATTRIBUTION" AS fa
-                ON fa."COMPONENT_ID" = req.component_id
-               AND fa."VULNERABILITY_ID" = req.vulnerability_id
+             INNER JOIN LATERAL (
+               SELECT *
+                 FROM "FINDINGATTRIBUTION" AS fa
+                WHERE c."ID" = fa."COMPONENT_ID"
+                  AND v."ID" = fa."VULNERABILITY_ID"
+                  AND fa."DELETED_AT" IS NULL
+                ORDER BY fa."DELETED_AT" DESC NULLS FIRST
+                       , fa."ID"
+                LIMIT 1
+             ) AS fa ON TRUE
               LEFT JOIN "ANALYSIS" AS a
                 ON a."COMPONENT_ID" = req.component_id
                AND a."VULNERABILITY_ID" = req.vulnerability_id

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -41,6 +41,7 @@ import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMappers;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.Define;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 
 import java.util.ArrayList;
@@ -172,7 +173,10 @@ public interface NotificationSubjectDao extends SqlObject {
                  FROM "FINDINGATTRIBUTION" AS fa
                 WHERE c."ID" = fa."COMPONENT_ID"
                   AND v."ID" = fa."VULNERABILITY_ID"
-                ORDER BY fa."ID"
+                <#if !includeInactiveFindings>
+                  AND fa."DELETED_AT" IS NULL
+                </#if>
+                ORDER BY fa."DELETED_AT" DESC NULLS FIRST, fa."ID"
                 LIMIT 1
              ) AS fa ON TRUE
               LEFT JOIN "ANALYSIS" AS a
@@ -181,7 +185,7 @@ public interface NotificationSubjectDao extends SqlObject {
              WHERE a."SUPPRESSED" IS DISTINCT FROM TRUE
             """)
     @RegisterRowMapper(NotificationSubjectNewVulnerabilityRowMapper.class)
-    List<NewVulnerabilitySubject> getForNewVulnerabilities(List<Long> componentIds, List<Long> vulnerabilityIds);
+    List<NewVulnerabilitySubject> getForNewVulnerabilities(List<Long> componentIds, List<Long> vulnerabilityIds, @Define boolean includeInactiveFindings);
 
     default List<NewVulnerableDependencySubject> getForNewVulnerableDependencies(Collection<Long> componentIds) {
         if (componentIds.isEmpty()) {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -185,7 +185,8 @@ public interface NotificationSubjectDao extends SqlObject {
              WHERE a."SUPPRESSED" IS DISTINCT FROM TRUE
             """)
     @RegisterRowMapper(NotificationSubjectNewVulnerabilityRowMapper.class)
-    List<NewVulnerabilitySubject> getForNewVulnerabilities(List<Long> componentIds, List<Long> vulnerabilityIds, @Define boolean includeInactiveFindings);
+    List<NewVulnerabilitySubject> getForNewVulnerabilities(
+            List<Long> componentIds, List<Long> vulnerabilityIds, @Define boolean includeInactiveFindings);
 
     default List<NewVulnerableDependencySubject> getForNewVulnerableDependencies(Collection<Long> componentIds) {
         if (componentIds.isEmpty()) {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationVulnerabilityRowMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationVulnerabilityRowMapper.java
@@ -70,6 +70,7 @@ public class NotificationVulnerabilityRowMapper implements RowMapper<Vulnerabili
         maybeSet(
                 rs, "vulnAliasesJson", NotificationVulnerabilityRowMapper::maybeConvertAliases, builder::addAllAliases);
         maybeSet(rs, "vulnIsKev", ResultSet::getBoolean, builder::setIsKev);
+        maybeSet(rs, "vulnAnalyzerIdentity", ResultSet::getString, builder::setAnalyzerIdentity);
         return builder.build();
     }
 

--- a/apiserver/src/main/java/org/dependencytrack/vulnanalysis/ReconcileVulnAnalysisResultsActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulnanalysis/ReconcileVulnAnalysisResultsActivity.java
@@ -802,7 +802,7 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
             vulnDbIds.add(findingKey.vulnDbId());
         });
 
-        return dao.getForNewVulnerabilities(componentIds, vulnDbIds).stream()
+        return dao.getForNewVulnerabilities(componentIds, vulnDbIds, false).stream()
                 .map(subject -> createNewVulnerabilityNotification(
                         subject.getProject(),
                         subject.getComponent(),
@@ -825,7 +825,7 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
             vulnDbIds.add(findingKey.vulnDbId());
         });
 
-        return dao.getForNewVulnerabilities(componentIds, vulnDbIds).stream()
+        return dao.getForNewVulnerabilities(componentIds, vulnDbIds, true).stream()
                 .map(subject -> createVulnerabilityRetractedNotification(
                         subject.getProject(), subject.getComponent(), subject.getVulnerability()))
                 .toList();

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
@@ -235,7 +235,8 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                                     "cvssV2Vector": "(AV:N/AC:M/Au:S/C:P/I:P/A:P)",
                                     "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
                                     "owaspRRVector": "(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)",
-                                    "isKev": true
+                                    "isKev": true,
+                                    "analyzerIdentity": "internal"
                                   }
                                 }
                                 """));
@@ -314,7 +315,8 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                             "cvssV2Vector": "",
                             "cvssV3Vector": "cvssV3VectorOverwrite",
                             "owaspRRVector": "owaspRrVector",
-                            "isKev": false
+                            "isKev": false,
+                            "analyzerIdentity": "internal"
                           },
                           "affectedProjects": [
                             {

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
@@ -155,10 +155,10 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                 .withState(AnalysisState.FALSE_POSITIVE)
                 .withSuppress(true));
 
-        final List<NewVulnerabilitySubject> subjects =
-                withJdbiHandle(handle -> handle.attach(NotificationSubjectDao.class)
-                        .getForNewVulnerabilities(
-                                List.of(component.getId(), component.getId()), List.of(vulnA.getId(), vulnB.getId()), false));
+        final List<NewVulnerabilitySubject> subjects = withJdbiHandle(handle -> handle.attach(
+                        NotificationSubjectDao.class)
+                .getForNewVulnerabilities(
+                        List.of(component.getId(), component.getId()), List.of(vulnA.getId(), vulnB.getId()), false));
 
         assertThat(subjects)
                 .satisfiesExactly(subject -> assertThatJson(JsonFormat.printer().print(subject))

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
@@ -158,7 +158,7 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
         final List<NewVulnerabilitySubject> subjects =
                 withJdbiHandle(handle -> handle.attach(NotificationSubjectDao.class)
                         .getForNewVulnerabilities(
-                                List.of(component.getId(), component.getId()), List.of(vulnA.getId(), vulnB.getId())));
+                                List.of(component.getId(), component.getId()), List.of(vulnA.getId(), vulnB.getId()), false));
 
         assertThat(subjects)
                 .satisfiesExactly(subject -> assertThatJson(JsonFormat.printer().print(subject))
@@ -284,7 +284,7 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
 
         final List<NewVulnerabilitySubject> subjects =
                 withJdbiHandle(handle -> handle.attach(NotificationSubjectDao.class)
-                        .getForNewVulnerabilities(List.of(component.getId()), List.of(vuln.getId())));
+                        .getForNewVulnerabilities(List.of(component.getId()), List.of(vuln.getId()), false));
 
         assertThat(subjects).hasSize(1);
         assertThatJson(JsonFormat.printer().print(subjects.getFirst()))

--- a/notification/api/src/main/proto/org/dependencytrack/notification/v1/notification.proto
+++ b/notification/api/src/main/proto/org/dependencytrack/notification/v1/notification.proto
@@ -226,6 +226,8 @@ message Vulnerability {
 
   // Whether the vulnerability is known to be exploited.
   optional bool is_kev = 21 [json_name = "isKev"];
+
+  // Name of the analyzer that identified the vulnerability first.
   optional string analyzer_identity = 22;
 
   message Alias {

--- a/notification/api/src/main/proto/org/dependencytrack/notification/v1/notification.proto
+++ b/notification/api/src/main/proto/org/dependencytrack/notification/v1/notification.proto
@@ -226,6 +226,7 @@ message Vulnerability {
 
   // Whether the vulnerability is known to be exploited.
   optional bool is_kev = 21 [json_name = "isKev"];
+  optional string analyzer_identity = 22;
 
   message Alias {
     string id = 1 [json_name = "vulnId"];


### PR DESCRIPTION
### Description

Expose the `analyzer_identity` for vulnerabilities in `NEW_VULNERABILITY` notifications. This lets notification consumers see which analyzer produced the finding.

### Addressed Issue

Closes https://github.com/DependencyTrack/dependency-track/issues/6701

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
