### PR TITLE
Fix vulnerability component pagination

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -862,6 +862,10 @@ public class QueryManager extends AlpineQueryManager {
         return getVulnerabilityQueryManager().getVulnerabilities(project, includeSuppressed);
     }
 
+    public PaginatedResult getVulnerabilitiesPaginated(Project project, boolean includeSuppressed) {
+        return getVulnerabilityQueryManager().getVulnerabilitiesPaginated(project, includeSuppressed);
+    }
+
     public List<VulnerabilityAlias> getVulnerabilityAliases(Vulnerability vulnerability) {
         return getVulnerabilityQueryManager().getVulnerabilityAliases(vulnerability);
     }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -460,7 +460,9 @@ final class VulnerabilityQueryManager extends QueryManager {
             vulnerability.setAffectedInactiveProjectCount(
                     vulnerabilityProjectCount.totalProjectCount() - vulnerabilityProjectCount.activeProjectCount());
         }
-        return (new PaginatedResult()).objects(componentVulnerabilities).total(componentVulnerabilities.size());
+        return (new PaginatedResult())
+                .objects(componentVulnerabilities)
+                .total(daoCountVulnerabilitiesByComponent(component, includeSuppressed));
     }
 
     /**
@@ -490,6 +492,10 @@ final class VulnerabilityQueryManager extends QueryManager {
      * @return a List of Vulnerability objects
      */
     public List<Vulnerability> getVulnerabilities(Project project, boolean includeSuppressed) {
+        return getVulnerabilitiesPaginated(project, includeSuppressed).getList(Vulnerability.class);
+    }
+
+    public PaginatedResult getVulnerabilitiesPaginated(Project project, boolean includeSuppressed) {
         List<Vulnerability> projectVulnerabilities;
         var vulnerableComponents = new HashMap<Long, Component>();
         try (final Handle jdbiHandle = openJdbiHandle((this.request))) {
@@ -511,7 +517,25 @@ final class VulnerabilityQueryManager extends QueryManager {
                         .toList());
             }
         }
