### PR TITLE
Improve efficiency of is_dependency_of and is_exclusive_dependency_of CEL functions

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyFunctions.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyFunctions.java
@@ -42,16 +42,11 @@ import java.time.Period;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.substringAfter;
 import static org.dependencytrack.persistence.jdbi.JdbiAttributes.ATTRIBUTE_QUERY_NAME;
@@ -136,18 +131,18 @@ final class CelPolicyFunctions {
         }
     }
 
-    static boolean isDependencyOf(final Component leafComponent, final Component rootComponent) {
-        if (leafComponent.getUuid().isBlank()) {
-            LOGGER.warn("%s: leaf component does not have a UUID; Unable to evaluate, returning false"
+    static boolean isDependencyOf(final Component dependencyComponent, final Component dependentTemplate) {
+        if (dependencyComponent.getUuid().isBlank()) {
+            LOGGER.warn("%s: dependency component does not have a UUID; Unable to evaluate, returning false"
                     .formatted(IS_DEPENDENCY_OF.functionName()));
             return false;
         }
 
-        final var compositeNodeFilter = CompositeDependencyNodeFilter.of(rootComponent);
+        final var compositeNodeFilter = CompositeDependencyNodeFilter.of(dependentTemplate);
         if (!compositeNodeFilter.hasSqlFilters()) {
             LOGGER.warn("""
-                    %s: Unable to construct filter expression from root component %s; \
-                    Unable to evaluate, returning false""".formatted(IS_DEPENDENCY_OF.functionName(), rootComponent));
+                    %s: Unable to construct filter expression from dependent component %s; \
+                    Unable to evaluate, returning false""".formatted(IS_DEPENDENCY_OF.functionName(), dependentTemplate));
             return false;
         }
 
@@ -157,7 +152,7 @@ final class CelPolicyFunctions {
                         WITH RECURSIVE "CTE_PROJECT" AS (
                           SELECT "PROJECT_ID" AS "ID"
                             FROM "COMPONENT"
-                           WHERE "UUID" = :leafComponentUuid
+                           WHERE "UUID" = :dependencyUuid
                         ),
                         "CTE_MATCHES" AS (
                           SELECT "ID"
@@ -166,29 +161,26 @@ final class CelPolicyFunctions {
                              AND "DIRECT_DEPENDENCIES" IS NOT NULL
                              AND ${filters}
                         ),
-                        "CTE_DEPENDENCIES" ("UUID", "PROJECT_ID", "FOUND", "PATH") AS (
+                        "CTE_DEPENDENTS" ("UUID", "PROJECT_ID", "FOUND") AS (
                           SELECT "C"."UUID"                                       AS "UUID"
                                , "C"."PROJECT_ID"                                 AS "PROJECT_ID"
                                , ("C"."ID" = ANY(SELECT "ID" FROM "CTE_MATCHES")) AS "FOUND"
-                               , ARRAY["C"."ID"]::BIGINT[]                        AS "PATH"
                             FROM "COMPONENT" AS "C"
                            WHERE EXISTS(SELECT 1 FROM "CTE_MATCHES")
                              AND "C"."PROJECT_ID" = (SELECT "ID" FROM "CTE_PROJECT")
-                             AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', :leafComponentUuid))
-                          UNION ALL
+                             AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', :dependencyUuid))
+                          UNION
                           SELECT "C"."UUID"                                       AS "UUID"
                                , "C"."PROJECT_ID"                                 AS "PROJECT_ID"
                                , ("C"."ID" = ANY(SELECT "ID" FROM "CTE_MATCHES")) AS "FOUND"
-                               , ARRAY_APPEND("PREVIOUS"."PATH", "C"."ID")        AS "PATH"
                             FROM "COMPONENT" AS "C"
-                           INNER JOIN "CTE_DEPENDENCIES" AS "PREVIOUS"
+                           INNER JOIN "CTE_DEPENDENTS" AS "PREVIOUS"
                               ON "PREVIOUS"."PROJECT_ID" = "C"."PROJECT_ID"
                            WHERE NOT "PREVIOUS"."FOUND"
-                             AND NOT ("C"."ID" = ANY("PREVIOUS"."PATH"))
                              AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', "PREVIOUS"."UUID"))
                         )
                         SELECT BOOL_OR("FOUND")
-                          FROM "CTE_DEPENDENCIES"
+                          FROM "CTE_DEPENDENTS"
                         """);
 
                 return query.define(
@@ -196,7 +188,7 @@ final class CelPolicyFunctions {
                                 "%s#isDependencyOf_withoutInMemoryFilters"
                                         .formatted(CelPolicyFunctions.class.getSimpleName()))
                         .define("filters", compositeNodeFilter.sqlFiltersConjunctive())
-                        .bind("leafComponentUuid", UUID.fromString(leafComponent.getUuid()))
+                        .bind("dependencyUuid", UUID.fromString(dependencyComponent.getUuid()))
                         .bindMap(compositeNodeFilter.sqlFilterParams())
                         .mapTo(Boolean.class)
                         .findOne()
@@ -207,7 +199,7 @@ final class CelPolicyFunctions {
                     WITH RECURSIVE "CTE_PROJECT" AS (
                       SELECT "PROJECT_ID" AS "ID"
                         FROM "COMPONENT"
-                       WHERE "UUID" = :leafComponentUuid
+                       WHERE "UUID" = :dependencyUuid
                     ),
                     "CTE_MATCHES" AS (
                       SELECT "ID"
@@ -216,7 +208,7 @@ final class CelPolicyFunctions {
                          AND "DIRECT_DEPENDENCIES" IS NOT NULL
                          AND ${filters}
                     ),
-                    "CTE_DEPENDENCIES" ("UUID", "PROJECT_ID", ${selectColumnNames?join(", ", "", ", ")} "FOUND", "PATH") AS (
+                    "CTE_DEPENDENTS" ("UUID", "PROJECT_ID", ${selectColumnNames?join(", ", "", ", ")} "FOUND") AS (
                       SELECT "C"."UUID" AS "UUID"
                            , "C"."PROJECT_ID" AS "PROJECT_ID"
                            <#list selectColumnNames as columnName>
@@ -226,12 +218,11 @@ final class CelPolicyFunctions {
                              END AS ${columnName}
                            </#list>
                            , ("C"."ID" = ANY(SELECT "ID" FROM "CTE_MATCHES")) AS "FOUND"
-                           , ARRAY["C"."ID"]::BIGINT[] AS "PATH"
                         FROM "COMPONENT" AS "C"
                        WHERE EXISTS(SELECT 1 FROM "CTE_MATCHES")
                          AND "C"."PROJECT_ID" = (SELECT "ID" FROM "CTE_PROJECT")
-                         AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', :leafComponentUuid))
-                      UNION ALL
+                         AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', :dependencyUuid))
+                      UNION
                       SELECT "C"."UUID" AS "UUID"
                            , "C"."PROJECT_ID" AS "PROJECT_ID"
                            <#list selectColumnNames as columnName>
@@ -241,15 +232,13 @@ final class CelPolicyFunctions {
                              END AS ${columnName}
                            </#list>
                            , ("C"."ID" = ANY(SELECT "ID" FROM "CTE_MATCHES")) AS "FOUND"
-                           , ARRAY_APPEND("PREVIOUS"."PATH", "C"."ID") AS "PATH"
                         FROM "COMPONENT" AS "C"
-                       INNER JOIN "CTE_DEPENDENCIES" AS "PREVIOUS"
+                       INNER JOIN "CTE_DEPENDENTS" AS "PREVIOUS"
                           ON "PREVIOUS"."PROJECT_ID" = "C"."PROJECT_ID"
-                       WHERE NOT ("C"."ID" = ANY("PREVIOUS"."PATH"))
-                         AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', "PREVIOUS"."UUID"))
+                       WHERE "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', "PREVIOUS"."UUID"))
                     )
                     SELECT ${selectColumnNames?join(", ")}
-                      FROM "CTE_DEPENDENCIES"
+                      FROM "CTE_DEPENDENTS"
                      WHERE "FOUND"
                     """);
 
@@ -259,7 +248,7 @@ final class CelPolicyFunctions {
                             "%s#isDependencyOf_withInMemoryFilters".formatted(CelPolicyFunctions.class.getSimpleName()))
                     .define("filters", compositeNodeFilter.sqlFiltersConjunctive())
                     .define("selectColumnNames", compositeNodeFilter.sqlSelectColumns())
-                    .bind("leafComponentUuid", UUID.fromString(leafComponent.getUuid()))
+                    .bind("dependencyUuid", UUID.fromString(dependencyComponent.getUuid()))
                     .bindMap(compositeNodeFilter.sqlFilterParams())
                     .map(ConstructorMapper.of(DependencyNode.class))
                     .stream()
@@ -267,119 +256,124 @@ final class CelPolicyFunctions {
         }
     }
 
-    static boolean isExclusiveDependencyOf(final Component leafComponent, final Component rootComponent) {
-        if (leafComponent.getUuid().isBlank()) {
-            LOGGER.warn("%s: leaf component does not have a UUID; Unable to evaluate, returning false"
+    static boolean isExclusiveDependencyOf(final Component dependencyComponent, final Component dependentTemplate) {
+        if (dependencyComponent.getUuid().isBlank()) {
+            LOGGER.warn("%s: dependency component does not have a UUID; Unable to evaluate, returning false"
                     .formatted(IS_EXCLUSIVE_DEPENDENCY_OF.functionName()));
             return false;
         }
 
-        final var compositeNodeFilter = CompositeDependencyNodeFilter.of(rootComponent);
+        final var compositeNodeFilter = CompositeDependencyNodeFilter.of(dependentTemplate);
         if (!compositeNodeFilter.hasSqlFilters()) {
             LOGGER.warn("""
-                    %s: Unable to construct filter expression from root component %s; \
-                    Unable to evaluate, returning false""".formatted(IS_EXCLUSIVE_DEPENDENCY_OF.functionName(), rootComponent));
+                    %s: Unable to construct filter expression from dependent component %s; \
+                    Unable to evaluate, returning false""".formatted(IS_EXCLUSIVE_DEPENDENCY_OF.functionName(), dependentTemplate));
             return false;
         }
 
         try (final Handle jdbiHandle = openJdbiHandle()) {
-            if (new CelPolicyDao(jdbiHandle).isDirectDependency(leafComponent)) {
+            if (new CelPolicyDao(jdbiHandle).isDirectDependency(dependencyComponent)) {
                 return false;
             }
 
+            final Query matchesQuery = jdbiHandle.createQuery("""
+                    WITH "CTE_PROJECT" AS (
+                      SELECT "PROJECT_ID" AS "ID"
+                        FROM "COMPONENT"
+                       WHERE "UUID" = :dependencyUuid
+                    )
+                    SELECT ${selectColumnNames?join(", ", "", ", ")} "ID"
+                      FROM "COMPONENT"
+                     WHERE "PROJECT_ID" = (SELECT "ID" FROM "CTE_PROJECT")
+                       AND "DIRECT_DEPENDENCIES" IS NOT NULL
+                       AND ${filters}
+                    """);
+
+            final List<Long> matchedComponentIds = matchesQuery
+                    .define(
+                            ATTRIBUTE_QUERY_NAME,
+                            "%s#isExclusiveDependencyOf_matches".formatted(CelPolicyFunctions.class.getSimpleName()))
+                    .define("filters", compositeNodeFilter.sqlFiltersConjunctive())
+                    .define("selectColumnNames", compositeNodeFilter.sqlSelectColumns())
+                    .bind("dependencyUuid", UUID.fromString(dependencyComponent.getUuid()))
+                    .bindMap(compositeNodeFilter.sqlFilterParams())
+                    .map(ConstructorMapper.of(DependencyNode.class))
+                    .stream()
+                    .filter(compositeNodeFilter.inMemoryFiltersConjunctive())
+                    .map(DependencyNode::id)
+                    .toList();
+            if (matchedComponentIds.isEmpty()) {
+                return false;
+            }
+
+            // Walk the graph upwards from the dependency component, stopping at matching components.
+            // It is an exclusive dependency of them if no path escapes to a component that is a
+            // direct dependency of the project, or that nothing else depends on.
             final Query query = jdbiHandle.createQuery("""
                     WITH RECURSIVE "CTE_PROJECT" AS (
                       SELECT "PROJECT_ID" AS "ID"
                         FROM "COMPONENT"
-                       WHERE "UUID" = :leafComponentUuid
+                       WHERE "UUID" = :dependencyUuid
                     ),
-                    "CTE_MATCHES" AS (
-                      SELECT "ID"
-                        FROM "COMPONENT"
-                       WHERE "PROJECT_ID" = (SELECT "ID" FROM "CTE_PROJECT")
-                         AND "DIRECT_DEPENDENCIES" IS NOT NULL
-                         AND ${filters}
-                    ),
-                    "CTE_DEPENDENCIES" ("ID", "UUID", "PROJECT_ID", ${selectColumnNames?join(", ", "", ", ")} "FOUND", "PATH") AS (
-                      SELECT "C"."ID" AS "ID"
-                           , "C"."UUID" AS "UUID"
+                    "CTE_DEPENDENTS" ("UUID", "PROJECT_ID", "FOUND") AS (
+                      SELECT "C"."UUID" AS "UUID"
                            , "C"."PROJECT_ID" AS "PROJECT_ID"
-                           <#list selectColumnNames as columnName>
-                           , CASE
-                               WHEN ("C"."ID" = ANY(SELECT "ID" FROM "CTE_MATCHES"))
-                               THEN "C".${columnName}
-                             END AS ${columnName}
-                           </#list>
-                           , ("C"."ID" = ANY(SELECT "ID" FROM "CTE_MATCHES")) AS "FOUND"
-                           , ARRAY["C"."ID"]::BIGINT[] AS "PATH"
+                           , ("C"."ID" = ANY(:matchedComponentIds)) AS "FOUND"
                         FROM "COMPONENT" AS "C"
-                       WHERE EXISTS(SELECT 1 FROM "CTE_MATCHES")
-                         AND "C"."PROJECT_ID" = (SELECT "ID" FROM "CTE_PROJECT")
-                         AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', :leafComponentUuid))
-                      UNION ALL
-                      SELECT "C"."ID" AS "ID"
-                           , "C"."UUID" AS "UUID"
+                       WHERE "C"."PROJECT_ID" = (SELECT "ID" FROM "CTE_PROJECT")
+                         AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', :dependencyUuid))
+                      UNION
+                      SELECT "C"."UUID" AS "UUID"
                            , "C"."PROJECT_ID" AS "PROJECT_ID"
-                           <#list selectColumnNames as columnName>
-                           , CASE
-                               WHEN ("C"."ID" = ANY(SELECT "ID" FROM "CTE_MATCHES"))
-                               THEN "C".${columnName}
-                             END AS ${columnName}
-                           </#list>
-                           , ("C"."ID" = ANY(SELECT "ID" FROM "CTE_MATCHES")) AS "FOUND"
-                           , ARRAY_APPEND("PREVIOUS"."PATH", "C"."ID") AS "PATH"
+                           , ("C"."ID" = ANY(:matchedComponentIds)) AS "FOUND"
                         FROM "COMPONENT" AS "C"
-                       INNER JOIN "CTE_DEPENDENCIES" AS "PREVIOUS"
+                       INNER JOIN "CTE_DEPENDENTS" AS "PREVIOUS"
                           ON "PREVIOUS"."PROJECT_ID" = "C"."PROJECT_ID"
-                       WHERE NOT ("C"."ID" = ANY("PREVIOUS"."PATH"))
+                       WHERE NOT "PREVIOUS"."FOUND"
                          AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', "PREVIOUS"."UUID"))
                     )
-                    SELECT "ID"
-                         , ${selectColumnNames?join(", ", "", ", ")} "FOUND"
-                         , "PATH"
-                      FROM "CTE_DEPENDENCIES"
+                    SELECT EXISTS(SELECT 1 FROM "CTE_DEPENDENTS")
+                       AND NOT EXISTS(
+                         SELECT 1
+                           FROM "CTE_DEPENDENTS" AS "DEPENDENT"
+                          WHERE NOT "DEPENDENT"."FOUND"
+                            AND (EXISTS(
+                              SELECT 1
+                                FROM "PROJECT"
+                               WHERE "PROJECT"."ID" = "DEPENDENT"."PROJECT_ID"
+                                 AND "PROJECT"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', "DEPENDENT"."UUID")))
+                                  OR NOT EXISTS(
+                                    SELECT 1
+                                      FROM "COMPONENT" AS "DIRECT_DEPENDENT"
+                                     WHERE "DIRECT_DEPENDENT"."PROJECT_ID" = "DEPENDENT"."PROJECT_ID"
+                                       AND "DIRECT_DEPENDENT"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', "DEPENDENT"."UUID"))
+                                  )
+                            )
+                       )
                     """);
 
-            final List<DependencyNode> nodes = query.define(
+            return query.define(
                             ATTRIBUTE_QUERY_NAME,
                             "%s#isExclusiveDependencyOf".formatted(CelPolicyFunctions.class.getSimpleName()))
-                    .define("filters", compositeNodeFilter.sqlFiltersConjunctive())
-                    .define("selectColumnNames", compositeNodeFilter.sqlSelectColumns())
-                    .bind("leafComponentUuid", UUID.fromString(leafComponent.getUuid()))
-                    .bindMap(compositeNodeFilter.sqlFilterParams())
-                    .map(ConstructorMapper.of(DependencyNode.class))
-                    .list();
-            if (nodes.isEmpty()) {
-                return false;
-            }
-
-            final Set<Long> matchedNodeIds = nodes.stream()
-                    .filter(node -> node.found() != null && node.found())
-                    .filter(compositeNodeFilter.inMemoryFiltersConjunctive())
-                    .map(DependencyNode::id)
-                    .collect(Collectors.toSet());
-            if (matchedNodeIds.isEmpty()) {
-                return false;
-            }
-
-            final List<List<Long>> paths = reducePaths(nodes);
-
-            return paths.stream().allMatch(path -> path.stream().anyMatch(matchedNodeIds::contains));
+                    .bind("dependencyUuid", UUID.fromString(dependencyComponent.getUuid()))
+                    .bindArray("matchedComponentIds", Long.class, matchedComponentIds)
+                    .mapTo(Boolean.class)
+                    .one();
         }
     }
 
-    static boolean isDirectDependencyOf(final Component childComponent, final Component parentTemplate) {
-        if (childComponent.getUuid().isBlank()) {
-            LOGGER.warn("%s: leaf component does not have a UUID; returning false"
+    static boolean isDirectDependencyOf(final Component dependencyComponent, final Component dependentTemplate) {
+        if (dependencyComponent.getUuid().isBlank()) {
+            LOGGER.warn("%s: dependency component does not have a UUID; returning false"
                     .formatted(IS_DIRECT_DEPENDENCY_OF.functionName()));
             return false;
         }
 
-        final var compositeNodeFilter = CompositeDependencyNodeFilter.of(parentTemplate);
+        final var compositeNodeFilter = CompositeDependencyNodeFilter.of(dependentTemplate);
         if (!compositeNodeFilter.hasSqlFilters()) {
             LOGGER.warn("""
-                    %s: Unable to construct filter expression from parent component %s; \
-                    returning false""".formatted(IS_DIRECT_DEPENDENCY_OF.functionName(), parentTemplate));
+                    %s: Unable to construct filter expression from dependent component %s; \
+                    returning false""".formatted(IS_DIRECT_DEPENDENCY_OF.functionName(), dependentTemplate));
             return false;
         }
 
@@ -389,14 +383,14 @@ final class CelPolicyFunctions {
                         WITH "CTE_PROJECT" AS (
                           SELECT "PROJECT_ID" AS "ID"
                             FROM "COMPONENT"
-                           WHERE "UUID" = :childUuid
+                           WHERE "UUID" = :dependencyUuid
                         )
                         SELECT EXISTS(
                           SELECT 1
-                            FROM "COMPONENT" AS "PARENT"
-                           WHERE "PARENT"."PROJECT_ID" = (SELECT "ID" FROM "CTE_PROJECT")
-                             AND "PARENT"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(
-                                   JSONB_BUILD_OBJECT('uuid', :childUuid))
+                            FROM "COMPONENT" AS "DEPENDENT"
+                           WHERE "DEPENDENT"."PROJECT_ID" = (SELECT "ID" FROM "CTE_PROJECT")
+                             AND "DEPENDENT"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(
+                                   JSONB_BUILD_OBJECT('uuid', :dependencyUuid))
                              AND ${filters}
                         )
                         """);
@@ -405,7 +399,7 @@ final class CelPolicyFunctions {
                                 "%s#isDirectDependencyOf_withoutInMemoryFilters"
                                         .formatted(CelPolicyFunctions.class.getSimpleName()))
                         .define("filters", compositeNodeFilter.sqlFiltersConjunctive())
-                        .bind("childUuid", UUID.fromString(childComponent.getUuid()))
+                        .bind("dependencyUuid", UUID.fromString(dependencyComponent.getUuid()))
                         .bindMap(compositeNodeFilter.sqlFilterParams())
                         .mapTo(Boolean.class)
                         .one();
@@ -415,30 +409,14 @@ final class CelPolicyFunctions {
                     WITH "CTE_PROJECT" AS (
                       SELECT "PROJECT_ID" AS "ID"
                         FROM "COMPONENT"
-                       WHERE "UUID" = :childUuid
-                    ),
-                    "CTE_PARENTS" ("ID", "UUID", "PROJECT_ID"
-                         , ${selectColumnNames?join(", ", "", ", ")} "FOUND", "PATH") AS (
-                      SELECT "PARENT"."ID" AS "ID"
-                           , "PARENT"."UUID" AS "UUID"
-                           , "PARENT"."PROJECT_ID" AS "PROJECT_ID"
-                           <#list selectColumnNames as columnName>
-                           , "PARENT".${columnName} AS ${columnName}
-                           </#list>
-                           , TRUE AS "FOUND"
-                           , ARRAY["PARENT"."ID"]::BIGINT[] AS "PATH"
-                        FROM "COMPONENT" AS "PARENT"
-                       WHERE "PARENT"."PROJECT_ID" = (SELECT "ID" FROM "CTE_PROJECT")
-                         AND "PARENT"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(
-                               JSONB_BUILD_OBJECT('uuid', :childUuid))
-                         AND ${filters}
+                       WHERE "UUID" = :dependencyUuid
                     )
-                    SELECT "ID"
-                         , "UUID"
-                         , "PROJECT_ID"
-                         , ${selectColumnNames?join(", ", "", ", ")} "FOUND"
-                         , "PATH"
-                      FROM "CTE_PARENTS"
+                    SELECT ${selectColumnNames?join(", ", "", ", ")} "DEPENDENT"."ID" AS "ID"
+                      FROM "COMPONENT" AS "DEPENDENT"
+                     WHERE "DEPENDENT"."PROJECT_ID" = (SELECT "ID" FROM "CTE_PROJECT")
+                       AND "DEPENDENT"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(
+                             JSONB_BUILD_OBJECT('uuid', :dependencyUuid))
+                       AND ${filters}
                     """);
 
             return query
@@ -448,7 +426,7 @@ final class CelPolicyFunctions {
                                     .formatted(CelPolicyFunctions.class.getSimpleName()))
                     .define("filters", compositeNodeFilter.sqlFiltersConjunctive())
                     .define("selectColumnNames", compositeNodeFilter.sqlSelectColumns())
-                    .bind("childUuid", UUID.fromString(childComponent.getUuid()))
+                    .bind("dependencyUuid", UUID.fromString(dependencyComponent.getUuid()))
                     .bindMap(compositeNodeFilter.sqlFilterParams())
                     .map(ConstructorMapper.of(DependencyNode.class))
                     .stream()
@@ -610,44 +588,8 @@ final class CelPolicyFunctions {
         return SpdxExpressions.requiresAny(expr, (List<String>) ids);
     }
 
-    /**
-     * Reduce paths of all {@link DependencyNode}s to complete, unique paths.
-     * e.g. [[3, 2, 1], [2, 1], [1]] reduces to [[3, 2, 1]].
-     */
-    static List<List<Long>> reducePaths(final List<DependencyNode> nodes) {
-        return nodes.stream()
-                .map(DependencyNode::path)
-                .sorted(Collections.reverseOrder(Comparator.comparingInt(List::size)))
-                .collect(
-                        ArrayList::new,
-                        (ArrayList<List<Long>> paths, List<Long> newPath) -> {
-                            final boolean isCovered = paths.stream().anyMatch(path -> containsExactly(path, newPath));
-                            if (!isCovered) {
-                                paths.add(newPath);
-                            }
-                        },
-                        ArrayList::addAll);
-    }
-
-    private static <T> boolean containsExactly(final List<T> lhs, final List<T> rhs) {
-        final int lhsSize = lhs.size();
-        final int rhsSize = rhs.size();
-        final int maxSize = Math.min(lhsSize, rhsSize);
-
-        if (lhsSize > rhsSize) {
-            return Objects.equals(lhs.subList(0, maxSize), rhs);
-        } else if (lhsSize < rhsSize) {
-            return Objects.equals(lhs, rhs.subList(0, maxSize));
-        }
-
-        return Objects.equals(lhs, rhs);
-    }
-
     public record DependencyNode(
-            @Nullable Long id,
-            @Nullable String version,
-            @Nullable Boolean found,
-            @Nullable List<Long> path) {}
+            @Nullable Long id, @Nullable String version) {}
 
     record CompositeDependencyNodeFilter(
             List<String> sqlFilters,

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
@@ -52,6 +52,7 @@ import org.dependencytrack.persistence.jdbi.PackageMetadataDao;
 import org.dependencytrack.persistence.jdbi.VulnerabilityAliasDao;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -2087,6 +2088,123 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
         assertThat(qm.getAllPolicyViolations(componentSpringBeans)).hasSize(1);
         assertThat(qm.getAllPolicyViolations(componentSpringExpression)).hasSize(1);
         assertThat(qm.getAllPolicyViolations(componentSpringCore)).hasSize(1);
+    }
+
+    @Test
+    @Timeout(60)
+    void testEvaluateProjectWithFuncComponentIsDependencyOfExclusiveComponentWithChainedDiamonds() throws Exception {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        //          /-> node-1 -\           /-> node-4 -\
+        // * -> node-0            > node-3 -             > node-6 -> ...
+        //          \-> node-2 -/           \-> node-5 -/
+        final int diamondCount = 20;
+        final var nodes = new ArrayList<Component>();
+        for (int i = 0; i <= diamondCount * 3; i++) {
+            final var component = new Component();
+            component.setProject(project);
+            component.setName("node-" + i);
+            qm.persist(component);
+            nodes.add(component);
+        }
+
+        project.setDirectDependencies("[%s]".formatted(new ComponentIdentity(nodes.getFirst()).toJSON()));
+        qm.persist(project);
+        for (int i = 0; i < diamondCount; i++) {
+            final Component top = nodes.get(i * 3);
+            final Component left = nodes.get(i * 3 + 1);
+            final Component right = nodes.get(i * 3 + 2);
+            final Component bottom = nodes.get(i * 3 + 3);
+            top.setDirectDependencies(
+                    "[%s, %s]".formatted(new ComponentIdentity(left).toJSON(), new ComponentIdentity(right).toJSON()));
+            left.setDirectDependencies("[%s]".formatted(new ComponentIdentity(bottom).toJSON()));
+            right.setDirectDependencies("[%s]".formatted(new ComponentIdentity(bottom).toJSON()));
+            qm.persist(top);
+            qm.persist(left);
+            qm.persist(right);
+        }
+
+        final Component lastNode = nodes.getLast();
+
+        final var policyEngine = new CelPolicyEngine();
+        final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
+
+        // Every path from the last node to the project root passes through the first node.
+        final PolicyCondition condition = qm.createPolicyCondition(
+                policy,
+                PolicyCondition.Subject.EXPRESSION,
+                PolicyCondition.Operator.MATCHES,
+                """
+                        component.is_exclusive_dependency_of(v1.Component{name: "node-0"})
+                        """,
+                PolicyViolation.Type.OPERATIONAL);
+        policyEngine.evaluateProject(project.getUuid());
+        assertThat(qm.getAllPolicyViolations(lastNode)).hasSize(1);
+
+        // Only one side of the first diamond leads through node-1.
+        condition.setValue("""
+                component.is_exclusive_dependency_of(v1.Component{name: "node-1"})
+                """);
+        policyEngine.evaluateProject(project.getUuid());
+        assertThat(qm.getAllPolicyViolations(lastNode)).isEmpty();
+    }
+
+    @Test
+    void testEvaluateProjectWithFuncComponentIsDependencyOfExclusiveComponentWithUnreachableParent() throws Exception {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var componentA = new Component();
+        componentA.setProject(project);
+        componentA.setName("acme-lib-a");
+        qm.persist(componentA);
+
+        final var componentB = new Component();
+        componentB.setProject(project);
+        componentB.setName("acme-lib-b");
+        qm.persist(componentB);
+
+        final var componentC = new Component();
+        componentC.setProject(project);
+        componentC.setName("acme-lib-c");
+        qm.persist(componentC);
+
+        // C depends on A, but nothing depends on C, making it unreachable from the project.
+        //
+        // * -> A -> B
+        //      ^
+        //      C
+        project.setDirectDependencies("[%s]".formatted(new ComponentIdentity(componentA).toJSON()));
+        componentA.setDirectDependencies("[%s]".formatted(new ComponentIdentity(componentB).toJSON()));
+        componentC.setDirectDependencies("[%s]".formatted(new ComponentIdentity(componentA).toJSON()));
+        qm.persist(project);
+        qm.persist(componentA);
+        qm.persist(componentC);
+
+        final var policyEngine = new CelPolicyEngine();
+        final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
+
+        // B is introduced exclusively through A.
+        final PolicyCondition condition = qm.createPolicyCondition(
+                policy,
+                PolicyCondition.Subject.EXPRESSION,
+                PolicyCondition.Operator.MATCHES,
+                """
+                        component.is_exclusive_dependency_of(v1.Component{name: "acme-lib-a"})
+                        """,
+                PolicyViolation.Type.OPERATIONAL);
+        policyEngine.evaluateProject(project.getUuid());
+        assertThat(qm.getAllPolicyViolations(componentB)).hasSize(1);
+
+        // B is not introduced through C at all.
+        condition.setValue("""
+                component.is_exclusive_dependency_of(v1.Component{name: "acme-lib-c"})
+                """);
+        policyEngine.evaluateProject(project.getUuid());
+        assertThat(qm.getAllPolicyViolations(componentB)).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

* Refactors `is_dependency_of` to use a `UNION` for deduplication instead of `UNION ALL` + path deduplication in Java. For diamond-shaped graphs the number of paths grow exponentially which made collecting them all expensive.
* Refactors `is_exclusive_dependency_of` to short-circuit when matches are found.

Also clarifies wording, i.e. parent/child -> dependent/dependency.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
