### PR TITLE
Backport: Fix excessive churn of vulnerable software associations during mirroring

### DIFF
--- a/src/main/java/org/dependencytrack/model/VulnerableSoftware.java
+++ b/src/main/java/org/dependencytrack/model/VulnerableSoftware.java
@@ -433,11 +433,10 @@ public class VulnerableSoftware implements ICpe, Serializable {
      * @since 4.10.0
      */
     public boolean equalsIgnoringDatastoreIdentity(final VulnerableSoftware otherVs) {
-        return Objects.equals(otherVs.getPurl(), this.getPurl())
-                && Objects.equals(otherVs.getPurlType(), this.getPurlType())
+        // NB: The full purl string and purlVersion are intentionally excluded.
+        return Objects.equals(otherVs.getPurlType(), this.getPurlType())
                 && Objects.equals(otherVs.getPurlNamespace(), this.getPurlNamespace())
                 && Objects.equals(otherVs.getPurlName(), this.getPurlName())
-                && Objects.equals(otherVs.getPurlVersion(), this.getPurlVersion())
                 && Objects.equals(otherVs.getPurlQualifiers(), this.getPurlQualifiers())
                 && Objects.equals(otherVs.getPurlSubpath(), this.getPurlSubpath())
                 && Objects.equals(otherVs.getCpe22(), this.getCpe22())
@@ -468,12 +467,11 @@ public class VulnerableSoftware implements ICpe, Serializable {
      * @since 4.10.0
      */
     public int hashCodeWithoutDatastoreIdentity() {
+        // NB: The full purl string and purlVersion are intentionally excluded.
         return Objects.hash(
-                this.getPurl(),
                 this.getPurlType(),
                 this.getPurlNamespace(),
                 this.getPurlName(),
-                this.getPurlVersion(),
                 this.getPurlQualifiers(),
                 this.getPurlSubpath(),
                 this.getCpe22(),

--- a/src/test/java/org/dependencytrack/tasks/OsvDownloadTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/OsvDownloadTaskTest.java
@@ -47,8 +47,11 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -885,6 +888,38 @@ class OsvDownloadTaskTest extends PersistenceCapableTest {
         Vulnerability vulnerability = qm.getVulnerabilityByVulnId("GITHUB", "GHSA-77rv-6vfw-x4gc", false);
         Assertions.assertNotNull(vulnerability);
         Assertions.assertEquals(Severity.CRITICAL, vulnerability.getSeverity());
+    }
+
+    @Test
+    void testUpdateDatasourceDoesNotChurnAttributionsWhenPurlVersionChanges() throws IOException {
+        final String advisoryJson = Files.readString(
+                Paths.get("src/test/resources/unit/osv.jsons/osv-UBUNTU-CVE-2025-6297.json"), StandardCharsets.UTF_8);
+
+        final var task = new OsvDownloadTask();
+        task.updateDatasource(parser.parse(new JSONObject(advisoryJson)));
+
+        qm.getPersistenceManager().evictAll();
+        final Map<Long, Date> firstSeenByVsId = firstSeenByVulnerableSoftwareId("UBUNTU-CVE-2025-6297");
+        assertThat(firstSeenByVsId).hasSize(8);
+
+        // Ubuntu bumps the source package version embedded in the advisory's PURL whenever the
+        // advisory is updated, even though the version range derived from it stays the same.
+        // The affected version attributions must survive that, instead of being deleted and re-created.
+        task.updateDatasource(parser.parse(new JSONObject(advisoryJson
+                .replace("dpkg@1.21.1ubuntu2.3", "dpkg@1.21.1ubuntu2.4")
+                .replace("It was discovered", "It was later discovered"))));
+
+        qm.getPersistenceManager().evictAll();
+        assertThat(firstSeenByVulnerableSoftwareId("UBUNTU-CVE-2025-6297")).isEqualTo(firstSeenByVsId);
+    }
+
+    private Map<Long, Date> firstSeenByVulnerableSoftwareId(final String vulnId) {
+        final Vulnerability vuln = qm.getVulnerabilityByVulnId(Vulnerability.Source.OSV, vulnId, false);
+        assertThat(vuln).isNotNull();
+        return qm.getAffectedVersionAttributions(vuln, vuln.getVulnerableSoftware()).stream()
+                .collect(Collectors.toMap(
+                        attribution -> attribution.getVulnerableSoftware().getId(),
+                        AffectedVersionAttribution::getFirstSeen));
     }
 
     private void prepareJsonObject(String filePath) throws IOException {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes excessive churn of vulnerable software associations during mirroring.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #6499

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
