### PR TITLE
fix: stop eager-loading the project tree for root-only listings

### DIFF
--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -99,6 +99,29 @@ import java.util.UUID;
                 @Persistent(name = "metadata"),
                 @Persistent(name = "isLatest")
         }),
+        // ALL minus "children": root-only listings need to know THAT a child exists, not the child's
+        // subtree. Loading children here drags every descendant Project (default fetch group, the
+        // DIRECT_DEPENDENCIES CLOB included) through the ORM for one page of roots.
+        @FetchGroup(name = "ROOT_LIST", members = {
+                @Persistent(name = "name"),
+                @Persistent(name = "authors"),
+                @Persistent(name = "publisher"),
+                @Persistent(name = "supplier"),
+                @Persistent(name = "group"),
+                @Persistent(name = "description"),
+                @Persistent(name = "version"),
+                @Persistent(name = "classifier"),
+                @Persistent(name = "cpe"),
+                @Persistent(name = "purl"),
+                @Persistent(name = "swidTagId"),
+                @Persistent(name = "uuid"),
+                @Persistent(name = "parent"),
+                @Persistent(name = "properties"),
+                @Persistent(name = "tags"),
+                @Persistent(name = "accessTeams"),
+                @Persistent(name = "metadata"),
+                @Persistent(name = "isLatest")
+        }),
         @FetchGroup(name = "METADATA", members = {
                 @Persistent(name = "metadata")
         }),
@@ -153,7 +176,8 @@ public class Project implements Serializable {
         PARENT,
         PORTFOLIO_METRICS_UPDATE,
         PROJECT_TAGS,
-        PROJECT_VULN_ANALYSIS
+        PROJECT_VULN_ANALYSIS,
+        ROOT_LIST
     }
 
     @PrimaryKey

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -52,6 +52,7 @@ import org.dependencytrack.model.PolicyViolation;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectCollectionLogic;
 import org.dependencytrack.model.ProjectMetadata;
+import org.dependencytrack.model.ProjectMetrics;
 import org.dependencytrack.model.ProjectProperty;
 import org.dependencytrack.model.ProjectVersion;
 import org.dependencytrack.model.ServiceComponent;
@@ -126,7 +127,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
 
         if (onlyRoot){
             filterBuilder.excludeChildProjects();
-            query.getFetchPlan().addGroup(Project.FetchGroup.ALL.name());
+            query.getFetchPlan().addGroup(Project.FetchGroup.ROOT_LIST.name());
         }
 
         if(notAssignedToTeam != null) {
@@ -153,9 +154,14 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         if (includeMetrics) {
             // Populate each Project object in the paginated result with transitive related
             // data to minimize the number of round trips a client needs to make, process, and render.
+            // Runs on the managed objects: the metrics query binds by identity, which a detached
+            // copy does not satisfy — withRootChildren carries the result over.
             for (Project project : result.getList(Project.class)) {
                 project.setMetrics(getMostRecentProjectMetrics(project));
             }
+        }
+        if (onlyRoot) {
+            withRootChildren(result);
         }
         return result;
     }
@@ -196,7 +202,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
 
         if (onlyRoot) {
             filterBuilder.excludeChildProjects();
-            query.getFetchPlan().addGroup(Project.FetchGroup.ALL.name());
+            query.getFetchPlan().addGroup(Project.FetchGroup.ROOT_LIST.name());
         }
 
         if(notAssignedToTeam != null) {
@@ -207,7 +213,8 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         final Map<String, Object> params = filterBuilder.getParams();
 
         preprocessACLs(query, queryFilter, params, false);
-        return execute(query, params);
+        final PaginatedResult result = execute(query, params);
+        return onlyRoot ? withRootChildren(result) : result;
     }
 
     /**
@@ -308,14 +315,15 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
 
         if (onlyRoot){
             filterBuilder.excludeChildProjects();
-            query.getFetchPlan().addGroup(Project.FetchGroup.ALL.name());
+            query.getFetchPlan().addGroup(Project.FetchGroup.ROOT_LIST.name());
         }
 
         final String queryFilter = filterBuilder.buildFilter();
         final Map<String, Object> params = filterBuilder.getParams();
 
         preprocessACLs(query, queryFilter, params, bypass);
-        return execute(query, params);
+        final PaginatedResult result = execute(query, params);
+        return onlyRoot ? withRootChildren(result) : result;
     }
 
     /**
@@ -337,7 +345,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
 
         if (onlyRoot){
             filterBuilder.excludeChildProjects();
-            query.getFetchPlan().addGroup(Project.FetchGroup.ALL.name());
+            query.getFetchPlan().addGroup(Project.FetchGroup.ROOT_LIST.name());
         }
 
         if (filter != null) {
@@ -353,9 +361,14 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         if (includeMetrics) {
             // Populate each Project object in the paginated result with transitive related
             // data to minimize the number of round trips a client needs to make, process, and render.
+            // Runs on the managed objects: the metrics query binds by identity, which a detached
+            // copy does not satisfy — withRootChildren carries the result over.
             for (Project project : result.getList(Project.class)) {
                 project.setMetrics(getMostRecentProjectMetrics(project));
             }
+        }
+        if (onlyRoot) {
+            withRootChildren(result);
         }
         return result;
     }
@@ -379,7 +392,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
 
         if (onlyRoot){
             filterBuilder.excludeChildProjects();
-            query.getFetchPlan().addGroup(Project.FetchGroup.ALL.name());
+            query.getFetchPlan().addGroup(Project.FetchGroup.ROOT_LIST.name());
         }
 
         final String queryFilter = filterBuilder.buildFilter();
@@ -390,10 +403,83 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         if (includeMetrics) {
             // Populate each Project object in the paginated result with transitive related
             // data to minimize the number of round trips a client needs to make, process, and render.
+            // Runs on the managed objects: the metrics query binds by identity, which a detached
+            // copy does not satisfy — withRootChildren carries the result over.
             for (Project project : result.getList(Project.class)) {
                 project.setMetrics(getMostRecentProjectMetrics(project));
             }
         }
+        if (onlyRoot) {
+            withRootChildren(result);
+        }
+        return result;
+    }
+
+    /**
+     * Root-only listings used to add {@link Project.FetchGroup#ALL} to the fetch plan so that
+     * {@code children} is populated for the UI's expander. That materialised every descendant
+     * Project with its default fetch group for one page of roots (80–100 s on a 2.5k-project
+     * portfolio). The UI only inspects {@code children[].active} / {@code .classifier}, so we
+     * attach lightweight stubs from one projection query instead.
+     * <p>
+     * Stubs are attached to DETACHED copies: setting a persistent field on a managed object
+     * outside a transaction would be flushed by DataNucleus.
+     */
+    private PaginatedResult withRootChildren(final PaginatedResult result) {
+        final List<Project> roots = result.getList(Project.class);
+        if (roots.isEmpty()) {
+            return result;
+        }
+
+        // metrics is transient, so detachCopy drops it — remember it per id and put it back.
+        final Map<Long, ProjectMetrics> metricsByProjectId = new HashMap<>();
+        for (final Project root : roots) {
+            if (root.getMetrics() != null) {
+                metricsByProjectId.put(root.getId(), root.getMetrics());
+            }
+        }
+
+        final FetchPlan fetchPlan = pm.getFetchPlan();
+        final Set<String> previousGroups = new HashSet<>(fetchPlan.getGroups());
+        final List<Project> detachedRoots;
+        try {
+            fetchPlan.setDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS);
+            fetchPlan.setGroups(FetchPlan.DEFAULT, Project.FetchGroup.ROOT_LIST.name());
+            detachedRoots = new ArrayList<>(pm.detachCopyAll(roots));
+        } finally {
+            fetchPlan.setGroups(previousGroups);
+        }
+        for (final Project root : detachedRoots) {
+            root.setMetrics(metricsByProjectId.get(root.getId()));
+        }
+
+        final List<Long> parentIds = detachedRoots.stream().map(Project::getId).toList();
+        final Map<Long, List<Project>> childrenByParentId = new HashMap<>();
+        final Query<Project> query = pm.newQuery(Project.class);
+        try {
+            query.setFilter(":parentIds.contains(parent.id)");
+            query.setResult("parent.id, uuid, name, version, active, isLatest, classifier");
+            query.setOrdering("name asc, version desc");
+            @SuppressWarnings("unchecked")
+            final List<Object[]> rows = (List<Object[]>) query.executeWithMap(Map.of("parentIds", parentIds));
+            for (final Object[] row : rows) {
+                final Project stub = new Project();
+                stub.setUuid((UUID) row[1]);
+                stub.setName((String) row[2]);
+                stub.setVersion((String) row[3]);
+                stub.setActive((Boolean) row[4]);
+                stub.setIsLatest((Boolean) row[5]);
+                stub.setClassifier((Classifier) row[6]);
+                childrenByParentId.computeIfAbsent((Long) row[0], k -> new ArrayList<>()).add(stub);
+            }
+        } finally {
+            query.closeAll();
+        }
+
+        for (final Project root : detachedRoots) {
+            root.setChildren(childrenByParentId.getOrDefault(root.getId(), List.of()));
+        }
+        result.setObjects(detachedRoots);
         return result;
     }
 

--- a/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
@@ -132,4 +132,44 @@ class ProjectQueryManagerTest extends PersistenceCapableTest {
         }
     }
 
+    @Test
+    public void getRootProjectsAttachesShallowChildrenTest() {
+        final Project root = qm.createProject("root", null, "1.0", null, null, null, true, false);
+        final Project activeChild = qm.createProject("child-active", null, "1.0", null, root, null, true, false);
+        final Project inactiveChild = qm.createProject("child-inactive", null, "1.0", null, root, null, false, false);
+        qm.createProject("grandchild", null, "1.0", null, activeChild, null, true, false);
+        final Project childless = qm.createProject("childless", null, "1.0", null, null, null, true, false);
+        // The dependency-graph CLOB is in the default fetch group; the old code hauled it in for every child.
+        activeChild.setDirectDependencies("[{\"uuid\":\"00000000-0000-0000-0000-000000000000\"}]");
+        qm.persist(activeChild);
+        final long projectCountBefore = qm.getProjects(false, false, false, null).getTotal();
+
+        final List<Project> roots = qm.getProjects(true, false, true, null).getList(Project.class);
+
+        Assert.assertEquals(2, roots.size());
+        final Project rootResult = roots.stream()
+                .filter(p -> p.getUuid().equals(root.getUuid())).findFirst().orElseThrow();
+        Assert.assertNotNull(rootResult.getChildren());
+        Assert.assertEquals(2, rootResult.getChildren().size());
+
+        final Project activeChildStub = rootResult.getChildren().stream()
+                .filter(c -> c.getUuid().equals(activeChild.getUuid())).findFirst().orElseThrow();
+        Assert.assertEquals("child-active", activeChildStub.getName());
+        Assert.assertEquals("1.0", activeChildStub.getVersion());
+        Assert.assertTrue(activeChildStub.isActive());
+        Assert.assertNull("child stubs must not carry their own subtree", activeChildStub.getChildren());
+        Assert.assertNull("child stubs must not carry the dependency-graph CLOB", activeChildStub.getDirectDependencies());
+
+        Assert.assertTrue(rootResult.getChildren().stream()
+                .anyMatch(c -> c.getUuid().equals(inactiveChild.getUuid()) && !c.isActive()));
+
+        final Project childlessResult = roots.stream()
+                .filter(p -> p.getUuid().equals(childless.getUuid())).findFirst().orElseThrow();
+        Assert.assertNotNull("childless roots keep an empty array for the frontend", childlessResult.getChildren());
+        Assert.assertTrue(childlessResult.getChildren().isEmpty());
+
+        Assert.assertEquals("listing must not persist stub children",
+                projectCountBefore, qm.getProjects(false, false, false, null).getTotal());
+    }
+
 }

--- a/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
@@ -133,7 +133,7 @@ class ProjectQueryManagerTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void getRootProjectsAttachesShallowChildrenTest() {
+    void getRootProjectsAttachesShallowChildrenTest() {
         final Project root = qm.createProject("root", null, "1.0", null, null, null, true, false);
         final Project activeChild = qm.createProject("child-active", null, "1.0", null, root, null, true, false);
         final Project inactiveChild = qm.createProject("child-inactive", null, "1.0", null, root, null, false, false);
@@ -143,33 +143,41 @@ class ProjectQueryManagerTest extends PersistenceCapableTest {
         activeChild.setDirectDependencies("[{\"uuid\":\"00000000-0000-0000-0000-000000000000\"}]");
         qm.persist(activeChild);
         final long projectCountBefore = qm.getProjects(false, false, false, null).getTotal();
+        // includeMetrics=true must still populate metrics on the (detached) root rows.
+        final ProjectMetrics rootMetrics = new ProjectMetrics();
+        rootMetrics.setProject(root);
+        rootMetrics.setVulnerabilities(3);
+        rootMetrics.setFirstOccurrence(new Date());
+        rootMetrics.setLastOccurrence(new Date());
+        qm.persist(rootMetrics);
 
         final List<Project> roots = qm.getProjects(true, false, true, null).getList(Project.class);
 
-        Assert.assertEquals(2, roots.size());
+        Assertions.assertEquals(2, roots.size());
         final Project rootResult = roots.stream()
                 .filter(p -> p.getUuid().equals(root.getUuid())).findFirst().orElseThrow();
-        Assert.assertNotNull(rootResult.getChildren());
-        Assert.assertEquals(2, rootResult.getChildren().size());
+        Assertions.assertNotNull(rootResult.getChildren());
+        Assertions.assertEquals(2, rootResult.getChildren().size());
+        Assertions.assertNotNull(rootResult.getMetrics(), "metrics must survive the detach");
+        Assertions.assertEquals(3, rootResult.getMetrics().getVulnerabilities());
 
         final Project activeChildStub = rootResult.getChildren().stream()
                 .filter(c -> c.getUuid().equals(activeChild.getUuid())).findFirst().orElseThrow();
-        Assert.assertEquals("child-active", activeChildStub.getName());
-        Assert.assertEquals("1.0", activeChildStub.getVersion());
-        Assert.assertTrue(activeChildStub.isActive());
-        Assert.assertNull("child stubs must not carry their own subtree", activeChildStub.getChildren());
-        Assert.assertNull("child stubs must not carry the dependency-graph CLOB", activeChildStub.getDirectDependencies());
+        Assertions.assertEquals("child-active", activeChildStub.getName());
+        Assertions.assertEquals("1.0", activeChildStub.getVersion());
+        Assertions.assertTrue(activeChildStub.isActive());
+        Assertions.assertNull(activeChildStub.getChildren(), "child stubs must not carry their own subtree");
+        Assertions.assertNull(activeChildStub.getDirectDependencies(), "child stubs must not carry the dependency-graph CLOB");
 
-        Assert.assertTrue(rootResult.getChildren().stream()
+        Assertions.assertTrue(rootResult.getChildren().stream()
                 .anyMatch(c -> c.getUuid().equals(inactiveChild.getUuid()) && !c.isActive()));
 
         final Project childlessResult = roots.stream()
                 .filter(p -> p.getUuid().equals(childless.getUuid())).findFirst().orElseThrow();
-        Assert.assertNotNull("childless roots keep an empty array for the frontend", childlessResult.getChildren());
-        Assert.assertTrue(childlessResult.getChildren().isEmpty());
+        Assertions.assertNotNull(childlessResult.getChildren(), "childless roots keep an empty array for the frontend");
+        Assertions.assertTrue(childlessResult.getChildren().isEmpty());
 
-        Assert.assertEquals("listing must not persist stub children",
-                projectCountBefore, qm.getProjects(false, false, false, null).getTotal());
+        Assertions.assertEquals(projectCountBefore, qm.getProjects(false, false, false, null).getTotal(), "listing must not persist stub children");
     }
 
 }

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -1837,6 +1837,29 @@ class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
+    void getRootProjectsChildrenAreShallowStubsTest() {
+        Project parent = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
+        Project child = qm.createProject("DEF", null, "1.0", null, parent, null, true, false);
+        qm.createProject("GHI", null, "1.0", null, child, null, true, false);
+        Response response = jersey.target(V1_PROJECT)
+                .queryParam("onlyRoot", true)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        Assertions.assertEquals(200, response.getStatus(), 0);
+        JsonArray children = parseJsonArray(response).getJsonObject(0).getJsonArray("children");
+        Assertions.assertEquals(1, children.size());
+        JsonObject childJson = children.getJsonObject(0);
+        Assertions.assertEquals("DEF", childJson.getString("name"));
+        Assertions.assertEquals("1.0", childJson.getString("version"));
+        Assertions.assertEquals(child.getUuid().toString(), childJson.getString("uuid"));
+        Assertions.assertTrue(childJson.getBoolean("active"));
+        Assertions.assertFalse(childJson.getBoolean("isLatest"));
+        Assertions.assertFalse(childJson.containsKey("children"), "stubs must not serialise a subtree");
+        Assertions.assertFalse(childJson.containsKey("directDependencies"), "stubs must not serialise the dependency graph");
+    }
+
+    @Test
     void getChildrenProjectsTest() {
         Project parent = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         Project child = qm.createProject("DEF", null, "1.0", null, parent, null, true, false);


### PR DESCRIPTION
Fixes #7263

`onlyRoot=true` added `FetchGroup.ALL`, whose `children` member materialises every descendant `Project` (default fetch group, `DIRECT_DEPENDENCIES` CLOB included, recursing into grandchildren) to render one page of roots — 80–100 s on a 2.5k-project portfolio (numbers in the linked issue).

This introduces `Project.FetchGroup.ROOT_LIST` (= `ALL` minus `children`) for the five `onlyRoot` sites in `ProjectQueryManager`, and `withRootChildren()`, which attaches shallow child stubs (`uuid, name, version, active, isLatest, classifier`) from a single projection query. Stubs are attached to detached copies so no managed object is mutated outside a transaction; the transient `metrics` is carried over by id because `getMostRecentProjectMetrics` binds by identity and detach drops transient fields.

Wire format for the frontend is unchanged: `children` is still an array, elements still carry `active`/`classifier`, childless roots still get `[]`. Only the unused subtree and the per-child CLOB disappear from the payload.

Tests:
- `ProjectQueryManagerTest#getRootProjectsAttachesShallowChildrenTest` — fails before (`expected null, but was:<[grandchild : 1.0]>`), passes after; also asserts metrics survive and nothing is persisted.
- `ProjectResourceTest#getRootProjectsChildrenAreShallowStubsTest` — JSON contract of the stubs.

Measured on a 2,484-project / 87-root portfolio with the patch applied to 4.12.4: `onlyRoot=true&pageSize=100` 96.6 s → 1.3–2.5 s; flat view unchanged; expander still lazy-loads via `/children`.

The touched code is identical from 4.12.4 through `master`.
