### PR TITLE
Resolve project parent before other fields in updateProject

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -251,6 +251,32 @@ final class ProjectQueryManager extends QueryManager {
     public Project updateProject(Project transientProject, boolean commitIndex) {
         return callInTransaction(() -> {
             final Project project = getObjectByUuid(Project.class, transientProject.getUuid());
+
+            // NB: Resolve the parent BEFORE setting any field below, for the same reason the
+            // collection tag is resolved before collectionLogic further down: getObjectByUuid
+            // triggers a query, which flushes dirty state. Doing that after e.g. setClassifier
+            // has run, but before setCollectionLogic clears it, can flush a row that violates
+            // PROJECT_COLLECTION_CLASSIFIER_check (see #7241).
+            if (transientProject.getParent() != null
+                    && transientProject.getParent().getUuid() != null) {
+                if (project.getUuid().equals(transientProject.getParent().getUuid())) {
+                    throw new IllegalArgumentException("A project cannot select itself as a parent");
+                }
+                Project parent = getObjectByUuid(
+                        Project.class, transientProject.getParent().getUuid());
+                if (parent.getInactiveSince() != null) {
+                    throw new IllegalArgumentException("An inactive project cannot be selected as a parent");
+                } else if (isChildOf(parent, transientProject.getUuid())) {
+                    throw new IllegalArgumentException(
+                            "The new parent project cannot be a child of the current project.");
+                } else {
+                    project.setParent(parent);
+                }
+                project.setParent(parent);
+            } else {
+                project.setParent(null);
+            }
+
             project.setAuthors(transientProject.getAuthors());
             project.setPublisher(transientProject.getPublisher());
             project.setManufacturer(transientProject.getManufacturer());
@@ -282,26 +308,6 @@ final class ProjectQueryManager extends QueryManager {
                 }
             }
             project.setIsLatest(transientProject.isLatest());
-
-            if (transientProject.getParent() != null
-                    && transientProject.getParent().getUuid() != null) {
-                if (project.getUuid().equals(transientProject.getParent().getUuid())) {
-                    throw new IllegalArgumentException("A project cannot select itself as a parent");
-                }
-                Project parent = getObjectByUuid(
-                        Project.class, transientProject.getParent().getUuid());
-                if (parent.getInactiveSince() != null) {
-                    throw new IllegalArgumentException("An inactive project cannot be selected as a parent");
-                } else if (isChildOf(parent, transientProject.getUuid())) {
-                    throw new IllegalArgumentException(
-                            "The new parent project cannot be a child of the current project.");
-                } else {
-                    project.setParent(parent);
-                }
-                project.setParent(parent);
-            } else {
-                project.setParent(null);
-            }
 
             // Prevent illegal states of collection projects (must not contain components or services).
             final ProjectCollectionLogic newCollectionLogic = transientProject.getCollectionLogic();

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -5300,6 +5300,44 @@ class ProjectResourceTest extends ResourceTest {
         assertThat(json.containsKey("classifier")).isFalse();
     }
 
+    /**
+     * https://github.com/DependencyTrack/dependency-track/issues/7241
+     */
+    @Test
+    void shouldConvertCollectionProjectBackToRegularWithParent() {
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_UPDATE);
+
+        final var parentProject = new Project();
+        parentProject.setName("acme-app-parent");
+        qm.persist(parentProject);
+
+        final var project = qm.createProject("acme-app", null, "1.0", null, null, null, null, false);
+        project.setCollectionLogic(ProjectCollectionLogic.AGGREGATE_DIRECT_CHILDREN);
+        project.setClassifier(null);
+        project.setParent(parentProject);
+        qm.persist(project);
+
+        final Response response = jersey.target(V1_PROJECT)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "uuid": "%s",
+                          "name": "acme-app",
+                          "version": "1.0",
+                          "classifier": "LIBRARY",
+                          "parent": {
+                            "uuid": "%s"
+                          }
+                        }
+                        """.formatted(project.getUuid(), parentProject.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(200);
+        final JsonObject json = parseJsonObject(response);
+        assertThat(json.getString("classifier")).isEqualTo("LIBRARY");
+        assertThat(json.containsKey("collectionLogic")).isFalse();
+        assertThat(json.getJsonObject("parent").getString("uuid")).isEqualTo(parentProject.getUuid().toString());
+    }
+
     @Test
     void shouldPatchCollectionLogicAndNullClassifier() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_UPDATE);


### PR DESCRIPTION
### Description

`ProjectQueryManager.updateProject` sets the new classifier on the persistent project, then resolves the new parent (if any) via a `getObjectByUuid` call, and only clears `collectionLogic` afterward. `getObjectByUuid` runs a query, and DataNucleus flushes pending dirty state before any query executes. If a request converts a collection project back to a regular one (clearing `collectionLogic`, setting a `classifier`) while also carrying a `parent`, that flush writes a row with both `classifier` and `collectionLogic` non-null, violating the `PROJECT_COLLECTION_CLASSIFIER_check` database constraint and surfacing as an uncaught 500 instead of the expected 200.

This is the same class of hazard already documented and guarded a few lines below for `collectionTag` (`resolveTags` is deliberately called before `collectionLogic` is set, for the same reason) — parent resolution just wasn't given the same treatment.

This PR moves parent resolution to the very start of `updateProject`, before any field is set on the persistent object, so the query runs while it's still clean and nothing flushes prematurely. No other ordering changes.

**Scope note:** `hasActiveChild` (raw SQL) and `getLatestProjectVersion` (JDOQL), used by the `isActive`/`isLatest` branches, run queries in the same position in the method and have the same latent hazard. Neither is exercised by the reported issue or the added test, so I left them alone to keep this change scoped to what's reported and verified — flagging here in case a maintainer wants a follow-up.

### Addressed Issue

fixes #7241

### Additional Details

Added `shouldConvertCollectionProjectBackToRegularWithParent` to `ProjectResourceTest`, reproducing the exact reported request shape: a collection project's classifier is set, `collectionLogic` is omitted (cleared), and a `parent` is included in the same `POST /api/v1/project` body. Verified it fails with the original 500 when the fix is reverted (with the test kept), and passes with the fix applied.

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations