### PR TITLE
Fix management server preventing shutdown on initialization failures

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/Application.java
+++ b/apiserver/src/main/java/org/dependencytrack/Application.java
@@ -99,12 +99,15 @@ public final class Application {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Application.class);
 
-    public static void main(final String[] args) {
+    public static void main(final String[] args) throws Exception {
         SLF4JBridgeHandler.removeHandlersForRootLogger();
         SLF4JBridgeHandler.install();
 
         final Config config = ConfigProvider.getConfig();
         new LoggingConfiguration(config).apply((LoggerContext) LoggerFactory.getILoggerFactory());
+
+        Thread.setDefaultUncaughtExceptionHandler(
+                (thread, throwable) -> LOGGER.error("Unhandled exception in thread {}", thread.getName(), throwable));
 
         LOGGER.info(
                 "Starting {} {} (built {})",
@@ -147,41 +150,28 @@ public final class Application {
                 config.getOptionalValue(ConfigKeys.MANAGEMENT_PORT, int.class).orElse(9000);
         final var managementServer = new ManagementServer(
                 managementHost, managementPort, healthCheckRegistry, prometheusMeterRegistry, config);
-        try {
-            managementServer.start();
-        } catch (Exception e) {
-            LOGGER.error("Failed to start management server", e);
-            System.exit(-1);
-        }
+        managementServer.start();
 
         // Execute init tasks.
-        // Failures must exit the JVM explicitly: the management server started above
-        // keeps the JVM alive with its non-daemon threads, so an exception escaping
-        // the main thread would leave the process running but forever unready.
         final var dataSourceRegistry = DataSourceRegistry.getInstance();
         if (config.getValue(ConfigKeys.INIT_TASKS_ENABLED, boolean.class)) {
-            try {
-                final String dataSourceName = config.getValue(ConfigKeys.INIT_TASKS_DATASOURCE_NAME, String.class);
-                final var initTaskExecutor =
-                        new InitTaskExecutor(config, dataSourceRegistry.get(dataSourceName), initTasksHealthCheck);
+            final String dataSourceName = config.getValue(ConfigKeys.INIT_TASKS_DATASOURCE_NAME, String.class);
+            final var initTaskExecutor =
+                    new InitTaskExecutor(config, dataSourceRegistry.get(dataSourceName), initTasksHealthCheck);
 
-                // NB: Init tasks include schema migrations, whose statements legitimately
-                // run longer than the default query timeout allows. Bypass the timeout for them.
-                QueryTimeout.bypassing(() -> {
-                    initTaskExecutor.execute();
-                    return null;
-                });
+            // NB: Init tasks include schema migrations, whose statements legitimately
+            // run longer than the default query timeout allows. Bypass the timeout for them.
+            QueryTimeout.bypassing(() -> {
+                initTaskExecutor.execute();
+                return null;
+            });
 
-                if (config.getValue(ConfigKeys.INIT_TASKS_DATASOURCE_CLOSE_AFTER_COMPLETION, boolean.class)) {
-                    dataSourceRegistry.close(dataSourceName);
-                }
-                if (config.getValue(ConfigKeys.INIT_TASKS_EXIT_AFTER_COMPLETION, boolean.class)) {
-                    LOGGER.info("Exiting because dt.init-tasks.exit-after-completion is enabled");
-                    System.exit(0);
-                }
-            } catch (Exception e) {
-                LOGGER.error("Failed to execute init tasks", e);
-                System.exit(-1);
+            if (config.getValue(ConfigKeys.INIT_TASKS_DATASOURCE_CLOSE_AFTER_COMPLETION, boolean.class)) {
+                dataSourceRegistry.close(dataSourceName);
+            }
+            if (config.getValue(ConfigKeys.INIT_TASKS_EXIT_AFTER_COMPLETION, boolean.class)) {
+                LOGGER.info("Exiting because dt.init-tasks.exit-after-completion is enabled");
+                System.exit(0);
             }
         }
         initTasksHealthCheck.markInitialized();
@@ -214,12 +204,7 @@ public final class Application {
 
         final URL staticUrl = Application.class.getResource("/static");
         if (staticUrl != null) {
-            try {
-                context.setBaseResource(ResourceFactory.of(context).newResource(staticUrl.toURI()));
-            } catch (Exception e) {
-                LOGGER.error("Failed to set base resource", e);
-                System.exit(-1);
-            }
+            context.setBaseResource(ResourceFactory.of(context).newResource(staticUrl.toURI()));
         }
 
         context.addEventListener(new CacheManagerInitializer());
@@ -269,13 +254,7 @@ public final class Application {
         compressionHandler.putCompression(gzipCompression);
         compressionHandler.setHandler(context);
         server.setHandler(compressionHandler);
-
-        try {
-            server.start();
-        } catch (Exception e) {
-            LOGGER.error("Failed to start server", e);
-            System.exit(-1);
-        }
+        server.start();
 
         for (final var handler : server.getContainedBeans(ServletHandler.class)) {
             handler.setDecodeAmbiguousURIs(true);

--- a/apiserver/src/main/java/org/dependencytrack/observability/ManagementServer.java
+++ b/apiserver/src/main/java/org/dependencytrack/observability/ManagementServer.java
@@ -68,7 +68,7 @@ public final class ManagementServer implements Closeable {
                 .orElse(null);
     }
 
-    public void start() throws IOException {
+    public void start() throws IOException, InterruptedException {
         if (!started.compareAndSet(false, true)) {
             throw new IllegalStateException("Already started");
         }
@@ -82,7 +82,10 @@ public final class ManagementServer implements Closeable {
             server.createContext("/metrics", new MetricsHandler(meterRegistry, basicAuthUsername, basicAuthPassword));
         }
 
-        server.start();
+        final var starterThread = new Thread(server::start, "ManagementServerStarter");
+        starterThread.setDaemon(true);
+        starterThread.start();
+        starterThread.join();
     }
 
     int getPort() {


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes management server preventing shutdown on initialization failures.

Starts the management server from a daemon thread so that the JVM isn't blocked by it, should init tasks or other parts of the startup sequence throw.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes #7273 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
