### PR TITLE
Relocate analyzer_identity notification field

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationSubjectNewVulnerabilityRowMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationSubjectNewVulnerabilityRowMapper.java
@@ -44,6 +44,7 @@ public class NotificationSubjectNewVulnerabilityRowMapper implements RowMapper<N
                 .setComponent(componentRowMapper.map(rs, ctx))
                 .setProject(projectRowMapper.map(rs, ctx))
                 .setVulnerability(vulnRowMapper.map(rs, ctx));
+        builder.setAnalyzerIdentity(rs.getString("vulnAnalyzerIdentity"));
         builder.addAffectedProjects(builder.getProject());
         return builder.build();
     }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationVulnerabilityRowMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationVulnerabilityRowMapper.java
@@ -70,7 +70,6 @@ public class NotificationVulnerabilityRowMapper implements RowMapper<Vulnerabili
         maybeSet(
                 rs, "vulnAliasesJson", NotificationVulnerabilityRowMapper::maybeConvertAliases, builder::addAllAliases);
         maybeSet(rs, "vulnIsKev", ResultSet::getBoolean, builder::setIsKev);
-        maybeSet(rs, "vulnAnalyzerIdentity", ResultSet::getString, builder::setAnalyzerIdentity);
         return builder.build();
     }
 

--- a/apiserver/src/main/java/org/dependencytrack/vulnanalysis/ReconcileVulnAnalysisResultsActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulnanalysis/ReconcileVulnAnalysisResultsActivity.java
@@ -807,7 +807,8 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
                         subject.getProject(),
                         subject.getComponent(),
                         subject.getVulnerability(),
-                        convertAnalysisTrigger(analysisTrigger)))
+                        convertAnalysisTrigger(analysisTrigger),
+                        subject.getAnalyzerIdentity()))
                 .toList();
     }
 

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
@@ -235,9 +235,9 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                                     "cvssV2Vector": "(AV:N/AC:M/Au:S/C:P/I:P/A:P)",
                                     "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
                                     "owaspRRVector": "(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)",