-        return projectVulnerabilities;
+        return (new PaginatedResult())
+                .objects(projectVulnerabilities)
+                .total(daoCountVulnerabilitiesByProject(project, includeSuppressed));
+    }
+
+    private long daoCountVulnerabilitiesByComponent(final Component component, final boolean includeSuppressed) {
+        try (final Handle jdbiHandle = openJdbiHandle(this.request)) {
+            return jdbiHandle
+                    .attach(VulnerabilityDao.class)
+                    .countVulnerabilitiesByComponent(component.getId(), includeSuppressed);
+        }
+    }
+
+    private long daoCountVulnerabilitiesByProject(final Project project, final boolean includeSuppressed) {
+        try (final Handle jdbiHandle = openJdbiHandle(this.request)) {
+            return jdbiHandle
+                    .attach(VulnerabilityDao.class)
+                    .countVulnerabilitiesByProject(project.getId(), includeSuppressed);
+        }
     }
 
     public List<VulnerabilityAlias> getVulnerabilityAliases(Vulnerability vulnerability) {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
@@ -26,6 +26,7 @@ import org.dependencytrack.persistence.jdbi.mapping.VulnerableSoftwareRowMapper;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.config.RegisterFieldMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.customizer.AllowUnusedBindings;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.Define;
 import org.jdbi.v3.sqlobject.customizer.DefineNamedBindings;
@@ -278,6 +279,8 @@ public interface VulnerabilityDao {
 
     @SqlQuery(/* language=InjectedFreeMarker */ """
             <#-- @ftlvariable name="apiFilterParameter" type="String" -->
+            <#-- @ftlvariable name="apiOffsetLimitClause" type="String" -->
+            <#-- @ftlvariable name="apiOrderByClause" type="String" -->
             <#-- @ftlvariable name="includeSuppressed" type="boolean" -->
             SELECT "V"."ID" AS "ID"
                  , "V"."VULNID"
@@ -377,10 +380,61 @@ public interface VulnerabilityDao {
                     AND fa."VULNERABILITY_ID" = "V"."ID"
                     AND fa."DELETED_AT" IS NULL
                )
-            ORDER BY "V"."ID"
+            <#if apiOrderByClause??>
+              ${apiOrderByClause}
+            <#else>
+              ORDER BY "V"."ID"
+            </#if>
+            ${apiOffsetLimitClause!}
             """)
+    @AllowApiOrdering(
+            alwaysBy = @AllowApiOrdering.AlwaysBy(queryName = "\"V\".\"ID\""),
+            by = {
+                @AllowApiOrdering.Column(name = "vulnId", queryName = "\"V\".\"VULNID\""),
+                @AllowApiOrdering.Column(name = "source", queryName = "\"V\".\"SOURCE\""),
+                @AllowApiOrdering.Column(name = "title", queryName = "\"V\".\"TITLE\""),
+                @AllowApiOrdering.Column(name = "severity", queryName = "\"V\".\"SEVERITY\""),
+                @AllowApiOrdering.Column(name = "created", queryName = "\"V\".\"CREATED\""),
+                @AllowApiOrdering.Column(name = "published", queryName = "\"V\".\"PUBLISHED\""),
+                @AllowApiOrdering.Column(name = "updated", queryName = "\"V\".\"UPDATED\"")
+            })
+    @AllowUnusedBindings
+    @DefineNamedBindings
     @RegisterRowMapper(VulnerabilityRowMapper.class)
     List<Vulnerability> getVulnerabilitiesByComponent(@Bind Long componentId, @Define boolean includeSuppressed);
+
+    @SqlQuery(/* language=InjectedFreeMarker */ """
+            <#-- @ftlvariable name="apiFilterParameter" type="String" -->
+            <#-- @ftlvariable name="includeSuppressed" type="boolean" -->
+            SELECT COUNT(DISTINCT "V"."ID")
+              FROM "VULNERABILITY" AS "V"
+             INNER JOIN "COMPONENTS_VULNERABILITIES"
+                ON "V"."ID" = "COMPONENTS_VULNERABILITIES"."VULNERABILITY_ID"
+               AND "COMPONENTS_VULNERABILITIES"."COMPONENT_ID" = :componentId
+             INNER JOIN "COMPONENT"
+                ON "COMPONENTS_VULNERABILITIES"."COMPONENT_ID" = "COMPONENT"."ID"
+              LEFT JOIN "ANALYSIS"
+                ON "V"."ID" = "ANALYSIS"."VULNERABILITY_ID"
+               AND "COMPONENT"."ID" = "ANALYSIS"."COMPONENT_ID"
+               AND "COMPONENT"."PROJECT_ID" = "ANALYSIS"."PROJECT_ID"
+             WHERE TRUE
+            <#if !includeSuppressed>
+               AND "ANALYSIS"."SUPPRESSED" IS DISTINCT FROM TRUE
+            </#if>
+            <#if apiFilterParameter??>
+               AND (LOWER("V"."VULNID") LIKE ('%' || LOWER(${apiFilterParameter}) || '%'))
+            </#if>
+               AND EXISTS (
+                 SELECT 1
+                   FROM "FINDINGATTRIBUTION" AS fa
+                  WHERE fa."COMPONENT_ID" = "COMPONENT"."ID"
+                    AND fa."VULNERABILITY_ID" = "V"."ID"
+                    AND fa."DELETED_AT" IS NULL
+               )
+            """)
+    @AllowUnusedBindings
+    @DefineNamedBindings
+    long countVulnerabilitiesByComponent(@Bind Long componentId, @Define boolean includeSuppressed);
 
     @SqlQuery(/* language=InjectedFreeMarker */ """
             <#-- @ftlvariable name="includeSuppressed" type="boolean" -->
@@ -423,9 +477,10 @@ public interface VulnerabilityDao {
 
     @SqlQuery(/* language=InjectedFreeMarker */ """
             <#-- @ftlvariable name="apiFilterParameter" type="String" -->
+            <#-- @ftlvariable name="apiOffsetLimitClause" type="String" -->
+            <#-- @ftlvariable name="apiOrderByClause" type="String" -->
             <#-- @ftlvariable name="includeSuppressed" type="boolean" -->
-            SELECT DISTINCT ON ("V"."ID")
-                   "V"."ID"
+            SELECT "V"."ID"
                  , "V"."VULNID"
                  , "V"."SOURCE"
                  , "V"."FRIENDLYVULNID"
@@ -525,10 +580,61 @@ public interface VulnerabilityDao {
                     AND fa."DELETED_AT" IS NULL
                )
              GROUP BY "V"."ID", "EPSS"."SCORE", "EPSS"."PERCENTILE"
-             ORDER BY "V"."ID"
+            <#if apiOrderByClause??>
+              ${apiOrderByClause}
+            <#else>
+              ORDER BY "V"."ID"
+            </#if>
+            ${apiOffsetLimitClause!}
             """)
+    @AllowApiOrdering(
+            alwaysBy = @AllowApiOrdering.AlwaysBy(queryName = "\"V\".\"ID\""),
+            by = {
+                @AllowApiOrdering.Column(name = "vulnId", queryName = "\"V\".\"VULNID\""),
+                @AllowApiOrdering.Column(name = "source", queryName = "\"V\".\"SOURCE\""),
+                @AllowApiOrdering.Column(name = "title", queryName = "\"V\".\"TITLE\""),
+                @AllowApiOrdering.Column(name = "severity", queryName = "\"V\".\"SEVERITY\""),
+                @AllowApiOrdering.Column(name = "created", queryName = "\"V\".\"CREATED\""),
+                @AllowApiOrdering.Column(name = "published", queryName = "\"V\".\"PUBLISHED\""),
+                @AllowApiOrdering.Column(name = "updated", queryName = "\"V\".\"UPDATED\"")
+            })
+    @AllowUnusedBindings
+    @DefineNamedBindings
     @RegisterRowMapper(VulnerabilityRowMapper.class)
     List<Vulnerability> getVulnerabilitiesByProject(@Bind long projectId, @Define boolean includeSuppressed);
+
+    @SqlQuery(/* language=InjectedFreeMarker */ """
+            <#-- @ftlvariable name="apiFilterParameter" type="String" -->
+            <#-- @ftlvariable name="includeSuppressed" type="boolean" -->
+            SELECT COUNT(DISTINCT "V"."ID")
+              FROM "VULNERABILITY" AS "V"
+             INNER JOIN "COMPONENTS_VULNERABILITIES"
+                ON "V"."ID" = "COMPONENTS_VULNERABILITIES"."VULNERABILITY_ID"
+             INNER JOIN "COMPONENT"
+                ON "COMPONENTS_VULNERABILITIES"."COMPONENT_ID" = "COMPONENT"."ID"
+              LEFT JOIN "ANALYSIS"
+                ON "V"."ID" = "ANALYSIS"."VULNERABILITY_ID"
+               AND "COMPONENT"."ID" = "ANALYSIS"."COMPONENT_ID"
+               AND "COMPONENT"."PROJECT_ID" = "ANALYSIS"."PROJECT_ID"
+             WHERE "COMPONENT"."PROJECT_ID" = :projectId
+            <#if !includeSuppressed>
+               AND "ANALYSIS"."SUPPRESSED" IS DISTINCT FROM TRUE
+            </#if>
+            <#if apiFilterParameter??>
+               AND (LOWER("V"."VULNID") LIKE ('%' || LOWER(${apiFilterParameter}) || '%'))
+            </#if>
+               AND EXISTS (
+                 SELECT 1
+                   FROM "FINDINGATTRIBUTION" AS fa
+                  WHERE fa."PROJECT_ID" = :projectId
+                    AND fa."COMPONENT_ID" = "COMPONENT"."ID"
+                    AND fa."VULNERABILITY_ID" = "V"."ID"
+                    AND fa."DELETED_AT" IS NULL
+               )
+            """)
+    @AllowUnusedBindings
+    @DefineNamedBindings
+    long countVulnerabilitiesByProject(@Bind long projectId, @Define boolean includeSuppressed);
 
     @SqlQuery("""
             SELECT DISTINCT "C"."ID"

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
@@ -189,10 +189,9 @@ public class VulnerabilityResource extends AbstractApiResource {
             if (project != null) {
                 requireAccess(qm, project);
 
-                // TODO: This should honor pagination but it doesn't.
-                final List<Vulnerability> vulnerabilities = qm.getVulnerabilities(project, suppressed);
-                return Response.ok(vulnerabilities)
-                        .header(TOTAL_COUNT_HEADER, vulnerabilities.size())
+                final PaginatedResult result = qm.getVulnerabilitiesPaginated(project, suppressed);
+                return Response.ok(result.getObjects())
+                        .header(TOTAL_COUNT_HEADER, result.getTotal())
                         .build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND)

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -129,6 +129,57 @@ public class VulnerabilityResourceTest extends ResourceTest {
     }
 
     @Test
+    public void getVulnerabilitiesByComponentUuidShouldHonorPaginatedApiQueryParameters() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+
+        SampleData sampleData = new SampleData();
+        Response response = jersey.target(V1_VULNERABILITY + "/component/" + sampleData.c1.getUuid())
+                .queryParam("filter", "INT")
+                .queryParam("sortName", "vulnId")
+                .queryParam("sortOrder", "desc")
+                .queryParam("pageNumber", "1")
+                .queryParam("pageSize", "1")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("2", response.getHeaderString(TOTAL_COUNT_HEADER));
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                [
+                    {
+                        "vulnId": "INT-2",
+                        "source": "INTERNAL",
+                        "description": "Description 2",
+                        "isKev": false,
+                        "severity": "HIGH",
+                        "cwes": [
+                          {
+                            "cweId": 321,
+                            "name": "Use of Hard-coded Cryptographic Key"
+                          }
+                        ],
+                        "uuid": "${json-unit.any-string}",
+                        "affectedProjectCount": 1,
+                        "affectedActiveProjectCount": 1,
+                        "affectedInactiveProjectCount": 0
+                    }
+                ]
+                """);
+
+        response = jersey.target(V1_VULNERABILITY + "/component/" + sampleData.c1.getUuid())
+                .queryParam("offset", "1")
+                .queryParam("limit", "1")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("2", response.getHeaderString(TOTAL_COUNT_HEADER));
+        assertThatJson(getPlainTextBody(response)).inPath("$[0].vulnId").isEqualTo("INT-2");
+    }
+
+    @Test
     public void getVulnerabilitiesByComponentUuidWithDeletedFindingTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 


### PR DESCRIPTION
### Description

Fixes pagination handling for v1 vulnerability list endpoints.

The affected endpoints were annotated with @PaginatedApi, but their custom JDBI queries did not apply the request-level pagination, filtering, or sorting clauses. This change wires those queries into the existing API request infrastructure so pageNumber/pageSize/offset/limit/filter/searchText/sortName/sortOrder are honored correctly.

### Addressed Issue

Fixes ##7210

### Additional Details

The fix applies SQL level pagination, filtering, and sorting for vulnerability list queries instead of slicing results in memory. This keeps X-Total-Count accurate and avoids fetching the full result set before pagination.

A separate paginated query path was added for the REST resource while preserving the existing internal List<Vulnerability>
<img width="1499" height="784" alt="Screenshot 2026-09-12 at 9 37 33 AM" src="https://github.com/user-attachments/assets/5bc5b190-6955-4914-b541-de24db3cc887" />
 API used by other code paths.

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`