### PR TITLE
Refactor component metrics computation to avoid pathological query plans

### DIFF
--- a/migration/src/main/resources/org/dependencytrack/migration/R__compute_component_metrics.sql
+++ b/migration/src/main/resources/org/dependencytrack/migration/R__compute_component_metrics.sql
@@ -54,18 +54,40 @@ $$
        AND "PROPERTYTYPE" = 'INTEGER'
   ),
   components_vulns AS (
-    SELECT cv."COMPONENT_ID" AS component_id
-         , cv."VULNERABILITY_ID" AS vulnerability_id
-      FROM "COMPONENTS_VULNERABILITIES" AS cv
-     INNER JOIN comp
-        ON comp.id = cv."COMPONENT_ID"
-     WHERE EXISTS(
-       SELECT 1
-         FROM "FINDINGATTRIBUTION" AS fa
-        WHERE fa."COMPONENT_ID" = cv."COMPONENT_ID"
-          AND fa."VULNERABILITY_ID" = cv."VULNERABILITY_ID"
-          AND fa."DELETED_AT" IS NULL
-     )
+    SELECT cv.component_id
+         , cv.vulnerability_id
+         , cv.analysis_severity
+         , cv.analysis_suppressed
+      FROM comp
+     CROSS JOIN LATERAL (
+       -- Fetch analyses once per component, not once per finding. Forced via MATERIALIZED.
+       -- Don't want this to fire N times if a component is affected by N vulns.
+       WITH a AS MATERIALIZED (
+         SELECT "VULNERABILITY_ID", "SEVERITY", "SUPPRESSED"
+           FROM "ANALYSIS"
+          WHERE "COMPONENT_ID" = comp.id
+       )
+       SELECT cv."COMPONENT_ID" AS component_id
+            , cv."VULNERABILITY_ID" AS vulnerability_id
+            , a."SEVERITY" AS analysis_severity
+            , a."SUPPRESSED" AS analysis_suppressed
+         FROM "COMPONENTS_VULNERABILITIES" AS cv
+         LEFT JOIN a
+           ON a."VULNERABILITY_ID" = cv."VULNERABILITY_ID"
+        WHERE cv."COMPONENT_ID" = comp.id
+          AND EXISTS(
+            SELECT 1
+              FROM "FINDINGATTRIBUTION" AS fa
+             WHERE fa."COMPONENT_ID" = cv."COMPONENT_ID"
+               AND fa."VULNERABILITY_ID" = cv."VULNERABILITY_ID"
+               AND fa."DELETED_AT" IS NULL
+          )
+       -- Prevent the planner from inlining this subquery (https://stackoverflow.com/a/14897817).
+       -- Naively joining `comp` with COMPONENT_VULNERABILITIES has been observed to produce
+       -- bad query plans due to inaccurate n_distinct statistics on the COMPONENT_ID column of the latter.
+       -- By forcing a for-each access pattern, every component gets a predictable index lookup regardless of bad stats.
+       OFFSET 0
+     ) AS cv
   ),
   kev_alias_group AS MATERIALIZED (
     SELECT DISTINCT va."GROUP_ID" AS group_id
@@ -112,19 +134,16 @@ $$
   vuln_deduped AS (
     SELECT DISTINCT ON (cvs.component_id, vag.group_id, CASE WHEN vag.group_id IS NULL THEN vag.vulnerability_id END)
            cvs.component_id AS component_id
-         , COALESCE(a."SEVERITY", vag.severity) AS effective_severity
+         , COALESCE(cvs.analysis_severity, vag.severity) AS effective_severity
          , vag.is_kev AS is_kev
       FROM components_vulns AS cvs
      INNER JOIN vuln_alias_group AS vag
         ON vag.vulnerability_id = cvs.vulnerability_id
-      LEFT JOIN "ANALYSIS" AS a
-        ON a."COMPONENT_ID" = cvs.component_id
-       AND a."VULNERABILITY_ID" = cvs.vulnerability_id
-     WHERE a."SUPPRESSED" IS DISTINCT FROM TRUE
+     WHERE cvs.analysis_suppressed IS DISTINCT FROM TRUE
      ORDER BY cvs.component_id
             , vag.group_id
             , CASE WHEN vag.group_id IS NULL THEN vag.vulnerability_id END
-            , COALESCE(a."SEVERITY", vag.severity) DESC
+            , COALESCE(cvs.analysis_severity, vag.severity) DESC
   ),
   vuln_counts AS (
     SELECT vuln_deduped.component_id
@@ -137,60 +156,6 @@ $$
          , COUNT(*) FILTER (WHERE is_kev)::INT AS kev
       FROM vuln_deduped
      GROUP BY vuln_deduped.component_id
-  ),
-  analysis_counts AS (
-    SELECT a."COMPONENT_ID" AS component_id
-         , COUNT(*) FILTER (
-             WHERE a."SUPPRESSED" = FALSE
-               AND a."STATE" NOT IN ('NOT_SET', 'IN_TRIAGE')
-           )::INT AS findings_audited
-         , COUNT(*) FILTER (WHERE a."SUPPRESSED" = TRUE)::INT AS findings_suppressed
-      FROM "ANALYSIS" AS a
-     INNER JOIN comp
-        ON comp.id = a."COMPONENT_ID"
-     WHERE EXISTS(
-       SELECT 1 FROM "FINDINGATTRIBUTION" AS fa
-        WHERE fa."COMPONENT_ID" = a."COMPONENT_ID"
-          AND fa."VULNERABILITY_ID" = a."VULNERABILITY_ID"
-          AND fa."DELETED_AT" IS NULL
-     )
-     GROUP BY a."COMPONENT_ID"
-  ),
-  violation_counts AS (
-    SELECT pv."COMPONENT_ID" AS component_id
-         , COUNT(*)::INT AS total
-         , COUNT(*) FILTER (WHERE p."VIOLATIONSTATE" = 'FAIL')::INT AS fail
-         , COUNT(*) FILTER (WHERE p."VIOLATIONSTATE" = 'WARN')::INT AS warn
-         , COUNT(*) FILTER (WHERE p."VIOLATIONSTATE" = 'INFO')::INT AS info
-         , COUNT(*) FILTER (WHERE pv."TYPE" = 'LICENSE')::INT AS license_total
-         , COUNT(*) FILTER (WHERE pv."TYPE" = 'OPERATIONAL')::INT AS operational_total
-         , COUNT(*) FILTER (WHERE pv."TYPE" = 'SECURITY')::INT AS security_total
-      FROM "POLICYVIOLATION" AS pv
-     INNER JOIN comp
-        ON comp.id = pv."COMPONENT_ID"
-     INNER JOIN "POLICYCONDITION" AS pc
-        ON pv."POLICYCONDITION_ID" = pc."ID"
-     INNER JOIN "POLICY" AS p
-        ON pc."POLICY_ID" = p."ID"
-      LEFT JOIN "VIOLATIONANALYSIS" AS va
-        ON va."COMPONENT_ID" = pv."COMPONENT_ID"
-       AND va."POLICYVIOLATION_ID" = pv."ID"
-     WHERE (va IS NULL OR va."SUPPRESSED" = FALSE)
-     GROUP BY pv."COMPONENT_ID"
-  ),
-  violation_audit_counts AS (
-    SELECT va."COMPONENT_ID" AS component_id
-         , COUNT(*) FILTER (WHERE pv."TYPE" = 'LICENSE')::INT AS license_audited
-         , COUNT(*) FILTER (WHERE pv."TYPE" = 'OPERATIONAL')::INT AS operational_audited
-         , COUNT(*) FILTER (WHERE pv."TYPE" = 'SECURITY')::INT AS security_audited
-      FROM "VIOLATIONANALYSIS" AS va
-     INNER JOIN comp
-        ON comp.id = va."COMPONENT_ID"
-     INNER JOIN "POLICYVIOLATION" AS pv
-        ON pv."ID" = va."POLICYVIOLATION_ID"
-     WHERE va."SUPPRESSED" = FALSE
-       AND va."STATE" != 'NOT_SET'
-     GROUP BY va."COMPONENT_ID"
   )
   SELECT comp.id
        , COALESCE(vc.vulnerabilities, 0)
@@ -208,37 +173,80 @@ $$
            + COALESCE(vc.unassigned, 0) * risk_score_weights.w_unassigned
          , 0)::NUMERIC
        , COALESCE(vc.vulnerabilities, 0)
-       , COALESCE(ac.findings_audited, 0)
-       , COALESCE(vc.vulnerabilities, 0) - COALESCE(ac.findings_audited, 0)
-       , COALESCE(ac.findings_suppressed, 0)
-       , COALESCE(pvc.total, 0)
-       , COALESCE(pvc.fail, 0)
-       , COALESCE(pvc.warn, 0)
-       , COALESCE(pvc.info, 0)
-       , COALESCE(pvac.license_audited, 0)
-         + COALESCE(pvac.operational_audited, 0)
-         + COALESCE(pvac.security_audited, 0)
-       , COALESCE(pvc.total, 0)
-         - (COALESCE(pvac.license_audited, 0)
-            + COALESCE(pvac.operational_audited, 0)
-            + COALESCE(pvac.security_audited, 0))
-       , COALESCE(pvc.license_total, 0)
-       , COALESCE(pvac.license_audited, 0)
-       , COALESCE(pvc.license_total, 0) - COALESCE(pvac.license_audited, 0)
-       , COALESCE(pvc.operational_total, 0)
-       , COALESCE(pvac.operational_audited, 0)
-       , COALESCE(pvc.operational_total, 0) - COALESCE(pvac.operational_audited, 0)
-       , COALESCE(pvc.security_total, 0)
-       , COALESCE(pvac.security_audited, 0)
-       , COALESCE(pvc.security_total, 0) - COALESCE(pvac.security_audited, 0)
+       , ac.findings_audited
+       , COALESCE(vc.vulnerabilities, 0) - ac.findings_audited
+       , ac.findings_suppressed
+       , pvc.total
+       , pvc.fail
+       , pvc.warn
+       , pvc.info
+       , pvac.license_audited
+         + pvac.operational_audited
+         + pvac.security_audited
+       , pvc.total
+         - (pvac.license_audited
+            + pvac.operational_audited
+            + pvac.security_audited)
+       , pvc.license_total
+       , pvac.license_audited
+       , pvc.license_total - pvac.license_audited
+       , pvc.operational_total
+       , pvac.operational_audited
+       , pvc.operational_total - pvac.operational_audited
+       , pvc.security_total
+       , pvac.security_audited
+       , pvc.security_total - pvac.security_audited
     FROM comp
    CROSS JOIN risk_score_weights
     LEFT JOIN vuln_counts AS vc
       ON vc.component_id = comp.id
-    LEFT JOIN analysis_counts AS ac
-      ON ac.component_id = comp.id
-    LEFT JOIN violation_counts AS pvc
-      ON pvc.component_id = comp.id
-    LEFT JOIN violation_audit_counts AS pvac
-      ON pvac.component_id = comp.id
+   CROSS JOIN LATERAL (
+     SELECT COUNT(*) FILTER (
+              WHERE a."SUPPRESSED" = FALSE
+                AND a."STATE" NOT IN ('NOT_SET', 'IN_TRIAGE')
+            )::INT AS findings_audited
+          , COUNT(*) FILTER (WHERE a."SUPPRESSED" = TRUE)::INT AS findings_suppressed
+       FROM (
+         SELECT "COMPONENT_ID", "VULNERABILITY_ID", "STATE", "SUPPRESSED"
+           FROM "ANALYSIS"
+          WHERE "COMPONENT_ID" = comp.id
+         OFFSET 0
+       ) AS a
+      WHERE EXISTS(
+          SELECT 1 FROM "FINDINGATTRIBUTION" AS fa
+           WHERE fa."COMPONENT_ID" = a."COMPONENT_ID"
+             AND fa."VULNERABILITY_ID" = a."VULNERABILITY_ID"
+             AND fa."DELETED_AT" IS NULL
+        )
+   ) AS ac
+   CROSS JOIN LATERAL (
+     SELECT COUNT(*)::INT AS total
+          , COUNT(*) FILTER (WHERE p."VIOLATIONSTATE" = 'FAIL')::INT AS fail
+          , COUNT(*) FILTER (WHERE p."VIOLATIONSTATE" = 'WARN')::INT AS warn
+          , COUNT(*) FILTER (WHERE p."VIOLATIONSTATE" = 'INFO')::INT AS info
+          , COUNT(*) FILTER (WHERE pv."TYPE" = 'LICENSE')::INT AS license_total
+          , COUNT(*) FILTER (WHERE pv."TYPE" = 'OPERATIONAL')::INT AS operational_total
+          , COUNT(*) FILTER (WHERE pv."TYPE" = 'SECURITY')::INT AS security_total
+       FROM "POLICYVIOLATION" AS pv
+      INNER JOIN "POLICYCONDITION" AS pc
+         ON pv."POLICYCONDITION_ID" = pc."ID"
+      INNER JOIN "POLICY" AS p
+         ON pc."POLICY_ID" = p."ID"
+       LEFT JOIN "VIOLATIONANALYSIS" AS va
+         ON va."COMPONENT_ID" = pv."COMPONENT_ID"
+        AND va."POLICYVIOLATION_ID" = pv."ID"
+      WHERE pv."COMPONENT_ID" = comp.id
+        AND (va IS NULL OR va."SUPPRESSED" = FALSE)
+   ) AS pvc
+   CROSS JOIN LATERAL (
+     SELECT COUNT(*) FILTER (WHERE pv."TYPE" = 'LICENSE')::INT AS license_audited
+          , COUNT(*) FILTER (WHERE pv."TYPE" = 'OPERATIONAL')::INT AS operational_audited
+          , COUNT(*) FILTER (WHERE pv."TYPE" = 'SECURITY')::INT AS security_audited
+       FROM "VIOLATIONANALYSIS" AS va
+      INNER JOIN "POLICYVIOLATION" AS pv
+         ON pv."ID" = va."POLICYVIOLATION_ID"
+      WHERE va."COMPONENT_ID" = comp.id
+        AND va."SUPPRESSED" = FALSE
+        AND va."STATE" != 'NOT_SET'
+   ) AS pvac
 $$;


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Refactors component metrics computation to avoid pathological query plans.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #7211

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