-                                    "isKev": true,
-                                    "analyzerIdentity": "internal"
-                                  }
+                                    "isKev": true
+                                  },
+                                  "analyzerIdentity": "internal"
                                 }
                                 """));
     }
@@ -315,9 +315,9 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                             "cvssV2Vector": "",
                             "cvssV3Vector": "cvssV3VectorOverwrite",
                             "owaspRRVector": "owaspRrVector",
-                            "isKev": false,
-                            "analyzerIdentity": "internal"
+                            "isKev": false
                           },
+                          "analyzerIdentity": "internal",
                           "affectedProjects": [
                             {
                               "uuid": "${json-unit.matches:projectUuid}",

--- a/e2e/src/test/java/org/dependencytrack/e2e/BomUploadProcessingE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/BomUploadProcessingE2ET.java
@@ -259,6 +259,7 @@ class BomUploadProcessingE2ET extends AbstractE2ET {
                                 "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
                                 "isKev": false
                               },
+                              "analyzerIdentity": "internal",
                               "affectedProjectsReference": {
                                 "apiUri": "/api/v1/vulnerability/source/INTERNAL/vuln/INT-123/projects",
                                 "frontendUri": "/vulnerabilities/INTERNAL/INT-123/affectedProjects"

--- a/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
+++ b/e2e/src/test/java/org/dependencytrack/e2e/VulnerabilityPolicyE2ET.java
@@ -564,6 +564,7 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
                                 "cvssV3Vector" : "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
                                 "isKev": false
                               },
+                              "analyzerIdentity": "internal",
                               "analysisTrigger" : "ANALYSIS_TRIGGER_BOM_UPLOAD",
                               "vulnerabilityAnalysisLevel": "BOM_UPLOAD_ANALYSIS",
                               "affectedProjects": [
@@ -625,6 +626,7 @@ class VulnerabilityPolicyE2ET extends AbstractE2ET {
                                 "cvssV3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
                                 "isKev": false
                               },
+                              "analyzerIdentity": "internal",
                               "analysisTrigger" : "ANALYSIS_TRIGGER_BOM_UPLOAD",
                               "vulnerabilityAnalysisLevel": "BOM_UPLOAD_ANALYSIS",
                               "affectedProjects": [

--- a/notification/api/src/main/java/org/dependencytrack/notification/api/NotificationFactory.java
+++ b/notification/api/src/main/java/org/dependencytrack/notification/api/NotificationFactory.java
@@ -238,11 +238,16 @@ public final class NotificationFactory {
 
     @SuppressWarnings("deprecation")
     public static Notification createNewVulnerabilityNotification(
-            Project project, Component component, Vulnerability vulnerability, AnalysisTrigger analysisTrigger) {
+            Project project,
+            Component component,
+            Vulnerability vulnerability,
+            AnalysisTrigger analysisTrigger,
+            String analyzerIdentity) {
         requireNonNull(project, "project must not be null");
         requireNonNull(component, "component must not be null");
         requireNonNull(vulnerability, "vulnerability must not be null");
         requireNonNull(analysisTrigger, "analysisTrigger must not be null");
+        requireNonNull(analyzerIdentity, "analyzerIdentity must not be null");
 
         var title = "New Vulnerability Identified on Project: [" + project.getName();
         if (project.hasVersion()) {
@@ -258,6 +263,7 @@ public final class NotificationFactory {
                         .setComponent(component)
                         .setVulnerability(vulnerability)
                         .setAnalysisTrigger(analysisTrigger)
+                        .setAnalyzerIdentity(analyzerIdentity)
                         .setVulnerabilityAnalysisLevel(
                                 switch (analysisTrigger) {
                                     case ANALYSIS_TRIGGER_BOM_UPLOAD -> "BOM_UPLOAD_ANALYSIS";

--- a/notification/api/src/main/java/org/dependencytrack/notification/api/TestNotificationFactory.java
+++ b/notification/api/src/main/java/org/dependencytrack/notification/api/TestNotificationFactory.java
@@ -197,7 +197,7 @@ public final class TestNotificationFactory {
 
     public static Notification createNewVulnerabilityTestNotification() {
         return createNewVulnerabilityNotification(
-                createProject(), createComponent(), createVulnerability(), ANALYSIS_TRIGGER_BOM_UPLOAD);
+                createProject(), createComponent(), createVulnerability(), ANALYSIS_TRIGGER_BOM_UPLOAD, "internal");
     }
 
     public static Notification createNewVulnerableDependencyTestNotification() {

--- a/notification/api/src/main/proto/org/dependencytrack/notification/v1/notification.proto
+++ b/notification/api/src/main/proto/org/dependencytrack/notification/v1/notification.proto
@@ -124,6 +124,9 @@ message NewVulnerabilitySubject {
 
   // The trigger of the analysis that identified the vulnerability.
   AnalysisTrigger analysis_trigger = 7;
+
+  // Name of the analyzer that identified the vulnerability first.
+  string analyzer_identity = 8;
 }
 
 message NewVulnerableDependencySubject {
@@ -226,9 +229,6 @@ message Vulnerability {
 
   // Whether the vulnerability is known to be exploited.
   optional bool is_kev = 21 [json_name = "isKev"];
-
-  // Name of the analyzer that identified the vulnerability first.
-  optional string analyzer_identity = 22;
 
   message Alias {
     string id = 1 [json_name = "vulnId"];

--- a/notification/api/src/test/java/org/dependencytrack/notification/api/NotificationFactoryTest.java
+++ b/notification/api/src/test/java/org/dependencytrack/notification/api/NotificationFactoryTest.java
@@ -20,6 +20,7 @@ package org.dependencytrack.notification.api;
 
 import org.dependencytrack.notification.proto.v1.AnalysisTrigger;
 import org.dependencytrack.notification.proto.v1.Component;
+import org.dependencytrack.notification.proto.v1.NewVulnerabilitySubject;
 import org.dependencytrack.notification.proto.v1.Notification;
 import org.dependencytrack.notification.proto.v1.Project;
 import org.dependencytrack.notification.proto.v1.Vulnerability;
@@ -106,8 +107,34 @@ class NotificationFactoryTest {
                 Project.newBuilder().setName("acme-app").build(),
                 Component.newBuilder().setName("acme-lib").build(),
                 vulnerability,
-                AnalysisTrigger.ANALYSIS_TRIGGER_BOM_UPLOAD);
+                AnalysisTrigger.ANALYSIS_TRIGGER_BOM_UPLOAD,
+                "internal");
         assertThat(notification.getContent()).isEqualTo(expectedContent);
+    }
+
+    @Test
+    void createNewVulnerabilityNotificationShouldPopulateAnalyzerIdentity() throws Exception {
+        final Notification notification = createNewVulnerabilityNotification(
+                Project.newBuilder().setName("acme-app").build(),
+                Component.newBuilder().setName("acme-lib").build(),
+                Vulnerability.newBuilder().setVulnId("CVE-100").build(),
+                AnalysisTrigger.ANALYSIS_TRIGGER_BOM_UPLOAD,
+                "internal");
+
+        final NewVulnerabilitySubject subject = notification.getSubject().unpack(NewVulnerabilitySubject.class);
+        assertThat(subject.getAnalyzerIdentity()).isEqualTo("internal");
+    }
+
+    @Test
+    void createNewVulnerabilityNotificationShouldThrowWhenAnalyzerIdentityIsNull() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> createNewVulnerabilityNotification(
+                        Project.newBuilder().setName("acme-app").build(),
+                        Component.newBuilder().setName("acme-lib").build(),
+                        Vulnerability.newBuilder().setVulnId("CVE-100").build(),
+                        AnalysisTrigger.ANALYSIS_TRIGGER_BOM_UPLOAD,
+                        null))
+                .withMessage("analyzerIdentity must not be null");
     }
 
     @ParameterizedTest

--- a/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/webhook/WebhookNotificationPublisherTest.java
+++ b/notification/publishing/src/test/java/org/dependencytrack/notification/publishing/webhook/WebhookNotificationPublisherTest.java
@@ -277,6 +277,7 @@ class WebhookNotificationPublisherTest extends AbstractNotificationPublisherTest
                               },
                               "vulnerabilityAnalysisLevel": "BOM_UPLOAD_ANALYSIS",
                               "analysisTrigger": "ANALYSIS_TRIGGER_BOM_UPLOAD",
+                              "analyzerIdentity": "internal",
                               "affectedProjects": [
                                 {
                                   "uuid": "c9c9539a-e381-4b36-ac52-6a7ab83b2c95",


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Relocates the `analyzer_identity` field in the notification proto schema from the shared `Vulnerability` message to `NewVulnerabilitySubject`.

Reason being that the field is not relevant to all messages that convey vulnerability information, and related fields like `analysis_trigger` are also not on the `Vulnerability` message.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #6701 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

This performs a breaking change in the notification Proto schema. The field it moves was introduced via #7206 but not yet released. So no client-facing breakage.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
