### PR TITLE
Backport: Remove unnecessary enrichment when querying for individual projects

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -247,15 +247,9 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
 
         preprocessACLs(query, queryFilter, params, false);
         query.setFilter(queryFilter);
+        query.setNamedParameters(params);
         query.setRange(0, 1);
-        final Project project = singleResult(query.executeWithMap(params));
-        if (project != null) {
-            // set Metrics to prevent extra round trip
-            project.setMetrics(getMostRecentProjectMetrics(project));
-            // set ProjectVersions to prevent extra round trip
-            project.setVersions(getProjectVersions(project));
-        }
-        return project;
+        return executeAndCloseUnique(query);
     }
 
 
@@ -278,16 +272,9 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
 
         preprocessACLs(query, queryFilter, params, false);
         query.setFilter(queryFilter);
+        query.setNamedParameters(params);
         query.setRange(0, 1);
-
-        final Project project = singleResult(query.executeWithMap(params));
-        if (project != null) {
-            // set Metrics to prevent extra round trip
-            project.setMetrics(getMostRecentProjectMetrics(project));
-            // set ProjectVersions to prevent extra round trip
-            project.setVersions(getProjectVersions(project));
-        }
-        return project;
+        return executeAndCloseUnique(query);
     }
 
     /**
@@ -1834,7 +1821,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         return hasActiveChild;
     }
 
-    private List<ProjectVersion> getProjectVersions(Project project) {
+    public List<ProjectVersion> getProjectVersions(Project project) {
         final Query<Project> query = pm.newQuery(Project.class);
         query.setFilter("name == :name");
         query.setParameters(project.getName());

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -65,6 +65,7 @@ import org.dependencytrack.model.PortfolioMetrics;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectMetrics;
 import org.dependencytrack.model.ProjectProperty;
+import org.dependencytrack.model.ProjectVersion;
 import org.dependencytrack.model.Repository;
 import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
@@ -396,6 +397,10 @@ public class QueryManager extends AlpineQueryManager {
 
     public Project getLatestProjectVersion(final String name) {
         return getProjectQueryManager().getLatestProjectVersion(name);
+    }
+
+    public List<ProjectVersion> getProjectVersions(final Project project) {
+        return getProjectQueryManager().getProjectVersions(project);
     }
 
     public PaginatedResult getProjects(final Team team, final boolean excludeInactive, final boolean bypass, final boolean onlyRoot) {

--- a/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -204,6 +204,10 @@ public class ProjectResource extends AlpineResource {
             final Project project = qm.getProject(name, version);
             if (project != null) {
                 if (qm.hasAccess(super.getPrincipal(), project)) {
+                    // Enrich here rather than in the query manager, so that call sites
+                    // which don't need this data don't pay for it.
+                    project.setMetrics(qm.getMostRecentProjectMetrics(project));
+                    project.setVersions(qm.getProjectVersions(project));
                     return Response.ok(project).build();
                 } else {
                     return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
@@ -240,6 +244,10 @@ public class ProjectResource extends AlpineResource {
             final Project project = qm.getLatestProjectVersion(name);
             if (project != null) {
                 if (qm.hasAccess(super.getPrincipal(), project)) {
+                    // Enrich here rather than in the query manager, so that call sites
+                    // which don't need this data don't pay for it.
+                    project.setMetrics(qm.getMostRecentProjectMetrics(project));
+                    project.setVersions(qm.getProjectVersions(project));
                     return Response.ok(project).build();
                 } else {
                     return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -54,6 +54,7 @@ import org.dependencytrack.model.OrganizationalContact;
 import org.dependencytrack.model.OrganizationalEntity;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectMetadata;
+import org.dependencytrack.model.ProjectMetrics;
 import org.dependencytrack.model.ProjectProperty;
 import org.dependencytrack.model.ServiceComponent;
 import org.dependencytrack.model.Tag;
@@ -77,6 +78,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -208,6 +210,7 @@ class ProjectResourceTest extends ResourceTest {
         for (int i=0; i<500; i++) {
             qm.createProject("Acme Example", null, String.valueOf(i), null, null, null, false, false);
         }
+        persistProjectMetrics(qm.getProject("Acme Example", "10"), 42);
         Response response = jersey.target(V1_PROJECT+"/lookup")
                 .queryParam("name", "Acme Example")
                 .queryParam("version", "10")
@@ -224,6 +227,36 @@ class ProjectResourceTest extends ResourceTest {
         Assertions.assertNotNull(json.getJsonArray("versions").getJsonObject(100).getString("uuid"));
         Assertions.assertNotEquals("", json.getJsonArray("versions").getJsonObject(100).getString("uuid"));
         Assertions.assertEquals("100", json.getJsonArray("versions").getJsonObject(100).getString("version"));
+        Assertions.assertEquals(42, json.getJsonObject("metrics").getInt("vulnerabilities"));
+    }
+
+    @Test
+    void getLatestProjectByNameTest() {
+        qm.createProject("Acme Example", null, "1.0", null, null, null, false, false);
+        final Project latest = qm.createProject("Acme Example", null, "2.0", null, null, null, false, false);
+        latest.setIsLatest(true);
+        qm.persist(latest);
+        persistProjectMetrics(latest, 7);
+
+        final Response response = jersey.target(V1_PROJECT + "/latest/Acme Example")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        final JsonObject json = parseJsonObject(response);
+        Assertions.assertEquals("2.0", json.getString("version"));
+        // Both are enriched by the resource, not by the query manager.
+        Assertions.assertEquals(2, json.getJsonArray("versions").size());
+        Assertions.assertEquals(7, json.getJsonObject("metrics").getInt("vulnerabilities"));
+    }
+
+    private void persistProjectMetrics(final Project project, final int vulnerabilities) {
+        final var metrics = new ProjectMetrics();
+        metrics.setProject(project);
+        metrics.setVulnerabilities(vulnerabilities);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(new Date());
+        qm.persist(metrics);
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Removes unnecessary enrichment when querying for individual projects.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Backports #6514

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
